### PR TITLE
fix(dx): pre-commit e scripts npm funcionais na edição derivada

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,4 @@
 set -e
 
+# Local quality gate: the same checks the PR CI runs (lint, type-check, i18n, tests).
 bun check
-
-# Skill safety gate (mirrors publish-skill.yml): build the skill trees and block the commit on ANY
-# Hermes CRITICAL finding (1 critical = "dangerous" verdict → the Hermes scanner refuses to install
-# the skill by every path, and --force does not cover it). Catch it here, not after the push in CI.
-# See tooling/skills/scan-criticals.mjs.
-cd tooling/skills
-npm run build >/dev/null
-node scan-criticals.mjs

--- a/package.json
+++ b/package.json
@@ -30,12 +30,6 @@
     "i18n:extract": "bun scripts/i18n-extract.ts",
     "openapi:generate": "bun scripts/build-openapi.ts --write",
     "openapi:check": "bun scripts/build-openapi.ts",
-    "derive:check": "bun tooling/derivation/check-markers.ts",
-    "derive:pro": "bun tooling/derivation/derive.ts pro",
-    "derive:free": "bun tooling/derivation/derive.ts free",
-    "build:pro": "bun tooling/derivation/derive.ts pro --out /tmp/derive-pro --validate",
-    "build:free": "bun tooling/derivation/derive.ts free --out /tmp/derive-free --validate",
-    "check:editions": "bash scripts/check-editions.sh",
     "check": "bun run lint && bun run build-check && bun run build-check:worker && bun run openapi:check && bun run i18n:extract && bun run test",
     "prepare": "husky"
   },


### PR DESCRIPTION
## O problema

Dois artefatos desta edição referenciam tooling que existe apenas no master interno e é removida na derivação:

1. **`.husky/pre-commit`** herdava o gate de skills do master e terminava com `cd tooling/skills`, então qualquer contribuidor que rodasse `bun install` (que instala os hooks via `prepare`) tinha **todo commit bloqueado**: a suíte inteira passava e o hook morria em `cd: tooling/skills: No such file or directory`. Encontrado ao contribuir na #7.
2. **`package.json`** trazia `derive:check`, `derive:pro`, `derive:free`, `build:pro`, `build:free` e `check:editions`, que só podem falhar aqui (`tooling/derivation/…` e `scripts/check-editions.sh` não existem nesta edição).

## A solução

- O pre-commit desta edição agora contém **apenas o gate local que o CI da PR roda** (`bun check`), sem qualquer referência à tooling interna do master.
- Os seis scripts saem do `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined pre-commit hooks to run only essential validation checks, removing build process and safety scan steps from the development pipeline.
  * Removed multiple obsolete build configuration and derivation scripts from development tooling to reduce complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->