### PR TITLE
fix(integrations): asaas_payment_status consulta cobrança PIX direta; create devolve o paymentId

### DIFF
--- a/src/client/lib/toolpackTools.ts
+++ b/src/client/lib/toolpackTools.ts
@@ -71,7 +71,7 @@ export function toolpackToolMeta(name: string, t: TFunction): ToolpackToolMeta {
         label: t("toolpackTools.asaas_payment_status.label", "Check payment"),
         description: t(
           "toolpackTools.asaas_payment_status.desc",
-          "Check the status of an Asaas payment link.",
+          "Check the status of an Asaas charge (PIX) or payment link.",
         ),
       };
     case "calendar_list_events":

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1729,7 +1729,7 @@
       "label": "Payment link"
     },
     "asaas_payment_status": {
-      "desc": "Check the status of an Asaas payment link.",
+      "desc": "Check the status of an Asaas charge (PIX) or payment link.",
       "label": "Check payment"
     },
     "calendar_cancel_event": {

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1735,7 +1735,7 @@
       "label": "Gerar link de pagamento"
     },
     "asaas_payment_status": {
-      "desc": "Consulta o status de um link de pagamento Asaas.",
+      "desc": "Consulta o status de uma cobrança (PIX) ou de um link de pagamento Asaas.",
       "label": "Consultar pagamento"
     },
     "calendar_cancel_event": {

--- a/src/modules/integrations/toolpacks/asaas.ts
+++ b/src/modules/integrations/toolpacks/asaas.ts
@@ -471,8 +471,17 @@ function buildStatusTool(
         paymentId = linkId;
         linkId = undefined;
       }
-      if (!paymentId && !linkId)
-        return "Provide paymentId (pay_..., returned by asaas_create_pix_charge) or paymentLinkId (returned by asaas_payment_link_create).";
+      const guidance =
+        "Provide paymentId (pay_..., returned by asaas_create_pix_charge) or paymentLinkId (returned by asaas_payment_link_create). Do NOT use the invoice/payment page URL or its slug.";
+      // Reject pasted URLs outright — Asaas ids never contain slashes or colons; letting an
+      // invoice URL through would surface as a confusing 404 from the provider.
+      const looksLikeUrl = (v: string) => /[/:]/.test(v);
+      if (
+        (paymentId && looksLikeUrl(paymentId)) ||
+        (linkId && looksLikeUrl(linkId))
+      )
+        return guidance;
+      if (!paymentId && !linkId) return guidance;
       // Path-interpolated ids are URL-encoded; the origin stays the fixed constant above.
       // When both arrive, the payment wins: its status is the terminal fact (a link stays
       // `active` even after it was paid).
@@ -487,6 +496,10 @@ function buildStatusTool(
         return "Failed to reach the payment provider.";
       }
       if (res.status < 200 || res.status >= 300) {
+        // An invoice-URL SLUG is shape-indistinguishable from a real link id, so it can only be
+        // caught here: turn the provider's 404 into recoverable guidance instead of a dead end.
+        if (res.status === 404)
+          return "The payment provider returned HTTP 404 (id not found). If this value was extracted from an invoice/payment URL, that slug is not a valid id — use the paymentId returned by asaas_create_pix_charge or the paymentLinkId returned by asaas_payment_link_create.";
         return `The payment provider returned HTTP ${res.status}.`;
       }
       const d = (res.json ?? {}) as Record<string, unknown>;

--- a/src/modules/integrations/toolpacks/asaas.ts
+++ b/src/modules/integrations/toolpacks/asaas.ts
@@ -137,8 +137,22 @@ const PIX_CHARGE_SCHEMA = z.object({
     .describe("Due date as YYYY-MM-DD (optional; defaults to today)"),
 });
 
+// NOTE: field order is the arg order the UI projection renders (argsFromZod iterates the shape).
+// Exactly one id is required, enforced in code (not .refine) so the model gets a short
+// instructive message instead of a zod validation dump.
 const PAYMENT_STATUS_SCHEMA = z.object({
-  paymentLinkId: z.string().min(1).describe("The Asaas payment link id"),
+  paymentId: z
+    .string()
+    .optional()
+    .describe(
+      "Asaas payment id (starts with pay_...), returned by asaas_create_pix_charge. Use for PIX/direct charges.",
+    ),
+  paymentLinkId: z
+    .string()
+    .optional()
+    .describe(
+      "Asaas payment link id, returned by asaas_payment_link_create. NOT the slug from the invoice/payment URL.",
+    ),
 });
 
 const ASAAS_TOOL_SPECS: ToolSpec[] = [
@@ -424,12 +438,13 @@ function buildCreatePixChargeTool(
         lines.push(
           "The charge exists but no payment code was returned; check the Asaas dashboard.",
         );
+      lines.push(`(paymentId: ${paymentId})`);
       return lines.join("\n");
     },
     {
       name: "asaas_create_pix_charge",
       description:
-        "Create a PIX charge in Asaas for a customer and return the copy-and-paste PIX code plus the payment page to send them. Use when the customer wants to pay by PIX.",
+        "Create a PIX charge in Asaas for a customer and return the copy-and-paste PIX code plus the payment page to send them. Use when the customer wants to pay by PIX. Returns the paymentId — use it with asaas_payment_status to check whether it was paid.",
       schema: PIX_CHARGE_SCHEMA,
     },
   );
@@ -443,22 +458,30 @@ function buildStatusTool(
   const base = ASAAS_ORIGINS[env];
 
   return tool(
-    async (input: { paymentLinkId: string }) => {
+    async (input: { paymentId?: string; paymentLinkId?: string }) => {
       const token = sel.credentialRef
         ? await ctx.resolveCredential(sel.credentialRef)
         : null;
       if (!token)
         return "Asaas credential is not configured for this integration.";
-      // Path-interpolated id is URL-encoded; the origin stays the fixed constant above.
-      const id = encodeURIComponent(input.paymentLinkId);
+      let paymentId = input.paymentId?.trim() || undefined;
+      let linkId = input.paymentLinkId?.trim() || undefined;
+      // Defensive: a pay_... id in the link field is a payment id (models mix them up).
+      if (!paymentId && linkId?.startsWith("pay_")) {
+        paymentId = linkId;
+        linkId = undefined;
+      }
+      if (!paymentId && !linkId)
+        return "Provide paymentId (pay_..., returned by asaas_create_pix_charge) or paymentLinkId (returned by asaas_payment_link_create).";
+      // Path-interpolated ids are URL-encoded; the origin stays the fixed constant above.
+      // When both arrive, the payment wins: its status is the terminal fact (a link stays
+      // `active` even after it was paid).
+      const path = paymentId
+        ? `/payments/${encodeURIComponent(paymentId)}`
+        : `/paymentLinks/${encodeURIComponent(linkId as string)}`;
       let res: AsaasResponse;
       try {
-        res = await asaasFetch(
-          base,
-          `/paymentLinks/${id}`,
-          { method: "GET", token },
-          ctx,
-        );
+        res = await asaasFetch(base, path, { method: "GET", token }, ctx);
       } catch (err) {
         logger.warn({ err, env }, "asaas: payment status request failed");
         return "Failed to reach the payment provider.";
@@ -467,7 +490,19 @@ function buildStatusTool(
         return `The payment provider returned HTTP ${res.status}.`;
       }
       const d = (res.json ?? {}) as Record<string, unknown>;
-      // Bounded projection (no secrets; status-relevant fields only).
+      // Bounded projections (no secrets; status-relevant fields only). The payment path skips
+      // netValue (merchant-facing fee math), invoiceUrl (possibly stale page) and
+      // externalReference (internal correlation token).
+      if (paymentId) {
+        return JSON.stringify({
+          id: d.id,
+          status: d.status,
+          value: d.value,
+          billingType: d.billingType,
+          dueDate: d.dueDate,
+          paymentDate: d.paymentDate,
+        });
+      }
       return JSON.stringify({
         id: d.id,
         active: d.active,
@@ -479,7 +514,7 @@ function buildStatusTool(
     {
       name: "asaas_payment_status",
       description:
-        "Check the status of an Asaas payment link by its id (the paymentLinkId returned at creation).",
+        "Check the status of an Asaas payment. Pass paymentId (pay_..., returned by asaas_create_pix_charge) OR paymentLinkId (returned by asaas_payment_link_create); never the invoice URL or its slug. Payment status is PENDING/RECEIVED/CONFIRMED/OVERDUE/REFUNDED.",
       schema: PAYMENT_STATUS_SCHEMA,
     },
   );

--- a/tests/modules/toolpack-specs.test.ts
+++ b/tests/modules/toolpack-specs.test.ts
@@ -25,6 +25,22 @@ describe("toolpack tool specs (UI projection)", () => {
     expect(mobile?.required).toBe(false);
   });
 
+  test("asaas_payment_status exposes paymentId + paymentLinkId, both optional", () => {
+    const views = getToolpackToolViews("ASAAS");
+    const status = views.find((v) => v.name === "asaas_payment_status");
+    expect(status?.args.map((a) => a.name)).toEqual([
+      "paymentId",
+      "paymentLinkId",
+    ]);
+    expect(status?.args.every((a) => a.required === false)).toBe(true);
+    expect(
+      status?.args.find((a) => a.name === "paymentId")?.description,
+    ).toContain("pay_");
+    expect(
+      status?.args.find((a) => a.name === "paymentLinkId")?.description,
+    ).toContain("link");
+  });
+
   test("getToolpackToolNames is the fail-closed allowlist; empty for unknown/native", () => {
     expect(getToolpackToolNames("ASAAS")).toContain("asaas_create_pix_charge");
     expect(getToolpackToolNames("GOOGLE_DRIVE")).toEqual([

--- a/tests/modules/toolpacks-asaas-payment-status.test.ts
+++ b/tests/modules/toolpacks-asaas-payment-status.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import type { PrismaClient } from "@/../generated/prisma/client";
+import { asaasToolpack } from "@/modules/integrations/toolpacks/asaas";
+import type {
+  IntegrationSelection,
+  ToolpackCtx,
+} from "@/modules/integrations/toolpacks/types";
+
+// NOTE: harness mirrored from toolpacks-asaas.test.ts on purpose — this suite covers the
+// payment-status surface (direct charges) and stays independent from that file.
+function stubFetch(status: number, json: unknown) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return new Response(JSON.stringify(json), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+function scriptedFetch(
+  routes: Array<{
+    match: (url: string, init: RequestInit) => boolean;
+    status: number;
+    json: unknown;
+  }>,
+) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const i = init ?? {};
+    calls.push({ url: String(url), init: i });
+    const r = routes.find((x) => x.match(String(url), i));
+    return new Response(JSON.stringify(r?.json ?? {}), {
+      status: r?.status ?? 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const noopAssert = async () => undefined;
+
+function baseCtx(over: Partial<ToolpackCtx> = {}): ToolpackCtx {
+  return {
+    tenantId: 1n,
+    base: undefined as unknown as PrismaClient,
+    threadId: "1:1:1",
+    resolveCredential: async () => "tok_live",
+    assertSafe: noopAssert,
+    ...over,
+  };
+}
+
+function sel(over: Partial<IntegrationSelection> = {}): IntegrationSelection {
+  return {
+    instanceId: 1n,
+    catalogType: "ASAAS",
+    config: {},
+    credentialRef: "asaas-token",
+    enabledTools: [],
+    ...over,
+  };
+}
+
+function statusTool(ctx: ToolpackCtx) {
+  return asaasToolpack.build(
+    sel({ enabledTools: ["asaas_payment_status"] }),
+    ctx,
+  )[0];
+}
+
+// Distinct sentinel values per field so the projection negatives cannot false-pass.
+const PAYMENT_JSON = {
+  id: "pay_1",
+  status: "RECEIVED",
+  value: 500,
+  billingType: "PIX",
+  dueDate: "2026-08-01",
+  paymentDate: "2026-08-02",
+  netValue: 487.55,
+  customer: "cus_secret",
+  invoiceUrl: "https://sandbox.asaas.com/i/secret-slug",
+};
+
+describe("asaas payment status — direct (non-link) charges", () => {
+  test("create_pix_charge returns the paymentId for later status checks", async () => {
+    const { impl } = scriptedFetch([
+      {
+        match: (u, i) =>
+          u.includes("/customers?cpfCnpj=") && i.method === "GET",
+        status: 200,
+        json: { data: [{ id: "cus_exist" }], totalCount: 1 },
+      },
+      {
+        match: (u, i) => u.endsWith("/payments") && i.method === "POST",
+        status: 200,
+        json: {
+          id: "pay_pix_1",
+          invoiceUrl: "https://sandbox.asaas.com/i/pix1",
+          status: "PENDING",
+        },
+      },
+      {
+        match: (u) => u.includes("/payments/pay_pix_1/pixQrCode"),
+        status: 200,
+        json: { payload: "00020126PIXCOPYPASTE6304ABCD" },
+      },
+    ]);
+    const tool = asaasToolpack.build(
+      sel({ enabledTools: ["asaas_create_pix_charge"] }),
+      baseCtx({ fetchImpl: impl }),
+    )[0];
+    const out = (await tool?.invoke({
+      value: 199.9,
+      customerName: "Maria Souza",
+      cpfCnpj: "12345678909",
+    })) as string;
+    expect(out).toContain("(paymentId: pay_pix_1)");
+  });
+
+  test("paymentId routes to GET /payments/{id} with the payment projection", async () => {
+    const { impl, calls } = stubFetch(200, PAYMENT_JSON);
+    const tool = statusTool(baseCtx({ fetchImpl: impl }));
+    const out = (await tool?.invoke({ paymentId: "pay_1" })) as string;
+    expect(calls[0]?.url).toBe(
+      "https://api-sandbox.asaas.com/v3/payments/pay_1",
+    );
+    expect(out).toContain("RECEIVED");
+    expect(out).toContain("2026-08-02");
+    // Merchant-facing / internal fields never reach the model.
+    expect(out).not.toContain("487.55");
+    expect(out).not.toContain("cus_secret");
+    expect(out).not.toContain("secret-slug");
+  });
+
+  test("paymentLinkId keeps hitting GET /paymentLinks/{id} with the link projection", async () => {
+    const { impl, calls } = stubFetch(200, {
+      id: "plink_1",
+      active: true,
+      value: 100,
+      billingType: "UNDEFINED",
+      chargeType: "DETACHED",
+    });
+    const tool = statusTool(baseCtx({ fetchImpl: impl }));
+    const out = (await tool?.invoke({ paymentLinkId: "plink_1" })) as string;
+    expect(calls[0]?.url).toBe(
+      "https://api-sandbox.asaas.com/v3/paymentLinks/plink_1",
+    );
+    expect(out).toContain("DETACHED");
+  });
+
+  test("a pay_-prefixed id passed as paymentLinkId routes to /payments", async () => {
+    const { impl, calls } = stubFetch(200, PAYMENT_JSON);
+    const tool = statusTool(baseCtx({ fetchImpl: impl }));
+    await tool?.invoke({ paymentLinkId: "pay_1" });
+    expect(calls[0]?.url).toBe(
+      "https://api-sandbox.asaas.com/v3/payments/pay_1",
+    );
+  });
+
+  test("both ids → paymentId wins (single call to /payments)", async () => {
+    const { impl, calls } = stubFetch(200, PAYMENT_JSON);
+    const tool = statusTool(baseCtx({ fetchImpl: impl }));
+    await tool?.invoke({ paymentId: "pay_1", paymentLinkId: "plink_9" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(
+      "https://api-sandbox.asaas.com/v3/payments/pay_1",
+    );
+  });
+
+  test("no identifier → instructive message, no fetch", async () => {
+    const { impl, calls } = stubFetch(200, PAYMENT_JSON);
+    const tool = statusTool(baseCtx({ fetchImpl: impl }));
+    const out = (await tool?.invoke({})) as string;
+    expect(out).toContain("paymentId");
+    expect(out).toContain("paymentLinkId");
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/tests/modules/toolpacks-asaas-payment-status.test.ts
+++ b/tests/modules/toolpacks-asaas-payment-status.test.ts
@@ -178,4 +178,30 @@ describe("asaas payment status — direct (non-link) charges", () => {
     expect(out).toContain("paymentLinkId");
     expect(calls).toHaveLength(0);
   });
+
+  test("a pasted invoice URL is rejected with guidance before any fetch", async () => {
+    const { impl, calls } = stubFetch(200, PAYMENT_JSON);
+    const tool = statusTool(baseCtx({ fetchImpl: impl }));
+    const viaLink = (await tool?.invoke({
+      paymentLinkId: "https://sandbox.asaas.com/i/qwomgrsmq0xyxn86",
+    })) as string;
+    const viaPayment = (await tool?.invoke({
+      paymentId: "https://www.asaas.com/i/abc123",
+    })) as string;
+    expect(viaLink).toContain("asaas_create_pix_charge");
+    expect(viaPayment).toContain("asaas_create_pix_charge");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("a 404 on an unknown id explains the invoice-slug trap", async () => {
+    // A bare invoice-URL slug is shape-indistinguishable from a link id, so it reaches the
+    // provider and 404s — the message must route the model back to the real id sources.
+    const { impl } = stubFetch(404, {});
+    const tool = statusTool(baseCtx({ fetchImpl: impl }));
+    const out = (await tool?.invoke({
+      paymentLinkId: "qwomgrsmq0xyxn86",
+    })) as string;
+    expect(out).toContain("404");
+    expect(out).toContain("asaas_create_pix_charge");
+  });
 });


### PR DESCRIPTION
## Resumo

Não existia caminho funcional para o agente consultar o status de uma **cobrança PIX direta**: `asaas_create_pix_charge` nunca devolvia o `payment.id` real ao modelo (só o código copia-e-cola e a `invoiceUrl`), e `asaas_payment_status` só aceitava `paymentLinkId` com rota fixa `GET /paymentLinks/{id}` — cuja projeção nem carrega status de pagamento. O modelo improvisava o slug da `invoiceUrl`, que nunca é um id válido (404).

- `asaas_create_pix_charge` passa a devolver `(paymentId: pay_...)`, espelhando o `(paymentLinkId: ...)` do link tool.
- `asaas_payment_status` aceita `paymentId` OU `paymentLinkId` (exatamente um, validado em código com mensagem instrutiva, sem dump de validação zod): `paymentId` → `GET /payments/{id}` com projeção `id/status/value/billingType/dueDate/paymentDate` (sem `netValue`/`invoiceUrl`/`externalReference`); `paymentLinkId` → comportamento atual intacto. Valor com prefixo `pay_` passado no campo de link roteia defensivamente para `/payments`.
- Descrições da tool e da UI atualizadas (EN + pt-BR) para cobrir os dois ids e avisar contra o slug da invoice URL.

Fixes #14

## Validação

- Red-first: os testes novos reproduziam o gap (schema rejeitava `paymentId`; o retorno do create não continha o id) e agora travam o comportamento novo, incluindo a projeção sem campos internos (`netValue`/`customer`/`invoiceUrl`) e a regressão do caminho de link.
- Endpoint e campos confirmados na documentação oficial do Asaas (`GET /v3/payments/{id}`).
- Suíte completa verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asaas payment status checks now support PIX payment IDs and payment-link IDs.
  * PIX charge creation now returns a payment ID for subsequent status checks.
  * Status results provide relevant fields for each payment type.

* **Bug Fixes**
  * Improved handling and routing of payment identifiers.
  * Added validation for missing, malformed, or unsupported identifiers, including invoice URLs and slugs.
  * Updated English and Brazilian Portuguese guidance for these workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->