### PR TITLE
fix(chatwoot): retry no download do anexo e visibilidade da falha no …

### DIFF
--- a/docs/stt.md
+++ b/docs/stt.md
@@ -12,7 +12,7 @@ incoming message with an audio attachment (gate=act)
         │ yes
         ▼
    transcribeInboundAudio:
-     download data_url (client.downloadAttachment, anti-SSRF) →
+     download data_url (client.downloadAttachment, anti-SSRF, 404-retry) →
      provider.transcribe (key from vault) →
      cleanTranscription (drop Whisper's Amara.org silence hallucination) →
      client.updateAttachmentMeta { transcribed_text }   ← write-back (no body mirrored in OUR DB)
@@ -22,6 +22,8 @@ incoming message with an audio attachment (gate=act)
 ```
 
 STT runs **before** arming/answering so the debounce re-fetch (and the direct path) get text instead of an empty audio message. The transcription lives only in Chatwoot (attachment meta), never in our DB — consistent with the anti-PII no-body-mirror rule. Best-effort: any STT failure leaves the audio to render as a "please send text" marker and never strands the delivery.
+
+**The download races Chatwoot's own storage write.** `message_created` carries the attachment's `data_url` but is dispatched *before* ActiveStorage finishes writing the file, so the eager download (it fires ~70ms after the webhook) can hit the storage service ahead of the bytes and get a **404** — the voice note then goes untranscribed and the customer is asked to "send text" for an audio that is perfectly fine. `downloadAttachment` therefore takes `retryOnMissing`, retrying **404 only** on a bounded backoff (250/750/1500ms, ~3 extra seconds worst case, inside a typical debounce window); every other status still fails immediately. The eager STT/vision path opts in; the interactive media proxy (`getConversationMedia`) does **not**, because there a 404 means the file is genuinely gone and the operator must not wait out the backoff. A download failure now also emits its own `stt`/`vision` line (warn + `status: error`, `detail.step = "download"`): it sits outside the `withFlowStage` span, so before this it left **no** trace on the Logs page at all.
 
 ## Generic provider abstraction (`src/modules/stt/providers.ts`)
 

--- a/src/modules/chatwoot/client.ts
+++ b/src/modules/chatwoot/client.ts
@@ -25,6 +25,17 @@ const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 // slow/unreachable — fail fast so the caller can degrade gracefully (serve metadata + a retry).
 const INTERACTIVE_TIMEOUT_MS = 10_000;
 
+// NOTE: Chatwoot fires `message_created` (with the attachment's data_url already in the payload)
+// BEFORE ActiveStorage finishes writing the file, so an immediate GET on a fresh voice note loses the
+// race and the storage service answers 404. Measured on a disk-backed instance: the blob row is
+// committed ~400ms before the file lands, and the eager-media download fires ~70ms after the webhook.
+// These delays cover that window with headroom while staying well inside a typical debounce window.
+// Only 404 is retried (missing file); every other status is a real error and fails immediately.
+const ATTACHMENT_RETRY_DELAYS_MS = [250, 750, 1500];
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export class ChatwootApiError extends Error {
   readonly status: number;
   readonly endpoint: string;
@@ -47,6 +58,15 @@ export interface ChatwootClientConfig {
 export interface ChatwootClientDeps {
   fetchImpl?: typeof fetch;
   assertSafe?: (url: string) => Promise<URL>;
+}
+
+export interface AttachmentDownloadOptions {
+  // Opt-in bounded retry for the write race described on ATTACHMENT_RETRY_DELAYS_MS. The eager media
+  // path (STT/vision, right off the webhook) sets it; the interactive media proxy does NOT — there a
+  // 404 means the attachment is really gone and the operator must not wait out the backoff.
+  retryOnMissing?: boolean;
+  // Injectable for tests (no real waiting).
+  sleep?: (ms: number) => Promise<void>;
 }
 
 export type ChatwootMessageType = "outgoing" | "incoming";
@@ -620,8 +640,10 @@ export class ChatwootClient {
   // Storage-backend redirects (e.g. S3) are followed; a size cap bounds memory. NOTE: redirect
   // targets are not re-validated (TOCTOU) — the data_url comes from the HMAC-authenticated webhook
   // of the tenant's own Chatwoot, the same trust as every other call to this instance.
+  // `opts.retryOnMissing` retries a 404 on the backoff above (the file-not-written-yet race).
   async downloadAttachment(
     dataUrl: string,
+    opts: AttachmentDownloadOptions = {},
   ): Promise<{ bytes: ArrayBuffer; contentType: string | null }> {
     await assertSafeOutboundUrl(dataUrl);
     let sameHost = false;
@@ -630,20 +652,30 @@ export class ChatwootClient {
     } catch {
       throw new ChatwootApiError(400, "GET attachment");
     }
-    const res = await this.fetchImpl(dataUrl, {
-      method: "GET",
-      headers: sameHost
-        ? { [CHATWOOT_AUTH_HEADER]: this.config.adminToken }
-        : {},
-      redirect: "follow",
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    if (!res.ok) throw new ChatwootApiError(res.status, "GET attachment");
-    const bytes = await res.arrayBuffer();
-    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
-      throw new ChatwootApiError(413, "GET attachment");
+    const delays = opts.retryOnMissing ? ATTACHMENT_RETRY_DELAYS_MS : [];
+    const sleep = opts.sleep ?? realSleep;
+    for (let attempt = 0; ; attempt++) {
+      const res = await this.fetchImpl(dataUrl, {
+        method: "GET",
+        headers: sameHost
+          ? { [CHATWOOT_AUTH_HEADER]: this.config.adminToken }
+          : {},
+        redirect: "follow",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      if (res.ok) {
+        const bytes = await res.arrayBuffer();
+        if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+          throw new ChatwootApiError(413, "GET attachment");
+        }
+        return { bytes, contentType: res.headers.get("content-type") };
+      }
+      const delay = delays[attempt];
+      if (res.status !== 404 || delay === undefined) {
+        throw new ChatwootApiError(res.status, "GET attachment");
+      }
+      await sleep(delay);
     }
-    return { bytes, contentType: res.headers.get("content-type") };
   }
 
   // The account's display name (admin token). `GET /api/v1/accounts/:id` (the account-base root)

--- a/src/modules/stt/service.ts
+++ b/src/modules/stt/service.ts
@@ -130,9 +130,29 @@ export async function transcribeInboundAudio(
     base,
     makeClient: params.deps?.makeClient,
   });
-  const { bytes, contentType } = await client.downloadAttachment(
-    params.dataUrl,
-  );
+  // NOTE: the download sits OUTSIDE the withFlowStage span below, so a failure here used to leave NO
+  // `stt` line at all — the operator saw a turn that answered "não consegui ouvir" with nothing on the
+  // Logs page to explain it. Emit the stage line, then re-throw (the caller decides; see the contract
+  // above). `retryOnMissing` absorbs Chatwoot's write race on a fresh voice note.
+  let bytes: ArrayBuffer;
+  let contentType: string | null;
+  try {
+    ({ bytes, contentType } = await client.downloadAttachment(params.dataUrl, {
+      retryOnMissing: true,
+    }));
+  } catch (err) {
+    if (params.flow) {
+      emitFlowEvent(params.flow, {
+        stage: "stt",
+        level: "warn",
+        status: "error",
+        provider: cfg.provider,
+        detail: { step: "download" },
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+    throw err;
+  }
   const raw = await withFlowStage(
     params.flow,
     "stt",

--- a/src/modules/vision/service.ts
+++ b/src/modules/vision/service.ts
@@ -138,9 +138,27 @@ export async function extractInboundFile(
     base,
     makeClient: params.deps?.makeClient,
   });
-  const { bytes, contentType } = await client.downloadAttachment(
-    params.dataUrl,
-  );
+  // Mirrors STT: the download is outside the span below, so surface its failure as a `vision` line
+  // instead of letting it vanish, and absorb Chatwoot's write race on a freshly-posted attachment.
+  let bytes: ArrayBuffer;
+  let contentType: string | null;
+  try {
+    ({ bytes, contentType } = await client.downloadAttachment(params.dataUrl, {
+      retryOnMissing: true,
+    }));
+  } catch (err) {
+    if (params.flow) {
+      emitFlowEvent(params.flow, {
+        stage: "vision",
+        level: "warn",
+        status: "error",
+        provider: cfg.provider,
+        detail: { step: "download" },
+        errorMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+    throw err;
+  }
   const kind = visionKindForMime(contentType);
   if (!kind) return skip("unsupported_mime"); // unsupported mime → marker
   if (kind === "document" && !provider.supportsDocuments)

--- a/tests/modules/chatwoot-client.test.ts
+++ b/tests/modules/chatwoot-client.test.ts
@@ -290,6 +290,88 @@ describe("ChatwootClient", () => {
     expect(calls[0]?.url).toContain("/inboxes/8");
   });
 
+  // Chatwoot puts the attachment's data_url in the message_created payload BEFORE ActiveStorage has
+  // written the file, so the eager STT/vision download races it and gets a 404 on a fresh voice note.
+  // The retry is opt-in: the interactive media proxy must still fail fast on a genuinely missing file.
+  describe("downloadAttachment write race", () => {
+    // A public documentation IP (RFC 5737) keeps the real anti-SSRF guard happy without a DNS lookup —
+    // downloadAttachment always uses the real guard, never deps.assertSafe.
+    const HOST = "https://203.0.113.10";
+    const URL_ = `${HOST}/rails/active_storage/blobs/redirect/abc/audio.ogg`;
+
+    function downloadStub(statuses: number[]) {
+      const slept: number[] = [];
+      let calls = 0;
+      const fetchImpl = (async () => {
+        const status = statuses[calls++] ?? 200;
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          arrayBuffer: async () => new ArrayBuffer(3),
+          headers: { get: () => "audio/ogg" },
+        } as unknown as Response;
+      }) as unknown as typeof fetch;
+      return {
+        fetchImpl,
+        slept,
+        sleep: async (ms: number) => {
+          slept.push(ms);
+        },
+        count: () => calls,
+      };
+    }
+
+    const clientFor = (fetchImpl: typeof fetch) =>
+      createChatwootClient(
+        { ...baseConfig, baseUrl: HOST },
+        { fetchImpl, assertSafe: passthroughSafe },
+      );
+
+    test("retries a 404 on the backoff and returns the file once it lands", async () => {
+      const s = downloadStub([404, 404, 200]);
+      const client = await clientFor(s.fetchImpl);
+      const out = await client.downloadAttachment(URL_, {
+        retryOnMissing: true,
+        sleep: s.sleep,
+      });
+      expect(out.bytes.byteLength).toBe(3);
+      expect(out.contentType).toBe("audio/ogg");
+      expect(s.count()).toBe(3);
+      expect(s.slept).toEqual([250, 750]);
+    });
+
+    test("does not retry by default (interactive media proxy fails fast)", async () => {
+      const s = downloadStub([404, 200]);
+      const client = await clientFor(s.fetchImpl);
+      const err = await client.downloadAttachment(URL_).catch((e) => e);
+      expect(err).toBeInstanceOf(ChatwootApiError);
+      expect((err as ChatwootApiError).status).toBe(404);
+      expect(s.count()).toBe(1);
+    });
+
+    test("does not retry a non-404 even when opted in", async () => {
+      const s = downloadStub([403, 200]);
+      const client = await clientFor(s.fetchImpl);
+      const err = await client
+        .downloadAttachment(URL_, { retryOnMissing: true, sleep: s.sleep })
+        .catch((e) => e);
+      expect((err as ChatwootApiError).status).toBe(403);
+      expect(s.count()).toBe(1);
+      expect(s.slept).toEqual([]);
+    });
+
+    test("gives up after the bounded backoff", async () => {
+      const s = downloadStub([404, 404, 404, 404, 404]);
+      const client = await clientFor(s.fetchImpl);
+      const err = await client
+        .downloadAttachment(URL_, { retryOnMissing: true, sleep: s.sleep })
+        .catch((e) => e);
+      expect((err as ChatwootApiError).status).toBe(404);
+      expect(s.count()).toBe(4);
+      expect(s.slept).toEqual([250, 750, 1500]);
+    });
+  });
+
   test("throws ChatwootApiError (without body) on non-2xx", async () => {
     const { fetchImpl } = stub(403, { error: "nope" });
     const client = await createChatwootClient(baseConfig, {


### PR DESCRIPTION
…flowlog

O Chatwoot dispara o message_created com o data_url do anexo antes de o ActiveStorage terminar de gravar o arquivo, entao o download ansioso do STT/vision (que sai ~70ms depois do webhook) perde a corrida e recebe 404. Medido numa instancia com storage em disco: a linha do blob e commitada ~400ms antes de o arquivo aparecer. Resultado em producao: toda nota de voz ficava sem transcricao e o agente pedia "manda por texto" para um audio perfeitamente audivel.

downloadAttachment passa a aceitar retryOnMissing, que repete APENAS o 404 num backoff limitado (250/750/1500ms, ~3s no pior caso, dentro de uma janela de debounce tipica). Qualquer outro status continua falhando de imediato. O caminho ansioso opta por ele; o proxy de midia interativo nao, porque ali um 404 significa que o arquivo realmente sumiu e o operador nao pode esperar o backoff.

O download fica fora do span withFlowStage, entao uma falha dele nao deixava nenhuma linha no /logs: o operador via um turno respondendo "nao consegui ouvir" sem nada que explicasse. Agora emite a linha de stt/vision (warn + status error, detail.step = "download") antes de repropagar o erro.


Claude-Session: https://claude.ai/code/session_01PFPmYfvdJxt84mpjcorv3s