### PR TITLE
fix(chatwoot): watermark de mensagens tratadas avança em todo desfecho deliberado

### DIFF
--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -18,6 +18,7 @@ import {
 } from "@/modules/chatwoot/normalize";
 import { renderInboundMessage } from "@/modules/chatwoot/render";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
+import { advanceHandledWatermark } from "@/modules/debounce/watermark";
 import {
   emitFlowEvent,
   type FlowContext,
@@ -576,7 +577,7 @@ export async function runAgentTurn(
   });
   if (!loaded) return "no-agent";
 
-  return runLoadedTurn({
+  const outcome = await runLoadedTurn({
     loaded,
     tenantId,
     instanceId,
@@ -589,4 +590,27 @@ export async function runAgentTurn(
     base,
     deps: params.deps,
   });
+  // The direct path never uses shouldPost (no supersede gate), so nothing else advances the handled
+  // watermark here — left alone it stays NULL forever, and the first flush after debounce is later
+  // enabled (or after an arm failure fell back here) re-answers the whole recent page (issue #8).
+  // Every completed outcome consumed this message: posted/empty/blocked, or taken over (the human
+  // owns it now). Best-effort — the reply is already delivered, a watermark miss must not fail the
+  // turn.
+  if (n.message?.id != null && loaded.conversationDbId !== null) {
+    try {
+      await advanceHandledWatermark({
+        tenantId,
+        conversationDbId: loaded.conversationDbId,
+        toMessageId: n.message.id,
+        base,
+      });
+    } catch (e) {
+      logger.warn(
+        "advance handled watermark failed (conv=%s): %s",
+        String(conversationId),
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  }
+  return outcome;
 }

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -39,6 +39,7 @@ import {
   recordConversationError,
 } from "@/modules/conversations/error";
 import { armDebounce, resolveDebounceConfig } from "@/modules/debounce/service";
+import { advanceHandledWatermark } from "@/modules/debounce/watermark";
 import { cancelPendingJob } from "@/modules/scheduler/service";
 import {
   resolveSttConfig,
@@ -1179,6 +1180,7 @@ export async function processChatwootDelivery(
               threadId,
               agentBotId: params.agentBotId,
               cfg,
+              lastMessageId: n.message?.id ?? undefined,
               base,
             });
             armed = true;
@@ -1305,6 +1307,34 @@ export async function processChatwootDelivery(
       n.event,
       isNewIncoming,
     );
+  }
+
+  // A new inbound message the bot deliberately leaves unanswered — the conversation is human-owned
+  // (!act) or a command/test-mode gate consumed it — still advances the handled watermark: it is
+  // context, not a pending task. Left behind, these pile up below the watermark and the first flush
+  // after a human returns the conversation re-answers the whole human-era backlog, handoff reason
+  // included (issue #8). When a turn WILL run (act && !consumed), the turn/flush owns the advance.
+  // Best-effort: a miss only widens a later re-coalesce.
+  if (
+    isNewIncoming &&
+    (!act || consumed) &&
+    n.message?.id != null &&
+    mirror.conversationRowId !== null
+  ) {
+    try {
+      await advanceHandledWatermark({
+        tenantId: params.tenantId,
+        conversationDbId: mirror.conversationRowId,
+        toMessageId: n.message.id,
+        base,
+      });
+    } catch (err) {
+      logger.warn(
+        "chatwoot: advance handled watermark failed (conv=%s): %s",
+        convLabel,
+        errMsg(err),
+      );
+    }
   }
 
   // Continuous ingestion (production + enabled only): fold the messages no turn handled into the

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -26,7 +26,9 @@ import { emitFlowEvent } from "@/modules/flowlog/service";
 import type { FlowStage } from "@/modules/flowlog/stages";
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
+import { readLastMessageId } from "./service";
 import { readDebounceConfig } from "./settings";
+import { advanceHandledWatermark } from "./watermark";
 
 // The DEBOUNCE flush: re-fetch the conversation from Chatwoot, coalesce the inbound messages past the
 // watermark into one turn, and answer once. Two re-fetches by design: the first builds the burst to
@@ -133,7 +135,17 @@ export async function coalesceAndRunTurn(
   const rendered = pending
     .map((m) => renderInboundMessage(toRenderable(m), { resolveQuoted }))
     .filter((s) => s.length > 0);
-  if (rendered.length === 0) return "empty";
+  if (rendered.length === 0) {
+    // Nothing in the burst renders to answerable text — it never will, so mark it handled or every
+    // future flush re-fetches and re-stops on the same messages.
+    await advanceHandledWatermark({
+      tenantId,
+      conversationDbId: convDbId,
+      toMessageId: targetWatermark,
+      base,
+    });
+    return "empty";
+  }
   const text = rendered.join("\n");
 
   // 2. Post gate: re-fetch to detect mid-turn arrivals (supersede), then advance the watermark
@@ -159,18 +171,11 @@ export async function coalesceAndRunTurn(
         err(e),
       );
     }
-    return runScopedOn(base, sysCtx(tenantId), async (db) => {
-      const cas = await db.conversation.updateMany({
-        where: {
-          id: convDbId,
-          OR: [
-            { lastHandledMessageId: null },
-            { lastHandledMessageId: { lt: targetWatermark } },
-          ],
-        },
-        data: { lastHandledMessageId: targetWatermark },
-      });
-      return cas.count > 0;
+    return advanceHandledWatermark({
+      tenantId,
+      conversationDbId: convDbId,
+      toMessageId: targetWatermark,
+      base,
     });
   };
 
@@ -213,6 +218,21 @@ export async function coalesceAndRunTurn(
     deps,
     shouldPost,
   });
+  // Every completed outcome except "superseded" consumed the burst: answered ("posted" — where
+  // shouldPost's CAS already advanced, making this a no-op), answered by the input-guardrail
+  // template (which never consults shouldPost), or deliberately dropped (taken over mid-turn, empty
+  // reply, guardrail "silent"). Advance so the next flush cannot re-answer the same burst (issue
+  // #8: the pre-handoff backlog was re-coalesced — and the bot re-transferred for the old reason —
+  // after a human returned the conversation). "superseded" stays put by design: the re-armed flush
+  // answers the FULL burst.
+  if (outcome !== "superseded") {
+    await advanceHandledWatermark({
+      tenantId,
+      conversationDbId: convDbId,
+      toMessageId: targetWatermark,
+      base,
+    });
+  }
   logger.info(
     "%s: conv=%s msgs=%d watermark→%d outcome=%s",
     ctx.label,
@@ -270,7 +290,7 @@ export async function flushDebounceJob(
         { ourAgentBotId: agentBotId },
       )
     ) {
-      return "gate-closed" as const;
+      return { gateClosed: true as const, convDbId: conv.id };
     }
     const inbox = await db.inbox.findUnique({
       where: { id: conv.inboxId },
@@ -296,8 +316,25 @@ export async function flushDebounceJob(
       settings: agentRow?.settings ?? {},
     };
   });
-  // No agent / unbound inbox / human took over → nothing to do (not a failure).
-  if (ctx === null || ctx === "gate-closed") return { outcome: "done" };
+  // No agent / unbound inbox → nothing to do (not a failure).
+  if (ctx === null) return { outcome: "done" };
+  // Human took over between the arm and this flush: the burst is the human's to answer now, so it
+  // still counts as handled. The arm path kept the burst's newest message id in the payload
+  // precisely so this advance needs no network fetch (issue #8) — without it, the burst would sit
+  // below the watermark and the first flush after the human returns the conversation would
+  // re-answer it.
+  if ("gateClosed" in ctx) {
+    const last = readLastMessageId(job.payload);
+    if (last !== null) {
+      await advanceHandledWatermark({
+        tenantId,
+        conversationDbId: ctx.convDbId,
+        toMessageId: last,
+        base,
+      });
+    }
+    return { outcome: "done" };
+  }
 
   // Coalesce the burst past the watermark and answer once. A thrown error (LLM/Chatwoot) bubbles to
   // the worker → retry with backoff (watermark not advanced, so the retry re-answers the same burst).

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -54,11 +54,22 @@ function readBurstStart(payload: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
 
+// The burst's newest known Chatwoot message id, kept in the job payload so a flush abandoned by the
+// human-takeover gate can still advance the handled watermark without a network fetch (issue #8).
+export function readLastMessageId(payload: unknown): number | null {
+  if (!payload || typeof payload !== "object") return null;
+  const v = (payload as Record<string, unknown>).lastMessageId;
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
 export interface ArmDebounceParams {
   tenantId: bigint;
   threadId: string;
   agentBotId: number | null;
   cfg: DebounceConfig;
+  // Chatwoot id of the inbound message arming this flush (see readLastMessageId). Optional: an arm
+  // without it keeps the burst's previous high-water mark.
+  lastMessageId?: number;
   base?: PrismaClient;
   now?: Date;
 }
@@ -85,6 +96,13 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
           ? readBurstStart(existing.payload)
           : null;
       const burstStartedAt = prevBurst ?? nowMs;
+      // High-water message id across the burst's arms (a fresh burst starts over, like burstStartedAt).
+      const prevLast =
+        existing?.status === "PENDING"
+          ? readLastMessageId(existing.payload)
+          : null;
+      const lastMessageId =
+        Math.max(prevLast ?? 0, params.lastMessageId ?? 0) || null;
       const runAtMs = Math.min(
         nowMs + cfg.windowSeconds * 1000,
         burstStartedAt + cfg.maxWindowSeconds * 1000,
@@ -93,6 +111,7 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         threadId,
         agentBotId,
         burstStartedAt,
+        ...(lastMessageId !== null ? { lastMessageId } : {}),
       } satisfies Prisma.InputJsonObject;
       await db.schedulerJob.upsert({
         where: {

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -101,8 +101,8 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         existing?.status === "PENDING"
           ? readLastMessageId(existing.payload)
           : null;
-      const lastMessageId =
-        Math.max(prevLast ?? 0, params.lastMessageId ?? 0) || null;
+      const lastCandidate = Math.max(prevLast ?? 0, params.lastMessageId ?? 0);
+      const lastMessageId = lastCandidate > 0 ? lastCandidate : null;
       const runAtMs = Math.min(
         nowMs + cfg.windowSeconds * 1000,
         burstStartedAt + cfg.maxWindowSeconds * 1000,

--- a/src/modules/debounce/watermark.ts
+++ b/src/modules/debounce/watermark.ts
@@ -1,0 +1,45 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+import basePrisma from "@/api/lib/prisma";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+
+// `Conversation.lastHandledMessageId` marks the last inbound message the bot either responded to or
+// DELIBERATELY skipped (handoff mid-turn, human-owned period, consumed /commands, guardrail
+// suppression). Every writer goes through this monotonic CAS: a stale advance (target ≤ current)
+// loses silently, so concurrent flushes and webhook deliveries can never move the watermark
+// backwards. Advancing means "never re-ANSWER this", not "never remember it" — skipped messages
+// still reach the agent's memory through ingestion. Left behind, the watermark makes the next
+// debounce flush re-coalesce the whole human-era backlog (handoff reason included) after a human
+// returns a conversation to the bot (issue #8).
+
+function sysCtx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}
+
+export interface AdvanceHandledWatermarkParams {
+  tenantId: bigint;
+  conversationDbId: bigint;
+  // Chatwoot id of the newest message now considered handled.
+  toMessageId: number;
+  base?: PrismaClient;
+}
+
+// Returns true when this call moved the watermark (the CAS won), false when a concurrent writer
+// already advanced it past `toMessageId`.
+export async function advanceHandledWatermark(
+  params: AdvanceHandledWatermarkParams,
+): Promise<boolean> {
+  const base = params.base ?? basePrisma;
+  return runScopedOn(base, sysCtx(params.tenantId), async (db) => {
+    const cas = await db.conversation.updateMany({
+      where: {
+        id: params.conversationDbId,
+        OR: [
+          { lastHandledMessageId: null },
+          { lastHandledMessageId: { lt: params.toMessageId } },
+        ],
+      },
+      data: { lastHandledMessageId: params.toMessageId },
+    });
+    return cas.count > 0;
+  });
+}

--- a/tests/modules/chatwoot-receiver.test.ts
+++ b/tests/modules/chatwoot-receiver.test.ts
@@ -344,6 +344,47 @@ describe.skipIf(!dbUp)("chatwoot webhook receiver", () => {
     expect(r.outcome).toBe("ignored");
     expect(r.deliveryRowId).toBeUndefined();
   });
+
+  test("issue #8: an inbound message during a human-owned period advances the handled watermark", async () => {
+    // A customer message while a human owns the conversation (!act): the bot deliberately stays
+    // silent, but the message must count as handled — otherwise the first debounce flush after the
+    // human returns the conversation re-answers the whole human-era backlog.
+    const body = JSON.stringify({
+      event: "message_created",
+      id: 2001,
+      content: "isso está um absurdo!",
+      message_type: "incoming",
+      private: false,
+      conversation: {
+        id: 44,
+        inbox_id: 7,
+        status: "open",
+        meta: { assignee_type: "User", assignee: { id: 5 } },
+      },
+    });
+    const r = await receiveChatwootWebhook({
+      routeToken,
+      rawBody: body,
+      getHeader: signedHeaders(body, NOW, "uuid-hmn"),
+      nowSeconds: NOW,
+      base: appDb,
+    });
+    expect(r.outcome).toBe("queued");
+    const proc = await processChatwootDelivery({
+      tenantId,
+      instanceId: r.instanceId as bigint,
+      deliveryRowId: r.deliveryRowId as bigint,
+      agentBotId: r.agentBotId ?? null,
+      normalized: r.normalized as NonNullable<typeof r.normalized>,
+      base: appDb,
+    });
+    expect(proc).toBe("processed");
+    const conv = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: 44 },
+      select: { lastHandledMessageId: true },
+    });
+    expect(conv.lastHandledMessageId).toBe(2001);
+  });
 });
 
 // ── provisioning ↔ receiver round trip (real DB, stubbed Chatwoot client) ──

--- a/tests/modules/debounce.test.ts
+++ b/tests/modules/debounce.test.ts
@@ -560,9 +560,7 @@ describe.skipIf(!dbUp)("debounce", () => {
   });
 
   test("armDebounce keeps the burst's highest lastMessageId across re-arms", async () => {
-    await suDb.$executeRawUnsafe(
-      `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId}`,
-    );
+    await suDb.schedulerJob.deleteMany({ where: { tenantId } });
     const thread = threadOf(702);
     const cfg = {
       enabled: true,

--- a/tests/modules/debounce.test.ts
+++ b/tests/modules/debounce.test.ts
@@ -11,6 +11,7 @@ import {
   debounceDedupeKey,
   resolveDebounceConfig,
 } from "@/modules/debounce/service";
+import { advanceHandledWatermark } from "@/modules/debounce/watermark";
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import {
   claimDueDebounceJobs,
@@ -116,12 +117,22 @@ async function seedConversation(
   });
 }
 
-function jobFor(convId: number): ClaimedJob {
+function jobFor(
+  convId: number,
+  extra: { lastMessageId?: number } = {},
+): ClaimedJob {
   return {
     id: 1n,
     tenantId,
     kind: "DEBOUNCE",
-    payload: { threadId: threadOf(convId), agentBotId: 9, burstStartedAt: 1 },
+    payload: {
+      threadId: threadOf(convId),
+      agentBotId: 9,
+      burstStartedAt: 1,
+      ...(extra.lastMessageId != null
+        ? { lastMessageId: extra.lastMessageId }
+        : {}),
+    },
     attempts: 0,
   };
 }
@@ -437,5 +448,174 @@ describe.skipIf(!dbUp)("debounce", () => {
     expect(out).toEqual({ outcome: "done" });
     expect(sent).toEqual([]);
     expect(calls.getMessages).toBe(0);
+  });
+
+  // ── Issue #8: the watermark must advance on every deliberate skip, not only on a post ──
+
+  test("advanceHandledWatermark is a monotonic CAS (never moves backwards)", async () => {
+    await seedConversation(803);
+    const conv = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: 803 },
+      select: { id: true },
+    });
+    const advance = (to: number) =>
+      advanceHandledWatermark({
+        tenantId,
+        conversationDbId: conv.id,
+        toMessageId: to,
+        base: appDb,
+      });
+    expect(await advance(5)).toBe(true);
+    expect(await watermarkOf(803)).toBe(5);
+    expect(await advance(3)).toBe(false); // stale writer loses silently
+    expect(await watermarkOf(803)).toBe(5);
+    expect(await advance(8)).toBe(true);
+    expect(await watermarkOf(803)).toBe(8);
+  });
+
+  test("an empty reply still advances the watermark (the burst was consumed)", async () => {
+    await seedConversation(804);
+    const sent: Array<[number, string]> = [];
+    const calls = { getMessages: 0 };
+    const out = await flushDebounceJob({
+      job: jobFor(804),
+      base: appDb,
+      deps: {
+        makeModel: () => new FakeListChatModel({ responses: [""] }),
+        makeClient: makeStub({
+          pages: [
+            page([
+              { id: 1, content: "oi" },
+              { id: 2, content: "tem horário amanhã?" },
+            ]),
+          ],
+          sent,
+          calls,
+        }),
+        checkpointer: new MemorySaver(),
+      },
+    });
+    expect(out).toEqual({ outcome: "done" });
+    expect(sent).toEqual([]);
+    expect(await watermarkOf(804)).toBe(2);
+  });
+
+  test("a human takeover mid-turn advances the watermark (no re-answer after the return)", async () => {
+    await seedConversation(805);
+    const sent: Array<[number, string]> = [];
+    let fetches = 0;
+    // The burst fetch runs after the job's own gate (still open) and before the turn; flipping the
+    // assignee there lands exactly in the window the post-LLM re-check inspects → "taken-over".
+    const client = {
+      getMessages: async () => {
+        fetches += 1;
+        if (fetches === 1) {
+          await suDb.conversation.updateMany({
+            where: { tenantId, chatwootConversationId: 805 },
+            data: { assigneeType: "User", status: "open" },
+          });
+        }
+        return page([{ id: 4, content: "quero falar com um humano AGORA" }]);
+      },
+      sendMessage: async (conversationId: number, content: string) => {
+        sent.push([conversationId, content]);
+        return {};
+      },
+    } as unknown as ChatwootClient;
+    const out = await flushDebounceJob({
+      job: jobFor(805),
+      base: appDb,
+      deps: {
+        makeModel: fakeModel,
+        makeClient: async () => client,
+        checkpointer: new MemorySaver(),
+      },
+    });
+    expect(out).toEqual({ outcome: "done" });
+    expect(sent).toEqual([]); // nothing posted — the human owns the reply
+    expect(await watermarkOf(805)).toBe(4); // …but the burst counts as handled
+  });
+
+  test("a gate-closed flush advances to the payload's lastMessageId without any fetch", async () => {
+    await seedConversation(806, { assigneeType: "User" });
+    const sent: Array<[number, string]> = [];
+    const calls = { getMessages: 0 };
+    const out = await flushDebounceJob({
+      job: jobFor(806, { lastMessageId: 12 }),
+      base: appDb,
+      deps: {
+        makeModel: fakeModel,
+        makeClient: makeStub({
+          pages: [page([{ id: 12, content: "oi" }])],
+          sent,
+          calls,
+        }),
+        checkpointer: new MemorySaver(),
+      },
+    });
+    expect(out).toEqual({ outcome: "done" });
+    expect(sent).toEqual([]);
+    expect(calls.getMessages).toBe(0);
+    expect(await watermarkOf(806)).toBe(12);
+  });
+
+  test("armDebounce keeps the burst's highest lastMessageId across re-arms", async () => {
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId}`,
+    );
+    const thread = threadOf(702);
+    const cfg = {
+      enabled: true,
+      windowSeconds: 15,
+      maxMessagesPerBurst: 20,
+      maxWindowSeconds: 60,
+    };
+    for (const lastMessageId of [3, 5, 4]) {
+      await armDebounce({
+        tenantId,
+        threadId: thread,
+        agentBotId: 9,
+        cfg,
+        lastMessageId,
+        base: appDb,
+      });
+    }
+    const row = await suDb.schedulerJob.findFirstOrThrow({
+      where: {
+        tenantId,
+        kind: "DEBOUNCE",
+        dedupeKey: debounceDedupeKey(thread),
+      },
+      select: { payload: true },
+    });
+    expect((row.payload as { lastMessageId?: number }).lastMessageId).toBe(5);
+  });
+
+  test("issue #8 regression: after a handoff-era backlog, the flush answers only the new message", async () => {
+    // Watermark at 8 = messages 5-8 arrived while a human owned the conversation (the webhook
+    // advance covered them); the human then returned it and the customer sent message 9.
+    await seedConversation(807, { lastHandledMessageId: 8 });
+    const sent: Array<[number, string]> = [];
+    const calls = { getMessages: 0 };
+    const fullHistory = page([
+      { id: 4, content: "quero remarcar" },
+      { id: 5, content: "isso está um absurdo!" },
+      { id: 6, content: "que atendimento péssimo" },
+      { id: 7, content: "obrigado pela ajuda" },
+      { id: 8, content: "até logo" },
+      { id: 9, content: "quero marcar um horário pra sexta" },
+    ]);
+    const out = await flushDebounceJob({
+      job: jobFor(807, { lastMessageId: 9 }),
+      base: appDb,
+      deps: {
+        makeModel: fakeModel,
+        makeClient: makeStub({ pages: [fullHistory], sent, calls }),
+        checkpointer: new MemorySaver(),
+      },
+    });
+    expect(out).toEqual({ outcome: "done" });
+    expect(sent).toEqual([[807, REPLY]]); // one reply, to the new request only
+    expect(await watermarkOf(807)).toBe(9);
   });
 });


### PR DESCRIPTION
## Problema (issue #8)

O `lastHandledMessageId` só avançava quando o flush do debounce postava uma resposta. Toda saída deliberada sem post deixava o watermark para trás: a mensagem que disparou o handoff (turno termina `taken-over`), mensagens recebidas enquanto um humano atende, comandos consumidos (`/teste`, `/reset`), guardrail silencioso, resposta vazia do modelo e o caminho direto (debounce desligado), que nunca avançava nada.

Resultado reproduzível (relatado pelo @rjsoux): humano devolve a conversa ao bot, o próximo flush recoalesce todo o backlog da era humana (`debounce: { coalesced: 5 }`) e o bot re-transfere citando a irritação antiga. Acontece na configuração padrão.

## Correção

Um único CAS monotônico novo (`advanceHandledWatermark`, `src/modules/debounce/watermark.ts`) usado em quatro pontos:

1. **Webhook**: entrada nova que o bot deliberadamente não vai responder (conversa em atendimento humano ou comando consumido) avança o watermark. É contexto, não tarefa pendente; a ingestão de memória segue inalterada.
2. **Flush**: qualquer desfecho completo exceto `superseded` avança (`posted` é no-op, o CAS do `shouldPost` já avançou; cobre `taken-over`, `empty`, `blocked` e o template do input guardrail, que nunca consulta `shouldPost`). `superseded` continua parado por design: o flush re-armado responde o burst completo.
3. **Gate fechado entre o arm e o flush**: o arm agora guarda o maior id do burst no payload do job (`lastMessageId`) e o flush abandonado pelo takeover humano avança sem nenhuma chamada de rede.
4. **Caminho direto**: avança o watermark da mensagem tratada ao fim do turno. Antes ficava `NULL` para sempre e o primeiro flush após ligar o debounce re-respondia a página recente inteira (até 20 mensagens).

## Testes

- CAS monotônico nunca anda para trás
- resposta vazia avança (burst consumido)
- takeover no meio do turno avança sem postar
- flush com gate fechado avança pelo payload, sem fetch
- `armDebounce` mantém o maior `lastMessageId` entre re-arms
- regressão do cenário da issue: backlog da era humana abaixo do watermark, flush responde só a mensagem nova
- webhook: mensagem durante atendimento humano avança o watermark (ponta a ponta no receiver)

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tracking of the latest handled message across direct replies, queued messages, and debounce retries.
  - Prevented stale updates from moving conversation progress backward.
  - Ensured messages received during human handoff or gated conversations are marked as handled without triggering bot responses.
  - Improved handling of empty replies and message bursts to prevent outdated backlog responses.

- **Tests**
  - Added coverage for human-assigned conversations, debounce retries, handoffs, gated conversations, and message ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->