### PR TITLE
fix(models): temperature volta a valer em gpt-5-chat (família não-reasoning)

### DIFF
--- a/src/graph/models.ts
+++ b/src/graph/models.ts
@@ -32,8 +32,11 @@ const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 // call — the agent's own turn, the guardrail pass and the TTS speech normalization all pin a
 // temperature and would 400 on every request. Drop the parameter for those models instead of clamping
 // it, and only for the OpenAI-shaped clients. Matches a bare id ("o4-mini", "gpt-5-mini") and a routed
-// one ("openai/o4-mini", OpenRouter); "gpt-4o" and "omni-…" deliberately do not match.
-const REASONING_MODEL_RE = /^(?:[\w.-]+\/)?(?:o\d+(?:-|$)|gpt-5)/i;
+// one ("openai/o4-mini", OpenRouter); "gpt-4o" and "omni-…" deliberately do not match. gpt-5-chat* is
+// exempted: it is the non-reasoning chat family and accepts `temperature` (same carve-out as
+// @langchain/openai's isReasoningModel), so dropping it there would silently discard the operator's
+// preference.
+const REASONING_MODEL_RE = /^(?:[\w.-]+\/)?(?:o\d+(?:-|$)|gpt-5(?!-chat))/i;
 
 function openaiTemperature(
   model: string,

--- a/tests/graph/model-temperature.test.ts
+++ b/tests/graph/model-temperature.test.ts
@@ -24,7 +24,23 @@ describe("createChatModel temperature on reasoning models", () => {
 
   test("dropped for the gpt-5 family", () => {
     expect(openai("gpt-5", 0.3).temperature).toBeUndefined();
+    expect(openai("gpt-5-mini", 0.3).temperature).toBeUndefined();
     expect(openai("gpt-5.4-mini", 0.7).temperature).toBeUndefined();
+  });
+
+  // NOTE: gpt-5-chat* is the non-reasoning chat family and accepts `temperature` (the
+  // @langchain/openai isReasoningModel predicate carries the same exemption); dropping it there
+  // silently discards the operator's preference instead of preventing a 400.
+  test("kept for gpt-5-chat (non-reasoning chat family)", () => {
+    expect(openai("gpt-5-chat-latest", 0.3).temperature).toBe(0.3);
+    expect(openai("gpt-5-chat", 0.7).temperature).toBe(0.7);
+    const routed = createChatModel({
+      provider: "openrouter",
+      model: "openai/gpt-5-chat",
+      apiKey: "test",
+      temperature: 0.3,
+    }) as ChatOpenAI;
+    expect(routed.temperature).toBe(0.3);
   });
 
   test("kept for models that accept it", () => {


### PR DESCRIPTION
## Problema

A queda de `temperature` para as famílias de raciocínio da OpenAI (#26) usa uma regex que também casa `gpt-5-chat*`. Essa é a família de chat sem raciocínio e aceita `temperature`; o efeito é silencioso: a preferência de temperature do operador simplesmente deixa de valer nesses modelos (o parâmetro nunca sai no request).

## Correção

Lookahead `(?!-chat)` na `REASONING_MODEL_RE`, cobrindo o id bare (`gpt-5-chat-latest`) e o roteado do OpenRouter (`openai/gpt-5-chat`). `gpt-5`, `gpt-5-mini`, `gpt-5.4-mini` e a o-series continuam com o drop.

Evidência de que `gpt-5-chat*` aceita o parâmetro:

- o `isReasoningModel` do `@langchain/openai` carrega exatamente essa isenção (`startsWith("gpt-5") && !startsWith("gpt-5-chat")`);
- o litellm teve o bug espelhado (guard de cliente tratando `gpt-5-chat-latest` como reasoning), reportado em BerriAI/litellm#13781.

## Testes

Red-first: o caso novo "kept for gpt-5-chat" falha no main (temperature vem `undefined` para `gpt-5-chat-latest`) e passa com o fix; regressão mantida para a família gpt-5 (`gpt-5`, `gpt-5-mini`, `gpt-5.4-mini`), a o-series e o id roteado do OpenRouter. Suíte completa, lint e typecheck verdes.

Fixes #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected temperature handling for GPT-5 chat models.
  * Preserved temperature settings for direct and routed GPT-5 chat configurations.
  * Continued applying reasoning-model behavior to GPT-5 mini models.

* **Tests**
  * Added coverage for GPT-5 mini and GPT-5 chat temperature handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->