### PR TITLE
fix(followups): supressão por agendamento enxerga o compromisso após o último lembrete

### DIFF
--- a/src/modules/appointments/context.ts
+++ b/src/modules/appointments/context.ts
@@ -46,6 +46,26 @@ function cleanText(v: unknown, max: number): string | null {
   return s || null;
 }
 
+// NOTE: One shared time-zone rule for startISO values WITHOUT an offset, mirrored by the follow-up
+// sweep's SQL normalization (followups/handlers.ts): all-day dates and offset-less datetimes are
+// pinned to UTC. Date.parse already reads a bare date as UTC midnight but reads an offset-less
+// DATETIME in the host zone — while Postgres would use the session TimeZone — so without the pin the
+// two liveness decisions could diverge when app and DB zones differ. startISO can carry an
+// offset-less datetime only via the model-input fallback in the Calendar toolpack (Google always
+// returns an offset); UTC is arbitrary there, but agreement matters more than the boundary instant.
+export function parseStartMs(startISO: string): number {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(startISO)) {
+    return Date.parse(`${startISO}T00:00:00Z`);
+  }
+  if (
+    /[Tt ]\d{2}:/.test(startISO) &&
+    !/(?:[Zz]|[+-]\d{2}:?\d{2})$/.test(startISO)
+  ) {
+    return Date.parse(`${startISO}Z`);
+  }
+  return Date.parse(startISO);
+}
+
 // Pure: scheduler rows → the LIVE appointments of a conversation. A row counts toward an event when
 // it is not tombstoned; an event is live when some row is still queued (PENDING/CLAIMED — the
 // reminder turn itself runs on a CLAIMED row) or when its start is still ahead of `now`. The freshest
@@ -82,7 +102,7 @@ export function projectAppointmentEvents(
       typeof winner.payload.startISO === "string"
         ? winner.payload.startISO
         : "";
-    const startMs = Date.parse(startISO);
+    const startMs = parseStartMs(startISO);
     const queued = group.rows.some(
       ({ row }) => row.status === "PENDING" || row.status === "CLAIMED",
     );

--- a/src/modules/appointments/context.ts
+++ b/src/modules/appointments/context.ts
@@ -46,6 +46,21 @@ function cleanText(v: unknown, max: number): string | null {
   return s || null;
 }
 
+// NOTE: Date.parse rolls impossible calendar dates over ("2026-02-30" parses as March 2) while the
+// SQL mirror's pg_input_is_valid REJECTS them — without this guard an impossible startISO would look
+// upcoming to the JS re-check but never to the sweep. Reject the roll-over up front: NaN, like garbage.
+function hasImpossibleDateParts(startISO: string): boolean {
+  const m = /^(\d{4})-(\d{2})-(\d{2})(?:[Tt ]|$)/.exec(startISO);
+  if (!m) return false;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const roundTrip = new Date(Date.UTC(y, mo - 1, d));
+  return (
+    roundTrip.getUTCFullYear() !== y ||
+    roundTrip.getUTCMonth() !== mo - 1 ||
+    roundTrip.getUTCDate() !== d
+  );
+}
+
 // NOTE: One shared time-zone rule for startISO values WITHOUT an offset, mirrored by the follow-up
 // sweep's SQL normalization (followups/handlers.ts): all-day dates and offset-less datetimes are
 // pinned to UTC. Date.parse already reads a bare date as UTC midnight but reads an offset-less
@@ -54,6 +69,7 @@ function cleanText(v: unknown, max: number): string | null {
 // offset-less datetime only via the model-input fallback in the Calendar toolpack (Google always
 // returns an offset); UTC is arbitrary there, but agreement matters more than the boundary instant.
 export function parseStartMs(startISO: string): number {
+  if (hasImpossibleDateParts(startISO)) return Number.NaN;
   if (/^\d{4}-\d{2}-\d{2}$/.test(startISO)) {
     return Date.parse(`${startISO}T00:00:00Z`);
   }

--- a/src/modules/appointments/context.ts
+++ b/src/modules/appointments/context.ts
@@ -53,7 +53,10 @@ function hasImpossibleDateParts(startISO: string): boolean {
   const m = /^(\d{4})-(\d{2})-(\d{2})(?:[Tt ]|$)/.exec(startISO);
   if (!m) return false;
   const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
-  const roundTrip = new Date(Date.UTC(y, mo - 1, d));
+  // NOTE: setUTCFullYear, not Date.UTC — Date.UTC maps years 0-99 to 1900-1999, which would flag
+  // valid ancient dates ("0099-02-28") as impossible.
+  const roundTrip = new Date(0);
+  roundTrip.setUTCFullYear(y, mo - 1, d);
   return (
     roundTrip.getUTCFullYear() !== y ||
     roundTrip.getUTCMonth() !== mo - 1 ||

--- a/src/modules/appointments/reminders.ts
+++ b/src/modules/appointments/reminders.ts
@@ -5,6 +5,7 @@ import { type AgentNudge, parseThreadId, runAgentNudge } from "@/graph/nudge";
 import type { RuntimeDeps } from "@/graph/runtime";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
   type ClaimedJob,
   cancelPendingJobsByPrefix,
@@ -147,25 +148,21 @@ export async function cancelAppointmentReminders(
   });
 }
 
-// True when this conversation (by thread) has at least one PENDING appointment reminder — i.e. a known
-// FUTURE appointment. The follow-up sweep + handler use it to pause re-engagement while a booking is
-// live (FollowUpConfig.pauseWhileAppointment): a customer who just booked should not get "still there?"
-// nudges; the reminder owns the conversation until the appointment passes / is cancelled. Tenant-scoped.
-export async function hasPendingAppointmentReminder(
+// True while this conversation (by thread) has at least one LIVE appointment — a queued reminder row
+// (PENDING/CLAIMED) or an already-fired one whose start is still ahead, tombstones excluded: the shared
+// projectAppointmentEvents predicate, via loadAppointmentContext. The follow-up handler uses it to
+// pause re-engagement while a booking is live (FollowUpConfig.pauseWhileAppointment): a customer who
+// just booked should not get "still there?" nudges until the appointment passes / is cancelled.
+// NOTE: Anchoring on PENDING rows alone went blind after the LAST reminder fired (issue #39).
+// Tenant-scoped.
+export async function hasLiveAppointment(
   tenantId: bigint,
   threadId: string,
   base: PrismaClient = basePrisma,
 ): Promise<boolean> {
   return runScopedOn(base, sysCtx(tenantId), async (db) => {
-    const row = await db.schedulerJob.findFirst({
-      where: {
-        kind: "APPOINTMENT_REMINDER",
-        status: "PENDING",
-        payload: { path: ["threadId"], equals: threadId },
-      },
-      select: { id: true },
-    });
-    return row !== null;
+    const events = await loadAppointmentContext(db, tenantId, threadId);
+    return events.length > 0;
   });
 }
 

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -132,8 +132,10 @@ async function sweepHandler(
         -- while it is still queued (PENDING/CLAIMED) OR its startISO is still ahead — firing marks
         -- rows DONE, so after the LAST reminder only the future-start arm keeps suppression on
         -- (issue #39). The cast is guarded (CASE + pg_input_is_valid; deploy mandates pg17):
-        -- startISO can be all-day (YYYY-MM-DD, forced to UTC midnight to match JS Date.parse) or
-        -- model-supplied garbage, and an unguarded cast would abort the WHOLE tenant sweep.
+        -- startISO can be all-day (YYYY-MM-DD) or model-supplied garbage, and an unguarded cast
+        -- would abort the WHOLE tenant sweep. Offset-less values are pinned to UTC exactly like
+        -- parseStartMs (all-day → UTC midnight; offset-less datetime → 'Z'), so the SQL and JS
+        -- liveness decisions agree regardless of the session/host time zones.
         -- Invalid/absent start = not-future (fail-safe: only the queued arm suppresses then).
         AND NOT (
           coalesce(a.settings->'followUp'->>'pauseWhileAppointment', 'true') <> 'false'
@@ -144,6 +146,9 @@ async function sweepHandler(
               SELECT CASE
                 WHEN sj.payload->>'startISO' ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
                   THEN sj.payload->>'startISO' || 'T00:00:00Z'
+                WHEN sj.payload->>'startISO' ~ '[Tt ][0-9]{2}:'
+                     AND sj.payload->>'startISO' !~ '([Zz]|[+-][0-9]{2}:?[0-9]{2})$'
+                  THEN sj.payload->>'startISO' || 'Z'
                 ELSE sj.payload->>'startISO'
               END AS start_iso
             ) norm

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -6,7 +6,7 @@ import { parseThreadId, runAgentNudge } from "@/graph/nudge";
 import type { RuntimeDeps } from "@/graph/runtime";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { isTestSilenced } from "@/modules/agents/test-mode";
-import { hasPendingAppointmentReminder } from "@/modules/appointments/reminders";
+import { hasLiveAppointment } from "@/modules/appointments/reminders";
 import {
   isOpenAt,
   nextOpenAt,
@@ -35,10 +35,11 @@ const SWEEP_INTERVAL_MS = 60_000;
 // nudging mid-turn. Anchored on lastEventAt, which the agent's own reply advances, so once the turn
 // finishes the follow-up naturally measures inactivity from the reply.
 const IN_FLIGHT_BACKOFF_MS = 30_000;
-// Back-off when the conversation has a pending appointment reminder (a future booking) and the agent
-// pauses follow-ups during appointments: hold the sequence and re-check later rather than nudging or
-// dying, so it resumes once the appointment passes / is cancelled. Coarse (1h) because the sweep
-// already filters these out — this only catches a FOLLOWUP that was in flight before the booking.
+// Back-off when the conversation has a LIVE appointment (queued reminder OR one already fired with
+// the start still ahead) and the agent pauses follow-ups during appointments: hold the sequence and
+// re-check later rather than nudging or dying, so it resumes once the appointment passes / is
+// cancelled. Coarse (1h) because the sweep already filters these out — this only catches a FOLLOWUP
+// that was in flight before the booking.
 const APPOINTMENT_BACKOFF_MS = 3_600_000;
 // NOTE: Back-off when the nudge could not run to completion without posting anything: the live-state GET
 // failed (fail-closed) or a pending human-in-the-loop interrupt deferred it. Retry the SAME step —
@@ -125,17 +126,40 @@ async function sweepHandler(
         -- NULL = never armed → fail-safe skip.
         AND a.follow_up_armed_at IS NOT NULL
         AND c.last_inbound_at >= a.follow_up_armed_at
-        -- Pause re-engagement while a FUTURE appointment exists (a pending APPOINTMENT_REMINDER),
-        -- unless the agent opted out (followUp.pauseWhileAppointment = false). Mirrors the handler's
-        -- suppression gate so the operator-facing estimate and the worker agree.
+        -- NOTE: Pause re-engagement while the conversation has a LIVE future appointment, unless the
+        -- agent opted out (followUp.pauseWhileAppointment = false). SQL mirror of
+        -- projectAppointmentEvents (appointments/context.ts): a non-tombstoned reminder row counts
+        -- while it is still queued (PENDING/CLAIMED) OR its startISO is still ahead — firing marks
+        -- rows DONE, so after the LAST reminder only the future-start arm keeps suppression on
+        -- (issue #39). The cast is guarded (CASE + pg_input_is_valid; deploy mandates pg17):
+        -- startISO can be all-day (YYYY-MM-DD, forced to UTC midnight to match JS Date.parse) or
+        -- model-supplied garbage, and an unguarded cast would abort the WHOLE tenant sweep.
+        -- Invalid/absent start = not-future (fail-safe: only the queued arm suppresses then).
         AND NOT (
           coalesce(a.settings->'followUp'->>'pauseWhileAppointment', 'true') <> 'false'
           AND EXISTS (
-            SELECT 1 FROM scheduler_jobs sj
+            SELECT 1
+            FROM scheduler_jobs sj
+            CROSS JOIN LATERAL (
+              SELECT CASE
+                WHEN sj.payload->>'startISO' ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+                  THEN sj.payload->>'startISO' || 'T00:00:00Z'
+                ELSE sj.payload->>'startISO'
+              END AS start_iso
+            ) norm
             WHERE sj.tenant_id = c.tenant_id
               AND sj.kind = 'APPOINTMENT_REMINDER'
-              AND sj.status = 'PENDING'
               AND sj.payload->>'threadId' = c.thread_id
+              AND sj.payload->>'cancelledAt' IS NULL
+              AND (
+                sj.status IN ('PENDING', 'CLAIMED')
+                OR CASE
+                  WHEN norm.start_iso IS NOT NULL
+                       AND pg_input_is_valid(norm.start_iso, 'timestamptz')
+                    THEN norm.start_iso::timestamptz > now()
+                  ELSE false
+                END
+              )
           )
         )
         -- Skip a conversation managed by a WhatsApp→chat redirect (channelRedirect): both the WIDGET
@@ -258,12 +282,13 @@ export async function followUpHandler(
   });
   if (!ctx) return { outcome: "done" };
 
-  // Appointment-reminder suppression: hold the follow-up while this conversation has a FUTURE
-  // appointment (a pending reminder). Re-check later instead of nudging OR ending the sequence, so it
-  // resumes once the appointment passes / is cancelled. Defense in depth — the inbound that booked the
-  // appointment already cancels any prior FOLLOWUP, and the sweep won't enqueue a new one meanwhile.
+  // Appointment suppression: hold the follow-up while this conversation has a LIVE appointment —
+  // queued reminder OR already-fired one with the start still ahead (issue #39). Re-check later
+  // instead of nudging OR ending the sequence, so it resumes once the appointment passes / is
+  // cancelled. Defense in depth — the inbound that booked the appointment already cancels any prior
+  // FOLLOWUP, and the sweep won't enqueue a new one meanwhile.
   if (ctx.followUpCfg.pauseWhileAppointment) {
-    const blockedByAppointment = await hasPendingAppointmentReminder(
+    const blockedByAppointment = await hasLiveAppointment(
       tenantId,
       threadId,
       base,

--- a/tests/modules/appointment-context-db.test.ts
+++ b/tests/modules/appointment-context-db.test.ts
@@ -8,6 +8,7 @@ import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
   cancelAppointmentReminders,
   enqueueAppointmentReminders,
+  hasLiveAppointment,
 } from "@/modules/appointments/reminders";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
@@ -199,5 +200,49 @@ describe.skipIf(!dbUp)("per-turn appointment context (issue #22)", () => {
     expect(after).toEqual([]);
     const prompt = await promptFor(103);
     expect(prompt).not.toContain("## Agendamentos deste atendimento");
+  });
+
+  // NOTE: hasLiveAppointment is the follow-up suppression predicate (issue #39) — the same shared
+  // liveness projection, adapted from a base PrismaClient. Covered here because this file already
+  // owns the enqueue/cancel fixtures.
+  test("hasLiveAppointment: true after the last reminder fired (DONE, future start)", async () => {
+    await seedConversation(104);
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_ctx3:1",
+        status: "DONE",
+        runAt: new Date(Date.now() - 3_600_000),
+        payload: {
+          threadId: threadOf(104),
+          eventId: "ev_ctx3",
+          startISO: inHours(2),
+        },
+      },
+    });
+    expect(await hasLiveAppointment(tenantId, threadOf(104), appDb)).toBe(true);
+  });
+
+  test("hasLiveAppointment: false once the appointment is cancelled (tombstoned)", async () => {
+    await seedConversation(105);
+    await enqueueAppointmentReminders({
+      tenantId,
+      threadId: threadOf(105),
+      eventId: "ev_ctx4",
+      calendarId: "primary",
+      credentialRef: null,
+      startISO: inHours(48),
+      offsetsHours: [24, 1],
+      askConfirmationOnLast: true,
+      summary: null,
+      calendarLabel: null,
+      base: appDb,
+    });
+    expect(await hasLiveAppointment(tenantId, threadOf(105), appDb)).toBe(true);
+    await cancelAppointmentReminders(tenantId, "ev_ctx4", appDb);
+    expect(await hasLiveAppointment(tenantId, threadOf(105), appDb)).toBe(
+      false,
+    );
   });
 });

--- a/tests/modules/appointment-context.test.ts
+++ b/tests/modules/appointment-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   type AppointmentJobRow,
   buildAppointmentContextSection,
+  parseStartMs,
   projectAppointmentEvents,
 } from "@/modules/appointments/context";
 
@@ -214,5 +215,33 @@ describe("buildAppointmentContextSection", () => {
     expect(withTools).toContain("event_id");
     const readOnly = buildAppointmentContextSection([event], false);
     expect(readOnly).not.toContain("calendar_update_event");
+  });
+});
+
+// NOTE: parseStartMs pins offset-less startISO values to UTC — the same rule the sweep SQL mirrors —
+// so the JS and Postgres liveness decisions cannot diverge when app and DB time zones differ.
+describe("parseStartMs", () => {
+  test("all-day date parses as UTC midnight", () => {
+    expect(parseStartMs("2026-06-13")).toBe(Date.parse("2026-06-13T00:00:00Z"));
+  });
+
+  test("an offset-less datetime is pinned to UTC (host-TZ independent)", () => {
+    expect(parseStartMs("2026-06-13T12:00:00")).toBe(
+      Date.parse("2026-06-13T12:00:00Z"),
+    );
+  });
+
+  test("explicit offsets and Z are honored unchanged", () => {
+    expect(parseStartMs("2026-06-13T12:00:00-03:00")).toBe(
+      Date.parse("2026-06-13T15:00:00Z"),
+    );
+    expect(parseStartMs("2026-06-13T12:00:00Z")).toBe(
+      Date.parse("2026-06-13T12:00:00Z"),
+    );
+  });
+
+  test("garbage stays NaN (fail-safe not-future)", () => {
+    expect(Number.isNaN(parseStartMs("amanhã de manhã"))).toBe(true);
+    expect(Number.isNaN(parseStartMs(""))).toBe(true);
   });
 });

--- a/tests/modules/appointment-context.test.ts
+++ b/tests/modules/appointment-context.test.ts
@@ -252,5 +252,7 @@ describe("parseStartMs", () => {
     expect(Number.isNaN(parseStartMs("2026-04-31T12:00:00"))).toBe(true);
     expect(Number.isNaN(parseStartMs("2023-02-29T10:00:00Z"))).toBe(true);
     expect(Number.isNaN(parseStartMs("2024-02-29"))).toBe(false);
+    // NOTE: Years below 0100 are valid — the guard must not let Date.UTC remap them to 19xx.
+    expect(parseStartMs("0099-02-28")).toBe(Date.parse("0099-02-28T00:00:00Z"));
   });
 });

--- a/tests/modules/appointment-context.test.ts
+++ b/tests/modules/appointment-context.test.ts
@@ -244,4 +244,13 @@ describe("parseStartMs", () => {
     expect(Number.isNaN(parseStartMs("amanhã de manhã"))).toBe(true);
     expect(Number.isNaN(parseStartMs(""))).toBe(true);
   });
+
+  // NOTE: Date.parse would roll these over (Feb 30 → Mar 2) while the sweep's pg_input_is_valid
+  // rejects them — NaN keeps the two liveness decisions in agreement.
+  test("impossible calendar dates are NaN, not rolled over", () => {
+    expect(Number.isNaN(parseStartMs("2026-02-30"))).toBe(true);
+    expect(Number.isNaN(parseStartMs("2026-04-31T12:00:00"))).toBe(true);
+    expect(Number.isNaN(parseStartMs("2023-02-29T10:00:00Z"))).toBe(true);
+    expect(Number.isNaN(parseStartMs("2024-02-29"))).toBe(false);
+  });
 });

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -1069,4 +1069,49 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
       }),
     ).toBeNull();
   });
+
+  test("(x) an impossible calendar date never suppresses (no Date.parse roll-over on either side)", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    await seedConversation(1049, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    // NOTE: Feb 30 of NEXT year: Date.parse would roll it over to a FUTURE March 2 (suppressing the
+    // follow-up), while pg_input_is_valid rejects it. Both sides must treat it as garbage.
+    const impossibleFuture = `${new Date().getUTCFullYear() + 1}-02-30T00:00:00Z`;
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_x:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 60 * 60_000),
+        payload: {
+          threadId: threadOf(1049),
+          eventId: "ev_x",
+          startISO: impossibleFuture,
+        },
+      },
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    await sweep?.(
+      { id: 992n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1049)}`,
+        },
+      }),
+    ).not.toBeNull();
+    expect(await hasLiveAppointment(tenantId, threadOf(1049), appDb)).toBe(
+      false,
+    );
+  });
 });

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -5,6 +5,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import { clearTurnInFlight, markTurnInFlight } from "@/graph/inflight";
+import { hasLiveAppointment } from "@/modules/appointments/reminders";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import {
   ensureAllTenantSweeps,
@@ -767,7 +768,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
       lastInboundAt: new Date(Date.now() - 5 * 60_000),
       lastFollowUpAt: null,
     });
-    // The last reminder already fired (DONE, runAt in the past) but the appointment is 2h ahead.
+    // NOTE: The last reminder already fired (DONE, runAt in the past) but the appointment is 2h ahead.
     await suDb.schedulerJob.create({
       data: {
         tenantId,
@@ -817,7 +818,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
         },
       },
     });
-    // The reminder's OWN turn runs with the row CLAIMED — also live, even without a startISO.
+    // NOTE: The reminder's OWN turn runs with the row CLAIMED — also live, even without a startISO.
     await seedConversation(1042, {
       lastInboundAt: new Date(Date.now() - 5 * 60_000),
       lastFollowUpAt: null,
@@ -898,7 +899,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
       lastInboundAt: new Date(Date.now() - 5 * 60_000),
       lastFollowUpAt: null,
     });
-    // Cancelling marks rows DONE too — the tombstone is what tells them apart from "fired".
+    // NOTE: Cancelling marks rows DONE too — the tombstone is what tells them apart from "fired".
     await suDb.schedulerJob.create({
       data: {
         tenantId,
@@ -935,8 +936,9 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     await setAgentSteps([
       { delayValue: 1, delayUnit: "minutes", instructions: "" },
     ]);
-    // Conv A carries model-supplied garbage in startISO; conv B is a plain eligible conversation.
-    // An unguarded ::timestamptz cast would throw on A and kill follow-ups for the WHOLE tenant.
+    // NOTE: Conv A carries model-supplied garbage in startISO; conv B is a plain eligible
+    // conversation. An unguarded ::timestamptz cast would throw on A and kill follow-ups for the
+    // WHOLE tenant.
     await seedConversation(1045, {
       lastInboundAt: new Date(Date.now() - 5 * 60_000),
       lastFollowUpAt: null,
@@ -965,7 +967,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
       { id: 995n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
       appDb,
     );
-    // Garbage = not-future = not suppressed (fail-safe), and the sweep survives for everyone.
+    // NOTE: Garbage = not-future = not suppressed (fail-safe), and the sweep survives for everyone.
     for (const convId of [1045, 1046]) {
       expect(
         await suDb.schedulerJob.findFirst({
@@ -977,6 +979,53 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
         }),
       ).not.toBeNull();
     }
+  });
+
+  test("(w) an offset-less datetime is read as UTC by BOTH sides (sweep and re-check agree)", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    await seedConversation(1048, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    // NOTE: The model-input fallback can leave startISO WITHOUT an offset; both runtimes must pin it
+    // to UTC (parseStartMs / the SQL normalization) or their decisions diverge across time zones.
+    const offsetLessFutureUtc = new Date(Date.now() + 2 * 3_600_000)
+      .toISOString()
+      .slice(0, 19);
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_w:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 60 * 60_000),
+        payload: {
+          threadId: threadOf(1048),
+          eventId: "ev_w",
+          startISO: offsetLessFutureUtc,
+        },
+      },
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    await sweep?.(
+      { id: 993n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1048)}`,
+        },
+      }),
+    ).toBeNull();
+    expect(await hasLiveAppointment(tenantId, threadOf(1048), appDb)).toBe(
+      true,
+    );
   });
 
   test("(v) an all-day (date-only) future start suppresses the sweep", async () => {
@@ -997,7 +1046,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
         payload: {
           threadId: threadOf(1047),
           eventId: "ev_v",
-          // All-day events carry a bare YYYY-MM-DD (UTC midnight per Date.parse).
+          // NOTE: All-day events carry a bare YYYY-MM-DD (UTC midnight, parseStartMs).
           startISO: new Date(Date.now() + 3 * 86_400_000)
             .toISOString()
             .slice(0, 10),

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -754,4 +754,270 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     });
     expect(ours.sent).toEqual([[1031, REPLY]]);
   });
+
+  // NOTE: Firing a reminder marks its row DONE. Suppression anchored on PENDING rows alone goes
+  // blind after the LAST reminder fires while the appointment is still ahead (issue #39) — both
+  // the handler re-check and the sweep must treat "DONE with a future start" as a live appointment,
+  // tombstoned (cancelled) rows excluded.
+  test("(q) follow-up stays paused after the LAST reminder fired while the appointment is ahead", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    await seedConversation(1040, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    // The last reminder already fired (DONE, runAt in the past) but the appointment is 2h ahead.
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_q:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 60 * 60_000),
+        payload: {
+          threadId: threadOf(1040),
+          eventId: "ev_q",
+          startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+        },
+      },
+    });
+    const s = stubClient();
+    const result = await followUpHandler(jobFor(1040), appDb, {
+      makeModel: fakeModel,
+      makeClient: s.makeClient,
+      checkpointer: new MemorySaver(),
+      persistUsage: async () => {},
+    });
+    expect(result.outcome).toBe("reschedule");
+    expect(s.sent).toEqual([]);
+    expect(s.notes).toEqual([]);
+    expect(await lastFollowUpOf(1040)).toBeNull();
+  });
+
+  test("(r) sweep skips conversations with a live appointment: DONE + future start, and CLAIMED", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    await seedConversation(1041, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_r:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 60 * 60_000),
+        payload: {
+          threadId: threadOf(1041),
+          eventId: "ev_r",
+          startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+        },
+      },
+    });
+    // The reminder's OWN turn runs with the row CLAIMED — also live, even without a startISO.
+    await seedConversation(1042, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_r2:0",
+        status: "CLAIMED",
+        runAt: new Date(),
+        payload: { threadId: threadOf(1042), eventId: "ev_r2" },
+      },
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    await sweep?.(
+      { id: 998n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      appDb,
+    );
+    for (const convId of [1041, 1042]) {
+      expect(
+        await suDb.schedulerJob.findFirst({
+          where: {
+            tenantId,
+            kind: "FOLLOWUP",
+            dedupeKey: `followup:${threadOf(convId)}`,
+          },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test("(s) sweep resumes once the appointment start has passed (DONE, past start)", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    await seedConversation(1043, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_s:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 3 * 3_600_000),
+        payload: {
+          threadId: threadOf(1043),
+          eventId: "ev_s",
+          startISO: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+        },
+      },
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    await sweep?.(
+      { id: 997n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1043)}`,
+        },
+      }),
+    ).not.toBeNull();
+  });
+
+  test("(t) sweep resumes for a cancelled appointment (tombstoned rows, start still ahead)", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    await seedConversation(1044, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    // Cancelling marks rows DONE too — the tombstone is what tells them apart from "fired".
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_t:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 60 * 60_000),
+        payload: {
+          threadId: threadOf(1044),
+          eventId: "ev_t",
+          startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+          cancelledAt: new Date().toISOString(),
+        },
+      },
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    await sweep?.(
+      { id: 996n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1044)}`,
+        },
+      }),
+    ).not.toBeNull();
+  });
+
+  test("(u) a garbage startISO never aborts the sweep for the tenant", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    // Conv A carries model-supplied garbage in startISO; conv B is a plain eligible conversation.
+    // An unguarded ::timestamptz cast would throw on A and kill follow-ups for the WHOLE tenant.
+    await seedConversation(1045, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_u:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 60 * 60_000),
+        payload: {
+          threadId: threadOf(1045),
+          eventId: "ev_u",
+          startISO: "amanhã de manhã",
+        },
+      },
+    });
+    await seedConversation(1046, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    await sweep?.(
+      { id: 995n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      appDb,
+    );
+    // Garbage = not-future = not suppressed (fail-safe), and the sweep survives for everyone.
+    for (const convId of [1045, 1046]) {
+      expect(
+        await suDb.schedulerJob.findFirst({
+          where: {
+            tenantId,
+            kind: "FOLLOWUP",
+            dedupeKey: `followup:${threadOf(convId)}`,
+          },
+        }),
+      ).not.toBeNull();
+    }
+  });
+
+  test("(v) an all-day (date-only) future start suppresses the sweep", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "" },
+    ]);
+    await seedConversation(1047, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: "reminder:ev_v:0",
+        status: "DONE",
+        runAt: new Date(Date.now() - 60 * 60_000),
+        payload: {
+          threadId: threadOf(1047),
+          eventId: "ev_v",
+          // All-day events carry a bare YYYY-MM-DD (UTC midnight per Date.parse).
+          startISO: new Date(Date.now() + 3 * 86_400_000)
+            .toISOString()
+            .slice(0, 10),
+        },
+      },
+    });
+    registerFollowUpHandlers();
+    const sweep = getJobHandler("FOLLOWUP_SWEEP");
+    await sweep?.(
+      { id: 994n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1047)}`,
+        },
+      }),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
## Symptom

`followUp.pauseWhileAppointment` (default on) is supposed to suppress re-engagement while the conversation has a FUTURE appointment. Both implementing sites anchored on `PENDING` `APPOINTMENT_REMINDER` rows only — but firing a reminder marks its row `DONE`, so after the **last** configured reminder fires there is no `PENDING` row left and the suppression silently turns off while the appointment is still ahead. The follow-up ladder resumes chasing a customer who is about to show up; the hole is exactly the smallest configured offset (the log in #22 shows a `followup step 1` two hours after the last reminder, with the appointment still in the future).

## Fix

Both sites now share the liveness predicate #38 introduced (`projectAppointmentEvents`): an appointment is live while some non-tombstoned reminder row is still queued (`PENDING`/`CLAIMED`) **or** its `startISO` is still ahead — `payload.cancelledAt` tombstones excluded, so a cancelled appointment (whose rows are also `DONE`) never suppresses.

- **Sweep** (`src/modules/followups/handlers.ts`): the `NOT EXISTS` clause becomes a SQL mirror of the predicate. Three deliberate details:
  - `startISO` can be an all-day date (`YYYY-MM-DD`) — normalized to `T00:00:00Z` so SQL agrees with JS `Date.parse` (UTC midnight) instead of drifting by the session TimeZone;
  - the cast is guarded (`CASE` + `pg_input_is_valid`, available on the pg17 the deploy mandates) because `startISO` can also be model-supplied garbage and an unguarded `::timestamptz` would abort the whole tenant's sweep — one bad payload row would kill follow-ups for everyone. A guard test pins this;
  - invalid/absent start = not-future (fail-safe, same as the JS `Number.isFinite` check): only the queued arm suppresses then.
- **Handler re-check** (`src/modules/appointments/reminders.ts`): `hasPendingAppointmentReminder` → **`hasLiveAppointment`**, now delegating to `loadAppointmentContext` (the shared predicate) instead of a PENDING-only query. Same signature, single call site; the 1h re-check backoff now genuinely holds the sequence until the start passes or the appointment is cancelled.

`FAILED` is deliberately not added to the queued arm: the scheduler never writes it (`failJob` → PENDING/DEAD, reaper → PENDING/DEAD), and the shared predicate treats any non-queued status as live only via the future-start arm — the SQL mirrors that exactly.

## Tests (written red-first)

In `tests/modules/followup-handler.test.ts` (sweep invoked via `getJobHandler("FOLLOWUP_SWEEP")`):

- **(q)** handler: `DONE` + future start → `reschedule`, nothing sent (the #22 log shape) — red before the fix;
- **(r)** sweep: `DONE` + future start AND a `CLAIMED` row both suppress — red before the fix;
- **(s)** sweep: `DONE` + past start is swept (follow-up resumes after the appointment) — boundary guard;
- **(t)** sweep: fully tombstoned event (cancelled, start still ahead) is swept — cancellation guard;
- **(u)** sweep: a garbage `startISO` in the same tenant neither aborts the sweep nor suppresses — the unguarded-cast regression;
- **(v)** sweep: all-day (`YYYY-MM-DD`) future start suppresses — red before the fix.

Existing (m)/(n) keep passing untouched and now pin the queued arm (a `PENDING` row without `startISO` still suppresses) and the opt-out. Two direct `hasLiveAppointment` tests in `tests/modules/appointment-context-db.test.ts` cover the wrapper (DONE+future → true; cancelled → false).

## Notes

- The operator-facing follow-up **estimate** (`conversations/service.ts`) has never applied appointment suppression — a pre-existing, orthogonal divergence (it can promise a follow-up the sweep will suppress). Left out deliberately; the sweep comment no longer claims parity with it. Worth its own issue if the estimate should learn about appointments.
- `DONE` reminder rows accumulate (there is no scheduler_jobs retention); the EXISTS rides the `(tenant_id, kind, dedupe_key)` index prefix exactly as before, with the new per-row expressions only evaluated on that already-scanned range. Pre-existing and shared with the per-turn context loader; also worth a separate look someday.

Fixes #39.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Follow-ups remain suppressed for live future appointments after reminders are completed or claimed.
  - All-day and offset-less appointment dates are handled consistently as UTC.
  - Follow-ups resume when an appointment starts or is canceled.
  - Invalid, missing, or impossible appointment dates no longer interrupt processing or incorrectly suppress follow-ups.
  - Fired reminders continue to suppress follow-ups when the appointment has not started.

- **Tests**
  - Added coverage for appointment status changes, cancellations, future dates, all-day appointments, and varied or malformed date formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation scope

No live Chatwoot validation in this round: no Chatwoot call changes — the fix is sweep SQL + an internal JS predicate. Unit + DB-backed e2e (the sweep harness above) close the loop to the observable effect (FOLLOWUP enqueued or suppressed).
