### PR TITLE
fix(calendar): clear the opposite time field when patching an event (all-day ⇄ timed)

### DIFF
--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -268,6 +268,18 @@ function toEventTime(value: string, timeZone: string): Record<string, string> {
   return { dateTime: v, timeZone };
 }
 
+// PATCH merges what we send, so a patch carrying only `dateTime` leaves the event's existing `date`
+// in place — and Google rejects an event holding both (HTTP 400), which makes every all-day ⇄ timed
+// conversion fail. Sending the opposite field as null clears it, so the patch replaces the time
+// representation instead of mixing the two.
+function toEventTimePatch(
+  value: string,
+  timeZone: string,
+): Record<string, string | null> {
+  const t = toEventTime(value, timeZone);
+  return "date" in t ? { ...t, dateTime: null } : { ...t, date: null };
+}
+
 // Flattens a Calendar start/end object to a single string for the model (dateTime or all-day date).
 function flattenTime(t: unknown): string | null {
   if (!t || typeof t !== "object") return null;
@@ -740,8 +752,9 @@ function buildUpdateEventTool(
       if (input.summary !== undefined) body.summary = input.summary;
       if (input.description !== undefined) body.description = input.description;
       if (input.start !== undefined)
-        body.start = toEventTime(input.start, timeZone);
-      if (input.end !== undefined) body.end = toEventTime(input.end, timeZone);
+        body.start = toEventTimePatch(input.start, timeZone);
+      if (input.end !== undefined)
+        body.end = toEventTimePatch(input.end, timeZone);
       if (Object.keys(body).length === 0) {
         return "No fields provided. Set at least one of summary, start, end or description.";
       }

--- a/tests/modules/toolpacks-google-calendar.test.ts
+++ b/tests/modules/toolpacks-google-calendar.test.ts
@@ -632,6 +632,59 @@ describe("google calendar toolpack — event date shaping + default timezone", (
       timeZone: "America/Sao_Paulo",
     });
   });
+
+  // A patch that sets only dateTime leaves the all-day `date` on the event, and Google rejects an
+  // event carrying both (HTTP 400). Both directions must null the field they replace.
+  test("update: all-day → timed nulls the date field", async () => {
+    const { impl, calls } = stubFetch(200, {
+      id: "ev_5",
+      extendedProperties: stampedExt,
+      start: { dateTime: "2026-06-20T00:00:00-03:00" },
+      end: { dateTime: "2026-06-20T23:59:00-03:00" },
+    });
+    await toolFor(
+      "calendar_update_event",
+      {},
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_5",
+      start: "2026-06-20T00:00:00-03:00",
+      end: "2026-06-20T23:59:00-03:00",
+    });
+    // calls[0] is the ownership re-fetch; calls[1] is the PATCH.
+    const body = bodyOf(calls[1] as { init: RequestInit });
+    expect(body.start).toEqual({
+      dateTime: "2026-06-20T00:00:00-03:00",
+      timeZone: "America/Sao_Paulo",
+      date: null,
+    });
+    expect(body.end).toEqual({
+      dateTime: "2026-06-20T23:59:00-03:00",
+      timeZone: "America/Sao_Paulo",
+      date: null,
+    });
+  });
+
+  test("update: timed → all-day nulls the dateTime field", async () => {
+    const { impl, calls } = stubFetch(200, {
+      id: "ev_6",
+      extendedProperties: stampedExt,
+      start: { date: "2026-06-20" },
+      end: { date: "2026-06-21" },
+    });
+    await toolFor(
+      "calendar_update_event",
+      {},
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_6",
+      start: "2026-06-20",
+      end: "2026-06-21",
+    });
+    const body = bodyOf(calls[1] as { init: RequestInit });
+    expect(body.start).toEqual({ date: "2026-06-20", dateTime: null });
+    expect(body.end).toEqual({ date: "2026-06-21", dateTime: null });
+  });
 });
 
 describe("google calendar toolpack — list + availability", () => {


### PR DESCRIPTION
Fixes #2.

`toEventTime` returns either `{ date }` or `{ dateTime, timeZone }`. On update the result goes
straight into a PATCH body, and PATCH merges: setting only `dateTime` leaves the event's existing
`date` untouched. Google rejects an event carrying both, so the call fails:

```
Google Calendar rejected the update (HTTP 400).
```

An all-day event can therefore never be converted to a timed one, nor the reverse. Creating a new
timed event works normally, so only the update path is affected.

## The change

A patch-specific variant that nulls the field it replaces — Google treats an explicit `null` as
"clear this" — leaving `toEventTime` alone for the create path:

```ts
function toEventTimePatch(value: string, timeZone: string): Record<string, string | null> {
  const t = toEventTime(value, timeZone);
  return "date" in t ? { ...t, dateTime: null } : { ...t, date: null };
}
```

## Tests

Two cases added to `tests/modules/toolpacks-google-calendar.test.ts`, covering both directions and
asserting on the PATCH body (`calls[1]`, after the ownership re-fetch).

Verified with `bun test tests/modules/toolpacks-google-calendar.test.ts`:

- with the fix: **41 pass, 0 fail**
- with the original source and the new tests: **39 pass, 2 fail** — the two new cases, so they do
  pin the behaviour rather than passing vacuously

## Where this came up

We import public holidays into the professionals' calendars as full-day busy blocks so
`calendar_check_availability` refuses those days. Converting an imported all-day holiday into a
timed 00:00–23:59 block is what first hit the 400.
