### PR TITLE
fix(stt): transcreve áudio anexado após message_created

### DIFF
--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -307,26 +307,21 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-// A few Chatwoot transports persist the attachment immediately after creating the message. In that
-// shape, message_created arms the turn without media and message_updated is the first event that
-// carries the audio/image. Analyze that late attachment, but never let the update drive debounce or
-// a second turn. A write-back update is a no-op because it already carries the extracted content.
+// A few Chatwoot transports persist the attachment only after creating the message. In that shape,
+// message_created arms the turn without media and message_updated is the first event that carries
+// the audio (the fork re-fires the update after a late audio attach). Analyze that late audio, but
+// never let the update drive debounce or a second turn. The STT write-back update is a no-op because
+// it carries `transcribed_text` in the payload. AUDIO ONLY on purpose: the vision write-back is not
+// serialized into webhook payloads (the fork's Attachment#push_event_data exposes no
+// image_description/extracted_text on any file type), so a visual leg here could not tell "never
+// analyzed" from "our own write-back" and would re-run vision on its own write-back event forever.
 export function hasPendingInboundMediaUpdate(
   n: NormalizedChatwootEvent,
 ): boolean {
   if (n.event !== "message_updated" || !isIncomingMessage(n)) return false;
   const audio = firstAudioAttachment(n);
-  if (
-    audio &&
-    !audio.transcribedText &&
-    !n.message?.transcribedText
-  ) {
-    return true;
-  }
   return Boolean(
-    firstVisualAttachment(n) &&
-      !n.message?.imageDescription &&
-      !n.message?.extractedText,
+    audio && !audio.transcribedText && !n.message?.transcribedText,
   );
 }
 
@@ -337,20 +332,17 @@ async function isTestConversationActivated(params: {
   base: PrismaClient;
 }): Promise<boolean> {
   if (params.conversationId === null) return false;
-  const row = await runScopedOn(
-    params.base,
-    sysCtx(params.tenantId),
-    (db) =>
-      db.conversation.findUnique({
-        where: {
-          tenantId_chatwootInstanceId_chatwootConversationId: {
-            tenantId: params.tenantId,
-            chatwootInstanceId: params.instanceId,
-            chatwootConversationId: params.conversationId as number,
-          },
+  const row = await runScopedOn(params.base, sysCtx(params.tenantId), (db) =>
+    db.conversation.findUnique({
+      where: {
+        tenantId_chatwootInstanceId_chatwootConversationId: {
+          tenantId: params.tenantId,
+          chatwootInstanceId: params.instanceId,
+          chatwootConversationId: params.conversationId as number,
         },
-        select: { testActivatedAt: true },
-      }),
+      },
+      select: { testActivatedAt: true },
+    }),
   );
   return row?.testActivatedAt != null;
 }
@@ -1024,19 +1016,20 @@ export async function processChatwootDelivery(
   const n = params.normalized;
 
   // Only message_created drives commands, debounce and the agent turn. A message_updated can still
-  // carry an attachment that was absent at creation time; it is eligible for media analysis only.
+  // carry an audio attachment that was absent at creation time; it is eligible for STT only.
   const isNewIncoming = isNewIncomingMessage(n);
   const hasLateMedia = hasPendingInboundMediaUpdate(n);
 
   // Resolve the bound agent for a new message or a late-media update. The latter never drives a turn.
-  const rt = isNewIncoming || hasLateMedia
-    ? await inboxAgentRuntime(
-        params.tenantId,
-        params.instanceId,
-        n.inboxId,
-        base,
-      )
-    : null;
+  const rt =
+    isNewIncoming || hasLateMedia
+      ? await inboxAgentRuntime(
+          params.tenantId,
+          params.instanceId,
+          n.inboxId,
+          base,
+        )
+      : null;
   const command = isNewIncoming ? controlCommand(n) : null;
   const commandActive = command !== null && rt?.mode === "test";
 
@@ -1146,7 +1139,7 @@ export async function processChatwootDelivery(
     }
   }
 
-  // Production analyzes every new incoming message. Some transports attach media just after
+  // Production analyzes every new incoming message. Some transports attach the audio just after
   // message_created, so the first useful attachment arrives on message_updated; analyze that update
   // without arming debounce or a second turn. Test mode keeps its cost fence and only analyzes a late
   // attachment when this conversation was explicitly activated.

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -58,6 +58,7 @@ import {
   firstAudioAttachment,
   firstVisualAttachment,
   isHumanAgentMessage,
+  isIncomingMessage,
   isNewIncomingMessage,
   normalizeChatwootEvent,
   shouldBotHandle,
@@ -304,6 +305,54 @@ export interface ProcessChatwootParams {
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+// A few Chatwoot transports persist the attachment immediately after creating the message. In that
+// shape, message_created arms the turn without media and message_updated is the first event that
+// carries the audio/image. Analyze that late attachment, but never let the update drive debounce or
+// a second turn. A write-back update is a no-op because it already carries the extracted content.
+export function hasPendingInboundMediaUpdate(
+  n: NormalizedChatwootEvent,
+): boolean {
+  if (n.event !== "message_updated" || !isIncomingMessage(n)) return false;
+  const audio = firstAudioAttachment(n);
+  if (
+    audio &&
+    !audio.transcribedText &&
+    !n.message?.transcribedText
+  ) {
+    return true;
+  }
+  return Boolean(
+    firstVisualAttachment(n) &&
+      !n.message?.imageDescription &&
+      !n.message?.extractedText,
+  );
+}
+
+async function isTestConversationActivated(params: {
+  tenantId: bigint;
+  instanceId: bigint;
+  conversationId: number | null;
+  base: PrismaClient;
+}): Promise<boolean> {
+  if (params.conversationId === null) return false;
+  const row = await runScopedOn(
+    params.base,
+    sysCtx(params.tenantId),
+    (db) =>
+      db.conversation.findUnique({
+        where: {
+          tenantId_chatwootInstanceId_chatwootConversationId: {
+            tenantId: params.tenantId,
+            chatwootInstanceId: params.instanceId,
+            chatwootConversationId: params.conversationId as number,
+          },
+        },
+        select: { testActivatedAt: true },
+      }),
+  );
+  return row?.testActivatedAt != null;
 }
 
 // Eager media analysis: transcribe an incoming voice note (STT) and extract an incoming image/document
@@ -974,18 +1023,13 @@ export async function processChatwootDelivery(
 
   const n = params.normalized;
 
-  // ONLY a brand-new incoming message (message_created) drives anything below. A message_updated
-  // re-delivered to the bot — notably our own STT/vision write-back, which the fork re-dispatches
-  // (Message#dispatch_update_event) — must do nothing but mirror. Hoisted here because it gates the
-  // agent-runtime read, the command flag, and the eager-media decision.
+  // Only message_created drives commands, debounce and the agent turn. A message_updated can still
+  // carry an attachment that was absent at creation time; it is eligible for media analysis only.
   const isNewIncoming = isNewIncomingMessage(n);
+  const hasLateMedia = hasPendingInboundMediaUpdate(n);
 
-  // Resolve the bound agent's runtime knobs (enabled + mode) once on a new incoming message (cheap
-  // scoped read). It gates two things: (1) command activeness — control commands (/teste, /reset)
-  // only apply to a TEST-mode agent, otherwise they are ordinary customer text, and the mirror must
-  // NOT count an ACTIVE command as genuine engagement (no lastInboundAt advance / follow-up arm); and
-  // (2) eager media — STT/vision run on every incoming message only for an ENABLED + PRODUCTION agent.
-  const rt = isNewIncoming
+  // Resolve the bound agent for a new message or a late-media update. The latter never drives a turn.
+  const rt = isNewIncoming || hasLateMedia
     ? await inboxAgentRuntime(
         params.tenantId,
         params.instanceId,
@@ -1102,12 +1146,26 @@ export async function processChatwootDelivery(
     }
   }
 
-  // Eager media (STT/vision) for an ENABLED + PRODUCTION agent runs on EVERY new incoming message —
-  // even one the agent won't reply to (out of hours, a human is handling, a closed conversation) — so
-  // the content is captured for the agent's memory/ingestion. Test-mode agents analyze only
-  // on the answer path (below); a disabled/unbound inbox never analyzes (no STT/vision cost). The
-  // call is idempotent, so the answer-path call below is a no-op when this already ran. Best-effort.
-  if (isNewIncoming && rt?.enabled && rt.mode === "production") {
+  // Production analyzes every new incoming message. Some transports attach media just after
+  // message_created, so the first useful attachment arrives on message_updated; analyze that update
+  // without arming debounce or a second turn. Test mode keeps its cost fence and only analyzes a late
+  // attachment when this conversation was explicitly activated.
+  const activatedTestLateMedia =
+    hasLateMedia &&
+    rt?.enabled === true &&
+    rt.mode === "test" &&
+    act &&
+    (await isTestConversationActivated({
+      tenantId: params.tenantId,
+      instanceId: params.instanceId,
+      conversationId: n.conversationId,
+      base,
+    }));
+  if (
+    rt?.enabled &&
+    ((isNewIncoming && rt.mode === "production") ||
+      (hasLateMedia && (rt.mode === "production" || activatedTestLateMedia)))
+  ) {
     await runEagerMedia(params.tenantId, params.instanceId, n, base);
   }
 

--- a/tests/modules/chatwoot-webhook.test.ts
+++ b/tests/modules/chatwoot-webhook.test.ts
@@ -16,7 +16,10 @@ import {
 } from "@/modules/chatwoot/normalize";
 import { verifyChatwootSignature } from "@/modules/chatwoot/signing";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
-import { runEagerMedia } from "@/modules/chatwoot/webhook";
+import {
+  hasPendingInboundMediaUpdate,
+  runEagerMedia,
+} from "@/modules/chatwoot/webhook";
 
 const sign = (secret: string, ts: number, body: string) =>
   `sha256=${createHmac("sha256", secret).update(`${ts}.${body}`).digest("hex")}`;
@@ -328,6 +331,54 @@ describe("isNewIncomingMessage (voice-note infinite-loop guard)", () => {
       meta: {},
     });
     expect(conv && isNewIncomingMessage(conv)).toBe(false);
+  });
+});
+
+describe("hasPendingInboundMediaUpdate", () => {
+  const updatedAudio = (transcribedText?: string) =>
+    normalizeChatwootEvent({
+      event: "message_updated",
+      id: 1001,
+      content: "",
+      message_type: "incoming",
+      private: false,
+      attachments: [
+        {
+          id: 77,
+          file_type: "audio",
+          data_url: "https://chat.example.com/a.ogg",
+          ...(transcribedText === undefined
+            ? {}
+            : { transcribed_text: transcribedText }),
+        },
+      ],
+      conversation: {
+        id: 42,
+        inbox_id: 7,
+        status: "pending",
+        meta: { assignee_type: null, assignee: null },
+      },
+    });
+
+  test("accepts an incoming update when the attachment first appears without transcription", () => {
+    const event = updatedAudio();
+    expect(event && hasPendingInboundMediaUpdate(event)).toBe(true);
+  });
+
+  test("rejects the write-back update after transcription and never treats it as a new turn", () => {
+    const event = updatedAudio("áudio já transcrito");
+    expect(event && hasPendingInboundMediaUpdate(event)).toBe(false);
+    expect(event && isNewIncomingMessage(event)).toBe(false);
+  });
+
+  test("rejects outgoing and message_created events", () => {
+    const outgoing = updatedAudio();
+    if (outgoing?.message) outgoing.message.messageType = "outgoing";
+    expect(outgoing && hasPendingInboundMediaUpdate(outgoing)).toBe(false);
+
+    const created = updatedAudio();
+    if (created) created.event = "message_created";
+    expect(created && hasPendingInboundMediaUpdate(created)).toBe(false);
   });
 });
 

--- a/tests/modules/chatwoot-webhook.test.ts
+++ b/tests/modules/chatwoot-webhook.test.ts
@@ -380,6 +380,34 @@ describe("hasPendingInboundMediaUpdate", () => {
     if (created) created.event = "message_created";
     expect(created && hasPendingInboundMediaUpdate(created)).toBe(false);
   });
+
+  test("rejects a visual attachment update (audio-only guard)", () => {
+    // The fork's webhook payload never serializes image_description/extracted_text (only audio
+    // carries transcribed_text), so an image update is indistinguishable from our own vision
+    // write-back re-dispatch (AttachmentsController#update -> send_update_event). Accepting it
+    // would re-run vision on every write-back: a paid call per cycle, forever.
+    const event = normalizeChatwootEvent({
+      event: "message_updated",
+      id: 1002,
+      content: "",
+      message_type: "incoming",
+      private: false,
+      attachments: [
+        {
+          id: 88,
+          file_type: "image",
+          data_url: "https://chat.example.com/img.jpg",
+        },
+      ],
+      conversation: {
+        id: 42,
+        inbox_id: 7,
+        status: "pending",
+        meta: { assignee_type: null, assignee: null },
+      },
+    });
+    expect(event && hasPendingInboundMediaUpdate(event)).toBe(false);
+  });
 });
 
 describe("audio attachment normalization (STT idempotency seam)", () => {


### PR DESCRIPTION
## Problema

Alguns transportes do Chatwoot emitem `message_created` antes de persistir o anexo. O áudio aparece apenas em `message_updated`. Como somente o evento inicial passava pelo STT, o debounce encontrava o áudio sem transcrição e o agente pedia que o cliente enviasse texto.

## Correção

- reconhece `message_updated` de entrada com mídia ainda não processada;
- executa somente STT/visão nesse evento, sem armar debounce nem iniciar outro turno;
- ignora a atualização gerada pelo próprio write-back quando a transcrição já existe;
- preserva o fence de custo do modo de teste, exigindo conversa ativada;
- adiciona testes de regressão para anexo tardio, write-back e eventos não elegíveis.

## Evidência em produção

Na conversa observada, os anexos de áudio chegaram ao Chatwoot com `transcribed_text: null`, não houve estágio `stt` no flowlog e o agente respondeu com o fallback de solicitar texto. Mensagens de texto, geração e TTS permaneceram funcionais.