### PR TITLE
fix(tools): autoria programática de HTTP tools aceita JSON Schema e {var} de chave simples (normalização canônica)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9753,7 +9753,7 @@
                     ]
                   },
                   "urlTemplate": {
-                    "description": "Request URL template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "string"
                   },
                   "allowedHosts": {
@@ -9771,7 +9771,7 @@
                     }
                   },
                   "inputSchema": {
-                    "description": "JSON Schema describing the parameters the agent must supply.",
+                    "description": "Input fields the agent supplies, as a compact map: {\"field\": {\"type\": \"string\"|\"integer\"|\"number\"|\"boolean\"|\"enum\"|\"array\"|\"object\", \"required\"?, \"description\"?, \"enumValues\"?, \"itemType\"?}}. Standard JSON Schema ({\"properties\", \"required\"}) is accepted and converted to this shape on write.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -9792,7 +9792,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -9873,7 +9873,7 @@
                     ]
                   },
                   "urlTemplate": {
-                    "description": "Request URL template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "string"
                   },
                   "allowedHosts": {
@@ -9891,7 +9891,7 @@
                     }
                   },
                   "inputSchema": {
-                    "description": "JSON Schema describing the parameters the agent must supply.",
+                    "description": "Input fields the agent supplies, as a compact map: {\"field\": {\"type\": \"string\"|\"integer\"|\"number\"|\"boolean\"|\"enum\"|\"array\"|\"object\", \"required\"?, \"description\"?, \"enumValues\"?, \"itemType\"?}}. Standard JSON Schema ({\"properties\", \"required\"}) is accepted and converted to this shape on write.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -9912,7 +9912,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -9993,7 +9993,7 @@
                     ]
                   },
                   "urlTemplate": {
-                    "description": "Request URL template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "string"
                   },
                   "allowedHosts": {
@@ -10011,7 +10011,7 @@
                     }
                   },
                   "inputSchema": {
-                    "description": "JSON Schema describing the parameters the agent must supply.",
+                    "description": "Input fields the agent supplies, as a compact map: {\"field\": {\"type\": \"string\"|\"integer\"|\"number\"|\"boolean\"|\"enum\"|\"array\"|\"object\", \"required\"?, \"description\"?, \"enumValues\"?, \"itemType\"?}}. Standard JSON Schema ({\"properties\", \"required\"}) is accepted and converted to this shape on write.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10032,7 +10032,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10349,7 +10349,7 @@
                     ]
                   },
                   "urlTemplate": {
-                    "description": "Request URL template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "string"
                   },
                   "allowedHosts": {
@@ -10367,7 +10367,7 @@
                     }
                   },
                   "inputSchema": {
-                    "description": "JSON Schema describing the parameters the agent must supply.",
+                    "description": "Input fields the agent supplies, as a compact map: {\"field\": {\"type\": \"string\"|\"integer\"|\"number\"|\"boolean\"|\"enum\"|\"array\"|\"object\", \"required\"?, \"description\"?, \"enumValues\"?, \"itemType\"?}}. Standard JSON Schema ({\"properties\", \"required\"}) is accepted and converted to this shape on write.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10388,7 +10388,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10469,7 +10469,7 @@
                     ]
                   },
                   "urlTemplate": {
-                    "description": "Request URL template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "string"
                   },
                   "allowedHosts": {
@@ -10487,7 +10487,7 @@
                     }
                   },
                   "inputSchema": {
-                    "description": "JSON Schema describing the parameters the agent must supply.",
+                    "description": "Input fields the agent supplies, as a compact map: {\"field\": {\"type\": \"string\"|\"integer\"|\"number\"|\"boolean\"|\"enum\"|\"array\"|\"object\", \"required\"?, \"description\"?, \"enumValues\"?, \"itemType\"?}}. Standard JSON Schema ({\"properties\", \"required\"}) is accepted and converted to this shape on write.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10508,7 +10508,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10589,7 +10589,7 @@
                     ]
                   },
                   "urlTemplate": {
-                    "description": "Request URL template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "string"
                   },
                   "allowedHosts": {
@@ -10607,7 +10607,7 @@
                     }
                   },
                   "inputSchema": {
-                    "description": "JSON Schema describing the parameters the agent must supply.",
+                    "description": "Input fields the agent supplies, as a compact map: {\"field\": {\"type\": \"string\"|\"integer\"|\"number\"|\"boolean\"|\"enum\"|\"array\"|\"object\", \"required\"?, \"description\"?, \"enumValues\"?, \"itemType\"?}}. Standard JSON Schema ({\"properties\", \"required\"}) is accepted and converted to this shape on write.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10628,7 +10628,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}

--- a/openapi.json
+++ b/openapi.json
@@ -9792,7 +9792,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "description": "Request body template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -9912,7 +9912,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "description": "Request body template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10032,7 +10032,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "description": "Request body template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10388,7 +10388,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "description": "Request body template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10508,7 +10508,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "description": "Request body template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -10628,7 +10628,7 @@
                     }
                   },
                   "body": {
-                    "description": "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "description": "Request body template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}

--- a/src/api/v1/tools.controller.ts
+++ b/src/api/v1/tools.controller.ts
@@ -92,7 +92,7 @@ export const writeBody = t.Object({
   body: t.Optional(
     t.Record(t.String(), t.Unknown(), {
       description:
-        "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+        "Request body template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
     }),
   ),
   credentialRef: t.Optional(

--- a/src/api/v1/tools.controller.ts
+++ b/src/api/v1/tools.controller.ts
@@ -58,7 +58,7 @@ export const writeBody = t.Object({
   urlTemplate: t.Optional(
     t.String({
       description:
-        "Request URL template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+        "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
     }),
   ),
   allowedHosts: t.Optional(
@@ -75,7 +75,7 @@ export const writeBody = t.Object({
   inputSchema: t.Optional(
     t.Record(t.String(), t.Unknown(), {
       description:
-        "JSON Schema describing the parameters the agent must supply.",
+        'Input fields the agent supplies, as a compact map: {"field": {"type": "string"|"integer"|"number"|"boolean"|"enum"|"array"|"object", "required"?, "description"?, "enumValues"?, "itemType"?}}. Standard JSON Schema ({"properties", "required"}) is accepted and converted to this shape on write.',
     }),
   ),
   outputSchema: t.Optional(
@@ -92,7 +92,7 @@ export const writeBody = t.Object({
   body: t.Optional(
     t.Record(t.String(), t.Unknown(), {
       description:
-        "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time.",
+        "Request body template; {{param}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
     }),
   ),
   credentialRef: t.Optional(

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -23,7 +23,10 @@ import { api } from "@/client/lib/api";
 import { cn } from "@/client/lib/utils";
 import { isValidUrlTemplate } from "@/client/lib/validation";
 import { normalizeToolName } from "@/graph/tools/toolName";
-import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
+import {
+  CONTEXT_VAR_NAMES,
+  normalizeToolShapes,
+} from "@/modules/tool-definitions/normalize";
 
 type ToolsData = Awaited<ReturnType<typeof api.api.v1.tools.get>>["data"];
 export type Tool = NonNullable<ToolsData>["tools"][number];
@@ -88,21 +91,11 @@ function loneTokenName(value: string): string | null {
 // alphanumeric/underscore name. Drives the inline {{token}} highlighting in the URL/query/headers/body.
 const TOOL_TOKEN_SOURCE = "\\{\\{\\s*([a-zA-Z0-9_]+)\\s*\\}\\}";
 
-// Context variable names the runtime interpolates (keep in sync with nativeVarItems). A {{token}} is
-// "known" (highlighted as a valid var, not a typo) when it names a declared AI field, one of these, or
-// {{secret}} (only when a credential is selected).
-const NATIVE_VAR_NAMES = new Set([
-  "conversation_id",
-  "message_id",
-  "contact_id",
-  "contact_name",
-  "contact_email",
-  "contact_phone",
-  "inbox_id",
-  "inbox_name",
-  "agent_name",
-  "company_name",
-]);
+// Context variable names the runtime interpolates (shared with the normalization module so the
+// lists cannot drift; keep nativeVarItems in sync). A {{token}} is "known" (highlighted as a valid
+// var, not a typo) when it names a declared AI field, one of these, or {{secret}} (only when a
+// credential is selected).
+const NATIVE_VAR_NAMES = new Set<string>(CONTEXT_VAR_NAMES);
 function isKnownToolToken(
   name: string,
   params: string[],

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -209,8 +209,9 @@ function emptyForm() {
 // fixed values + body assembly inside inputSchema/body.mode==="fields"; we reconstruct them as explicit
 // rows so the operator sees what was previously assembled by magic. Saving then writes the new shape.
 function formFromTool(tool: Tool) {
-  // Legacy rows authored programmatically may still carry pre-normalization shapes (JSON-Schema
-  // inputSchema, single-brace {var}); render the canonical form so the real AI fields show up.
+  // NOTE: legacy rows authored programmatically may still carry pre-normalization shapes
+  // (JSON-Schema inputSchema, single-brace {var}); render the canonical form so the real AI
+  // fields show up.
   const { shapes } = normalizeToolShapes({
     urlTemplate: tool.urlTemplate,
     query: tool.query ?? {},

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -91,10 +91,10 @@ function loneTokenName(value: string): string | null {
 // alphanumeric/underscore name. Drives the inline {{token}} highlighting in the URL/query/headers/body.
 const TOOL_TOKEN_SOURCE = "\\{\\{\\s*([a-zA-Z0-9_]+)\\s*\\}\\}";
 
-// Context variable names the runtime interpolates (shared with the normalization module so the
-// lists cannot drift; keep nativeVarItems in sync). A {{token}} is "known" (highlighted as a valid
-// var, not a typo) when it names a declared AI field, one of these, or {{secret}} (only when a
-// credential is selected).
+// NOTE: context variable names the runtime interpolates (shared with the normalization module so
+// the lists cannot drift; keep nativeVarItems in sync). A {{token}} is "known" (highlighted as a
+// valid var, not a typo) when it names a declared AI field, one of these, or {{secret}} (only when
+// a credential is selected).
 const NATIVE_VAR_NAMES = new Set<string>(CONTEXT_VAR_NAMES);
 function isKnownToolToken(
   name: string,
@@ -201,7 +201,8 @@ function emptyForm() {
 // Maps a stored tool (any of the new or legacy shapes) into the editor form. Legacy tools carry their
 // fixed values + body assembly inside inputSchema/body.mode==="fields"; we reconstruct them as explicit
 // rows so the operator sees what was previously assembled by magic. Saving then writes the new shape.
-function formFromTool(tool: Tool) {
+// NOTE: exported for the load/save regression tests (pure over its argument).
+export function formFromTool(tool: Tool) {
   // NOTE: legacy rows authored programmatically may still carry pre-normalization shapes
   // (JSON-Schema inputSchema, single-brace {var}); render the canonical form so the real AI
   // fields show up.
@@ -212,7 +213,7 @@ function formFromTool(tool: Tool) {
     body: tool.body ?? {},
     inputSchema: tool.inputSchema ?? {},
   });
-  const urlTemplate = (shapes.urlTemplate ?? tool.urlTemplate) as string;
+  let urlTemplate = (shapes.urlTemplate ?? tool.urlTemplate) as string;
   const schema = (shapes.inputSchema ?? {}) as Record<string, unknown>;
   const bodyCfg = (shapes.body ?? {}) as {
     mode?: string;
@@ -225,6 +226,19 @@ function formFromTool(tool: Tool) {
       (m) => m[1],
     ),
   );
+  // NOTE: a legacy fixed field bound to a URL placeholder has no editor row (aiFields skips fixed;
+  // the row reconstruction skips URL names), so saving would drop its binding and leave an
+  // unresolved {{token}}. Inline the fixed field's value template into the visible URL: the
+  // operator sees the effective URL and saving preserves the semantics.
+  for (const [name, raw] of Object.entries(schema)) {
+    const s = (raw ?? {}) as Record<string, unknown>;
+    if (s.source !== "fixed" || !inUrl.has(name)) continue;
+    const value = typeof s.value === "string" ? s.value : "";
+    urlTemplate = urlTemplate.replace(
+      new RegExp(`\\{\\{\\s*${name}\\s*\\}\\}`, "g"),
+      () => value,
+    );
+  }
 
   const query = (shapes.query ?? {}) as Record<string, unknown>;
   const queryRows: KvRow[] =

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -23,6 +23,7 @@ import { api } from "@/client/lib/api";
 import { cn } from "@/client/lib/utils";
 import { isValidUrlTemplate } from "@/client/lib/validation";
 import { normalizeToolName } from "@/graph/tools/toolName";
+import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
 
 type ToolsData = Awaited<ReturnType<typeof api.api.v1.tools.get>>["data"];
 export type Tool = NonNullable<ToolsData>["tools"][number];
@@ -208,23 +209,32 @@ function emptyForm() {
 // fixed values + body assembly inside inputSchema/body.mode==="fields"; we reconstruct them as explicit
 // rows so the operator sees what was previously assembled by magic. Saving then writes the new shape.
 function formFromTool(tool: Tool) {
-  const schema = (tool.inputSchema ?? {}) as Record<string, unknown>;
-  const bodyCfg = (tool.body ?? {}) as {
+  // Legacy rows authored programmatically may still carry pre-normalization shapes (JSON-Schema
+  // inputSchema, single-brace {var}); render the canonical form so the real AI fields show up.
+  const { shapes } = normalizeToolShapes({
+    urlTemplate: tool.urlTemplate,
+    query: tool.query ?? {},
+    headers: tool.headers ?? {},
+    body: tool.body ?? {},
+    inputSchema: tool.inputSchema ?? {},
+  });
+  const urlTemplate = (shapes.urlTemplate ?? tool.urlTemplate) as string;
+  const schema = (shapes.inputSchema ?? {}) as Record<string, unknown>;
+  const bodyCfg = (shapes.body ?? {}) as {
     mode?: string;
     raw?: string;
     rows?: { key?: unknown; value?: unknown }[];
   };
   const aiFields = aiFieldsFromSchema(schema);
   const inUrl = new Set(
-    [...tool.urlTemplate.matchAll(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g)].map(
+    [...urlTemplate.matchAll(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g)].map(
       (m) => m[1],
     ),
   );
 
+  const query = (shapes.query ?? {}) as Record<string, unknown>;
   const queryRows: KvRow[] =
-    tool.query && Object.keys(tool.query).length > 0
-      ? objToKv(tool.query as Record<string, unknown>)
-      : [];
+    Object.keys(query).length > 0 ? objToKv(query) : [];
 
   let bodyMode: "kv" | "raw" = "kv";
   let bodyRaw = "";
@@ -263,11 +273,11 @@ function formFromTool(tool: Tool) {
     label: tool.label,
     description: tool.description ?? "",
     method: tool.method as (typeof METHODS)[number],
-    urlTemplate: tool.urlTemplate,
+    urlTemplate,
     allowedHosts: tool.allowedHosts.join(", "),
     aiFields,
     queryRows,
-    headerRows: objToKv(tool.headers),
+    headerRows: objToKv((shapes.headers ?? {}) as Record<string, unknown>),
     headersMode: "kv" as const,
     headersRaw: "",
     bodyRows,

--- a/src/graph/tools/http.ts
+++ b/src/graph/tools/http.ts
@@ -382,6 +382,8 @@ export function buildHttpTool(
         throw new AppError(`tool ${def.name}: invalid urlTemplate`, 400);
       }
       const pathFields = placeholderNames(effectiveTemplate);
+      const isAiFieldName = (n: string): boolean =>
+        fields.some((f) => f.name === n && f.source !== "fixed");
       // NOTE: a URL placeholder that resolves to nothing produces a request that cannot be right (an
       // empty path segment / dangling query value). Instead of silently sending it, tell the model
       // which value is missing so it can retry with the field (or explain what it needs).
@@ -407,10 +409,22 @@ export function buildHttpTool(
       if (missingUrlNames.size > 0) {
         // NOTE: an unresolved {{secret}} is an operator/config problem (missing or unresolvable
         // credential): the model can never supply it, so a retry hint would just loop. Throw like
-        // the other config errors in this file; keep the retry message for real input fields.
+        // the other config errors in this file.
         if (missingUrlNames.has("secret")) {
           throw new AppError(
             `tool ${def.name}: the URL requires {{secret}} (directly or via a fixed field) but no credential resolved`,
+            400,
+          );
+        }
+        // NOTE: context variables, fixed-field dependencies and unknown tokens are injected by the
+        // platform, never supplied by the model, so those also throw; the retry message is reserved
+        // for placeholders the model can actually provide (AI-source input fields).
+        const nonInput = [...missingUrlNames].filter((n) => !isAiFieldName(n));
+        if (nonInput.length > 0) {
+          throw new AppError(
+            `tool ${def.name}: no value available for URL placeholder(s) ${nonInput
+              .map((n) => `{{${n}}}`)
+              .join(", ")} (resolved from context/config, not model input)`,
             400,
           );
         }
@@ -467,8 +481,6 @@ export function buildHttpTool(
       // query values, fixed values and the raw body; {{aiField}} resolves from model input.
       const lookupWithSecret = (n: string): string | undefined =>
         n === "secret" ? (secret ?? "") : valueLookup(n);
-      const isAiFieldName = (n: string): boolean =>
-        fields.some((f) => f.name === n && f.source !== "fixed");
 
       // Query: explicit Record<string,string> templates, applied for ANY method. Interpolated but NOT
       // pre-encoded (searchParams.set encodes once — pre-encoding would double-encode). A param already

--- a/src/graph/tools/http.ts
+++ b/src/graph/tools/http.ts
@@ -397,11 +397,11 @@ export function buildHttpTool(
         // NOTE: a fixed field whose own {{secret}}/context dependency was unavailable resolved to
         // "" above; surface the missing dependency instead of fetching an incomplete URL. AI input
         // never shadows a fixed name (the schema excludes fixed fields), so the map lookup is safe.
-        const deps = !(n in input && input[n] != null)
+        const missingDeps = !(n in input && input[n] != null)
           ? fixedMissingDeps.get(n)
           : undefined;
-        if (deps) {
-          for (const d of deps) missingUrlNames.add(d);
+        if (missingDeps) {
+          for (const d of missingDeps) missingUrlNames.add(d);
           return undefined;
         }
         return encodeURIComponent(v);

--- a/src/graph/tools/http.ts
+++ b/src/graph/tools/http.ts
@@ -388,6 +388,15 @@ export function buildHttpTool(
         return encodeURIComponent(v);
       });
       if (missingUrlNames.size > 0) {
+        // An unresolved {{secret}} is an operator/config problem (missing or unresolvable
+        // credential): the model can never supply it, so a retry hint would just loop. Throw like
+        // the other config errors in this file; keep the retry message for real input fields.
+        if (missingUrlNames.has("secret")) {
+          throw new AppError(
+            `tool ${def.name}: the URL references {{secret}} but no credential resolved`,
+            400,
+          );
+        }
         return `Error: no value available for URL placeholder(s): ${[
           ...missingUrlNames,
         ]

--- a/src/graph/tools/http.ts
+++ b/src/graph/tools/http.ts
@@ -2,6 +2,7 @@ import { type StructuredToolInterface, tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { AppError } from "@/lib/errors";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
+import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
 import { resolveSecretInjection } from "@/modules/vault/secret-types";
 import { normalizeToolName } from "./toolName";
 
@@ -174,10 +175,12 @@ function zodFor(f: ParsedField): z.ZodTypeAny {
   return zt;
 }
 
-// Backward-compatible export (used by tests): the zod schema for the AI-filled fields only.
+// Backward-compatible export (used by tests): the zod schema for the AI-filled fields only. A
+// JSON-Schema-shaped value is converted to the compact map first, mirroring buildHttpTool.
 export function parseToolInputSchema(raw: unknown): z.ZodObject<z.ZodRawShape> {
+  const { shapes } = normalizeToolShapes({ inputSchema: raw });
   const shape: Record<string, z.ZodType> = {};
-  for (const f of parseFields(raw)) {
+  for (const f of parseFields(shapes.inputSchema)) {
     if (f.source === "ai") shape[f.name] = zodFor(f);
   }
   return z.object(shape);
@@ -258,15 +261,31 @@ export function buildHttpTool(
   def: HttpToolDef,
   deps: HttpToolDeps,
 ): StructuredToolInterface {
-  const fields = parseFields(def.inputSchema);
-  const bodyCfg = parseBody(def.body);
+  const context = deps.context ?? {};
+  // Self-heal shapes authored before write-time normalization existed (or written straight to the
+  // DB): a JSON-Schema-shaped inputSchema becomes the compact map and known single-brace {var}
+  // placeholders become {{var}}, so pre-fix rows work without re-creation.
+  const { shapes } = normalizeToolShapes(
+    {
+      urlTemplate: def.urlTemplate,
+      query: def.query,
+      headers: def.headers,
+      body: def.body,
+      inputSchema: def.inputSchema,
+    },
+    {},
+    Object.keys(context),
+  );
+  const urlTemplate = shapes.urlTemplate as string;
+  const headerTemplates = (shapes.headers ?? {}) as Record<string, string>;
+  const fields = parseFields(shapes.inputSchema);
+  const bodyCfg = parseBody(shapes.body);
   const method = def.method.toUpperCase();
   const isBodyMethod =
     method === "POST" || method === "PUT" || method === "PATCH";
   const doFetch = deps.fetchImpl ?? fetch;
   const timeoutMs = deps.timeoutMs ?? 10_000;
   const maxChars = deps.maxResponseChars ?? 4000;
-  const context = deps.context ?? {};
 
   // Schema = the AI-filled fields. When an ack is configured, the model MUST write the holding message
   // itself (__wait_message is required, not optional): the operator's ackMessage is only a TONE example,
@@ -288,7 +307,7 @@ export function buildHttpTool(
   const schema = z.object(shape);
 
   // Resolve relative template: if urlTemplate starts with /, credential must supply a baseUrl.
-  const isRelative = def.urlTemplate.startsWith("/");
+  const isRelative = urlTemplate.startsWith("/");
   if (isRelative && !def.credentialBaseUrl) {
     throw new AppError(
       `tool ${def.name}: relative urlTemplate requires a credential with a base URL`,
@@ -296,8 +315,8 @@ export function buildHttpTool(
     );
   }
   const effectiveTemplate = isRelative
-    ? `${def.credentialBaseUrl}${def.urlTemplate}`
-    : def.urlTemplate;
+    ? `${def.credentialBaseUrl}${urlTemplate}`
+    : urlTemplate;
 
   return tool(
     async (input: Record<string, unknown>) => {
@@ -356,10 +375,27 @@ export function buildHttpTool(
         throw new AppError(`tool ${def.name}: invalid urlTemplate`, 400);
       }
       const pathFields = placeholderNames(effectiveTemplate);
+      // A URL placeholder that resolves to nothing produces a request that cannot be right (an
+      // empty path segment / dangling query value). Instead of silently sending it, tell the model
+      // which value is missing so it can retry with the field (or explain what it needs).
+      const missingUrlNames = new Set<string>();
       const interpolated = interpolate(effectiveTemplate, (n) => {
         const v = n === "secret" ? secret : valueLookup(n);
-        return v == null ? undefined : encodeURIComponent(v);
+        if (v == null) {
+          missingUrlNames.add(n);
+          return undefined;
+        }
+        return encodeURIComponent(v);
       });
+      if (missingUrlNames.size > 0) {
+        return `Error: no value available for URL placeholder(s): ${[
+          ...missingUrlNames,
+        ]
+          .map((n) => `{{${n}}}`)
+          .join(
+            ", ",
+          )}. Call the tool again providing the missing input field(s).`;
+      }
       let url: URL;
       try {
         url = new URL(interpolated);
@@ -395,8 +431,8 @@ export function buildHttpTool(
       // 2. Headers: the credential is available here via {{secret}}, alongside context + field values
       // (e.g. an {{conversation_id}} header).
       const headers: Record<string, string> = {};
-      for (const [k, v] of Object.entries(def.headers ?? {})) {
-        headers[k] = interpolate(v, (n) =>
+      for (const [k, v] of Object.entries(headerTemplates)) {
+        headers[k] = interpolate(String(v), (n) =>
           n === "secret" ? (secret ?? "") : valueLookup(n),
         );
       }
@@ -411,7 +447,7 @@ export function buildHttpTool(
       // Query: explicit Record<string,string> templates, applied for ANY method. Interpolated but NOT
       // pre-encoded (searchParams.set encodes once — pre-encoding would double-encode). A param already
       // on the URL (hand-written) wins; an empty resolution is skipped.
-      const queryMap = parseQuery(def.query);
+      const queryMap = parseQuery(shapes.query);
       const hasExplicitQuery = Object.keys(queryMap).length > 0;
       for (const [k, tpl] of Object.entries(queryMap)) {
         const v = interpolate(tpl, lookupWithSecret);

--- a/src/graph/tools/http.ts
+++ b/src/graph/tools/http.ts
@@ -262,7 +262,7 @@ export function buildHttpTool(
   deps: HttpToolDeps,
 ): StructuredToolInterface {
   const context = deps.context ?? {};
-  // Self-heal shapes authored before write-time normalization existed (or written straight to the
+  // NOTE: self-heal shapes authored before write-time normalization existed (or written straight to the
   // DB): a JSON-Schema-shaped inputSchema becomes the compact map and known single-brace {var}
   // placeholders become {{var}}, so pre-fix rows work without re-creation.
   const { shapes } = normalizeToolShapes(
@@ -345,13 +345,20 @@ export function buildHttpTool(
       }
 
       // Precompute fixed-field values (interpolated with CONTEXT + {{secret}} — never model input).
+      // NOTE: unresolved dependencies interpolate to "" (headers/body semantics) but are tracked
+      // per field, so the URL guard below can refuse to fetch with an incomplete URL segment.
       const ctxLookup = (n: string) => (n in context ? context[n] : undefined);
       const fixedValues: Record<string, string> = {};
+      const fixedMissingDeps = new Map<string, Set<string>>();
       for (const f of fields) {
         if (f.source === "fixed") {
-          fixedValues[f.name] = interpolate(f.value, (n) =>
-            n === "secret" ? (secret ?? "") : ctxLookup(n),
-          );
+          const missing = new Set<string>();
+          fixedValues[f.name] = interpolate(f.value, (n) => {
+            const v = n === "secret" ? secret : ctxLookup(n);
+            if (v == null) missing.add(n);
+            return v ?? undefined;
+          });
+          if (missing.size > 0) fixedMissingDeps.set(f.name, missing);
         }
       }
 
@@ -375,7 +382,7 @@ export function buildHttpTool(
         throw new AppError(`tool ${def.name}: invalid urlTemplate`, 400);
       }
       const pathFields = placeholderNames(effectiveTemplate);
-      // A URL placeholder that resolves to nothing produces a request that cannot be right (an
+      // NOTE: a URL placeholder that resolves to nothing produces a request that cannot be right (an
       // empty path segment / dangling query value). Instead of silently sending it, tell the model
       // which value is missing so it can retry with the field (or explain what it needs).
       const missingUrlNames = new Set<string>();
@@ -385,15 +392,25 @@ export function buildHttpTool(
           missingUrlNames.add(n);
           return undefined;
         }
+        // NOTE: a fixed field whose own {{secret}}/context dependency was unavailable resolved to
+        // "" above; surface the missing dependency instead of fetching an incomplete URL. AI input
+        // never shadows a fixed name (the schema excludes fixed fields), so the map lookup is safe.
+        const deps = !(n in input && input[n] != null)
+          ? fixedMissingDeps.get(n)
+          : undefined;
+        if (deps) {
+          for (const d of deps) missingUrlNames.add(d);
+          return undefined;
+        }
         return encodeURIComponent(v);
       });
       if (missingUrlNames.size > 0) {
-        // An unresolved {{secret}} is an operator/config problem (missing or unresolvable
+        // NOTE: an unresolved {{secret}} is an operator/config problem (missing or unresolvable
         // credential): the model can never supply it, so a retry hint would just loop. Throw like
         // the other config errors in this file; keep the retry message for real input fields.
         if (missingUrlNames.has("secret")) {
           throw new AppError(
-            `tool ${def.name}: the URL references {{secret}} but no credential resolved`,
+            `tool ${def.name}: the URL requires {{secret}} (directly or via a fixed field) but no credential resolved`,
             400,
           );
         }

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -1043,8 +1043,8 @@ async function createMissingComponents(
       });
       continue;
     }
-    // The import writes straight to the DB (not via the service), so canonicalize authoring shapes
-    // here too — a bundle exported from a pre-normalization instance may carry JSON-Schema
+    // NOTE: the import writes straight to the DB (not via the service), so canonicalize authoring
+    // shapes here too; a bundle exported from a pre-normalization instance may carry JSON-Schema
     // inputSchema / single-brace placeholders.
     const { shapes } = normalizeToolShapes({
       urlTemplate: tdef.urlTemplate,

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -26,6 +26,7 @@ import {
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import { isKnownCatalogType } from "@/modules/integrations/catalog";
 import { assertNoSecrets } from "@/modules/n8n-export/n8n";
+import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
 import {
   createPendingVaultEntry,
   formatVaultRef,
@@ -1042,6 +1043,16 @@ async function createMissingComponents(
       });
       continue;
     }
+    // The import writes straight to the DB (not via the service), so canonicalize authoring shapes
+    // here too — a bundle exported from a pre-normalization instance may carry JSON-Schema
+    // inputSchema / single-brace placeholders.
+    const { shapes } = normalizeToolShapes({
+      urlTemplate: tdef.urlTemplate,
+      query: tdef.query ?? {},
+      headers: tdef.headers,
+      body: tdef.body,
+      inputSchema: tdef.inputSchema,
+    });
     await db.toolDefinition.create({
       data: {
         tenantId,
@@ -1050,13 +1061,13 @@ async function createMissingComponents(
         label: tdef.label ?? tdef.name,
         description: tdef.description ?? null,
         method: tdef.method,
-        urlTemplate: tdef.urlTemplate,
+        urlTemplate: (shapes.urlTemplate ?? tdef.urlTemplate) as string,
         allowedHosts: tdef.allowedHosts,
-        headers: tdef.headers as Prisma.InputJsonValue,
-        inputSchema: tdef.inputSchema as Prisma.InputJsonValue,
+        headers: shapes.headers as Prisma.InputJsonValue,
+        inputSchema: shapes.inputSchema as Prisma.InputJsonValue,
         outputSchema: tdef.outputSchema as Prisma.InputJsonValue,
-        query: (tdef.query ?? {}) as Prisma.InputJsonValue,
-        body: tdef.body as Prisma.InputJsonValue,
+        query: shapes.query as Prisma.InputJsonValue,
+        body: shapes.body as Prisma.InputJsonValue,
         riskTier: tdef.riskTier,
         ackEnabled: tdef.ackEnabled,
         ackMessage: tdef.ackMessage ?? null,

--- a/src/modules/mcp/server.ts
+++ b/src/modules/mcp/server.ts
@@ -1353,7 +1353,7 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
       "tool_create",
       {
         description:
-          "Create an HTTP tool definition. Previews the normalized input and creates NOTHING unless dry_run is false. credential_ref accepts a vault entry NAME (resolved server-side; never a raw secret). allowed_hosts is the SSRF allowlist.",
+          'Create an HTTP tool definition. Previews the normalized input and creates NOTHING unless dry_run is false. input_schema is a compact field map — {"field": {"type": "string"|"integer"|"number"|"boolean"|"enum"|"array"|"object", "required"?: true, "description"?: "...", "enumValues"?: [...], "itemType"?: "..."}} — standard JSON Schema ({"properties": ..., "required": [...]}) is also accepted and converted to that shape. Reference a field as {{field}} inside url_template, query values, headers and the body; {{secret}} injects the credential and context vars like {{conversation_id}}/{{contact_name}} also resolve. Single-brace {field} is normalized to {{field}} when it matches a declared field or context var; the dry-run preview reports conversions and unrecognized placeholders as warnings. credential_ref accepts a vault entry NAME (resolved server-side; never a raw secret). allowed_hosts is the SSRF allowlist.',
         inputSchema: {
           name: z.string(),
           label: z.string().optional(),
@@ -1404,7 +1404,7 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
       "tool_update",
       {
         description:
-          "Update an HTTP tool definition. Previews a diff and applies NOTHING unless dry_run is false. credential_ref accepts a vault entry NAME (null clears it).",
+          "Update an HTTP tool definition. Previews a diff and applies NOTHING unless dry_run is false. Same authoring contract as tool_create: input_schema is the compact field map (standard JSON Schema is accepted and converted), fields are referenced as {{field}} in url_template/query/headers/body, and single-brace {field} is normalized when it matches a declared field or context var — the dry-run diff shows the canonical form plus warnings. credential_ref accepts a vault entry NAME (null clears it).",
         inputSchema: {
           tool_id: z.string(),
           name: z.string().optional(),

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -23,6 +23,7 @@ import {
   type McpConnectionUpdate,
   updateMcpConnection,
 } from "@/modules/mcp-connections/service";
+import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
 import {
   createToolDefinition,
   deleteToolDefinition,
@@ -509,13 +510,24 @@ export async function toolCreate(
     urlTemplate: args.url_template,
     allowedHosts: args.allowed_hosts,
   } as ToolDefinitionCreate;
+  // Surface what the service will canonicalize (JSON-Schema input_schema, single-brace {var}) so
+  // the author sees the converted shape — and probable typos — in the preview, before applying.
+  const norm = normalizeToolShapes({
+    urlTemplate: input.urlTemplate,
+    query: input.query,
+    headers: input.headers,
+    body: input.body,
+    inputSchema: input.inputSchema,
+  });
+  const warnings = norm.warnings.length > 0 ? { warnings: norm.warnings } : {};
   try {
     if (args.dry_run !== false) {
       return ok({
         dryRun: true,
         action: "create",
         resource: "tool",
-        preview: input,
+        preview: { ...input, ...norm.shapes },
+        ...warnings,
       });
     }
     const created = await createToolDefinition(ctx, input, base);
@@ -528,7 +540,13 @@ export async function toolCreate(
       before: null,
       after: truncForAudit({ id: created.id, name: created.name }),
     });
-    return ok({ dryRun: false, applied: true, target, tool: created });
+    return ok({
+      dryRun: false,
+      applied: true,
+      target,
+      tool: created,
+      ...warnings,
+    });
   } catch (e) {
     return failOf(e);
   }
@@ -551,12 +569,36 @@ export async function toolUpdate(
   }
   try {
     const current = await getToolDefinition(ctx, id, base);
+    // Preview the canonical form the service will store (JSON-Schema input_schema converted,
+    // single-brace {var} normalized against the effective field set) plus probable-typo warnings.
+    const norm = normalizeToolShapes(
+      {
+        urlTemplate: built.patch.urlTemplate,
+        query: built.patch.query,
+        headers: built.patch.headers,
+        body: built.patch.body,
+        inputSchema: built.patch.inputSchema,
+      },
+      {
+        urlTemplate: current.urlTemplate,
+        query: current.query,
+        headers: current.headers,
+        body: current.body,
+        inputSchema: current.inputSchema,
+      },
+    );
+    const normalizedPatch = {
+      ...built.patch,
+      ...norm.shapes,
+    } as ToolDefinitionUpdate;
+    const warnings =
+      norm.warnings.length > 0 ? { warnings: norm.warnings } : {};
     const keys = Object.keys(built.patch) as (keyof ToolDefinitionUpdate)[];
     const beforeProj: Record<string, unknown> = {};
     const afterProj: Record<string, unknown> = {};
     for (const k of keys) {
       beforeProj[k] = (current as unknown as Record<string, unknown>)[k];
-      afterProj[k] = built.patch[k];
+      afterProj[k] = normalizedPatch[k];
     }
     const target = `tool:${id}`;
     if (args.dry_run !== false) {
@@ -564,6 +606,7 @@ export async function toolUpdate(
         dryRun: true,
         target,
         diff: diffFields(beforeProj, afterProj),
+        ...warnings,
       });
     }
     const updated = await updateToolDefinition(ctx, id, built.patch, base);
@@ -583,6 +626,7 @@ export async function toolUpdate(
       applied: true,
       target,
       diff: diffFields(beforeProj, appliedProj),
+      ...warnings,
     });
   } catch (e) {
     return failOf(e);

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -510,8 +510,8 @@ export async function toolCreate(
     urlTemplate: args.url_template,
     allowedHosts: args.allowed_hosts,
   } as ToolDefinitionCreate;
-  // Surface what the service will canonicalize (JSON-Schema input_schema, single-brace {var}) so
-  // the author sees the converted shape — and probable typos — in the preview, before applying.
+  // NOTE: surface what the service will canonicalize (JSON-Schema input_schema, single-brace
+  // {var}) so the author sees the converted shape and probable typos in the preview.
   const norm = normalizeToolShapes({
     urlTemplate: input.urlTemplate,
     query: input.query,
@@ -569,7 +569,7 @@ export async function toolUpdate(
   }
   try {
     const current = await getToolDefinition(ctx, id, base);
-    // Preview the canonical form the service will store (JSON-Schema input_schema converted,
+    // NOTE: preview the canonical form the service will store (JSON-Schema input_schema converted,
     // single-brace {var} normalized against the effective field set) plus probable-typo warnings.
     const norm = normalizeToolShapes(
       {

--- a/src/modules/tool-definitions/normalize.ts
+++ b/src/modules/tool-definitions/normalize.ts
@@ -1,0 +1,277 @@
+// Normalization of programmatically-authored HTTP tool shapes. The canonical contract (what the
+// runtime executes and the UI produces) is a COMPACT input-schema map — {field: {type, required?,
+// description?, enumValues?, itemType?}} — and {{var}} placeholders in urlTemplate/query/headers/
+// body. API and MCP authors naturally write standard JSON Schema ({properties, required}) and
+// OpenAPI-style single-brace {var} path params instead; both used to be accepted verbatim and then
+// silently never interpolated. This module converts them to the canonical shape. It is called at
+// every write edge (service create/update, MCP tool_create/tool_update preview, agent import) so
+// storage stays canonical, at tool build time so rows stored before this normalization existed
+// self-heal, and by the editor so legacy rows render their real fields.
+// Pure + dependency-free: safe to import from the client bundle.
+
+export interface ToolShapePatch {
+  urlTemplate?: string;
+  query?: unknown;
+  headers?: unknown;
+  body?: unknown;
+  inputSchema?: unknown;
+}
+
+export interface NormalizedToolShapes {
+  // Only the keys present in the patch, normalized.
+  shapes: ToolShapePatch;
+  warnings: string[];
+}
+
+// Conversation/contact context variable names the runtime interpolates (mirror of the
+// httpToolContext built in graph/prepare.ts + the conversation_id/message_id merged at buildToolset
+// time). Used as the write-time allowlist for single-brace normalization.
+export const CONTEXT_VAR_NAMES = [
+  "conversation_id",
+  "message_id",
+  "contact_id",
+  "contact_name",
+  "contact_email",
+  "contact_phone",
+  "inbox_id",
+  "inbox_name",
+  "company_name",
+  "agent_name",
+] as const;
+
+const JSON_SCHEMA_KEYWORDS = new Set([
+  "$schema",
+  "$id",
+  "title",
+  "description",
+  "type",
+  "properties",
+  "required",
+  "additionalProperties",
+]);
+
+const SCALAR_TYPES = new Set(["string", "integer", "number", "boolean"]);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// A valid compact map has ONLY plain-object values (one FieldSpec per field). Standard JSON Schema
+// is recognized by `properties` being a map of plain objects PLUS a structural marker no compact
+// map can produce: a string `type`, an array `required`, or every top-level key being a JSON Schema
+// keyword. Requiring every `properties` value to be an object protects the pathological compact
+// field literally named "properties" ({properties: {type: "object"}} has the string value "object"
+// under it, so it stays compact).
+export function isJsonSchemaShape(raw: unknown): boolean {
+  if (!isPlainObject(raw)) return false;
+  const props = raw.properties;
+  if (!isPlainObject(props)) return false;
+  if (!Object.values(props).every(isPlainObject)) return false;
+  return (
+    typeof raw.type === "string" ||
+    Array.isArray(raw.required) ||
+    Object.keys(raw).every((k) => JSON_SCHEMA_KEYWORDS.has(k))
+  );
+}
+
+// JSON Schema → compact map. Flat scalar/enum/array-of-scalar properties convert faithfully;
+// anything deeper (nested properties, anyOf/oneOf, explicit type "object") degrades to the generic
+// "object" field type. The top-level `required` array marks per-field required flags.
+export function compactFromJsonSchema(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const props = raw.properties as Record<string, unknown>;
+  const required = new Set(
+    Array.isArray(raw.required)
+      ? raw.required.filter((v): v is string => typeof v === "string")
+      : [],
+  );
+  const out: Record<string, unknown> = {};
+  for (const [name, spec] of Object.entries(props)) {
+    const s = isPlainObject(spec) ? spec : {};
+    const field: Record<string, unknown> = {};
+    if (Array.isArray(s.enum)) {
+      field.type = "enum";
+      field.enumValues = s.enum.filter(
+        (v): v is string => typeof v === "string",
+      );
+    } else if (s.type === "array") {
+      field.type = "array";
+      const items = isPlainObject(s.items) ? s.items : {};
+      field.itemType =
+        typeof items.type === "string" && SCALAR_TYPES.has(items.type)
+          ? items.type
+          : "string";
+    } else if (
+      s.type === "object" ||
+      isPlainObject(s.properties) ||
+      Array.isArray(s.anyOf) ||
+      Array.isArray(s.oneOf)
+    ) {
+      field.type = "object";
+    } else {
+      field.type =
+        typeof s.type === "string" && SCALAR_TYPES.has(s.type)
+          ? s.type
+          : "string";
+    }
+    if (typeof s.description === "string" && s.description) {
+      field.description = s.description;
+    }
+    if (required.has(name)) field.required = true;
+    out[name] = field;
+  }
+  return out;
+}
+
+// A single-brace {name} that is not part of a {{name}} token. Lookarounds keep {{name}} (and the
+// ambiguous {name}} / {{name} halves) untouched, which also makes the rewrite idempotent.
+const SINGLE_BRACE = /(?<!\{)\{\s*([a-zA-Z0-9_]+)\s*\}(?!\})/g;
+
+function rewriteSingleBraces(template: string, names: Set<string>): string {
+  return template.replace(SINGLE_BRACE, (match, name: string) =>
+    names.has(name) ? `{{${name}}}` : match,
+  );
+}
+
+function collectUnknownTokens(
+  template: string,
+  names: Set<string>,
+  into: Set<string>,
+): void {
+  for (const m of template.matchAll(SINGLE_BRACE)) {
+    const name = m[1] as string;
+    if (!names.has(name)) into.add(name);
+  }
+}
+
+function fieldNames(schema: unknown): string[] {
+  return isPlainObject(schema) ? Object.keys(schema) : [];
+}
+
+// Normalizes the shapes present in `patch`. `current` supplies the rest of the row on partial
+// updates so the placeholder allowlist sees the effective field set; `extraNames` adds caller-known
+// interpolation names (e.g. the runtime's live context keys). Single-brace {name} is rewritten to
+// {{name}} ONLY when the name is a declared input field, a context variable or "secret" — an
+// unmatched {token} stays literal (it may be legitimate content, e.g. raw JSON) and is reported in
+// `warnings` as a probable typo.
+export function normalizeToolShapes(
+  patch: ToolShapePatch,
+  current: ToolShapePatch = {},
+  extraNames: Iterable<string> = [],
+): NormalizedToolShapes {
+  const warnings: string[] = [];
+  const shapes: ToolShapePatch = {};
+
+  const rawSchema =
+    patch.inputSchema !== undefined ? patch.inputSchema : current.inputSchema;
+  let effectiveSchema = rawSchema;
+  if (isJsonSchemaShape(rawSchema)) {
+    effectiveSchema = compactFromJsonSchema(
+      rawSchema as Record<string, unknown>,
+    );
+    if (patch.inputSchema !== undefined) {
+      warnings.push(
+        "input_schema was interpreted as standard JSON Schema and converted to the compact field map",
+      );
+    }
+  }
+  if (patch.inputSchema !== undefined) {
+    shapes.inputSchema = effectiveSchema;
+  }
+
+  const names = new Set<string>([
+    ...fieldNames(effectiveSchema),
+    ...CONTEXT_VAR_NAMES,
+    ...extraNames,
+    "secret",
+  ]);
+  const unknown = new Set<string>();
+
+  if (patch.urlTemplate !== undefined) {
+    shapes.urlTemplate = rewriteSingleBraces(patch.urlTemplate, names);
+    collectUnknownTokens(patch.urlTemplate, names, unknown);
+  }
+
+  for (const key of ["query", "headers"] as const) {
+    const value = patch[key];
+    if (value === undefined) continue;
+    if (!isPlainObject(value)) {
+      shapes[key] = value;
+      continue;
+    }
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (typeof v === "string") {
+        out[k] = rewriteSingleBraces(v, names);
+        collectUnknownTokens(v, names, unknown);
+      } else {
+        out[k] = v;
+      }
+    }
+    shapes[key] = out;
+  }
+
+  if (patch.body !== undefined) {
+    shapes.body = patch.body;
+    if (isPlainObject(patch.body)) {
+      const body = patch.body;
+      if (body.mode === "raw" && typeof body.raw === "string") {
+        shapes.body = {
+          ...body,
+          raw: rewriteSingleBraces(body.raw, names),
+        };
+        collectUnknownTokens(body.raw, names, unknown);
+      } else if (body.mode === "kv" && Array.isArray(body.rows)) {
+        shapes.body = {
+          ...body,
+          rows: body.rows.map((row) => {
+            if (!isPlainObject(row) || typeof row.value !== "string")
+              return row;
+            collectUnknownTokens(row.value, names, unknown);
+            return { ...row, value: rewriteSingleBraces(row.value, names) };
+          }),
+        };
+      }
+    }
+  }
+
+  // Legacy compact fields may carry source:"fixed" values that are templates too.
+  if (shapes.inputSchema !== undefined && isPlainObject(shapes.inputSchema)) {
+    const schema = shapes.inputSchema;
+    let rewritten: Record<string, unknown> | null = null;
+    for (const [name, spec] of Object.entries(schema)) {
+      if (!isPlainObject(spec) || typeof spec.value !== "string") continue;
+      collectUnknownTokens(spec.value, names, unknown);
+      const next = rewriteSingleBraces(spec.value, names);
+      if (next !== spec.value) {
+        rewritten = rewritten ?? { ...schema };
+        rewritten[name] = { ...spec, value: next };
+      }
+    }
+    if (rewritten) shapes.inputSchema = rewritten;
+  }
+
+  if (unknown.size > 0) {
+    warnings.push(
+      `unrecognized single-brace placeholder(s): ${[...unknown]
+        .map((n) => `{${n}}`)
+        .join(
+          ", ",
+        )} — single-brace tokens are only interpolated when they match a declared input field, a context variable or "secret"; left as literal text`,
+    );
+  }
+
+  return { shapes, warnings };
+}
+
+// Read-side convenience for consumers that only care about the input schema (e.g. the editor):
+// returns the compact map, converting a JSON-Schema-shaped value when needed.
+export function normalizeInputSchemaShape(
+  raw: unknown,
+): Record<string, unknown> {
+  if (isJsonSchemaShape(raw)) {
+    return compactFromJsonSchema(raw as Record<string, unknown>);
+  }
+  return isPlainObject(raw) ? raw : {};
+}

--- a/src/modules/tool-definitions/normalize.ts
+++ b/src/modules/tool-definitions/normalize.ts
@@ -1,4 +1,4 @@
-// Normalization of programmatically-authored HTTP tool shapes. The canonical contract (what the
+// NOTE: normalization of programmatically-authored HTTP tool shapes. The canonical contract (what the
 // runtime executes and the UI produces) is a COMPACT input-schema map — {field: {type, required?,
 // description?, enumValues?, itemType?}} — and {{var}} placeholders in urlTemplate/query/headers/
 // body. API and MCP authors naturally write standard JSON Schema ({properties, required}) and
@@ -23,7 +23,7 @@ export interface NormalizedToolShapes {
   warnings: string[];
 }
 
-// Conversation/contact context variable names the runtime interpolates (mirror of the
+// NOTE: conversation/contact context variable names the runtime interpolates (mirror of the
 // httpToolContext built in graph/prepare.ts + the conversation_id/message_id merged at buildToolset
 // time). Used as the write-time allowlist for single-brace normalization.
 export const CONTEXT_VAR_NAMES = [
@@ -56,7 +56,7 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-// A valid compact map has ONLY plain-object values (one FieldSpec per field). Standard JSON Schema
+// NOTE: a valid compact map has ONLY plain-object values (one FieldSpec per field). Standard JSON Schema
 // is recognized by `properties` being a map of plain objects PLUS a structural marker no compact
 // map can produce: a string `type`, an array `required`, or every top-level key being a JSON Schema
 // keyword. Requiring every `properties` value to be an object protects the pathological compact
@@ -74,7 +74,7 @@ export function isJsonSchemaShape(raw: unknown): boolean {
   );
 }
 
-// JSON Schema → compact map. Flat scalar/enum/array-of-scalar properties convert faithfully;
+// NOTE: JSON Schema → compact map. Flat scalar/enum/array-of-scalar properties convert faithfully;
 // anything deeper (nested properties, anyOf/oneOf, explicit type "object") degrades to the generic
 // "object" field type. The top-level `required` array marks per-field required flags. `warnings`
 // (optional collector) receives notes about lossy conversions.
@@ -97,9 +97,9 @@ export function compactFromJsonSchema(
         field.type = "enum";
         field.enumValues = s.enum as string[];
       } else {
-        // The compact contract only expresses string enums. Degrade a numeric/boolean enum to its
-        // base scalar type (wider but never rejects a declared value) instead of silently dropping
-        // the values and validating as a free string.
+        // NOTE: the compact contract only expresses string enums. Degrade a numeric/boolean enum
+        // to its base scalar type (wider but never rejects a declared value) instead of silently
+        // dropping the values and validating as a free string.
         field.type = s.enum.every((v) => typeof v === "number")
           ? s.enum.every((v) => Number.isInteger(v))
             ? "integer"
@@ -156,8 +156,8 @@ export function compactFromJsonSchema(
   return out;
 }
 
-// A single-brace {name} that is not part of a {{name}} token. Lookarounds keep {{name}} (and the
-// ambiguous {name}} / {{name} halves) untouched, which also makes the rewrite idempotent.
+// NOTE: a single-brace {name} that is not part of a {{name}} token. Lookarounds keep {{name}} (and
+// the ambiguous {name}} / {{name} halves) untouched, which also makes the rewrite idempotent.
 const SINGLE_BRACE = /(?<!\{)\{\s*([a-zA-Z0-9_]+)\s*\}(?!\})/g;
 
 function rewriteSingleBraces(template: string, names: Set<string>): string {
@@ -181,7 +181,7 @@ function fieldNames(schema: unknown): string[] {
   return isPlainObject(schema) ? Object.keys(schema) : [];
 }
 
-// Normalizes the shapes present in `patch`. `current` supplies the rest of the row on partial
+// NOTE: normalizes the shapes present in `patch`. `current` supplies the rest of the row on partial
 // updates so the placeholder allowlist sees the effective field set; `extraNames` adds caller-known
 // interpolation names (e.g. the runtime's live context keys). Single-brace {name} is rewritten to
 // {{name}} ONLY when the name is a declared input field, a context variable or "secret" — an
@@ -271,7 +271,7 @@ export function normalizeToolShapes(
     }
   }
 
-  // Legacy compact fields may carry source:"fixed" values that are templates too.
+  // NOTE: legacy compact fields may carry source:"fixed" values that are templates too.
   if (shapes.inputSchema !== undefined && isPlainObject(shapes.inputSchema)) {
     const schema = shapes.inputSchema;
     let rewritten: Record<string, unknown> | null = null;
@@ -300,8 +300,8 @@ export function normalizeToolShapes(
   return { shapes, warnings };
 }
 
-// Read-side convenience for consumers that only care about the input schema (e.g. the editor):
-// returns the compact map, converting a JSON-Schema-shaped value when needed.
+// NOTE: read-side convenience for consumers that only care about the input schema (e.g. the
+// editor): returns the compact map, converting a JSON-Schema-shaped value when needed.
 export function normalizeInputSchemaShape(
   raw: unknown,
 ): Record<string, unknown> {

--- a/src/modules/tool-definitions/normalize.ts
+++ b/src/modules/tool-definitions/normalize.ts
@@ -144,14 +144,16 @@ export function compactFromJsonSchema(
       s.type === "object" ||
       isPlainObject(s.properties) ||
       Array.isArray(s.anyOf) ||
-      Array.isArray(s.oneOf)
+      Array.isArray(s.oneOf) ||
+      Array.isArray(s.allOf)
     ) {
       field.type = "object";
       // NOTE: a bare {type: "object"} maps faithfully; only a discarded sub-schema is lossy.
       if (
         isPlainObject(s.properties) ||
         Array.isArray(s.anyOf) ||
-        Array.isArray(s.oneOf)
+        Array.isArray(s.oneOf) ||
+        Array.isArray(s.allOf)
       ) {
         warnings?.push(
           `field "${name}": nested/union sub-schema is not expressible in the compact schema; degraded to a generic "object" (structural validation lost)`,

--- a/src/modules/tool-definitions/normalize.ts
+++ b/src/modules/tool-definitions/normalize.ts
@@ -76,9 +76,11 @@ export function isJsonSchemaShape(raw: unknown): boolean {
 
 // JSON Schema → compact map. Flat scalar/enum/array-of-scalar properties convert faithfully;
 // anything deeper (nested properties, anyOf/oneOf, explicit type "object") degrades to the generic
-// "object" field type. The top-level `required` array marks per-field required flags.
+// "object" field type. The top-level `required` array marks per-field required flags. `warnings`
+// (optional collector) receives notes about lossy conversions.
 export function compactFromJsonSchema(
   raw: Record<string, unknown>,
+  warnings?: string[],
 ): Record<string, unknown> {
   const props = raw.properties as Record<string, unknown>;
   const required = new Set(
@@ -90,11 +92,25 @@ export function compactFromJsonSchema(
   for (const [name, spec] of Object.entries(props)) {
     const s = isPlainObject(spec) ? spec : {};
     const field: Record<string, unknown> = {};
-    if (Array.isArray(s.enum)) {
-      field.type = "enum";
-      field.enumValues = s.enum.filter(
-        (v): v is string => typeof v === "string",
-      );
+    if (Array.isArray(s.enum) && s.enum.length > 0) {
+      if (s.enum.every((v) => typeof v === "string")) {
+        field.type = "enum";
+        field.enumValues = s.enum as string[];
+      } else {
+        // The compact contract only expresses string enums. Degrade a numeric/boolean enum to its
+        // base scalar type (wider but never rejects a declared value) instead of silently dropping
+        // the values and validating as a free string.
+        field.type = s.enum.every((v) => typeof v === "number")
+          ? s.enum.every((v) => Number.isInteger(v))
+            ? "integer"
+            : "number"
+          : s.enum.every((v) => typeof v === "boolean")
+            ? "boolean"
+            : "string";
+        warnings?.push(
+          `field "${name}": non-string enum values are not expressible in the compact schema; degraded to type "${field.type}" (allowed values are no longer enforced)`,
+        );
+      }
     } else if (s.type === "array") {
       field.type = "array";
       const items = isPlainObject(s.items) ? s.items : {};
@@ -167,12 +183,15 @@ export function normalizeToolShapes(
     patch.inputSchema !== undefined ? patch.inputSchema : current.inputSchema;
   let effectiveSchema = rawSchema;
   if (isJsonSchemaShape(rawSchema)) {
+    const conversionWarnings: string[] = [];
     effectiveSchema = compactFromJsonSchema(
       rawSchema as Record<string, unknown>,
+      conversionWarnings,
     );
     if (patch.inputSchema !== undefined) {
       warnings.push(
         "input_schema was interpreted as standard JSON Schema and converted to the compact field map",
+        ...conversionWarnings,
       );
     }
   }

--- a/src/modules/tool-definitions/normalize.ts
+++ b/src/modules/tool-definitions/normalize.ts
@@ -56,6 +56,22 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+// NOTE: parsed JSON can carry an own "__proto__" key; plain assignment on a fresh {} would invoke
+// the inherited setter and silently drop it. Define an own property instead wherever a
+// caller-controlled key lands in an output map.
+function setOwn(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+}
+
 // NOTE: a valid compact map has ONLY plain-object values (one FieldSpec per field). Standard JSON Schema
 // is recognized by `properties` being a map of plain objects PLUS a structural marker no compact
 // map can produce: a string `type`, an array `required`, or every top-level key being a JSON Schema
@@ -151,7 +167,7 @@ export function compactFromJsonSchema(
       field.description = s.description;
     }
     if (required.has(name)) field.required = true;
-    out[name] = field;
+    setOwn(out, name, field);
   }
   return out;
 }
@@ -238,10 +254,10 @@ export function normalizeToolShapes(
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
       if (typeof v === "string") {
-        out[k] = rewriteSingleBraces(v, names);
+        setOwn(out, k, rewriteSingleBraces(v, names));
         collectUnknownTokens(v, names, unknown);
       } else {
-        out[k] = v;
+        setOwn(out, k, v);
       }
     }
     shapes[key] = out;
@@ -281,7 +297,7 @@ export function normalizeToolShapes(
       const next = rewriteSingleBraces(spec.value, names);
       if (next !== spec.value) {
         rewritten = rewritten ?? { ...schema };
-        rewritten[name] = { ...spec, value: next };
+        setOwn(rewritten, name, { ...spec, value: next });
       }
     }
     if (rewritten) shapes.inputSchema = rewritten;

--- a/src/modules/tool-definitions/normalize.ts
+++ b/src/modules/tool-definitions/normalize.ts
@@ -114,10 +114,16 @@ export function compactFromJsonSchema(
     } else if (s.type === "array") {
       field.type = "array";
       const items = isPlainObject(s.items) ? s.items : {};
-      field.itemType =
+      const scalarItem =
         typeof items.type === "string" && SCALAR_TYPES.has(items.type)
           ? items.type
-          : "string";
+          : null;
+      field.itemType = scalarItem ?? "string";
+      if (!scalarItem && items.type !== undefined) {
+        warnings?.push(
+          `field "${name}": array item type "${String(items.type)}" is not expressible in the compact schema; items validate as "string"`,
+        );
+      }
     } else if (
       s.type === "object" ||
       isPlainObject(s.properties) ||
@@ -125,6 +131,16 @@ export function compactFromJsonSchema(
       Array.isArray(s.oneOf)
     ) {
       field.type = "object";
+      // NOTE: a bare {type: "object"} maps faithfully; only a discarded sub-schema is lossy.
+      if (
+        isPlainObject(s.properties) ||
+        Array.isArray(s.anyOf) ||
+        Array.isArray(s.oneOf)
+      ) {
+        warnings?.push(
+          `field "${name}": nested/union sub-schema is not expressible in the compact schema; degraded to a generic "object" (structural validation lost)`,
+        );
+      }
     } else {
       field.type =
         typeof s.type === "string" && SCALAR_TYPES.has(s.type)

--- a/src/modules/tool-definitions/service.ts
+++ b/src/modules/tool-definitions/service.ts
@@ -3,6 +3,7 @@ import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, ConflictError, NotFoundError } from "@/lib/errors";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { normalizeToolShapes } from "./normalize";
 
 // Custom HTTP tool definitions (per-tenant). A definition is the LLM-facing parameter schema +
 // the server-trusted wiring (urlTemplate, allowedHosts, headers, credentialRef). The credential is
@@ -185,6 +186,15 @@ export async function createToolDefinition(
   }
   const tenantId = ctx.tenantId;
   const data = toolDefinitionCreateSchema.parse(input);
+  // Canonicalize programmatic authoring shapes (JSON-Schema inputSchema, single-brace {var}) so
+  // storage always holds what the runtime executes.
+  const { shapes } = normalizeToolShapes({
+    urlTemplate: data.urlTemplate,
+    query: data.query,
+    headers: data.headers,
+    body: data.body,
+    inputSchema: data.inputSchema,
+  });
   return runScopedOn(base, ctx, async (db) => {
     await assertNameFree(db, data.name);
     const row = await db.toolDefinition.create({
@@ -194,13 +204,13 @@ export async function createToolDefinition(
         label: data.label,
         description: data.description ?? null,
         method: data.method ?? "POST",
-        urlTemplate: data.urlTemplate,
+        urlTemplate: (shapes.urlTemplate ?? data.urlTemplate) as string,
         allowedHosts: data.allowedHosts,
-        headers: (data.headers ?? {}) as Prisma.InputJsonValue,
-        inputSchema: (data.inputSchema ?? {}) as Prisma.InputJsonValue,
+        headers: (shapes.headers ?? {}) as Prisma.InputJsonValue,
+        inputSchema: (shapes.inputSchema ?? {}) as Prisma.InputJsonValue,
         outputSchema: (data.outputSchema ?? {}) as Prisma.InputJsonValue,
-        query: (data.query ?? {}) as Prisma.InputJsonValue,
-        body: (data.body ?? {}) as Prisma.InputJsonValue,
+        query: (shapes.query ?? {}) as Prisma.InputJsonValue,
+        body: (shapes.body ?? {}) as Prisma.InputJsonValue,
         credentialRef: data.credentialRef ?? null,
         enabled: data.enabled ?? true,
         riskTier: data.riskTier ?? "medium",
@@ -223,7 +233,14 @@ export async function updateToolDefinition(
   return runScopedOn(base, ctx, async (db) => {
     const current = await db.toolDefinition.findUnique({
       where: { id },
-      select: { id: true },
+      select: {
+        id: true,
+        urlTemplate: true,
+        query: true,
+        headers: true,
+        body: true,
+        inputSchema: true,
+      },
     });
     if (!current) {
       throw new NotFoundError(
@@ -232,6 +249,24 @@ export async function updateToolDefinition(
       );
     }
     if (data.name) await assertNameFree(db, data.name, id);
+    // Canonicalize the patched shapes; the current row supplies the rest so the placeholder
+    // allowlist sees the effective field set on partial updates.
+    const { shapes } = normalizeToolShapes(
+      {
+        urlTemplate: data.urlTemplate,
+        query: data.query,
+        headers: data.headers,
+        body: data.body,
+        inputSchema: data.inputSchema,
+      },
+      {
+        urlTemplate: current.urlTemplate,
+        query: current.query,
+        headers: current.headers,
+        body: current.body,
+        inputSchema: current.inputSchema,
+      },
+    );
     const patchData: Prisma.ToolDefinitionUpdateInput = {};
     if (data.name !== undefined) patchData.name = data.name;
     if (data.label !== undefined) patchData.label = data.label;
@@ -239,19 +274,20 @@ export async function updateToolDefinition(
       patchData.description = data.description ?? null;
     if (data.method !== undefined) patchData.method = data.method;
     if (data.urlTemplate !== undefined)
-      patchData.urlTemplate = data.urlTemplate;
+      patchData.urlTemplate = (shapes.urlTemplate ??
+        data.urlTemplate) as string;
     if (data.allowedHosts !== undefined)
       patchData.allowedHosts = data.allowedHosts;
     if (data.headers !== undefined)
-      patchData.headers = data.headers as Prisma.InputJsonValue;
+      patchData.headers = shapes.headers as Prisma.InputJsonValue;
     if (data.inputSchema !== undefined)
-      patchData.inputSchema = data.inputSchema as Prisma.InputJsonValue;
+      patchData.inputSchema = shapes.inputSchema as Prisma.InputJsonValue;
     if (data.outputSchema !== undefined)
       patchData.outputSchema = data.outputSchema as Prisma.InputJsonValue;
     if (data.query !== undefined)
-      patchData.query = data.query as Prisma.InputJsonValue;
+      patchData.query = shapes.query as Prisma.InputJsonValue;
     if (data.body !== undefined)
-      patchData.body = data.body as Prisma.InputJsonValue;
+      patchData.body = shapes.body as Prisma.InputJsonValue;
     if (data.credentialRef !== undefined)
       patchData.credentialRef = data.credentialRef ?? null;
     if (data.enabled !== undefined) patchData.enabled = data.enabled;

--- a/src/modules/tool-definitions/service.ts
+++ b/src/modules/tool-definitions/service.ts
@@ -186,8 +186,8 @@ export async function createToolDefinition(
   }
   const tenantId = ctx.tenantId;
   const data = toolDefinitionCreateSchema.parse(input);
-  // Canonicalize programmatic authoring shapes (JSON-Schema inputSchema, single-brace {var}) so
-  // storage always holds what the runtime executes.
+  // NOTE: canonicalize programmatic authoring shapes (JSON-Schema inputSchema, single-brace
+  // {var}) so storage always holds what the runtime executes.
   const { shapes } = normalizeToolShapes({
     urlTemplate: data.urlTemplate,
     query: data.query,
@@ -249,7 +249,7 @@ export async function updateToolDefinition(
       );
     }
     if (data.name) await assertNameFree(db, data.name, id);
-    // Canonicalize the patched shapes; the current row supplies the rest so the placeholder
+    // NOTE: canonicalize the patched shapes; the current row supplies the rest so the placeholder
     // allowlist sees the effective field set on partial updates.
     const { shapes } = normalizeToolShapes(
       {

--- a/tests/client/pages/ToolEditModal.test.tsx
+++ b/tests/client/pages/ToolEditModal.test.tsx
@@ -1,0 +1,77 @@
+/// <reference lib="dom" />
+
+import { describe, expect, test } from "bun:test";
+import {
+  formFromTool,
+  type Tool,
+} from "@/client/pages/resources/ToolEditModal";
+
+// NOTE: formFromTool is pure over its argument; these tests exercise the legacy load path without
+// rendering the modal.
+
+function legacyTool(over: Partial<Tool> = {}): Tool {
+  return {
+    id: "1",
+    name: "legacy",
+    label: "Legacy",
+    description: null,
+    method: "GET",
+    urlTemplate: "https://api.example.com/accounts/{{tenant}}",
+    allowedHosts: ["api.example.com"],
+    headers: {},
+    inputSchema: {},
+    outputSchema: {},
+    query: {},
+    body: {},
+    credentialRef: null,
+    enabled: true,
+    riskTier: "medium",
+    ackEnabled: false,
+    ackMessage: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...over,
+  } as Tool;
+}
+
+describe("formFromTool — legacy fixed URL bindings", () => {
+  test("a fixed field bound to a URL placeholder is inlined so saving cannot drop it", () => {
+    const form = formFromTool(
+      legacyTool({
+        inputSchema: {
+          tenant: { source: "fixed", value: "acme" },
+          q: { type: "string", required: true },
+        },
+      }),
+    );
+    // NOTE: the visible URL carries the effective value; no orphan {{tenant}} token survives a
+    // save that only writes AI fields.
+    expect(form.urlTemplate).toBe("https://api.example.com/accounts/acme");
+    expect(form.aiFields.map((f) => f.name)).toEqual(["q"]);
+  });
+
+  test("a fixed URL binding whose value is a context template stays a template", () => {
+    const form = formFromTool(
+      legacyTool({
+        inputSchema: {
+          tenant: { source: "fixed", value: "{{conversation_id}}" },
+        },
+      }),
+    );
+    expect(form.urlTemplate).toBe(
+      "https://api.example.com/accounts/{{conversation_id}}",
+    );
+  });
+
+  test("an AI field bound to a URL placeholder keeps its {{token}} and its schema row", () => {
+    const form = formFromTool(
+      legacyTool({
+        inputSchema: { tenant: { type: "string", required: true } },
+      }),
+    );
+    expect(form.urlTemplate).toBe(
+      "https://api.example.com/accounts/{{tenant}}",
+    );
+    expect(form.aiFields.map((f) => f.name)).toEqual(["tenant"]);
+  });
+});

--- a/tests/graph/tools-http.test.ts
+++ b/tests/graph/tools-http.test.ts
@@ -816,3 +816,160 @@ describe("buildHttpTool — query params (any method)", () => {
     expect(new URL(captured.url as string).searchParams.get("foo")).toBe("X");
   });
 });
+
+describe("buildHttpTool — programmatic authoring shapes (JSON-Schema input_schema + single-brace placeholders)", () => {
+  // The natural shapes an API/MCP author writes: standard JSON Schema for the input and
+  // OpenAPI-style single-brace path params. Both must work (converted/normalized), not fail silently.
+  const JSON_SCHEMA_INPUT = {
+    required: ["valor"],
+    properties: { valor: { type: "string" } },
+  };
+
+  test("JSON-Schema input_schema exposes the real fields, not the schema keywords", () => {
+    const schema = parseToolInputSchema(JSON_SCHEMA_INPUT);
+    expect("valor" in schema.shape).toBe(true);
+    expect("properties" in schema.shape).toBe(false);
+    expect("required" in schema.shape).toBe(false);
+    expect(schema.safeParse({}).success).toBe(false); // valor is required
+    expect(schema.safeParse({ valor: "TESTE123" }).success).toBe(true);
+  });
+
+  test("single-brace path var + JSON-Schema input: the argument reaches the URL", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/anything/{valor}`,
+        inputSchema: JSON_SCHEMA_INPUT,
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    await tool.invoke({ valor: "TESTE123" });
+    expect(new URL(captured.url as string).pathname).toBe("/anything/TESTE123");
+  });
+
+  test("two single-brace path vars (compact schema) both substitute", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/debug-echo/{nome_cliente}/{faixa_etaria}`,
+        inputSchema: {
+          nome_cliente: { type: "string", required: true },
+          faixa_etaria: { type: "string", required: true },
+        },
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    await tool.invoke({ nome_cliente: "Maria", faixa_etaria: "30-40" });
+    expect(new URL(captured.url as string).pathname).toBe(
+      "/debug-echo/Maria/30-40",
+    );
+  });
+
+  test("single-brace value in the query dict resolves to the argument", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/v1/x`,
+        inputSchema: { nome_cliente: { type: "string", required: true } },
+        query: { nome_cliente: "{nome_cliente}" },
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    await tool.invoke({ nome_cliente: "Maria" });
+    expect(
+      new URL(captured.url as string).searchParams.get("nome_cliente"),
+    ).toBe("Maria");
+  });
+
+  test("single-brace value in a header resolves to the argument", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/v1/x`,
+        inputSchema: { nome_cliente: { type: "string", required: true } },
+        headers: { "X-Nome-Cliente": "{nome_cliente}" },
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    await tool.invoke({ nome_cliente: "Maria" });
+    const headers = captured.init?.headers as Record<string, string>;
+    expect(headers["X-Nome-Cliente"]).toBe("Maria");
+  });
+
+  test("POST with empty body config + JSON-Schema input: args land in the JSON body", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "POST",
+        urlTemplate: `https://${PUBLIC}/v1/x`,
+        inputSchema: JSON_SCHEMA_INPUT,
+        body: {},
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    await tool.invoke({ valor: "TESTE123" });
+    expect(JSON.parse(captured.init?.body as string)).toEqual({
+      valor: "TESTE123",
+    });
+  });
+
+  test("single-brace context var resolves in the URL", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/v1/conversations/{conversation_id}`,
+      }),
+      {
+        resolveCredential: async () => null,
+        fetchImpl: stubFetch(captured),
+        context: { conversation_id: "42" },
+      },
+    );
+    await tool.invoke({});
+    expect(new URL(captured.url as string).pathname).toBe(
+      "/v1/conversations/42",
+    );
+  });
+
+  test("a single-brace token matching nothing declared stays literal (raw body)", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "POST",
+        urlTemplate: `https://${PUBLIC}/v1/x`,
+        inputSchema: { name: { type: "string", required: true } },
+        body: {
+          mode: "raw",
+          raw: '{"who":"{{name}}","tpl":"{unknown_token}"}',
+        },
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    await tool.invoke({ name: "Maria" });
+    expect(JSON.parse(captured.init?.body as string)).toEqual({
+      who: "Maria",
+      tpl: "{unknown_token}",
+    });
+  });
+
+  test("unresolved URL placeholder returns an instructive error to the model, no fetch", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/v1/things/{{id}}`,
+        inputSchema: { id: { type: "string" } },
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    const out = await tool.invoke({});
+    expect(String(out)).toContain("id");
+    expect(String(out).toLowerCase()).toContain("error");
+    expect(captured.url).toBeUndefined();
+  });
+});

--- a/tests/graph/tools-http.test.ts
+++ b/tests/graph/tools-http.test.ts
@@ -957,6 +957,21 @@ describe("buildHttpTool — programmatic authoring shapes (JSON-Schema input_sch
     });
   });
 
+  test("{{secret}} in the URL with no resolvable credential throws a config error, no fetch", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/v1/x?token={{secret}}`,
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    // A missing credential is operator config, not model input: the model must never be told to
+    // retry with a "secret" field.
+    await expect(tool.invoke({})).rejects.toThrow(/credential/);
+    expect(captured.url).toBeUndefined();
+  });
+
   test("unresolved URL placeholder returns an instructive error to the model, no fetch", async () => {
     const captured: Captured = {};
     const tool = buildHttpTool(

--- a/tests/graph/tools-http.test.ts
+++ b/tests/graph/tools-http.test.ts
@@ -989,6 +989,24 @@ describe("buildHttpTool — programmatic authoring shapes (JSON-Schema input_sch
     expect(captured.url).toBeUndefined();
   });
 
+  test("a missing context variable in the URL throws (a retry hint would loop), no fetch", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/v1/contacts/{{contact_email}}`,
+      }),
+      {
+        resolveCredential: async () => null,
+        fetchImpl: stubFetch(captured),
+        context: {},
+      },
+    );
+    // NOTE: context vars are injected by the platform; the model can never supply them.
+    await expect(tool.invoke({})).rejects.toThrow(/contact_email/);
+    expect(captured.url).toBeUndefined();
+  });
+
   test("unresolved URL placeholder returns an instructive error to the model, no fetch", async () => {
     const captured: Captured = {};
     const tool = buildHttpTool(

--- a/tests/graph/tools-http.test.ts
+++ b/tests/graph/tools-http.test.ts
@@ -818,7 +818,7 @@ describe("buildHttpTool — query params (any method)", () => {
 });
 
 describe("buildHttpTool — programmatic authoring shapes (JSON-Schema input_schema + single-brace placeholders)", () => {
-  // The natural shapes an API/MCP author writes: standard JSON Schema for the input and
+  // NOTE: the natural shapes an API/MCP author writes: standard JSON Schema for the input and
   // OpenAPI-style single-brace path params. Both must work (converted/normalized), not fail silently.
   const JSON_SCHEMA_INPUT = {
     required: ["valor"],
@@ -966,8 +966,25 @@ describe("buildHttpTool — programmatic authoring shapes (JSON-Schema input_sch
       }),
       { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
     );
-    // A missing credential is operator config, not model input: the model must never be told to
+    // NOTE: a missing credential is operator config, not model input: the model must never be told to
     // retry with a "secret" field.
+    await expect(tool.invoke({})).rejects.toThrow(/credential/);
+    expect(captured.url).toBeUndefined();
+  });
+
+  test("a fixed URL field depending on an unavailable {{secret}} throws, no fetch", async () => {
+    const captured: Captured = {};
+    const tool = buildHttpTool(
+      def({
+        method: "GET",
+        urlTemplate: `https://${PUBLIC}/v1/x/{{token}}`,
+        inputSchema: { token: { source: "fixed", value: "{{secret}}" } },
+        credentialRef: "k",
+      }),
+      { resolveCredential: async () => null, fetchImpl: stubFetch(captured) },
+    );
+    // NOTE: the fixed value resolves to "" (headers/body semantics), but the URL guard must still refuse
+    // to fetch an incomplete URL and name the credential as the root cause.
     await expect(tool.invoke({})).rejects.toThrow(/credential/);
     expect(captured.url).toBeUndefined();
   });

--- a/tests/modules/agent-transfer.test.ts
+++ b/tests/modules/agent-transfer.test.ts
@@ -581,8 +581,8 @@ describe.skipIf(!dbUp)("agent export/import with components", () => {
     const exp = await exportAgent(srcCtx(), srcAgentId, appDb, {
       includeComponents: true,
     });
-    // Simulate a bundle exported from a pre-normalization instance: rename the tool so the import
-    // creates it fresh, and regress its shapes to the legacy authoring forms.
+    // NOTE: simulate a bundle exported from a pre-normalization instance: rename the tool so the
+    // import creates it fresh, and regress its shapes to the legacy authoring forms.
     const legacy = structuredClone(exp);
     const tool = legacy.components?.httpTools.find(
       (h) => h.name === "lookup_order",

--- a/tests/modules/agent-transfer.test.ts
+++ b/tests/modules/agent-transfer.test.ts
@@ -577,6 +577,39 @@ describe.skipIf(!dbUp)("agent export/import with components", () => {
     ]);
   });
 
+  test("import canonicalizes legacy authoring shapes (JSON-Schema inputSchema, single-brace {var})", async () => {
+    const exp = await exportAgent(srcCtx(), srcAgentId, appDb, {
+      includeComponents: true,
+    });
+    // Simulate a bundle exported from a pre-normalization instance: rename the tool so the import
+    // creates it fresh, and regress its shapes to the legacy authoring forms.
+    const legacy = structuredClone(exp);
+    const tool = legacy.components?.httpTools.find(
+      (h) => h.name === "lookup_order",
+    );
+    if (!tool) throw new Error("bundle missing lookup_order");
+    tool.name = "legacy_lookup";
+    tool.urlTemplate = "https://shop.example.com/orders/{order_id}";
+    tool.inputSchema = {
+      required: ["order_id"],
+      properties: { order_id: { type: "string" } },
+    };
+    const grant = legacy.agent.tools.find(
+      (g) => g.source === "HTTP" && g.tool === "lookup_order",
+    );
+    if (grant?.source === "HTTP") grant.tool = "legacy_lookup";
+    await importAgent(dstCtx(), legacy, appDb);
+    const row = await suDb.toolDefinition.findFirst({
+      where: { tenantId: dstTenant, name: "legacy_lookup" },
+    });
+    expect(row?.urlTemplate).toBe(
+      "https://shop.example.com/orders/{{order_id}}",
+    );
+    expect(row?.inputSchema).toEqual({
+      order_id: { type: "string", required: true },
+    });
+  });
+
   test("re-import reuses same-name components (never overwrites) and warns", async () => {
     const exp = await exportAgent(srcCtx(), srcAgentId, appDb, {
       includeComponents: true,

--- a/tests/modules/mcp-write-agents.test.ts
+++ b/tests/modules/mcp-write-agents.test.ts
@@ -223,6 +223,52 @@ describe.skipIf(!dbUp)("MCP agent-builder tools (DB)", () => {
     expect(row?.credentialRef).toBe(`vault:${credId}`);
   });
 
+  test("tool_create dry-run previews the canonical shapes + warnings; apply stores them", async () => {
+    const p = principal({ tenantId: tenantA });
+    const shapes = {
+      name: "consultar_cnpj",
+      url_template: "https://api.example.com/v1/cnpj/{cnpj}?x={typo_token}",
+      allowed_hosts: ["api.example.com"],
+      method: "GET" as const,
+      input_schema: {
+        required: ["cnpj"],
+        properties: { cnpj: { type: "string" } },
+      },
+    };
+    const dry = await toolCreate(p, shapes, { base: appDb });
+    expect(dry.ok).toBe(true);
+    if (dry.ok) {
+      const data = dry.data as {
+        preview: { urlTemplate: string; inputSchema: Record<string, unknown> };
+        warnings?: string[];
+      };
+      expect(data.preview.urlTemplate).toBe(
+        "https://api.example.com/v1/cnpj/{{cnpj}}?x={typo_token}",
+      );
+      expect(data.preview.inputSchema).toEqual({
+        cnpj: { type: "string", required: true },
+      });
+      expect(data.warnings?.join(" ")).toContain("JSON Schema");
+      expect(data.warnings?.join(" ")).toContain("{typo_token}");
+    }
+
+    const applied = await toolCreate(
+      p,
+      { ...shapes, dry_run: false },
+      { base: appDb },
+    );
+    expect(applied.ok).toBe(true);
+    const row = await suDb.toolDefinition.findFirst({
+      where: { tenantId: tenantA, name: "consultar_cnpj" },
+    });
+    expect(row?.urlTemplate).toBe(
+      "https://api.example.com/v1/cnpj/{{cnpj}}?x={typo_token}",
+    );
+    expect(row?.inputSchema).toEqual({
+      cnpj: { type: "string", required: true },
+    });
+  });
+
   test("tool_create with unknown credential → needsCredential + console URL (no write)", async () => {
     const p = principal({ tenantId: tenantA });
     const r = await toolCreate(

--- a/tests/modules/pools.test.ts
+++ b/tests/modules/pools.test.ts
@@ -166,6 +166,41 @@ describe.skipIf(!dbUp)("tier-1 pools CRUD", () => {
     expect(await listToolDefinitions(ctx(tenant), appDb)).toHaveLength(0);
   });
 
+  test("tool definitions: programmatic authoring shapes are stored canonical", async () => {
+    // JSON-Schema input + OpenAPI-style single-brace path param (what an API/MCP author writes).
+    const td = await createToolDefinition(
+      ctx(tenant),
+      {
+        name: "consultar_cnpj",
+        label: "Consultar CNPJ",
+        urlTemplate: "https://api.example.com/v1/cnpj/{cnpj}",
+        allowedHosts: ["api.example.com"],
+        method: "GET",
+        inputSchema: {
+          required: ["cnpj"],
+          properties: { cnpj: { type: "string", description: "CNPJ digits" } },
+        },
+      },
+      appDb,
+    );
+    expect(td.inputSchema).toEqual({
+      cnpj: { type: "string", description: "CNPJ digits", required: true },
+    });
+    expect(td.urlTemplate).toBe("https://api.example.com/v1/cnpj/{{cnpj}}");
+
+    // A partial update normalizes against the row's existing field set.
+    const updated = await updateToolDefinition(
+      ctx(tenant),
+      BigInt(td.id),
+      { urlTemplate: "https://api.example.com/v2/cnpj/{cnpj}" },
+      appDb,
+    );
+    expect(updated.urlTemplate).toBe(
+      "https://api.example.com/v2/cnpj/{{cnpj}}",
+    );
+    await deleteToolDefinition(ctx(tenant), BigInt(td.id), appDb);
+  });
+
   test("vault: write-only secret, list names, references, delete", async () => {
     const { id: openaiId } = await createVaultEntry(
       ctx(tenant),

--- a/tests/modules/pools.test.ts
+++ b/tests/modules/pools.test.ts
@@ -167,7 +167,7 @@ describe.skipIf(!dbUp)("tier-1 pools CRUD", () => {
   });
 
   test("tool definitions: programmatic authoring shapes are stored canonical", async () => {
-    // JSON-Schema input + OpenAPI-style single-brace path param (what an API/MCP author writes).
+    // NOTE: JSON-Schema input + OpenAPI-style single-brace path param (what an API/MCP author writes).
     const td = await createToolDefinition(
       ctx(tenant),
       {
@@ -188,7 +188,7 @@ describe.skipIf(!dbUp)("tier-1 pools CRUD", () => {
     });
     expect(td.urlTemplate).toBe("https://api.example.com/v1/cnpj/{{cnpj}}");
 
-    // A partial update normalizes against the row's existing field set.
+    // NOTE: a partial update normalizes against the row's existing field set.
     const updated = await updateToolDefinition(
       ctx(tenant),
       BigInt(td.id),

--- a/tests/modules/tool-definitions-normalize.test.ts
+++ b/tests/modules/tool-definitions-normalize.test.ts
@@ -54,6 +54,34 @@ describe("isJsonSchemaShape", () => {
   });
 });
 
+describe("prototype-safe output maps", () => {
+  test('a field literally named "__proto__" survives conversion as an own key', () => {
+    // NOTE: JSON.parse creates "__proto__" as an OWN key; a plain out[name] assignment would
+    // invoke the inherited setter and silently drop it.
+    const raw = JSON.parse(
+      '{"properties":{"__proto__":{"type":"string"}},"required":["__proto__"]}',
+    );
+    const out = compactFromJsonSchema(raw);
+    expect(Object.hasOwn(out, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(out, "__proto__")?.value).toEqual({
+      type: "string",
+      required: true,
+    });
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+  });
+
+  test('a query param named "__proto__" survives normalization as an own key', () => {
+    const { shapes } = normalizeToolShapes({
+      query: JSON.parse('{"__proto__":"static-value"}'),
+    });
+    const query = shapes.query as Record<string, unknown>;
+    expect(Object.hasOwn(query, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(query, "__proto__")?.value).toBe(
+      "static-value",
+    );
+  });
+});
+
 describe("compactFromJsonSchema", () => {
   test("converts scalars, required flags and descriptions", () => {
     const out = compactFromJsonSchema({

--- a/tests/modules/tool-definitions-normalize.test.ts
+++ b/tests/modules/tool-definitions-normalize.test.ts
@@ -118,6 +118,31 @@ describe("compactFromJsonSchema", () => {
     expect(out.anyof).toEqual({ type: "object" });
     expect(out.untyped).toEqual({ type: "string" });
   });
+
+  test("lossy structural conversions warn; faithful ones stay silent", () => {
+    const warnings: string[] = [];
+    const out = compactFromJsonSchema(
+      {
+        properties: {
+          docs: { type: "array", items: { type: "object" } },
+          bare_list: { type: "array" },
+          nested: { type: "object", properties: { x: { type: "string" } } },
+          plain_obj: { type: "object" },
+          either: { anyOf: [{ type: "string" }, { type: "integer" }] },
+        },
+      },
+      warnings,
+    );
+    expect(out.docs).toEqual({ type: "array", itemType: "string" });
+    expect(out.plain_obj).toEqual({ type: "object" });
+    const joined = warnings.join("\n");
+    expect(joined).toContain('"docs"');
+    expect(joined).toContain('"nested"');
+    expect(joined).toContain('"either"');
+    // Faithful mappings never warn: a bare {type: "object"} and an untyped array.
+    expect(joined).not.toContain('"plain_obj"');
+    expect(joined).not.toContain('"bare_list"');
+  });
 });
 
 describe("normalizeToolShapes — single-brace placeholders", () => {

--- a/tests/modules/tool-definitions-normalize.test.ts
+++ b/tests/modules/tool-definitions-normalize.test.ts
@@ -42,8 +42,8 @@ describe("isJsonSchemaShape", () => {
   });
 
   test("pathological compact field literally named 'properties' stays compact", () => {
-    // {properties: {type: "object"}} — the value under `properties` is a FieldSpec whose values
-    // are strings, not a JSON Schema properties map of objects.
+    // NOTE: {properties: {type: "object"}} has a FieldSpec (string values) under `properties`,
+    // not a JSON Schema properties map of objects.
     expect(isJsonSchemaShape({ properties: { type: "object" } })).toBe(false);
   });
 
@@ -91,7 +91,7 @@ describe("compactFromJsonSchema", () => {
     expect(out.misto).toEqual({ type: "string" });
     expect(warnings).toHaveLength(4);
     expect(warnings[0]).toContain('"nivel"');
-    // The lossy-enum warnings surface through normalizeToolShapes alongside the conversion notice.
+    // NOTE: the lossy-enum warnings surface through normalizeToolShapes with the conversion notice.
     const { warnings: shapeWarnings } = normalizeToolShapes({
       inputSchema: { properties: { nivel: { enum: [1, 2] } } },
     });
@@ -139,7 +139,7 @@ describe("compactFromJsonSchema", () => {
     expect(joined).toContain('"docs"');
     expect(joined).toContain('"nested"');
     expect(joined).toContain('"either"');
-    // Faithful mappings never warn: a bare {type: "object"} and an untyped array.
+    // NOTE: faithful mappings never warn: a bare {type: "object"} and an untyped array.
     expect(joined).not.toContain('"plain_obj"');
     expect(joined).not.toContain('"bare_list"');
   });

--- a/tests/modules/tool-definitions-normalize.test.ts
+++ b/tests/modules/tool-definitions-normalize.test.ts
@@ -72,6 +72,33 @@ describe("compactFromJsonSchema", () => {
     });
   });
 
+  test("non-string enums degrade to the base scalar type (never a free string that rejects them)", () => {
+    const warnings: string[] = [];
+    const out = compactFromJsonSchema(
+      {
+        properties: {
+          nivel: { enum: [1, 2, 3] },
+          fator: { enum: [1.5, 2.5] },
+          ativo: { enum: [true, false] },
+          misto: { enum: ["a", 1] },
+        },
+      },
+      warnings,
+    );
+    expect(out.nivel).toEqual({ type: "integer" });
+    expect(out.fator).toEqual({ type: "number" });
+    expect(out.ativo).toEqual({ type: "boolean" });
+    expect(out.misto).toEqual({ type: "string" });
+    expect(warnings).toHaveLength(4);
+    expect(warnings[0]).toContain('"nivel"');
+    // The lossy-enum warnings surface through normalizeToolShapes alongside the conversion notice.
+    const { warnings: shapeWarnings } = normalizeToolShapes({
+      inputSchema: { properties: { nivel: { enum: [1, 2] } } },
+    });
+    expect(shapeWarnings.some((w) => w.includes("JSON Schema"))).toBe(true);
+    expect(shapeWarnings.some((w) => w.includes('"nivel"'))).toBe(true);
+  });
+
   test("converts enum, array-of-scalars and degrades nested shapes to object", () => {
     const out = compactFromJsonSchema({
       properties: {

--- a/tests/modules/tool-definitions-normalize.test.ts
+++ b/tests/modules/tool-definitions-normalize.test.ts
@@ -163,6 +163,15 @@ describe("compactFromJsonSchema", () => {
     );
     expect(out.docs).toEqual({ type: "array", itemType: "string" });
     expect(out.plain_obj).toEqual({ type: "object" });
+    // NOTE: allOf is a composition keyword like anyOf/oneOf; an allOf-only field must degrade to
+    // "object" with a warning, never to a silent "string".
+    const allOfWarnings: string[] = [];
+    const allOfOut = compactFromJsonSchema(
+      { properties: { combo: { allOf: [{ type: "string" }] } } },
+      allOfWarnings,
+    );
+    expect(allOfOut.combo).toEqual({ type: "object" });
+    expect(allOfWarnings.join("\n")).toContain('"combo"');
     const joined = warnings.join("\n");
     expect(joined).toContain('"docs"');
     expect(joined).toContain('"nested"');

--- a/tests/modules/tool-definitions-normalize.test.ts
+++ b/tests/modules/tool-definitions-normalize.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CONTEXT_VAR_NAMES,
+  compactFromJsonSchema,
+  isJsonSchemaShape,
+  normalizeInputSchemaShape,
+  normalizeToolShapes,
+} from "@/modules/tool-definitions/normalize";
+
+describe("isJsonSchemaShape", () => {
+  test("recognizes the standard {properties, required} shape", () => {
+    expect(
+      isJsonSchemaShape({
+        required: ["valor"],
+        properties: { valor: { type: "string" } },
+      }),
+    ).toBe(true);
+  });
+
+  test("recognizes {type: 'object', properties}", () => {
+    expect(
+      isJsonSchemaShape({
+        type: "object",
+        properties: { q: { type: "string" } },
+      }),
+    ).toBe(true);
+  });
+
+  test("recognizes a bare {properties} (keys all JSON Schema keywords)", () => {
+    expect(isJsonSchemaShape({ properties: { q: { type: "string" } } })).toBe(
+      true,
+    );
+  });
+
+  test("a compact map is NOT JSON Schema", () => {
+    expect(
+      isJsonSchemaShape({
+        valor: { type: "string", required: true },
+        q: { type: "string" },
+      }),
+    ).toBe(false);
+  });
+
+  test("pathological compact field literally named 'properties' stays compact", () => {
+    // {properties: {type: "object"}} — the value under `properties` is a FieldSpec whose values
+    // are strings, not a JSON Schema properties map of objects.
+    expect(isJsonSchemaShape({ properties: { type: "object" } })).toBe(false);
+  });
+
+  test("non-objects and empty are not JSON Schema", () => {
+    expect(isJsonSchemaShape(null)).toBe(false);
+    expect(isJsonSchemaShape("x")).toBe(false);
+    expect(isJsonSchemaShape({})).toBe(false);
+  });
+});
+
+describe("compactFromJsonSchema", () => {
+  test("converts scalars, required flags and descriptions", () => {
+    const out = compactFromJsonSchema({
+      type: "object",
+      required: ["a", "n"],
+      properties: {
+        a: { type: "string", description: "the a" },
+        n: { type: "integer" },
+        opt: { type: "boolean" },
+      },
+    });
+    expect(out).toEqual({
+      a: { type: "string", description: "the a", required: true },
+      n: { type: "integer", required: true },
+      opt: { type: "boolean" },
+    });
+  });
+
+  test("converts enum, array-of-scalars and degrades nested shapes to object", () => {
+    const out = compactFromJsonSchema({
+      properties: {
+        status: { enum: ["open", "closed"] },
+        ids: { type: "array", items: { type: "integer" } },
+        nested: { type: "object", properties: { x: { type: "string" } } },
+        anyof: { anyOf: [{ type: "string" }, { type: "integer" }] },
+        untyped: {},
+      },
+    });
+    expect(out.status).toEqual({
+      type: "enum",
+      enumValues: ["open", "closed"],
+    });
+    expect(out.ids).toEqual({ type: "array", itemType: "integer" });
+    expect(out.nested).toEqual({ type: "object" });
+    expect(out.anyof).toEqual({ type: "object" });
+    expect(out.untyped).toEqual({ type: "string" });
+  });
+});
+
+describe("normalizeToolShapes — single-brace placeholders", () => {
+  test("rewrites {field} to {{field}} only for declared fields, context vars and secret", () => {
+    const { shapes, warnings } = normalizeToolShapes({
+      urlTemplate: "https://api.example.com/v1/cnpj/{cnpj}?k={secret}",
+      inputSchema: { cnpj: { type: "string", required: true } },
+      query: { nome: "{nome}", conv: "{conversation_id}" },
+      headers: { "X-Nome": "{cnpj}" },
+      body: { mode: "raw", raw: '{"doc":"{cnpj}","lit":"{unknown_token}"}' },
+    });
+    expect(shapes.urlTemplate).toBe(
+      "https://api.example.com/v1/cnpj/{{cnpj}}?k={{secret}}",
+    );
+    expect(shapes.query).toEqual({
+      nome: "{nome}",
+      conv: "{{conversation_id}}",
+    });
+    expect(shapes.headers).toEqual({ "X-Nome": "{{cnpj}}" });
+    expect(shapes.body).toEqual({
+      mode: "raw",
+      raw: '{"doc":"{{cnpj}}","lit":"{unknown_token}"}',
+    });
+    expect(warnings.join(" ")).toContain("{nome}");
+    expect(warnings.join(" ")).toContain("{unknown_token}");
+  });
+
+  test("is idempotent: {{field}} and the ambiguous halves are untouched", () => {
+    const tpl = "https://x.example/a/{{id}}/b/{id}}/c/{{id}";
+    const once = normalizeToolShapes({
+      urlTemplate: tpl,
+      inputSchema: { id: { type: "string" } },
+    }).shapes.urlTemplate as string;
+    const twice = normalizeToolShapes({
+      urlTemplate: once,
+      inputSchema: { id: { type: "string" } },
+    }).shapes.urlTemplate as string;
+    expect(once).toBe("https://x.example/a/{{id}}/b/{id}}/c/{{id}");
+    expect(twice).toBe(once);
+  });
+
+  test("kv body row values are rewritten; non-string values pass through", () => {
+    const { shapes } = normalizeToolShapes({
+      inputSchema: { v: { type: "number" } },
+      body: {
+        mode: "kv",
+        rows: [
+          { key: "v", value: "{v}" },
+          { key: "n", value: 7 },
+        ],
+      },
+    });
+    expect(shapes.body).toEqual({
+      mode: "kv",
+      rows: [
+        { key: "v", value: "{{v}}" },
+        { key: "n", value: 7 },
+      ],
+    });
+  });
+
+  test("legacy fixed-field values inside the schema are rewritten too", () => {
+    const { shapes } = normalizeToolShapes({
+      inputSchema: {
+        amount: { type: "number", required: true },
+        conv: { source: "fixed", value: "{conversation_id}" },
+      },
+    });
+    expect(shapes.inputSchema).toEqual({
+      amount: { type: "number", required: true },
+      conv: { source: "fixed", value: "{{conversation_id}}" },
+    });
+  });
+
+  test("update patch: allowlist comes from the current row when the patch omits the schema", () => {
+    const { shapes } = normalizeToolShapes(
+      { urlTemplate: "https://x.example/{cnpj}" },
+      { inputSchema: { cnpj: { type: "string", required: true } } },
+    );
+    expect(shapes.urlTemplate).toBe("https://x.example/{{cnpj}}");
+    expect(shapes.inputSchema).toBeUndefined();
+  });
+
+  test("JSON Schema conversion feeds the allowlist in the same pass", () => {
+    const { shapes, warnings } = normalizeToolShapes({
+      urlTemplate: "https://x.example/anything/{valor}",
+      inputSchema: {
+        required: ["valor"],
+        properties: { valor: { type: "string" } },
+      },
+    });
+    expect(shapes.inputSchema).toEqual({
+      valor: { type: "string", required: true },
+    });
+    expect(shapes.urlTemplate).toBe("https://x.example/anything/{{valor}}");
+    expect(warnings.some((w) => w.includes("JSON Schema"))).toBe(true);
+  });
+
+  test("only patched keys are returned", () => {
+    const { shapes } = normalizeToolShapes({
+      urlTemplate: "https://x.example/y",
+    });
+    expect(Object.keys(shapes)).toEqual(["urlTemplate"]);
+  });
+});
+
+describe("normalizeInputSchemaShape / CONTEXT_VAR_NAMES", () => {
+  test("converts JSON Schema on read, passes compact through", () => {
+    expect(
+      normalizeInputSchemaShape({
+        properties: { q: { type: "string" } },
+        required: ["q"],
+      }),
+    ).toEqual({ q: { type: "string", required: true } });
+    const compact = { q: { type: "string" } };
+    expect(normalizeInputSchemaShape(compact)).toBe(compact);
+    expect(normalizeInputSchemaShape(null)).toEqual({});
+  });
+
+  test("context var list covers the runtime's interpolation names", () => {
+    for (const name of [
+      "conversation_id",
+      "message_id",
+      "contact_name",
+      "agent_name",
+    ]) {
+      expect(CONTEXT_VAR_NAMES as readonly string[]).toContain(name);
+    }
+  });
+});


### PR DESCRIPTION
## What

HTTP tools authored programmatically (REST v1 / MCP `tool_create`) with a JSON-Schema-shaped `inputSchema` or OpenAPI-style single-brace `{var}` placeholders silently never substituted arguments: the request went out with the literal placeholder (or an empty field), with no error at write time and none at invoke time. Details and root-cause analysis in #19.

## How

Principle: generous input, canonical storage, self-healing runtime, instructive failure.

- **New shared pure normalizer** `src/modules/tool-definitions/normalize.ts`:
  - structural detection of a JSON-Schema-shaped `inputSchema` (a compact map only ever has plain-object top-level values; requiring every `properties` value to be an object protects the pathological compact field literally named `properties`) and conversion to the compact field map (scalars, enum, array-of-scalars, required flags, descriptions; nested/anyOf degrade to `object`);
  - single-brace `{name}` rewritten to `{{name}}` **only** when the name matches a declared field, a context variable or `secret`; lookarounds keep existing `{{name}}` (and ambiguous halves) untouched, making the rewrite idempotent; unmatched tokens stay literal and are reported as probable typos.
- **Write edges canonicalize storage**: service `create`/`update` (partial updates normalize against the merged row so the allowlist sees the effective field set) and the agent-bundle import (which writes straight to the DB).
- **Runtime self-heals**: `buildHttpTool` normalizes the definition at build time, so rows authored before this fix start working on the next turn without re-creation.
- **Instructive failure**: a URL placeholder that resolves to nothing now returns an error to the model naming the missing field(s), instead of silently fetching a URL with an empty segment.
- **Contract documented**: REST v1 `inputSchema` description no longer claims "JSON Schema" (it contradicted the runtime); MCP `tool_create`/`tool_update` descriptions now state the compact map, the `{{var}}` syntax and the accepted conversions; MCP dry-run previews include normalization warnings.
- **Editor**: renders legacy rows through the canonical shape so their real AI fields show up.

## Tests

- `tests/graph/tools-http.test.ts`: red-first matrix reproducing the exact failure modes (literal `%7Bvalor%7D` path, literal query/header values, empty POST body, phantom `required`/`properties` args), plus regressions pinning that unmatched single-brace tokens stay literal and canonical `{{var}}` behavior is unchanged.
- `tests/modules/tool-definitions-normalize.test.ts` (new): unit coverage of detection (including the pathological `properties`-as-field case), conversion, idempotency, allowlist gating and warnings.
- Edge coverage: service canonical storage on create + partial update (`pools.test.ts`), MCP preview warnings + applied canonical row (`mcp-write-agents.test.ts`), import canonicalization (`agent-transfer.test.ts`).

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP tool definitions now normalize legacy placeholders and standard JSON Schema inputs.
  * Creation, updates, imports, editing, and requests consistently use canonical formats.
  * Dry runs and previews show normalized values and warnings.
* **Bug Fixes**
  * Missing input placeholders now return retryable errors instead of sending incomplete requests.
  * Unresolved secrets and context values produce configuration errors.
* **Documentation**
  * Expanded guidance for placeholders, context variables, input formats, and normalization.
* **Tests**
  * Added coverage for normalization, imports, updates, requests, and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->