### PR TITLE
fix(followups): sweep aceita conversa bot-owned (AgentBot) e o mirror preserva o assignee

### DIFF
--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -557,8 +557,8 @@ export async function runAgentNudge(
       return shouldBotHandle(
         {
           assigneeType: conv?.assigneeType ?? null,
-          status: conv?.status ?? null,
           assigneeId: conv?.assigneeId ?? null,
+          status: conv?.status ?? null,
         },
         { ourAgentBotId: cfg.agentBotId },
       );

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -149,9 +149,9 @@ export async function mirrorChatwootEvent(
             inboxId: inboxRowId,
             contactId,
             status: createdStatus,
-            assigneeId: n.assigneeId,
-            assigneeType: n.assigneeType,
-            assigneeName: n.assigneeName,
+            assigneeId: n.assigneeId ?? null,
+            assigneeType: n.assigneeType ?? null,
+            assigneeName: n.assigneeName ?? null,
             threadId,
             lastEventAt: createdLastEventAt,
             lastInboundAt: inboundAt,
@@ -172,7 +172,7 @@ export async function mirrorChatwootEvent(
           conversation_id: String(created.id),
           inbox_id: inboxRowId != null ? String(inboxRowId) : null,
           status: createdStatus,
-          assignee_type: n.assigneeType,
+          assignee_type: n.assigneeType ?? null,
         });
         return {
           conversationRowId: created.id,
@@ -181,8 +181,8 @@ export async function mirrorChatwootEvent(
           prevStatus: null,
           applied: true,
           status: createdStatus,
-          assigneeId: n.assigneeId,
-          assigneeType: n.assigneeType,
+          assigneeId: n.assigneeId ?? null,
+          assigneeType: n.assigneeType ?? null,
           lastEventAt: createdLastEventAt,
         };
       }
@@ -206,17 +206,17 @@ export async function mirrorChatwootEvent(
         (n.status === "pending" || n.status === "open");
       const appliedStatus = staleMessageReopen ? null : n.status;
       const nextStatus = appliedStatus ?? existing.status;
-      const nextAssignee = staleMessageReopen
-        ? {
-            assigneeId: existing.assigneeId,
-            assigneeType: existing.assigneeType,
-            assigneeName: existing.assigneeName,
-          }
-        : {
-            assigneeId: n.assigneeId,
-            assigneeType: n.assigneeType,
-            assigneeName: n.assigneeName,
-          };
+      // NOTE: The assignee trio travels together and applies only when BOTH hold: the payload
+      // actually spoke about the assignee (`meta` present — undefined means "said nothing", and a
+      // degraded event must NOT wipe a stored 'AgentBot'/'User', the intermittent self-wipe behind
+      // issue #27) AND the snapshot is not the frozen stale one fenced above.
+      const assigneeKnown = n.assigneeType !== undefined && !staleMessageReopen;
+      const nextAssigneeId = assigneeKnown
+        ? (n.assigneeId ?? null)
+        : existing.assigneeId;
+      const nextAssigneeType = assigneeKnown
+        ? (n.assigneeType ?? null)
+        : existing.assigneeType;
       await db.conversation.update({
         where: { id: existing.id },
         data: {
@@ -226,7 +226,13 @@ export async function mirrorChatwootEvent(
           ...(inboxRowId != null ? { inboxId: inboxRowId } : {}),
           ...(contactId != null ? { contactId } : {}),
           ...(appliedStatus != null ? { status: appliedStatus } : {}),
-          ...nextAssignee,
+          ...(assigneeKnown
+            ? {
+                assigneeId: n.assigneeId ?? null,
+                assigneeType: n.assigneeType ?? null,
+                assigneeName: n.assigneeName ?? null,
+              }
+            : {}),
           lastEventAt: updatedLastEventAt,
           ...(inboundAt != null ? { lastInboundAt: inboundAt } : {}),
           // NOTE: Attribute bags are ASSIGNED (the payload always ships the whole jsonb), but only
@@ -248,12 +254,13 @@ export async function mirrorChatwootEvent(
           inbox_id: inboxIdStr,
           status: nextStatus,
           previous_status: existing.status,
-          assignee_type: nextAssignee.assigneeType,
+          assignee_type: nextAssigneeType,
         });
       }
       // Handoff = the assignee transitions to a human (User). Detect the bot→human edge:
       // prior assignee type was not User and the new one is User. A stale frozen snapshot never
-      // fires it — its assignee was not applied above.
+      // fires it — its assignee was not applied above. (An undefined trio — degraded payload —
+      // never equals "User" either, so it can neither fire nor mask the edge.)
       if (
         !staleMessageReopen &&
         existing.assigneeType !== "User" &&
@@ -271,8 +278,9 @@ export async function mirrorChatwootEvent(
         prevStatus: existing.status,
         applied: true,
         status: nextStatus,
-        assigneeId: nextAssignee.assigneeId,
-        assigneeType: nextAssignee.assigneeType,
+        // EFFECTIVE values (what is stored after this update), not the payload's silence.
+        assigneeId: nextAssigneeId,
+        assigneeType: nextAssigneeType,
         lastEventAt: updatedLastEventAt,
       };
     });

--- a/src/modules/chatwoot/normalize.ts
+++ b/src/modules/chatwoot/normalize.ts
@@ -55,9 +55,11 @@ export function normalizeChatwootEvent(
         : null,
     inboxId: conv ? num(conv.inbox_id) : null,
     status: conv ? str(conv.status) : null,
-    assigneeType: meta ? str(meta.assignee_type) : null,
-    assigneeId: assignee ? num(assignee.id) : null,
-    assigneeName: assignee ? str(assignee.name) : null,
+    // NOTE: No meta ⇒ undefined ("said nothing", the mirror preserves); meta without an assignee ⇒
+    // explicit null (a real unassign). Mirrors the attrs() sentinel above.
+    assigneeType: meta ? str(meta.assignee_type) : undefined,
+    assigneeId: meta ? (assignee ? num(assignee.id) : null) : undefined,
+    assigneeName: meta ? (assignee ? str(assignee.name) : null) : undefined,
   };
 
   if (isMessage) {

--- a/src/modules/chatwoot/types.ts
+++ b/src/modules/chatwoot/types.ts
@@ -98,10 +98,14 @@ export interface NormalizedChatwootEvent {
   contactInboxId: number | null;
   inboxId: number | null;
   status: string | null;
-  assigneeType: string | null;
-  assigneeId: number | null;
-  // Display name of the assignee (meta.assignee.name) — only meaningful for a human (User) assignee.
-  assigneeName: string | null;
+  // NOTE: The assignee trio uses `undefined` as "this payload said nothing" (no `meta`), so the
+  // mirror keeps the stored values instead of wiping them — same convention as the attribute bags.
+  // An explicit `null` means meta WAS present with no assignee: a real unassign, and it clears.
+  assigneeType?: string | null;
+  assigneeId?: number | null;
+  // NOTE: Display name of the assignee (meta.assignee.name) — the human's name for a User
+  // assignee, the bot's name for an AgentBot one.
+  assigneeName?: string | null;
   message?: NormalizedChatwootMessage;
   changedAttributes?: unknown;
   // ── mirror metadata (best-effort; absent on payloads that do not carry it) ──

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -1056,11 +1056,17 @@ export async function processChatwootDelivery(
   }
 
   // Gate, then the agent runtime — all network OUTSIDE the transaction.
+  // NOTE: The payload wins when it spoke (explicit null = a real unassign); when it said nothing
+  // (no meta), fall back to the mirror's EFFECTIVE state — it preserves the stored trio now, so a
+  // degraded event on a human-owned conversation must not read as bot-owned.
+  const assigneeKnown = n.assigneeType !== undefined;
   const act = shouldBotHandle(
     {
-      assigneeType: n.assigneeType,
+      assigneeType: assigneeKnown
+        ? (n.assigneeType ?? null)
+        : mirror.assigneeType,
       status: n.status,
-      assigneeId: n.assigneeId,
+      assigneeId: assigneeKnown ? (n.assigneeId ?? null) : mirror.assigneeId,
     },
     { ourAgentBotId: params.agentBotId },
   );

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -102,7 +102,13 @@ async function sweepHandler(
       JOIN agents a ON a.id = i.agent_id
       WHERE c.tenant_id = ${tenantId}
         AND c.status = 'pending'
-        AND c.assignee_type IS NULL
+        -- NOTE: Bot-owned = anything but a human, mirroring shouldBotHandle: NULL (unassigned — Chatwoot
+        -- < 4.16.2, Dialogflow-style hooks) AND 'AgentBot' (the NORMAL state since Chatwoot 4.16.2
+        -- auto-assigns the connected bot at conversation creation). IS DISTINCT FROM because
+        -- NULL <> 'User' evaluates to NULL. A foreign bot's AgentBot is deliberately NOT filtered
+        -- here: the nudge's own ownership gate (assignee bot id vs ours) re-checks before invoking
+        -- the model, so a rare false positive costs one no-op job cycle.
+        AND c.assignee_type IS DISTINCT FROM 'User'
         AND c.inbox_id IS NOT NULL
         AND a.enabled = true
         AND (a.mode <> 'test' OR c.test_activated_at IS NOT NULL)

--- a/tests/modules/chatwoot-receiver.test.ts
+++ b/tests/modules/chatwoot-receiver.test.ts
@@ -6,7 +6,10 @@ import { decryptJson, encryptJson } from "@/api/lib/crypto";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { loadChatwootClient } from "@/modules/chatwoot/instance";
 import { mirrorChatwootEvent } from "@/modules/chatwoot/mirror";
-import { shouldBotHandle } from "@/modules/chatwoot/normalize";
+import {
+  normalizeChatwootEvent,
+  shouldBotHandle,
+} from "@/modules/chatwoot/normalize";
 import { ensureAgentBot } from "@/modules/chatwoot/provisioning";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import {
@@ -384,6 +387,77 @@ describe.skipIf(!dbUp)("chatwoot webhook receiver", () => {
       select: { lastHandledMessageId: true },
     });
     expect(conv.lastHandledMessageId).toBe(2001);
+  });
+
+  // NOTE: End-to-end pin of the degraded-payload fallback (issue #27's second bug): a signed
+  // message_created whose conversation snapshot carries NO meta must neither wipe the mirrored
+  // human assignee nor read as bot-owned — the gate falls back to the mirror's effective state,
+  // so the message takes the handled-skip path (watermark advances, no turn).
+  test("a signed event without meta keeps the human owner and the gate stays closed", async () => {
+    const deliver = async (body: string, uuid: string) => {
+      const r = await receiveChatwootWebhook({
+        routeToken,
+        rawBody: body,
+        getHeader: signedHeaders(body, NOW, uuid),
+        nowSeconds: NOW,
+        base: appDb,
+      });
+      expect(r.outcome).toBe("queued");
+      const proc = await processChatwootDelivery({
+        tenantId,
+        instanceId: r.instanceId as bigint,
+        deliveryRowId: r.deliveryRowId as bigint,
+        agentBotId: r.agentBotId ?? null,
+        normalized: r.normalized as NonNullable<typeof r.normalized>,
+        base: appDb,
+      });
+      expect(proc).toBe("processed");
+    };
+
+    // A human owns conversation 46 (meta present).
+    await deliver(
+      JSON.stringify({
+        event: "message_created",
+        id: 2100,
+        content: "quero falar com um atendente",
+        message_type: "incoming",
+        private: false,
+        conversation: {
+          id: 46,
+          inbox_id: 7,
+          status: "pending",
+          meta: { assignee_type: "User", assignee: { id: 5, name: "Rita" } },
+        },
+      }),
+      "uuid-degraded-1",
+    );
+
+    // Degraded snapshot: same conversation, NO meta at all.
+    await deliver(
+      JSON.stringify({
+        event: "message_created",
+        id: 2101,
+        content: "alô?",
+        message_type: "incoming",
+        private: false,
+        conversation: { id: 46, inbox_id: 7, status: "pending" },
+      }),
+      "uuid-degraded-2",
+    );
+
+    const conv = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: 46 },
+      select: {
+        assigneeType: true,
+        assigneeId: true,
+        lastHandledMessageId: true,
+      },
+    });
+    // Mirror guard: the stored human assignee survived the degraded event.
+    expect(conv.assigneeType).toBe("User");
+    expect(conv.assigneeId).toBe(5);
+    // Gate: read the mirror's effective state → !act → handled-skip advances the watermark.
+    expect(conv.lastHandledMessageId).toBe(2101);
   });
 });
 
@@ -924,6 +998,90 @@ describe.skipIf(!dbUp)("chatwoot mirror sync", () => {
     });
     expect(dated.customAttributes).toEqual({ plano: "pro" });
     expect(dated.customAttributesAt).not.toBeNull();
+  });
+
+  // NOTE: Same sentinel convention as the attribute bags right above: `undefined` = "this payload
+  // said nothing about the assignee" (no meta) and must preserve the stored trio; an explicit null
+  // = a real unassign carried by meta. Without the guard, any degraded event silently wipes an
+  // 'AgentBot'/'User' — which is what made issue #27 intermittent.
+  test("an event without meta preserves the stored assignee; meta with null assignee clears it", async () => {
+    await mirrorChatwootEvent(
+      tenantId,
+      instanceId,
+      ev({
+        conversationId: 560,
+        lastActivityAt: 9800,
+        assigneeType: "AgentBot",
+        assigneeId: 9,
+        assigneeName: "Bot",
+      }),
+      appDb,
+    );
+
+    // Degraded payload: the normalizer saw no meta, so the trio is undefined.
+    const degraded = await mirrorChatwootEvent(
+      tenantId,
+      instanceId,
+      ev({
+        conversationId: 560,
+        lastActivityAt: 9900,
+        assigneeType: undefined,
+        assigneeId: undefined,
+        assigneeName: undefined,
+      }),
+      appDb,
+    );
+    expect(degraded.applied).toBe(true);
+    let conv = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: 560 },
+    });
+    expect(conv.assigneeType).toBe("AgentBot");
+    expect(conv.assigneeId).toBe(9);
+    expect(conv.assigneeName).toBe("Bot");
+    // The mirror result reports the EFFECTIVE state (what is stored), not the payload's silence.
+    expect(degraded.assigneeType).toBe("AgentBot");
+    expect(degraded.assigneeId).toBe(9);
+
+    // Meta present with no assignee = a real unassign; it must still clear.
+    await mirrorChatwootEvent(
+      tenantId,
+      instanceId,
+      ev({
+        conversationId: 560,
+        lastActivityAt: 10000,
+        assigneeType: null,
+        assigneeId: null,
+        assigneeName: null,
+      }),
+      appDb,
+    );
+    conv = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: 560 },
+    });
+    expect(conv.assigneeType).toBeNull();
+    expect(conv.assigneeId).toBeNull();
+    expect(conv.assigneeName).toBeNull();
+  });
+
+  test("normalize: a payload without meta leaves the assignee trio undefined; meta without assignee yields null", () => {
+    const noMeta = normalizeChatwootEvent({
+      event: "conversation_updated",
+      id: 561,
+      status: "pending",
+    });
+    expect(noMeta?.assigneeType).toBeUndefined();
+    expect(noMeta?.assigneeId).toBeUndefined();
+    expect(noMeta?.assigneeName).toBeUndefined();
+
+    const unassigned = normalizeChatwootEvent({
+      event: "conversation_updated",
+      id: 561,
+      status: "pending",
+      meta: { assignee_type: null, assignee: null },
+    });
+    expect(unassigned?.assigneeType).toBeNull();
+    expect(unassigned?.assigneeId).toBeNull();
+    expect(unassigned?.assigneeName).toBeNull();
   });
 });
 

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -9,8 +9,10 @@ import type { ChatwootClient } from "@/modules/chatwoot/client";
 import {
   ensureAllTenantSweeps,
   followUpHandler,
+  registerFollowUpHandlers,
 } from "@/modules/followups/handlers";
 import type { ClaimedJob } from "@/modules/scheduler/service";
+import { getJobHandler } from "@/modules/scheduler/worker";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
@@ -48,17 +50,19 @@ function fakeModel() {
   return new FakeListChatModel({ responses: [REPLY] });
 }
 
-function stubClient() {
+function stubClient(over: { liveMeta?: Record<string, unknown> } = {}) {
   const sent: Array<[number, string]> = [];
   const notes: Array<[number, string]> = [];
   const labelSets: string[][] = [];
   const resolved: number[] = [];
   let currentLabels: string[] = [];
   const client = {
+    // NOTE: `liveMeta` lets a test make the LIVE state (the requireLiveBotOwnership probe) agree
+    // with the mirrored assignee it seeded — the default `{}` reads as unassigned.
     getConversation: async (c: number) => ({
       id: c,
       status: "pending",
-      meta: {},
+      meta: over.liveMeta ?? {},
     }),
     sendMessage: async (c: number, t: string) => {
       sent.push([c, t]);
@@ -134,6 +138,7 @@ async function seedConversation(
     lastFollowUpAt?: Date | null;
     status?: string;
     assigneeType?: string | null;
+    assigneeId?: number | null;
   } = {},
 ) {
   // Two minutes ago so the inactivity threshold (1min delay agent) is exceeded.
@@ -153,6 +158,7 @@ async function seedConversation(
       chatwootConversationId: convId,
       status: over.status ?? "pending",
       assigneeType: over.assigneeType ?? null,
+      assigneeId: over.assigneeId ?? null,
       threadId: threadOf(convId),
       lastEventAt,
       lastInboundAt:
@@ -172,6 +178,7 @@ async function seedConversation(
         over.lastFollowUpAt !== undefined ? over.lastFollowUpAt : null,
       status: over.status ?? "pending",
       assigneeType: over.assigneeType ?? null,
+      assigneeId: over.assigneeId ?? null,
     },
   });
 }
@@ -647,5 +654,104 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     // The agent opted out of pausing, so the follow-up fires normally.
     expect(result).toEqual({ outcome: "done" });
     expect(s.sent.length).toBeGreaterThan(0);
+  });
+
+  // NOTE: Chatwoot ≥ 4.16.2 auto-assigns the connected Agent Bot at conversation creation, so
+  // `assignee_type = 'AgentBot'` is the NORMAL bot-owned state — the sweep must treat it exactly
+  // like unassigned (shouldBotHandle's `!== 'User'`), or follow-up never fires in ordinary
+  // operation (issue #27).
+  test("(o) sweep enqueues for a bot-owned conversation (AgentBot) and skips a human-owned one", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        settings: {
+          followUp: {
+            enabled: true,
+            steps: [{ delayValue: 1, delayUnit: "minutes", instructions: "" }],
+          },
+        },
+      },
+    });
+    await seedConversation(1020, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await seedConversation(1021, {
+      assigneeType: "User",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    expect(sweep).toBeDefined();
+    await sweep?.(
+      {
+        id: 999n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+      },
+      appDb,
+    );
+    const botJob = await suDb.schedulerJob.findFirst({
+      where: {
+        tenantId,
+        kind: "FOLLOWUP",
+        dedupeKey: `followup:${threadOf(1020)}`,
+      },
+    });
+    const humanJob = await suDb.schedulerJob.findFirst({
+      where: {
+        tenantId,
+        kind: "FOLLOWUP",
+        dedupeKey: `followup:${threadOf(1021)}`,
+      },
+    });
+    expect(botJob).not.toBeNull();
+    expect(humanJob).toBeNull();
+  });
+
+  // NOTE: The permissive sweep makes a conversation owned by a DIFFERENT Agent Bot reachable, so
+  // the nudge's ownership gate must exclude it by id — our bot messages only its own conversations.
+  test("(p) a conversation owned by a FOREIGN Agent Bot is never messaged; our own is", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    // NOTE: Our bot is chatwootAgentBotId 5 (beforeAll); 777 is another bot on the same account.
+    await seedConversation(1030, {
+      assigneeType: "AgentBot",
+      assigneeId: 777,
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    const foreign = stubClient({
+      liveMeta: { assignee_type: "AgentBot", assignee: { id: 777 } },
+    });
+    await followUpHandler(jobFor(1030), appDb, {
+      makeModel: fakeModel,
+      makeClient: foreign.makeClient,
+      checkpointer: new MemorySaver(),
+      persistUsage: async () => {},
+    });
+    expect(foreign.sent).toEqual([]);
+
+    await seedConversation(1031, {
+      assigneeType: "AgentBot",
+      assigneeId: 5,
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    const ours = stubClient({
+      liveMeta: { assignee_type: "AgentBot", assignee: { id: 5 } },
+    });
+    await followUpHandler(jobFor(1031), appDb, {
+      makeModel: fakeModel,
+      makeClient: ours.makeClient,
+      checkpointer: new MemorySaver(),
+      persistUsage: async () => {},
+    });
+    expect(ours.sent).toEqual([[1031, REPLY]]);
   });
 });


### PR DESCRIPTION
## Problem

The follow-up sweep's eligibility SQL requires `c.assignee_type IS NULL`. That is the ONLY gate in the codebase with that shape — every other attribution check goes through `shouldBotHandle` (`status === 'pending' && assigneeType !== 'User'`, with a foreign-bot exclusion), including the `followUpHandler` that runs right after the sweep and the operator-facing follow-up estimate (which therefore promises a countdown the sweep never delivers).

The version cut that turned this into "follow-up never fires in normal operation": upstream Chatwoot `56e72eff8d` ("feat: assign connected agent bot owner", v4.16.2, 2026-07) makes every new conversation on an inbox with an active Agent Bot be born `pending` **with `assignee_agent_bot` set** — so `meta.assignee_type = "AgentBot"` is now the NORMAL bot-owned state, on any channel and any edition. `NULL` remains legitimate (Chatwoot < 4.16.2, Dialogflow-style hooks, post-handoff unassign), so both must be eligible.

## An aggravating second bug

The mirror wrote the assignee trio (`assigneeId`/`assigneeType`/`assigneeName`) UNCONDITIONALLY on every update, while every neighboring field is written only when the payload carried it. A degraded event (no `meta`) therefore silently wiped a stored `AgentBot`/`User` back to `NULL` — which made the sweep bug intermittent (a conversation became "eligible" only if a degraded event happened to land first) and poisons the handoff analytics and the console listing.

## Fix

- Sweep: `AND c.assignee_type IS DISTINCT FROM 'User'` (`IS DISTINCT FROM` because `NULL <> 'User'` evaluates to `NULL`), mirroring `shouldBotHandle`. A foreign bot's `AgentBot` is deliberately not filtered in SQL: the nudge's own ownership gate re-checks the assignee bot id before invoking the model, so a rare false positive costs one no-op job cycle.
- Mirror: the normalizer now distinguishes "the payload said nothing" (`undefined`, no `meta` — same sentinel convention the attribute bags already use) from "meta present with no assignee" (`null`, a real unassign). The mirror writes the trio only when it is known, and its result reports the EFFECTIVE stored values. The webhook gate keeps its exact prior semantics via `?? null`.

## Tests

Red-first, in the reported modes: (1) two identically-eligible conversations, one `assignee_type = 'AgentBot'` and one `'User'` → running the `FOLLOWUP_SWEEP` handler enqueues only the bot-owned one (red on main: neither is enqueued); (2) a mirrored `AgentBot` conversation hit by an event without `meta` keeps its assignee, and the mirror result reports the stored value (red on main: wiped to `NULL`); an event WITH `meta` and no assignee still clears it, and a `User` assignee still records the handoff edge; (3) the normalizer's sentinel (`undefined` without `meta`, explicit `null` with it).

Fixes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing assignee information when events omit assignee metadata.
  * Correctly cleared assignee details for explicit unassignments.
  * Improved status updates to reflect the effective assignee.
  * Follow-up processing now includes unassigned and bot-assigned conversations while excluding human-assigned conversations.
  * Prevented messaging when a conversation is assigned to another bot.

* **Tests**
  * Added coverage for assignee handling, follow-ups, and bot ownership checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->