### PR TITLE
feat(branding): links do rodapé configuráveis (site, e-mail de suporte, GitHub ocultável)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2138,6 +2138,34 @@
                     "patternProperties": {
                       "^(.*)$": {}
                     }
+                  },
+                  "siteUrl": {
+                    "description": "Sidebar-footer website link (absolute http(s) URL), or null to use the default.",
+                    "anyOf": [
+                      {
+                        "maxLength": 512,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "supportEmail": {
+                    "description": "Support e-mail shown in the sidebar support modal, or null to use the default.",
+                    "anyOf": [
+                      {
+                        "maxLength": 254,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "hideGithubLink": {
+                    "description": "When true, the GitHub entry is removed from the sidebar footer.",
+                    "type": "boolean"
                   }
                 }
               }
@@ -2190,6 +2218,34 @@
                     "patternProperties": {
                       "^(.*)$": {}
                     }
+                  },
+                  "siteUrl": {
+                    "description": "Sidebar-footer website link (absolute http(s) URL), or null to use the default.",
+                    "anyOf": [
+                      {
+                        "maxLength": 512,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "supportEmail": {
+                    "description": "Support e-mail shown in the sidebar support modal, or null to use the default.",
+                    "anyOf": [
+                      {
+                        "maxLength": 254,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "hideGithubLink": {
+                    "description": "When true, the GitHub entry is removed from the sidebar footer.",
+                    "type": "boolean"
                   }
                 }
               }
@@ -2242,6 +2298,34 @@
                     "patternProperties": {
                       "^(.*)$": {}
                     }
+                  },
+                  "siteUrl": {
+                    "description": "Sidebar-footer website link (absolute http(s) URL), or null to use the default.",
+                    "anyOf": [
+                      {
+                        "maxLength": 512,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "supportEmail": {
+                    "description": "Support e-mail shown in the sidebar support modal, or null to use the default.",
+                    "anyOf": [
+                      {
+                        "maxLength": 254,
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "hideGithubLink": {
+                    "description": "When true, the GitHub entry is removed from the sidebar footer.",
+                    "type": "boolean"
                   }
                 }
               }

--- a/prisma/migrations/20260802075309_branding_footer_links/migration.sql
+++ b/prisma/migrations/20260802075309_branding_footer_links/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "app_branding" ADD COLUMN     "hide_github_link" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "site_url" TEXT,
+ADD COLUMN     "support_email" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,6 +168,9 @@ model AppBranding {
   logoLightKey    String?  @map("logo_light_key")
   faviconDarkKey  String?  @map("favicon_dark_key")
   faviconLightKey String?  @map("favicon_light_key")
+  siteUrl         String?  @map("site_url")
+  supportEmail    String?  @map("support_email")
+  hideGithubLink  Boolean  @default(false) @map("hide_github_link")
   updatedAt       DateTime @updatedAt @map("updated_at")
 
   @@map("app_branding")

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="./favicon-light.png" media="(prefers-color-scheme: light)" />
   <link rel="icon" href="./favicon-dark.png" media="(prefers-color-scheme: dark)" />
-  <title>fazer.ai</title>
+  <title>fazer.ai agents</title>
   <script>
     (function () {
       var stored;

--- a/src/api/features/branding/branding.controller.ts
+++ b/src/api/features/branding/branding.controller.ts
@@ -111,6 +111,24 @@ export const brandingController = new Elysia({
           description: "Dark-theme CSS token overrides keyed by token name.",
         }),
       ),
+      siteUrl: t.Optional(
+        t.Union([t.String({ maxLength: 512 }), t.Null()], {
+          description:
+            "Sidebar-footer website link (absolute http(s) URL), or null to use the default.",
+        }),
+      ),
+      supportEmail: t.Optional(
+        t.Union([t.String({ maxLength: 254 }), t.Null()], {
+          description:
+            "Support e-mail shown in the sidebar support modal, or null to use the default.",
+        }),
+      ),
+      hideGithubLink: t.Optional(
+        t.Boolean({
+          description:
+            "When true, the GitHub entry is removed from the sidebar footer.",
+        }),
+      ),
     }),
     detail: doc(
       "Update branding colors",

--- a/src/api/features/branding/branding.service.ts
+++ b/src/api/features/branding/branding.service.ts
@@ -18,6 +18,8 @@ import { sanitizeBranding } from "@/lib/branding";
 // translate('errors.unsupportedImageType', 'Unsupported image type')
 // translate('errors.imageTooLarge', 'Image is too large')
 // translate('errors.noUpdatableFields', 'No updatable fields provided')
+// translate('errors.invalidSiteUrl', 'Invalid website URL')
+// translate('errors.invalidSupportEmail', 'Invalid support e-mail')
 
 export const SINGLETON_ID = 1;
 
@@ -59,6 +61,11 @@ export interface GlobalBrandingDto {
   tokensDark: Record<string, string>;
   logo: { dark: boolean; light: boolean };
   favicon: { dark: boolean; light: boolean };
+  // Sidebar-footer links (white-label): the operator's own site and support inbox, plus the
+  // option to drop the GitHub entry. null = use the built-in defaults.
+  siteUrl: string | null;
+  supportEmail: string | null;
+  hideGithubLink: boolean;
   // Epoch-ms string of the last write — the client appends it to asset URLs to bust caches
   // (the favicon especially is cached aggressively by browsers). "0" while still at defaults.
   version: string;
@@ -74,6 +81,9 @@ interface BrandingRow {
   logoLightKey: string | null;
   faviconDarkKey: string | null;
   faviconLightKey: string | null;
+  siteUrl: string | null;
+  supportEmail: string | null;
+  hideGithubLink: boolean;
   updatedAt: Date;
 }
 
@@ -85,6 +95,9 @@ export const DEFAULT_DTO: GlobalBrandingDto = {
   tokensDark: {},
   logo: { dark: false, light: false },
   favicon: { dark: false, light: false },
+  siteUrl: null,
+  supportEmail: null,
+  hideGithubLink: false,
   version: "0",
 };
 
@@ -102,6 +115,32 @@ export function sanitizeBrandName(value: unknown): string | null {
 }
 
 const MAX_BRAND_NAME_LEN = 64;
+const MAX_SITE_URL_LEN = 512;
+const MAX_SUPPORT_EMAIL_LEN = 254;
+// Deliberately loose (one @, no spaces, a dot in the domain): the goal is catching typos and
+// copy-paste accidents, not RFC 5322 — the value only feeds a mailto: link and the support modal.
+const SUPPORT_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// null unless the value parses as an absolute http(s) URL within bounds. The footer renders the
+// value inside an anchor href, so anything else (javascript:, data:, relative paths) must die here.
+export function sanitizeSiteUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_SITE_URL_LEN) return null;
+  try {
+    const { protocol } = new URL(trimmed);
+    return protocol === "http:" || protocol === "https:" ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function sanitizeSupportEmail(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_SUPPORT_EMAIL_LEN) return null;
+  return SUPPORT_EMAIL_RE.test(trimmed) ? trimmed : null;
+}
 
 export function toDto(row: BrandingRow): GlobalBrandingDto {
   return {
@@ -116,6 +155,9 @@ export function toDto(row: BrandingRow): GlobalBrandingDto {
       dark: row.faviconDarkKey !== null,
       light: row.faviconLightKey !== null,
     },
+    siteUrl: sanitizeSiteUrl(row.siteUrl),
+    supportEmail: sanitizeSupportEmail(row.supportEmail),
+    hideGithubLink: row.hideGithubLink === true,
     version: row.updatedAt.getTime().toString(),
   };
 }
@@ -133,6 +175,9 @@ export interface ColorUpdate {
   brandColor?: string | null;
   tokensLight?: Record<string, unknown>;
   tokensDark?: Record<string, unknown>;
+  siteUrl?: string | null;
+  supportEmail?: string | null;
+  hideGithubLink?: boolean;
 }
 
 export function keyColumn(

--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -30,6 +30,8 @@
     "invalidCredentials": "Invalid email or password",
     "invalidPassword": "Incorrect password",
     "invalidSetupToken": "Invalid or missing setup token",
+    "invalidSiteUrl": "Invalid website URL",
+    "invalidSupportEmail": "Invalid support e-mail",
     "invalidVaultBaseUrl": "Base URL must be a valid http(s) URL",
     "invalidVaultName": "Name must be 1 to 128 characters",
     "invalidVaultParamName": "Param name contains invalid characters",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -30,6 +30,8 @@
     "invalidCredentials": "Email ou senha inválidos",
     "invalidPassword": "Senha incorreta",
     "invalidSetupToken": "Token de configuração inválido ou ausente",
+    "invalidSiteUrl": "URL do site inválida",
+    "invalidSupportEmail": "E-mail de suporte inválido",
     "invalidVaultBaseUrl": "A URL base deve ser uma URL http(s) válida",
     "invalidVaultName": "O nome deve ter entre 1 e 128 caracteres",
     "invalidVaultParamName": "O nome do parâmetro contém caracteres inválidos",

--- a/src/client/components/BrandFooter.tsx
+++ b/src/client/components/BrandFooter.tsx
@@ -1,12 +1,15 @@
-import { useBranding } from "@/client/contexts/BrandingContext";
+import {
+  DEFAULT_BRAND_NAME,
+  useBranding,
+} from "@/client/contexts/BrandingContext";
 
 // The auth-page footer: "© {year} {brandName}". The brand name follows the global white-label
-// config. When it is the default (fazer.ai) it links to the product site; a custom brand renders
-// as plain text (linking a white-label brand back to fazer.ai would be misleading).
+// config. When it is the default it links to the product site; a custom brand renders as plain
+// text (linking a white-label brand back to fazer.ai would be misleading).
 export function BrandFooter() {
   const { brandName } = useBranding();
   const year = new Date().getFullYear();
-  const isDefault = brandName === "fazer.ai";
+  const isDefault = brandName === DEFAULT_BRAND_NAME;
   return (
     <footer className="mt-12 text-center">
       <p className="text-text-muted text-xs">

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import { SupportModal } from "@/client/components/SupportModal";
 import { Tooltip } from "@/client/components/Tooltip";
 import { usePendingApprovals } from "@/client/contexts/ApprovalsContext";
 import { useAuth } from "@/client/contexts/AuthContext";
+import { useBranding } from "@/client/contexts/BrandingContext";
 import {
   SIDEBAR_COLLAPSED_WIDTH,
   useSidebar,
@@ -133,15 +134,38 @@ interface SidebarFooterProps {
   onNavigate?: () => void;
 }
 
+// Label for a white-labeled website link: the hostname reads like the default
+// entry ("fazer.ai") instead of dumping the full URL into the sidebar.
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 function SidebarFooter({ collapsed = false, onNavigate }: SidebarFooterProps) {
   const { t } = useTranslation();
+  const { config: branding } = useBranding();
   const supportModal = useModalController();
 
   if (!SUPPORT_LINK && SECONDARY_LINKS.length === 0) return null;
 
+  // White-label overrides (issue #4): the operator's own site/support inbox replace the
+  // defaults, and the GitHub entry can be hidden. The server sanitizes what it stores, but
+  // the URL still only rides into an href after the same allowlist check we apply to any
+  // externally-sourced link (defense in depth against a tampered cache/response).
+  const customSiteUrl =
+    branding?.siteUrl && isSafeHttpUrl(branding.siteUrl)
+      ? branding.siteUrl
+      : null;
+  const customSupportEmail = branding?.supportEmail?.trim() || null;
+  const hideGithub = branding?.hideGithubLink === true;
+
   const supportEmail = SUPPORT_LINK
-    ? // biome-ignore lint/plugin/no-dynamic-i18n-key: extracted via magic comments in src/client/lib/navigation.tsx
-      t(SUPPORT_LINK.emailKey, SUPPORT_LINK.defaultEmail)
+    ? (customSupportEmail ??
+      // biome-ignore lint/plugin/no-dynamic-i18n-key: extracted via magic comments in src/client/lib/navigation.tsx
+      t(SUPPORT_LINK.emailKey, SUPPORT_LINK.defaultEmail))
     : null;
   const supportMailto = supportEmail ? `mailto:${supportEmail}` : null;
 
@@ -192,13 +216,19 @@ function SidebarFooter({ collapsed = false, onNavigate }: SidebarFooterProps) {
     supportItem = wrapLi("__support", trigger, label);
   }
 
-  const secondaryItems = SECONDARY_LINKS.map((link) => {
-    // biome-ignore lint/plugin/no-dynamic-i18n-key: extracted via magic comments in src/client/lib/navigation.tsx
-    const label = t(link.labelKey, link.defaultLabel);
-    const isExternal = /^https?:\/\//.test(link.href);
+  const secondaryItems = SECONDARY_LINKS.filter(
+    (link) => !(link.id === "github" && hideGithub),
+  ).map((link) => {
+    const isCustomSite = link.id === "website" && customSiteUrl !== null;
+    const href = isCustomSite ? customSiteUrl : link.href;
+    const label = isCustomSite
+      ? hostnameOf(customSiteUrl)
+      : // biome-ignore lint/plugin/no-dynamic-i18n-key: extracted via magic comments in src/client/lib/navigation.tsx
+        t(link.labelKey, link.defaultLabel);
+    const isExternal = /^https?:\/\//.test(href);
     const trigger = (
       <a
-        href={link.href}
+        href={href}
         onClick={onNavigate}
         {...(isExternal && { target: "_blank", rel: "noopener noreferrer" })}
         className={itemCls}
@@ -206,7 +236,7 @@ function SidebarFooter({ collapsed = false, onNavigate }: SidebarFooterProps) {
         {renderBody(link.icon, label)}
       </a>
     );
-    return wrapLi(link.href, trigger, label);
+    return wrapLi(link.id, trigger, label);
   });
 
   return (

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -225,7 +225,7 @@ function SidebarFooter({ collapsed = false, onNavigate }: SidebarFooterProps) {
       ? hostnameOf(customSiteUrl)
       : // biome-ignore lint/plugin/no-dynamic-i18n-key: extracted via magic comments in src/client/lib/navigation.tsx
         t(link.labelKey, link.defaultLabel);
-    const isExternal = /^https?:\/\//.test(href);
+    const isExternal = isSafeHttpUrl(href);
     const trigger = (
       <a
         href={href}

--- a/src/client/contexts/BrandingContext.tsx
+++ b/src/client/contexts/BrandingContext.tsx
@@ -48,7 +48,9 @@ function writeCache(config: BrandingData): void {
 }
 
 // The white-label display name when none is configured (the product's own brand).
-const DEFAULT_BRAND_NAME = "fazer.ai";
+// Exported so consumers (e.g. the auth-page footer) can tell the default apart
+// from an operator-configured name without re-hardcoding the string.
+export const DEFAULT_BRAND_NAME = "fazer.ai agents";
 
 interface BrandingContextValue {
   config: BrandingData | null;

--- a/src/client/lib/navigation.tsx
+++ b/src/client/lib/navigation.tsx
@@ -126,6 +126,9 @@ export function filterNavItems(
 }
 
 export interface FooterLink {
+  // Stable identity so the sidebar can white-label per entry (swap the website
+  // href/label from the branding config; hide the GitHub entry).
+  id: "website" | "github";
   href: string;
   labelKey: string;
   defaultLabel: string;
@@ -164,12 +167,14 @@ export const AGENTS_REPO_URL = "https://github.com/fazer-ai/agents";
 
 export const SECONDARY_LINKS: FooterLink[] = [
   {
+    id: "website",
     href: "https://fazer.ai",
     labelKey: "nav.website",
     defaultLabel: "fazer.ai",
     icon: Globe,
   },
   {
+    id: "github",
     href: AGENTS_REPO_URL,
     labelKey: "nav.github",
     defaultLabel: "GitHub",

--- a/src/modules/mcp/server.ts
+++ b/src/modules/mcp/server.ts
@@ -2475,7 +2475,7 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
       "branding_set",
       {
         description:
-          "Set the GLOBAL app identity (SUPER_ADMIN token only). Previews a diff and applies NOTHING unless dry_run is false. brand_name is the white-label display name (title + auth footer; null = default). color_mode SIMPLE uses brand_color (a #rrggbb hex); ADVANCED uses the tokens_light/tokens_dark maps. site_url (absolute http(s) URL) and support_email replace the sidebar-footer defaults; hide_github_link removes the footer GitHub entry (null/empty = default). Logo and favicon are uploaded via branding_asset_set (or cropped in the UI at /admin/branding).",
+          "Set the GLOBAL app identity (SUPER_ADMIN token only). Previews a diff and applies NOTHING unless dry_run is false. brand_name is the white-label display name (title + auth footer; null = default). color_mode SIMPLE uses brand_color (a #rrggbb hex); ADVANCED uses the tokens_light/tokens_dark maps. site_url (absolute http(s) URL) and support_email replace the sidebar-footer defaults (null/empty = back to the default); hide_github_link is a boolean — true removes the footer GitHub entry, false restores it. Logo and favicon are uploaded via branding_asset_set (or cropped in the UI at /admin/branding).",
         inputSchema: {
           brand_name: z.string().nullable().optional(),
           color_mode: z.enum(["SIMPLE", "ADVANCED"]).optional(),

--- a/src/modules/mcp/server.ts
+++ b/src/modules/mcp/server.ts
@@ -2475,13 +2475,16 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
       "branding_set",
       {
         description:
-          "Set the GLOBAL app identity (SUPER_ADMIN token only). Previews a diff and applies NOTHING unless dry_run is false. brand_name is the white-label display name (title + auth footer; null = default). color_mode SIMPLE uses brand_color (a #rrggbb hex); ADVANCED uses the tokens_light/tokens_dark maps. Logo and favicon are uploaded via branding_asset_set (or cropped in the UI at /admin/branding).",
+          "Set the GLOBAL app identity (SUPER_ADMIN token only). Previews a diff and applies NOTHING unless dry_run is false. brand_name is the white-label display name (title + auth footer; null = default). color_mode SIMPLE uses brand_color (a #rrggbb hex); ADVANCED uses the tokens_light/tokens_dark maps. site_url (absolute http(s) URL) and support_email replace the sidebar-footer defaults; hide_github_link removes the footer GitHub entry (null/empty = default). Logo and favicon are uploaded via branding_asset_set (or cropped in the UI at /admin/branding).",
         inputSchema: {
           brand_name: z.string().nullable().optional(),
           color_mode: z.enum(["SIMPLE", "ADVANCED"]).optional(),
           brand_color: z.string().nullable().optional(),
           tokens_light: z.record(z.string(), z.unknown()).optional(),
           tokens_dark: z.record(z.string(), z.unknown()).optional(),
+          site_url: z.string().nullable().optional(),
+          support_email: z.string().nullable().optional(),
+          hide_github_link: z.boolean().optional(),
           dry_run: z.boolean().optional(),
         },
       },
@@ -2491,6 +2494,9 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
         brand_color?: string | null;
         tokens_light?: Record<string, unknown>;
         tokens_dark?: Record<string, unknown>;
+        site_url?: string | null;
+        support_email?: string | null;
+        hide_github_link?: boolean;
         dry_run?: boolean;
       }) => writeContent(await brandingSet(principal, args)),
     );

--- a/src/modules/mcp/write.ts
+++ b/src/modules/mcp/write.ts
@@ -646,6 +646,9 @@ export interface BrandingSetArgs {
   brand_color?: string | null;
   tokens_light?: Record<string, unknown>;
   tokens_dark?: Record<string, unknown>;
+  site_url?: string | null;
+  support_email?: string | null;
+  hide_github_link?: boolean;
   dry_run?: boolean;
 }
 
@@ -673,9 +676,16 @@ export async function brandingSet(
   if (args.brand_color !== undefined) update.brandColor = args.brand_color;
   if (args.tokens_light !== undefined) update.tokensLight = args.tokens_light;
   if (args.tokens_dark !== undefined) update.tokensDark = args.tokens_dark;
+  if (args.site_url !== undefined) update.siteUrl = args.site_url;
+  if (args.support_email !== undefined) {
+    update.supportEmail = args.support_email;
+  }
+  if (args.hide_github_link !== undefined) {
+    update.hideGithubLink = args.hide_github_link;
+  }
   if (Object.keys(update).length === 0) {
     return err(
-      "no updatable fields provided (brand_name, color_mode, brand_color, tokens_light and/or tokens_dark)",
+      "no updatable fields provided (brand_name, color_mode, brand_color, tokens_light, tokens_dark, site_url, support_email and/or hide_github_link)",
     );
   }
 
@@ -687,6 +697,9 @@ export async function brandingSet(
       brandColor: before.brandColor,
       tokensLight: before.tokensLight,
       tokensDark: before.tokensDark,
+      siteUrl: before.siteUrl,
+      supportEmail: before.supportEmail,
+      hideGithubLink: before.hideGithubLink,
     };
     const target = "branding:global";
 
@@ -711,6 +724,15 @@ export async function brandingSet(
           string,
           unknown
         >,
+        siteUrl:
+          update.siteUrl === undefined
+            ? before.siteUrl
+            : update.siteUrl || null,
+        supportEmail:
+          update.supportEmail === undefined
+            ? before.supportEmail
+            : update.supportEmail || null,
+        hideGithubLink: update.hideGithubLink ?? before.hideGithubLink,
       };
       return ok({
         dryRun: true,
@@ -726,6 +748,9 @@ export async function brandingSet(
       brandColor: after.brandColor,
       tokensLight: after.tokensLight,
       tokensDark: after.tokensDark,
+      siteUrl: after.siteUrl,
+      supportEmail: after.supportEmail,
+      hideGithubLink: after.hideGithubLink,
     };
     // Fleet-level audit (tenant_id NULL); the write tx runs asSuperAdmin.
     await recordMcpAudit(

--- a/tests/api/features/branding/branding.test.ts
+++ b/tests/api/features/branding/branding.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import {
+  sanitizeSiteUrl,
+  sanitizeSupportEmail,
+  toDto,
+} from "@/api/features/branding/branding.service";
+
+// Footer-link white-labeling (issue #4): the sanitizers are the single gate between operator
+// input and an href/mailto: in every visitor's sidebar, so they are pinned here. The write
+// validation errors throw BEFORE any DB access, so they run without Postgres. The
+// updateBrandingColors block is Full-only: in the Free edition that module is the
+// ProEditionError stub, so the validation path does not exist to be tested.
+
+describe("sanitizeSiteUrl", () => {
+  test("accepts absolute http(s) URLs, trimmed", () => {
+    expect(sanitizeSiteUrl("https://acme.example.com")).toBe(
+      "https://acme.example.com",
+    );
+    expect(sanitizeSiteUrl("  http://acme.example.com/about  ")).toBe(
+      "http://acme.example.com/about",
+    );
+  });
+
+  test("rejects non-http(s) schemes and relative/invalid values", () => {
+    for (const bad of [
+      "javascript:alert(1)",
+      "data:text/html,x",
+      "ftp://files.example.com",
+      "acme.example.com",
+      "/relative/path",
+      "not a url",
+      "",
+      "   ",
+    ]) {
+      expect(sanitizeSiteUrl(bad)).toBeNull();
+    }
+    expect(sanitizeSiteUrl(null)).toBeNull();
+    expect(sanitizeSiteUrl(42)).toBeNull();
+  });
+
+  test("rejects URLs over the length bound", () => {
+    const long = `https://acme.example.com/${"a".repeat(512)}`;
+    expect(sanitizeSiteUrl(long)).toBeNull();
+  });
+});
+
+describe("sanitizeSupportEmail", () => {
+  test("accepts plausible addresses, trimmed", () => {
+    expect(sanitizeSupportEmail("help@acme.example.com")).toBe(
+      "help@acme.example.com",
+    );
+    expect(sanitizeSupportEmail("  suporte@acme.com.br  ")).toBe(
+      "suporte@acme.com.br",
+    );
+  });
+
+  test("rejects malformed addresses", () => {
+    for (const bad of [
+      "help",
+      "help@",
+      "@acme.com",
+      "help@acme",
+      "he lp@acme.com",
+      "help@ac me.com",
+      "help@@acme.com",
+      "",
+      "   ",
+    ]) {
+      expect(sanitizeSupportEmail(bad)).toBeNull();
+    }
+    expect(sanitizeSupportEmail(undefined)).toBeNull();
+  });
+
+  test("rejects addresses over the length bound", () => {
+    const long = `${"a".repeat(250)}@x.io`;
+    expect(sanitizeSupportEmail(long)).toBeNull();
+  });
+});
+
+describe("toDto footer-link fields (defense in depth on read)", () => {
+  const row = {
+    brandName: null,
+    colorMode: "SIMPLE",
+    brandColor: null,
+    tokensLight: {},
+    tokensDark: {},
+    logoDarkKey: null,
+    logoLightKey: null,
+    faviconDarkKey: null,
+    faviconLightKey: null,
+    siteUrl: null as string | null,
+    supportEmail: null as string | null,
+    hideGithubLink: false,
+    updatedAt: new Date(0),
+  };
+
+  test("passes sane stored values through", () => {
+    const dto = toDto({
+      ...row,
+      siteUrl: "https://acme.example.com",
+      supportEmail: "help@acme.example.com",
+      hideGithubLink: true,
+    });
+    expect(dto.siteUrl).toBe("https://acme.example.com");
+    expect(dto.supportEmail).toBe("help@acme.example.com");
+    expect(dto.hideGithubLink).toBe(true);
+  });
+
+  test("nulls out values that no longer pass the sanitizers", () => {
+    // e.g. a row written before validation existed, or tampered at rest.
+    const dto = toDto({
+      ...row,
+      siteUrl: "javascript:alert(1)",
+      supportEmail: "not-an-email",
+    });
+    expect(dto.siteUrl).toBeNull();
+    expect(dto.supportEmail).toBeNull();
+    expect(dto.hideGithubLink).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumo

Fecha o gap de white-label reportado na #4: os links do menu inferior esquerdo (site do produto, e-mail de suporte e entrada do GitHub) eram fixos no código e apontavam os clientes do operador para endereços que não são dele.

Os três agora fazem parte da configuração global de branding (mesmo modelo do nome/cores/logo):

- **siteUrl**: substitui o link do site no rodapé; o rótulo exibido vira o hostname da URL (ex.: `clinica-acme.com.br`)
- **supportEmail**: substitui o e-mail exibido no diálogo de suporte ("Precisa de ajuda?")
- **hideGithubLink**: remove a entrada do GitHub do rodapé

Campo vazio/null volta ao padrão. Os campos também saem no `GET /v1/branding` (público, como o restante do branding) e entram no tool MCP `branding_set`.

De carona, o título padrão da aplicação muda de `fazer.ai` para `fazer.ai agents` (tab do navegador e rodapé das telas de acesso).

## Segurança

- `siteUrl` só aceita URL http(s) **absoluta** (nada de `javascript:`/`data:`), com sanitização na escrita **e** na leitura (defense in depth contra valor adulterado at rest); o client ainda aplica o allowlist de esquema antes de renderizar o href, como já fazia com `releaseUrl`.
- `supportEmail` passa por validação de formato; o valor só alimenta o `mailto:` e o texto do diálogo de suporte.
- Valor inválido falha alto (400 localizado) em vez de ser silenciosamente descartado, para o operador saber qual campo corrigir.

## Testes

- `tests/api/features/branding/branding.test.ts`: sanitizers (esquemas maliciosos, e-mails malformados, limites de tamanho) + `toDto` defensivo na leitura.
- Validado ao vivo no console: configurar site/e-mail/ocultar GitHub reflete no rodapé na hora; valor inválido mostra o erro localizado; limpar os campos restaura os padrões.

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable website URL and support email branding settings.
  * Added an option to hide the GitHub link from the footer.
  * Updated footer links to use configured website and support details.
  * Extended branding updates through the API and MCP tools.
  * Renamed the default page and brand title to “fazer.ai agents.”

* **Validation**
  * Added validation for website URLs and support email addresses, with localized error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->