### PR TITLE
feat(integrations): URL do webhook volta a ser legível no modal de edição

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -20,12 +20,30 @@ Endpoint: `POST /api/v1/integrations/inbound/:routeToken` (`integrations.control
 
 Flow (`receiveInbound` → ack; `processInboundDelivery` → detached async):
 
-1. **Resolve tenant by route token.** The token is an opaque 256-bit value; only its SHA-256 hash is stored (`IntegrationInstance.routeTokenHash`, unique), so lookup is a constant-time B-tree probe (no linear scan / timing oracle) and a DB dump yields no usable token. The plaintext is returned **once** at creation (`createIntegrationInstance`) and never logged. Resolution is cross-tenant → `asSuperAdmin`.
+1. **Resolve tenant by route token.** The token is an opaque 256-bit value. Its SHA-256 hash is stored in `IntegrationInstance.routeTokenHash` (unique), so lookup is a constant-time B-tree probe — no linear scan, no timing oracle. Resolution is cross-tenant → `asSuperAdmin`. See "The webhook URL is re-readable" below for why the token itself is *also* stored, encrypted.
 2. **Verify auth AFTER resolving the tenant** (so the secret read is tenant-scoped). Strategies: `NONE` | `STATIC_HEADER` | `HMAC_SHA256` (secret from the vault by `inboundSecretRef`; header names overridable per instance via `config`, because providers dictate their own). Unknown token, disabled instance, and bad auth all return the **same uniform 401** (no oracle for which tokens are live).
 3. **Ack fast (<5s), process async.** A slow/non-2xx ack makes some providers (Chatwoot) auto-escalate `pending→open`. `receiveInbound` does the cheap work (resolve, auth, normalize, persist) and returns; the controller fires `processInboundDelivery` detached.
 4. **Normalize via the integration's pure mapper** (below). `{ ok: false, reason: "unhandled" }` (lifecycle noise we deliberately skip) → ignored, no persistence. `{ ok: false, reason: "invalid" }` (the payload SHOULD have matched and did not — schema drift) → `logger.warn` (catalogType/instance/zod issue paths only, never the body) + a durable `FAILED` delivery with `payload: { reason: "invalid", issues }` and a body-digest dedupeKey, same fail-closed mold as no-mapper; the response carries `outcome: "invalid"` so the provider's delivery log shows the distinction.
 5. **Persist an idempotent `InboundDelivery`** — unique `(tenantId, integrationInstanceId, dedupeKey)`. The stored `payload` is the mapper's **allowlisted** projection (PII-bearing; never the raw external JSON, never echoed in logs/audit). A duplicate returns the existing id.
 6. **Dispatch** (`processInboundDelivery`) under a status CAS (`PENDING→PROCESSING→PROCESSED`, re-entry is a no-op). `conversion` → correlate `externalId`→thread via `IntegrationExternalRef` then record `ConversionEvent` idempotently (`ON CONFLICT DO NOTHING`, so the surrounding tx stays alive); an uncorrelated/duplicate conversion is dropped with a log, never invented. `status_update`/`agent_nudge` are declared **seams** (Fases 3/4), no-op for now.
+
+### The webhook URL is re-readable (and rotatable)
+
+The operator pastes `…/api/v1/integrations/inbound/<routeToken>` into the provider's dashboard (Asaas). That is an **address**, not the authenticator — inbound calls are authenticated by `inboundAuthStrategy` + the vault secret — and an address you cannot look up again is a dead end: configure Asaas from another machine, or simply lose the tab, and the integration is unrecoverable.
+
+So the token is persisted **twice**, each copy serving a different reader:
+
+| Column | Form | Read by |
+| --- | --- | --- |
+| `routeTokenHash` | SHA-256 | the hot inbound path (`resolveInboundRouteByToken`), a unique-index probe |
+| `routeToken` | `encryptJson()` blob in a plain `String` column | the editor, via `GET /v1/integrations/instances/:id` |
+
+Consequences worth knowing:
+
+- **Only the single-instance read returns it.** `GET /instances` leaves `routeToken` null — that screen shows no URL, so shipping N tokens to the browser would be pure exposure. The list/update/delete DTOs never carry it either.
+- **Three states, never two.** The DTO carries `routeTokenStatus`: `present` (readable), `absent` (nothing stored — an instance older than this column, or an outbound-only entry), `unreadable` (a blob the key can no longer decrypt). A decrypt failure degrades instead of throwing — the one place that bends the "throw, don't fall back" rule of the [Encryption](../CLAUDE.md#encryption) section, deliberately: nothing downstream makes a security decision on this value, and throwing would 500 the edit modal of every integration. But it must not collapse into `absent` either, or the editor tells the operator "this predates the feature" when the real cause is the key. Both non-present states recover by rotating; the UI just names the right one. The `logger.warn` on failure is the ops signal.
+- **`GET /instances/:id` sets `Cache-Control: no-store`.** It is the only read that returns the decrypted token and nothing global sets the header (same treatment as `branding.controller.ts`).
+- **`POST /instances/:id/route-token` rotates.** It mints a new token, replaces both columns, and returns the plaintext. **The old URL stops resolving the moment it commits**, so the caller must tell the operator to update the provider — the editor does this with a danger-styled confirm. Rotation covers the two cases the stored copy cannot: a row created before the column existed (`routeToken` null — hash-only, plaintext gone for good) and a leaked URL. Outbound-only catalog entries (Calendar/Drive) have no inbound surface, so rotating one is a 400.
 
 ## Mappers (`src/modules/integrations/mappers.ts`)
 

--- a/openapi.json
+++ b/openapi.json
@@ -18807,7 +18807,7 @@
           "Integrations"
         ],
         "summary": "List integration instances",
-        "description": "Returns the tenant's configured integration instances; the routeToken is never returned after creation.",
+        "description": "Returns the tenant's configured integration instances. The routeToken is omitted here; read a single instance to get it.",
         "responses": {
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
@@ -18868,7 +18868,7 @@
           "Integrations"
         ],
         "summary": "Create integration instance",
-        "description": "Creates an integration instance and returns its id plus the opaque routeToken, which is shown only once and never returned again.",
+        "description": "Creates an integration instance and returns its id plus the opaque routeToken for the inbound webhook URL. The token stays readable afterwards via GET /instances/:id.",
         "requestBody": {
           "required": true,
           "content": {
@@ -19141,7 +19141,7 @@
           "Integrations"
         ],
         "summary": "Get integration instance",
-        "description": "Fetches a single integration instance by id; the routeToken is never returned after creation.",
+        "description": "Fetches a single integration instance by id, including its inbound routeToken (null when the entry has no inbound surface, or when the instance predates token storage — rotate to mint a readable one).",
         "parameters": [
           {
             "name": "id",
@@ -19249,7 +19249,7 @@
           "Integrations"
         ],
         "summary": "Update integration instance",
-        "description": "Updates fields of an integration instance by id; the routeToken is never returned after creation.",
+        "description": "Updates fields of an integration instance by id. The routeToken is not returned here; read the instance or rotate it.",
         "parameters": [
           {
             "name": "id",
@@ -19626,6 +19626,116 @@
           }
         },
         "operationId": "deleteV1IntegrationsInstancesById"
+      }
+    },
+    "/v1/integrations/instances/{id}/route-token": {
+      "post": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Rotate inbound route token",
+        "description": "Mints a new inbound webhook token for the instance and returns it. The previous URL stops working immediately, so the provider's dashboard must be updated.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Integration instance id (BigInt serialized as a string).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postV1IntegrationsInstancesByIdRoute-token"
       }
     },
     "/v1/knowledge/bases": {

--- a/prisma/migrations/20260804160000_integration_route_token_readable/migration.sql
+++ b/prisma/migrations/20260804160000_integration_route_token_readable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "integration_instances" ADD COLUMN     "route_token" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,9 @@
 //   * Secrets at rest are encryptJson() base64 blobs stored in plain String columns
 //     (never Json, never logged). VaultEntry.secret, ChatwootInstance.*Token, etc.
 //   * Opaque tokens (routeToken, quote access token) are stored as SHA-256 hashes for
-//     constant-time unique-index lookup; the plaintext is shown once at creation.
+//     constant-time unique-index lookup. The quote token is shown once at creation.
+//     IntegrationInstance.routeToken ALSO keeps an encryptJson() copy so the operator can
+//     re-read the inbound webhook URL in the editor (see the model for why).
 //   * `catalogType` is a String validated against the in-code integration registry, not a
 //     DB enum, so new integrations need no enum migration.
 
@@ -784,8 +786,14 @@ model McpServerConnection {
   @@map("mcp_server_connections")
 }
 
-// NOTE: routeToken is stored as a SHA-256 hash for constant-time unique-index lookup;
-// inbound auth secret lives in the vault by reference. See docs/integrations.md.
+// NOTE: routeTokenHash is the SHA-256 of the route token, for constant-time unique-index lookup on
+// the hot inbound path. `routeToken` is the SAME token as an encryptJson() blob, kept because the
+// operator pastes this URL into the provider's dashboard (Asaas) and legitimately needs to re-read
+// it later — a hash-only design forced a rotation (and a re-paste upstream) just to see it again.
+// It is an ADDRESS, not the authenticator: inbound calls are authenticated by inboundAuthStrategy +
+// the vault secret. Returned only by GET /instances/:id (never by the list), never logged.
+// NULL on rows created before this column existed → the editor offers a rotation instead.
+// The inbound auth secret itself lives in the vault by reference. See docs/integrations.md.
 model IntegrationInstance {
   id                  BigInt              @id @default(autoincrement())
   tenantId            BigInt              @map("tenant_id")
@@ -797,6 +805,7 @@ model IntegrationInstance {
   inboundAuthStrategy InboundAuthStrategy @default(NONE) @map("inbound_auth_strategy")
   inboundSecretRef    String?             @map("inbound_secret_ref")
   routeTokenHash      String?             @unique @map("route_token_hash")
+  routeToken          String?             @map("route_token")
   createdAt           DateTime            @default(now()) @map("created_at")
   updatedAt           DateTime            @updatedAt @map("updated_at")
 

--- a/src/api/v1/integrations-admin.controller.ts
+++ b/src/api/v1/integrations-admin.controller.ts
@@ -12,6 +12,7 @@ import {
   getIntegrationInstance,
   listCatalog,
   listIntegrationInstances,
+  rotateIntegrationRouteToken,
   updateIntegrationInstance,
 } from "@/modules/integrations/service";
 import { getToolpackToolViews } from "@/modules/integrations/toolpacks";
@@ -19,7 +20,8 @@ import { getToolpackToolViews } from "@/modules/integrations/toolpacks";
 // Integration-instance management (per-tenant). TENANT_ADMIN. Separate from the PUBLIC inbound
 // receptor controller (same /v1/integrations prefix, no path overlap: /catalog + /instances* here
 // vs /inbound/:routeToken there) so the high-volume webhook path stays free of the session lookup.
-// The opaque routeToken is returned ONCE on create and never again.
+// The opaque routeToken comes back on create and on the single-instance read (the editor shows the
+// webhook URL); POST /instances/:id/route-token mints a new one and invalidates the old.
 
 function ctxOrThrow(ctx: TenantContext | null): TenantContext {
   if (!ctx) throw new ForbiddenError();
@@ -118,25 +120,30 @@ export const integrationsAdminController = new Elysia({
       requireRole: "TENANT_ADMIN",
       detail: doc(
         "List integration instances",
-        "Returns the tenant's configured integration instances; the routeToken is never returned after creation.",
+        "Returns the tenant's configured integration instances. The routeToken is omitted here; read a single instance to get it.",
       ),
       response: errors(401, 403),
     },
   )
   .get(
     "/instances/:id",
-    async ({ tenantContext, params }) => ({
-      instance: instanceIdentity,
-      integration: await getIntegrationInstance(
-        ctxOrThrow(tenantContext),
-        BigInt(params.id),
-      ),
-    }),
+    async ({ tenantContext, params, set }) => {
+      // NOTE: no-store — this is the ONE read that returns the decrypted routeToken, and nothing
+      // global sets the header. Keeps the webhook URL out of the browser's disk cache.
+      set.headers["cache-control"] = "no-store";
+      return {
+        instance: instanceIdentity,
+        integration: await getIntegrationInstance(
+          ctxOrThrow(tenantContext),
+          BigInt(params.id),
+        ),
+      };
+    },
     {
       requireRole: "TENANT_ADMIN",
       detail: doc(
         "Get integration instance",
-        "Fetches a single integration instance by id; the routeToken is never returned after creation.",
+        "Fetches a single integration instance by id, including its inbound routeToken (null when the entry has no inbound surface, or when the instance predates token storage — rotate to mint a readable one).",
       ),
       params: t.Object({
         id: t.String({
@@ -167,7 +174,8 @@ export const integrationsAdminController = new Elysia({
       return {
         instance: instanceIdentity,
         id: String(created.id),
-        // Shown ONCE — paste into the upstream provider; it is never returned again.
+        // NOTE: Paste into the upstream provider. Also readable later via GET /instances/:id, so
+        // losing this response is no longer a dead end.
         routeToken: created.routeToken,
       };
     },
@@ -175,7 +183,7 @@ export const integrationsAdminController = new Elysia({
       requireRole: "TENANT_ADMIN",
       detail: doc(
         "Create integration instance",
-        "Creates an integration instance and returns its id plus the opaque routeToken, which is shown only once and never returned again.",
+        "Creates an integration instance and returns its id plus the opaque routeToken for the inbound webhook URL. The token stays readable afterwards via GET /instances/:id.",
       ),
       body: t.Object({
         catalogType: t.String({
@@ -234,7 +242,7 @@ export const integrationsAdminController = new Elysia({
       requireRole: "TENANT_ADMIN",
       detail: doc(
         "Update integration instance",
-        "Updates fields of an integration instance by id; the routeToken is never returned after creation.",
+        "Updates fields of an integration instance by id. The routeToken is not returned here; read the instance or rotate it.",
       ),
       params: t.Object({
         id: t.String({
@@ -273,6 +281,33 @@ export const integrationsAdminController = new Elysia({
               "New vault reference name for the inbound auth secret, or null to clear it.",
           }),
         ),
+      }),
+      response: errors(400, 401, 403, 404),
+    },
+  )
+  // NOTE: Rotation is a POST because it MUTATES: the old URL stops resolving the moment it commits.
+  // It exists for the two cases the stored token cannot cover — an instance created before the
+  // token was persisted (hash only), and a URL that leaked.
+  .post(
+    "/instances/:id/route-token",
+    async ({ tenantContext, params }) => ({
+      instance: instanceIdentity,
+      ...(await rotateIntegrationRouteToken(
+        ctxOrThrow(tenantContext),
+        BigInt(params.id),
+      )),
+    }),
+    {
+      requireRole: "TENANT_ADMIN",
+      detail: doc(
+        "Rotate inbound route token",
+        "Mints a new inbound webhook token for the instance and returns it. The previous URL stops working immediately, so the provider's dashboard must be updated.",
+      ),
+      params: t.Object({
+        id: t.String({
+          description:
+            "Integration instance id (BigInt serialized as a string).",
+        }),
       }),
       response: errors(400, 401, 403, 404),
     },

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1135,13 +1135,22 @@
     "saveError": "Could not save.",
     "sharedNotice": "This is a shared integration. Changes affect every agent that uses it.",
     "subtitle": "Activate ready-made integrations your agents can use.",
-    "tokenHint": "Copy this URL into the provider's webhook settings. It is shown only once.",
+    "tokenHint": "Copy this URL into the provider's webhook settings. You can read it again later by editing this integration.",
     "tokenTitle": "Inbound webhook URL",
     "toolsTitle": "What this integration can do",
     "type": "Integration",
     "webhook": {
       "explain": "When a charge is paid, Asaas calls this webhook and the agent is woken on the exact conversation that generated the charge. It then decides whether to message the customer (and may use its tools). You paste the webhook URL into the Asaas panel after saving.",
-      "title": "Payment webhook"
+      "rotate": "Generate new URL",
+      "rotateConfirm": "Generate",
+      "rotateError": "Could not generate.",
+      "rotateMessage": "The current URL stops working immediately. You must paste the new one into the provider's panel, or payment notifications stop arriving.",
+      "rotateTitle": "Generate a new URL",
+      "title": "Payment webhook",
+      "url": "Webhook URL",
+      "urlHint": "Paste this into the provider's panel.",
+      "urlMissing": "This integration was created before the URL could be shown again, so we no longer have it. Generate a new one and update it in the provider's panel.",
+      "urlUnreadable": "The stored URL can no longer be decrypted, which usually means the encryption key changed. Generate a new one and update it in the provider's panel."
     }
   },
   "invite": {

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1138,13 +1138,22 @@
     "saveError": "Não foi possível salvar.",
     "sharedNotice": "Esta é uma integração compartilhada. Alterações afetam todos os agentes que a usam.",
     "subtitle": "Ative integrações prontas que seus agentes podem usar.",
-    "tokenHint": "Copie esta URL para as configurações de webhook do provedor. Ela é exibida apenas uma vez.",
+    "tokenHint": "Copie esta URL para as configurações de webhook do provedor. Você pode consultá-la depois editando esta integração.",
     "tokenTitle": "URL do webhook de entrada",
     "toolsTitle": "O que esta integração faz",
     "type": "Integração",
     "webhook": {
       "explain": "Quando uma cobrança é paga, o Asaas chama este webhook e o agente é acordado exatamente na conversa que gerou a cobrança. Ele então decide se manda uma mensagem ao cliente (podendo usar as ferramentas). Você cola a URL do webhook no painel do Asaas depois de salvar.",
-      "title": "Webhook de pagamento"
+      "rotate": "Gerar nova URL",
+      "rotateConfirm": "Gerar",
+      "rotateError": "Não foi possível gerar.",
+      "rotateMessage": "A URL atual para de funcionar na hora. Você precisa colar a nova no painel do provedor, senão os avisos de pagamento deixam de chegar.",
+      "rotateTitle": "Gerar uma nova URL",
+      "title": "Webhook de pagamento",
+      "url": "URL do webhook",
+      "urlHint": "Cole esta URL no painel do provedor.",
+      "urlMissing": "Esta integração foi criada antes de a URL poder ser exibida de novo, então não temos mais como mostrá-la. Gere uma nova e atualize no painel do provedor.",
+      "urlUnreadable": "A URL guardada não pode mais ser decifrada, o que normalmente significa que a chave de criptografia mudou. Gere uma nova e atualize no painel do provedor."
     }
   },
   "invite": {

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -12,6 +12,8 @@ import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
+  ConfirmDialog,
+  type ConfirmPayload,
   CredentialPicker,
   FormField,
   Input,
@@ -535,6 +537,16 @@ export function IntegrationEditModal({
   };
   const { showToast } = useToast();
   const tokenModal = useModalController<{ url: string }>();
+  const rotateConfirm = useModalController<ConfirmPayload>();
+  // NOTE: The instance's inbound webhook token, read back on edit so the operator can copy the URL
+  // again. When it is null the STATUS says why: "absent" (nothing was ever stored — an instance
+  // older than this feature) vs "unreadable" (a blob the key can no longer decrypt). Both are fixed
+  // by rotating, but pointing at the wrong cause sends the operator hunting in the wrong place.
+  const [routeToken, setRouteToken] = useState<string | null>(null);
+  const [routeTokenStatus, setRouteTokenStatus] = useState<
+    "present" | "absent" | "unreadable"
+  >("absent");
+  const [rotating, setRotating] = useState(false);
   const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
   const [form, setForm] = useState<Form>(emptyForm());
   const [saving, setSaving] = useState(false);
@@ -667,6 +679,8 @@ export function IntegrationEditModal({
               setCatalog(list);
               return list;
             })();
+        setRouteToken(null);
+        setRouteTokenStatus("absent");
         if (!payloadId) {
           const first = catList[0];
           const ct = first?.catalogType ?? "";
@@ -703,6 +717,8 @@ export function IntegrationEditModal({
           inboundSecretRef: inst.inboundSecretRef ?? "",
         };
         setForm(next);
+        setRouteToken(inst.routeToken);
+        setRouteTokenStatus(inst.routeTokenStatus);
         formBaseline.current = JSON.stringify(next);
         syncSlotModes(next.config);
         // Pre-load the credential's calendars/folders so the picker reflects the saved selection.
@@ -800,6 +816,52 @@ export function IntegrationEditModal({
       void navigator.clipboard?.writeText(url);
       showToast(t("common.copied", "Copied"), "success");
     }
+  }
+
+  const inboundUrl = (token: string) =>
+    `${window.location.origin}/api/v1/integrations/inbound/${token}`;
+
+  function copyInboundUrl() {
+    if (!routeToken) return;
+    void navigator.clipboard?.writeText(inboundUrl(routeToken));
+    showToast(t("common.copied", "Copied"), "success");
+  }
+
+  // NOTE: Rotation is destructive from the provider's point of view — the old URL stops resolving
+  // the moment this commits, so the confirm spells that out instead of a generic "are you sure".
+  function askRotate() {
+    rotateConfirm.open({
+      title: t("integrations.webhook.rotateTitle", "Generate a new URL"),
+      message: t(
+        "integrations.webhook.rotateMessage",
+        "The current URL stops working immediately. You must paste the new one into the provider's panel, or payment notifications stop arriving.",
+      ),
+      danger: true,
+      confirmLabel: t("integrations.webhook.rotateConfirm", "Generate"),
+      onConfirm: async () => {
+        if (!editId) return;
+        setRotating(true);
+        try {
+          const { data, error } = await api.api.v1.integrations
+            .instances({ id: editId })
+            ["route-token"].post();
+          if (error || !data) throw error ?? new Error("no data");
+          setRouteToken(data.routeToken);
+          tokenModal.open({ url: inboundUrl(data.routeToken) });
+        } catch (e) {
+          showToast(
+            t("integrations.webhook.rotateError", "Could not generate."),
+            "error",
+          );
+          // NOTE: Rethrow — ConfirmDialog's contract is that a throwing onConfirm keeps the dialog
+          // open (the caller owns the toast). Swallowing it closes the dialog on failure, which
+          // reads as "done" for an action that did not happen.
+          throw e;
+        } finally {
+          setRotating(false);
+        }
+      },
+    });
   }
 
   const selectedCatalog = catalog.find(
@@ -1653,6 +1715,61 @@ export function IntegrationEditModal({
                     "When a charge is paid, Asaas calls this webhook and the agent is woken on the exact conversation that generated the charge. It then decides whether to message the customer (and may use its tools). You paste the webhook URL into the Asaas panel after saving.",
                   )}
                 </p>
+                {/* The URL only exists once the instance does, so it shows on edit, never create. */}
+                {editId && (
+                  <FormField
+                    label={t("integrations.webhook.url", "Webhook URL")}
+                    group
+                    description={
+                      routeToken
+                        ? t(
+                            "integrations.webhook.urlHint",
+                            "Paste this into the provider's panel.",
+                          )
+                        : routeTokenStatus === "unreadable"
+                          ? t(
+                              "integrations.webhook.urlUnreadable",
+                              "The stored URL can no longer be decrypted, which usually means the encryption key changed. Generate a new one and update it in the provider's panel.",
+                            )
+                          : t(
+                              "integrations.webhook.urlMissing",
+                              "This integration was created before the URL could be shown again, so we no longer have it. Generate a new one and update it in the provider's panel.",
+                            )
+                    }
+                  >
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      {routeToken && (
+                        <>
+                          <Input
+                            readOnly
+                            value={inboundUrl(routeToken)}
+                            onFocus={(e) => e.currentTarget.select()}
+                            aria-label={t(
+                              "integrations.webhook.url",
+                              "Webhook URL",
+                            )}
+                            className="font-mono text-xs"
+                          />
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={copyInboundUrl}
+                          >
+                            {t("common.copy", "Copy")}
+                          </Button>
+                        </>
+                      )}
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        loading={rotating}
+                        onClick={askRotate}
+                      >
+                        {t("integrations.webhook.rotate", "Generate new URL")}
+                      </Button>
+                    </div>
+                  </FormField>
+                )}
                 <SwitchField
                   checked={cfg.notifyOnPayment !== false}
                   onCheckedChange={(v) => setCfg({ notifyOnPayment: v })}
@@ -1726,7 +1843,7 @@ export function IntegrationEditModal({
           <p className="text-sm text-text-secondary">
             {t(
               "integrations.tokenHint",
-              "Copy this URL into the provider's webhook settings. It is shown only once.",
+              "Copy this URL into the provider's webhook settings. You can read it again later by editing this integration.",
             )}
           </p>
           <div className="flex items-center gap-2">
@@ -1740,6 +1857,8 @@ export function IntegrationEditModal({
           </div>
         </div>
       </Modal>
+
+      <ConfirmDialog modal={rotateConfirm} />
     </>
   );
 }

--- a/src/modules/integrations/service.ts
+++ b/src/modules/integrations/service.ts
@@ -3,6 +3,8 @@ import type {
   Prisma,
   PrismaClient,
 } from "@/../generated/prisma/client";
+import { decryptJson, encryptJson } from "@/api/lib/crypto";
+import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
@@ -13,9 +15,16 @@ import {
 import { CATALOG, getCatalogEntry } from "./catalog";
 import type { CatalogEntry } from "./types";
 
-// Integration instances: the per-tenant activation of a catalog entry. Creation mints the
-// opaque inbound route token (returned once); resolution maps an incoming token to the owning
-// tenant + instance via a constant-time hash lookup (cross-tenant, so asSuperAdmin).
+// Integration instances: the per-tenant activation of a catalog entry. Creation mints the opaque
+// inbound route token; resolution maps an incoming token to the owning tenant + instance via a
+// constant-time hash lookup (cross-tenant, so asSuperAdmin).
+//
+// NOTE: The token is persisted TWICE — `routeTokenHash` (SHA-256) is what the hot inbound path
+// probes, and `routeToken` is an encryptJson() copy that exists purely so the operator can re-read
+// the webhook URL in the editor. It is an ADDRESS, not the authenticator (inbound calls are
+// authenticated by inboundAuthStrategy + the vault secret), and it is returned only by the
+// single-instance read, never by the list. Rows created before that column exists decrypt to null,
+// and the editor offers rotateIntegrationRouteToken instead.
 
 export interface ResolvedInboundRoute {
   id: bigint;
@@ -60,9 +69,9 @@ export interface CreateIntegrationParams {
   enabled?: boolean;
 }
 
-// Returns the plaintext route token ONCE (never stored, never logged) for inbound-capable
-// integrations; outbound-only ones (Calendar/Drive) carry no token (routeTokenHash null, no
-// inbound auth). Callers surface the token to the operator who pastes it into the provider.
+// Returns the plaintext route token for inbound-capable integrations; outbound-only ones
+// (Calendar/Drive) carry no token (routeTokenHash null, no inbound auth). Callers surface it to the
+// operator who pastes it into the provider; it stays re-readable via getIntegrationInstance.
 export async function createIntegrationInstance(
   tenantId: bigint,
   params: CreateIntegrationParams,
@@ -91,6 +100,7 @@ export async function createIntegrationInstance(
             : "NONE",
           inboundSecretRef: minted ? (params.inboundSecretRef ?? null) : null,
           routeTokenHash: minted?.hash ?? null,
+          routeToken: minted ? encryptJson(minted.token) : null,
         },
         select: { id: true },
       }),
@@ -113,6 +123,12 @@ export interface IntegrationInstanceDto {
   credentialRef: string | null;
   inboundAuthStrategy: InboundAuthStrategy;
   inboundSecretRef: string | null;
+  // NOTE: The inbound webhook token, decrypted. Populated ONLY by getIntegrationInstance (the
+  // editor needs it to show the URL); the list leaves it null so N tokens are not sprayed to a
+  // screen that shows none of them. `routeTokenStatus` says WHY it is null when it is — see
+  // readRouteToken; the list always reports "absent" because it never reads the column.
+  routeToken: string | null;
+  routeTokenStatus: RouteTokenStatus;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -130,6 +146,28 @@ const INSTANCE_SELECT = {
   updatedAt: true,
 } as const;
 
+// NOTE: Why the three states are distinct. A blob that fails to decrypt does NOT throw here —
+// nothing downstream makes a security decision on this value (it is an address for the operator to
+// copy), and throwing would 500 the edit modal of every integration on the instance. But it must
+// not collapse into `absent` either: that would tell the operator "this predates the feature" when
+// the truth is "the key can no longer read it", which sends them looking in the wrong place. So the
+// failure keeps its own status, and the logger.warn stays as the ops signal. Both non-present
+// states resolve the same way — rotate — but the editor says which one it is.
+export type RouteTokenStatus = "present" | "absent" | "unreadable";
+
+function readRouteToken(blob: string | null | undefined): {
+  token: string | null;
+  status: RouteTokenStatus;
+} {
+  if (!blob) return { token: null, status: "absent" };
+  try {
+    return { token: decryptJson<string>(blob), status: "present" };
+  } catch {
+    logger.warn("integration route token failed to decrypt (rotation needed)");
+    return { token: null, status: "unreadable" };
+  }
+}
+
 function toInstanceDto(r: {
   id: bigint;
   catalogType: string;
@@ -139,6 +177,7 @@ function toInstanceDto(r: {
   credentialRef: string | null;
   inboundAuthStrategy: InboundAuthStrategy;
   inboundSecretRef: string | null;
+  routeToken?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }): IntegrationInstanceDto {
@@ -151,6 +190,10 @@ function toInstanceDto(r: {
     credentialRef: r.credentialRef,
     inboundAuthStrategy: r.inboundAuthStrategy,
     inboundSecretRef: r.inboundSecretRef,
+    ...(() => {
+      const { token, status } = readRouteToken(r.routeToken);
+      return { routeToken: token, routeTokenStatus: status };
+    })(),
     createdAt: r.createdAt,
     updatedAt: r.updatedAt,
   };
@@ -169,6 +212,8 @@ export async function listIntegrationInstances(
   return rows.map(toInstanceDto);
 }
 
+// NOTE: The only read that returns the decrypted routeToken — this is what backs the webhook URL
+// field in the editor. Keep it out of the list (see IntegrationInstanceDto.routeToken).
 export async function getIntegrationInstance(
   ctx: TenantContext,
   id: bigint,
@@ -177,7 +222,7 @@ export async function getIntegrationInstance(
   const row = await runScopedOn(base, ctx, (db) =>
     db.integrationInstance.findUnique({
       where: { id },
-      select: INSTANCE_SELECT,
+      select: { ...INSTANCE_SELECT, routeToken: true },
     }),
   );
   if (!row) {
@@ -239,6 +284,46 @@ export async function updateIntegrationInstance(
       select: INSTANCE_SELECT,
     });
     return toInstanceDto(row);
+  });
+}
+
+// NOTE: Mints a NEW inbound route token, invalidating the old URL the instant it commits. Two
+// reasons it exists: an instance created before `routeToken` was stored has no readable URL (only
+// the hash survives), and a leaked URL needs a way out. The caller must warn the operator that the
+// provider's dashboard has to be updated — nothing else can reach the old address afterwards.
+export async function rotateIntegrationRouteToken(
+  ctx: TenantContext,
+  id: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<{ routeToken: string }> {
+  return runScopedOn(base, ctx, async (db) => {
+    const current = await db.integrationInstance.findUnique({
+      where: { id },
+      select: { catalogType: true },
+    });
+    if (!current) {
+      throw new NotFoundError(
+        "integration instance not found",
+        "errors.integrationInstanceNotFound",
+      );
+    }
+    // Outbound-only entries (Calendar/Drive) have no inbound surface, so there is no URL to rotate.
+    if (!getCatalogEntry(current.catalogType)?.supportsInbound) {
+      throw new AppError(
+        `integration ${current.catalogType} has no inbound webhook`,
+        400,
+        "errors.integrationNoInboundWebhook",
+      );
+    }
+    const minted = generateRouteToken();
+    await db.integrationInstance.update({
+      where: { id },
+      data: {
+        routeTokenHash: minted.hash,
+        routeToken: encryptJson(minted.token),
+      },
+    });
+    return { routeToken: minted.token };
   });
 }
 

--- a/tests/modules/integration-route-token.test.ts
+++ b/tests/modules/integration-route-token.test.ts
@@ -1,0 +1,219 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { AppError, NotFoundError } from "@/lib/errors";
+import type { TenantContext } from "@/lib/tenancy";
+import {
+  createIntegrationInstance,
+  getIntegrationInstance,
+  listIntegrationInstances,
+  resolveInboundRouteByToken,
+  rotateIntegrationRouteToken,
+} from "@/modules/integrations/service";
+
+// NOTE: The inbound webhook URL is an ADDRESS the operator pastes into the provider's dashboard, so
+// it has to stay readable after creation. The token is therefore persisted twice — the SHA-256 hash
+// the hot inbound path probes, plus an encrypted copy for the editor — and rotation exists for the
+// two cases the stored copy cannot serve: a row created before the column existed, and a leak.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+const ctx = (): TenantContext => ({
+  tenantId,
+  userId: null,
+  role: "TENANT_ADMIN",
+});
+
+describe.skipIf(!dbUp)("integration route token", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "RT", slug: `rt-${process.pid}` },
+    });
+    tenantId = t.id;
+  });
+
+  afterAll(async () => {
+    if (dbUp && tenantId) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM integration_instances WHERE tenant_id = ${tenantId}`,
+      );
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await app?.$disconnect();
+    await su?.$disconnect();
+  });
+
+  test("the created token is readable again, and only on the single-instance read", async () => {
+    const created = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "ASAAS",
+        name: "asaas-read",
+      },
+      appDb,
+    );
+    expect(created.routeToken).toBeTruthy();
+
+    const one = await getIntegrationInstance(ctx(), created.id, appDb);
+    expect(one.routeToken).toBe(created.routeToken as string);
+    expect(one.routeTokenStatus).toBe("present");
+
+    // NOTE: The list backs a screen that shows no URL, so it must not ship N tokens to the browser.
+    const many = await listIntegrationInstances(ctx(), appDb);
+    const row = many.find((i) => i.id === String(created.id));
+    expect(row?.routeToken).toBeNull();
+  });
+
+  test("the stored copy is encrypted, never the plaintext", async () => {
+    const created = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "ASAAS",
+        name: "asaas-enc",
+      },
+      appDb,
+    );
+    const raw = await suDb.integrationInstance.findUniqueOrThrow({
+      where: { id: created.id },
+      select: { routeToken: true, routeTokenHash: true },
+    });
+    expect(raw.routeToken).not.toBe(created.routeToken);
+    expect(raw.routeToken).not.toContain(created.routeToken as string);
+    expect(raw.routeTokenHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("rotating mints a new token and kills the old address", async () => {
+    const created = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "ASAAS",
+        name: "asaas-rotate",
+      },
+      appDb,
+    );
+    const old = created.routeToken as string;
+    expect(await resolveInboundRouteByToken(old, suDb)).not.toBeNull();
+
+    const { routeToken: fresh } = await rotateIntegrationRouteToken(
+      ctx(),
+      created.id,
+      appDb,
+    );
+    expect(fresh).not.toBe(old);
+    // The provider must be updated: the previous URL stops resolving immediately.
+    expect(await resolveInboundRouteByToken(old, suDb)).toBeNull();
+    const resolved = await resolveInboundRouteByToken(fresh, suDb);
+    expect(resolved?.id).toBe(created.id);
+    // And the new one is readable, so the operator can copy it without the reveal modal.
+    expect(
+      (await getIntegrationInstance(ctx(), created.id, appDb)).routeToken,
+    ).toBe(fresh);
+  });
+
+  test("an instance predating the stored copy reads null and recovers by rotating", async () => {
+    const created = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "ASAAS",
+        name: "asaas-legacy",
+      },
+      appDb,
+    );
+    // NOTE: Exactly the shape of a row created before the column existed: the hash still resolves
+    // inbound calls, but nothing can recover the plaintext.
+    await suDb.integrationInstance.update({
+      where: { id: created.id },
+      data: { routeToken: null },
+    });
+    const legacy = await getIntegrationInstance(ctx(), created.id, appDb);
+    expect(legacy.routeToken).toBeNull();
+    expect(legacy.routeTokenStatus).toBe("absent");
+
+    const { routeToken } = await rotateIntegrationRouteToken(
+      ctx(),
+      created.id,
+      appDb,
+    );
+    expect(
+      (await getIntegrationInstance(ctx(), created.id, appDb)).routeToken,
+    ).toBe(routeToken);
+  });
+
+  test("a blob the key cannot read is 'unreadable', never confused with 'absent'", async () => {
+    const created = await createIntegrationInstance(
+      tenantId,
+      { catalogType: "ASAAS", name: "asaas-corrupt" },
+      appDb,
+    );
+    // NOTE: A blob that survives storage but fails authentication — what an ENCRYPTION_KEY rotation
+    // leaves behind. Collapsing this into "absent" would tell the operator the row predates the
+    // feature and send them hunting in the wrong place; both still recover by rotating.
+    await suDb.integrationInstance.update({
+      where: { id: created.id },
+      data: { routeToken: "bm90LWEtcmVhbC1ibG9i" },
+    });
+    const broken = await getIntegrationInstance(ctx(), created.id, appDb);
+    expect(broken.routeToken).toBeNull();
+    expect(broken.routeTokenStatus).toBe("unreadable");
+
+    // The read stays usable — a corrupt blob must not take the whole editor down with it.
+    expect(broken.name).toBe("asaas-corrupt");
+
+    const { routeToken } = await rotateIntegrationRouteToken(
+      ctx(),
+      created.id,
+      appDb,
+    );
+    const healed = await getIntegrationInstance(ctx(), created.id, appDb);
+    expect(healed.routeToken).toBe(routeToken);
+    expect(healed.routeTokenStatus).toBe("present");
+  });
+
+  test("an outbound-only integration has no URL and cannot be rotated", async () => {
+    const created = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "GOOGLE_CALENDAR",
+        name: "cal",
+      },
+      appDb,
+    );
+    expect(created.routeToken).toBeNull();
+    expect(
+      (await getIntegrationInstance(ctx(), created.id, appDb)).routeToken,
+    ).toBeNull();
+    await expect(
+      rotateIntegrationRouteToken(ctx(), created.id, appDb),
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  test("rotating an unknown instance is a 404, not a silent mint", async () => {
+    await expect(
+      rotateIntegrationRouteToken(ctx(), 999999999n, appDb),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});


### PR DESCRIPTION
## Problema

Depois de criar a integração, a URL do webhook nunca mais era exibida. A causa não era a UI: `generateRouteToken()` gera `randomBytes(32)`, persiste **só** o SHA-256 em `routeTokenHash` e descarta o texto puro. Quem fechasse a aba do modal de revelação, ou fosse configurar o Asaas de outra máquina, ficava sem recurso nenhum.

## Decisão

A URL é um **endereço**, não o autenticador: a chamada de entrada é autenticada por `inboundAuthStrategy` + o segredo do vault. Então o token passa a ser persistido duas vezes, cada cópia servindo um leitor diferente:

| Coluna | Forma | Lida por |
| --- | --- | --- |
| `routeTokenHash` | SHA-256 | o caminho quente de entrada (`resolveInboundRouteByToken`), sondagem em índice único |
| `routeToken` | blob `encryptJson()` em coluna `String` | o editor, via `GET /instances/:id` |

A **listagem continua sem devolver o token**: aquela tela não mostra URL nenhuma, então mandar N tokens para o navegador seria exposição pura. E o `GET /instances/:id`, que é a única leitura que devolve o texto puro, responde com `cache-control: no-store`.

## Rotação

`POST /instances/:id/route-token` cobre os dois casos que a cópia armazenada não serve: a instância criada **antes** desta coluna existir (só o hash sobreviveu, o texto puro é irrecuperável) e a URL vazada. A URL antiga para de resolver no instante do commit, então o confirm é estilizado como destrutivo e diz exatamente isso.

## Três estados, não dois

Um blob que não decifra é `unreadable`, nunca `absent`. Colapsar os dois diria ao operador "esta linha é anterior à feature" quando a verdade é "a chave não lê mais isto", e isso o manda procurar no lugar errado. Os dois se resolvem rotacionando, mas o editor diz qual é qual.

A falha de decifragem degrada para `null` em vez de lançar. É o único ponto onde dobro o "throw, don't fall back" do `CLAUDE.md`, e deliberadamente: nada a jusante decide segurança com esse valor, então depois de uma rotação de `ENCRYPTION_KEY` o resultado honesto é "não temos como mostrar, gere outra" — caminho que o editor já tem. Lançar derrubaria o modal de edição de todas as integrações da instância.

## Validação ao vivo

Contra a instância local, autenticado:

| Passo | Resultado |
| --- | --- |
| criar → `routeToken` | devolvido |
| reler `GET /instances/:id` | **mesmo** token |
| `GET /instances` | `routeToken: null` |
| `POST /inbound/<antiga>` | 200 |
| rotacionar | token diferente |
| `POST /inbound/<antiga>` | **401** |
| `POST /inbound/<nova>` | 200 |
| rotacionar outbound-only (Calendar) | **400** |

Mais 7 testes em `tests/modules/integration-route-token.test.ts`, incluindo a instância legada (`routeToken` NULL → lê `absent` → rotaciona → passa a ler) e o blob corrompido (`unreadable`, com o resto da leitura intacto).

Documentado em `docs/integrations.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
