### PR TITLE
fix(flowlog): falha de integração vira linha warn/error alertável no log de tools

### DIFF
--- a/docs/logs.md
+++ b/docs/logs.md
@@ -21,6 +21,10 @@ All three are in `TENANT_SCOPED_MODELS` with the standard `tenant_isolation` RLS
 
 `generate` (runtime + playground graph invoke), `stt` (`transcribeInboundAudio`), `vision` (`extractInboundFile` + the playground's `extractPlaygroundFile`; the two-step playground UI logs it under step 1's `extract` call), `tts` (`synthesizeReply`), `split` (`deliverReply`), `handoff` (assignee re-check in `runLoadedTurn`). **`embed` is in the vocabulary but not yet wired** — RAG search runs inside the `generate` span, so an embedding failure surfaces there; threading a flow context through the shared toolset builder is a deferred follow-up.
 
+### Tool lines and integration failures
+
+`ToolFlowLogger` (`src/graph/tool-flowlog.ts`) emits one `tool` line per tool call. A tool that **throws** is logged `warn`/`error` via `handleToolError`. A tool that degrades gracefully — returns a friendly string to the model instead of throwing (toolpacks, operator HTTP tools) — marks provider/credential failures with `toolFailure(...)` (`src/graph/tools/failure.ts`, built via `failableTool`): the model still sees the exact same string, but the line is logged `level: warn`, `status: error`, with the string as `errorMessage` — so alert channels with `minLevel: warn` fire on integration failures (expired OAuth, provider outage, rejected payloads). Business-level replies ("no free slots", policy limits, bad model input) stay `info`/`ok` — they are normal operation. For operator-authored HTTP tools every non-2xx counts as a failure.
+
 ## Alerting (`alerts.ts`, `alert-worker.ts`)
 
 - `dispatchAlertsForEvent` is called fire-and-forget from `emitFlowEvent` for `warn`/`error` events **on `source==="inbox"` only** (a playground error must not page). It matches channels by `minLevel` + stage allowlist and **coalesces**: a pending delivery for the same `(channel, stage, level)` is bumped (`count++`) instead of inserting a new row.

--- a/src/graph/tool-flowlog.ts
+++ b/src/graph/tool-flowlog.ts
@@ -25,7 +25,7 @@ function toolOutputValue(output: unknown): unknown {
   return output;
 }
 
-// A ToolMessage with status "error" is a tool-marked integration failure (failableTool/toolFailure —
+// NOTE: A ToolMessage with status "error" is a tool-marked integration failure (failableTool/toolFailure —
 // the friendly string went to the model, but the call must be logged as a failure). Thrown errors
 // take the handleToolError path instead; this only classifies returned outputs.
 function isErrorToolOutput(output: unknown): boolean {
@@ -82,7 +82,7 @@ export class ToolFlowLogger extends BaseCallbackHandler {
     this.starts.delete(runId);
     const failed = isErrorToolOutput(output);
     const value = toolOutputValue(output);
-    // Integration failure returned as a friendly string (failableTool): ONE line, level warn —
+    // NOTE: Integration failure returned as a friendly string (failableTool): ONE line, level warn —
     // same level as handleToolError, so alert channels (minLevel warn) can subscribe (issue #40).
     emitFlowEvent(this.flow, {
       stage: "tool",

--- a/src/graph/tool-flowlog.ts
+++ b/src/graph/tool-flowlog.ts
@@ -25,6 +25,18 @@ function toolOutputValue(output: unknown): unknown {
   return output;
 }
 
+// A ToolMessage with status "error" is a tool-marked integration failure (failableTool/toolFailure —
+// the friendly string went to the model, but the call must be logged as a failure). Thrown errors
+// take the handleToolError path instead; this only classifies returned outputs.
+function isErrorToolOutput(output: unknown): boolean {
+  return (
+    !!output &&
+    typeof output === "object" &&
+    "status" in output &&
+    (output as { status?: unknown }).status === "error"
+  );
+}
+
 // Logs each tool call the agent makes during a turn as a `tool` execution-flow line (name + status +
 // duration + the redacted args/result), so the operator can SEE which tools ran AND expand the marker
 // to inspect what was passed and returned (parity with the playground trace). Bound to the running
@@ -68,12 +80,23 @@ export class ToolFlowLogger extends BaseCallbackHandler {
     const s = this.starts.get(runId);
     if (!s) return;
     this.starts.delete(runId);
+    const failed = isErrorToolOutput(output);
+    const value = toolOutputValue(output);
+    // Integration failure returned as a friendly string (failableTool): ONE line, level warn —
+    // same level as handleToolError, so alert channels (minLevel warn) can subscribe (issue #40).
     emitFlowEvent(this.flow, {
       stage: "tool",
-      level: "info",
-      status: "ok",
+      level: failed ? "warn" : "info",
+      status: failed ? "error" : "ok",
       durationMs: Date.now() - s.at,
-      detail: { tool: s.tool, args: s.args, output: toolOutputValue(output) },
+      detail: { tool: s.tool, args: s.args, output: value },
+      ...(failed
+        ? {
+            errorMessage: sanitizeErrorMessage(
+              typeof value === "string" ? value : JSON.stringify(value),
+            ),
+          }
+        : {}),
     });
   }
 

--- a/src/graph/tools/failure.ts
+++ b/src/graph/tools/failure.ts
@@ -1,0 +1,55 @@
+import { ToolMessage } from "@langchain/core/messages";
+import {
+  type StructuredToolInterface,
+  type ToolRunnableConfig,
+  tool,
+} from "@langchain/core/tools";
+import type { z } from "zod";
+
+// Marks a friendly tool reply as an INTEGRATION FAILURE: the model still sees the exact same string
+// (graceful degradation is the right model-facing contract), but the flow log records the call as
+// warn/error so alert channels can fire on it (issue #40). Business-level replies — "no free slots",
+// policy limits, bad model input — must NOT use this: they are normal operation, not failures.
+export class ToolFailure {
+  constructor(readonly message: string) {}
+}
+
+export function toolFailure(message: string): ToolFailure {
+  return new ToolFailure(message);
+}
+
+type FailableFn = (
+  // NOTE: `never` keeps the wrapper assignable from any concretely-typed tool fn (parameter
+  // contravariance); each call site keeps its own inline input type, exactly as with tool().
+  input: never,
+  config: ToolRunnableConfig,
+) => Promise<string | ToolFailure>;
+
+// tool() wrapper whose fn may return toolFailure(...): the failure reaches the model as a
+// ToolMessage with status "error" and the SAME friendly string as content. LangChain's
+// direct-tool-output passthrough (_formatToolOutput → isDirectToolOutput) hands that ToolMessage
+// intact both to handleToolEnd (where ToolFlowLogger reads the status and logs warn/error) and to
+// ToolNode (so the model sees the string unchanged). Without a tool_call in scope (direct invocation
+// with plain args, e.g. unit tests) the failure degrades to the plain string — today's behavior —
+// because a ToolMessage requires a real tool_call_id.
+// NOTE: @langchain/anthropic and the OpenAI-family adapters currently ignore ToolMessage.status;
+// @langchain/google-genai wraps status "error" content as functionResponse.response.error.details
+// (string preserved). If an adapter upgrade starts emitting is_error, re-check the model-facing
+// contract for marked failures.
+export function failableTool(
+  fn: FailableFn,
+  fields: { name: string; description: string; schema: z.ZodTypeAny },
+): StructuredToolInterface {
+  return tool(async (input: unknown, config: ToolRunnableConfig) => {
+    const out = await fn(input as never, config);
+    if (!(out instanceof ToolFailure)) return out;
+    const id = config?.toolCall?.id;
+    if (!id) return out.message;
+    return new ToolMessage({
+      status: "error",
+      content: out.message,
+      tool_call_id: id,
+      name: fields.name,
+    });
+  }, fields) as unknown as StructuredToolInterface;
+}

--- a/src/graph/tools/failure.ts
+++ b/src/graph/tools/failure.ts
@@ -6,7 +6,7 @@ import {
 } from "@langchain/core/tools";
 import type { z } from "zod";
 
-// Marks a friendly tool reply as an INTEGRATION FAILURE: the model still sees the exact same string
+// NOTE: Marks a friendly tool reply as an INTEGRATION FAILURE: the model still sees the exact same string
 // (graceful degradation is the right model-facing contract), but the flow log records the call as
 // warn/error so alert channels can fire on it (issue #40). Business-level replies — "no free slots",
 // policy limits, bad model input — must NOT use this: they are normal operation, not failures.
@@ -25,7 +25,7 @@ type FailableFn = (
   config: ToolRunnableConfig,
 ) => Promise<string | ToolFailure>;
 
-// tool() wrapper whose fn may return toolFailure(...): the failure reaches the model as a
+// NOTE: tool() wrapper whose fn may return toolFailure(...): the failure reaches the model as a
 // ToolMessage with status "error" and the SAME friendly string as content. LangChain's
 // direct-tool-output passthrough (_formatToolOutput → isDirectToolOutput) hands that ToolMessage
 // intact both to handleToolEnd (where ToolFlowLogger reads the status and logs warn/error) and to

--- a/src/graph/tools/http.ts
+++ b/src/graph/tools/http.ts
@@ -1,5 +1,6 @@
-import { type StructuredToolInterface, tool } from "@langchain/core/tools";
+import type { StructuredToolInterface } from "@langchain/core/tools";
 import { z } from "zod";
+import { failableTool, toolFailure } from "@/graph/tools/failure";
 import { AppError } from "@/lib/errors";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
@@ -318,7 +319,7 @@ export function buildHttpTool(
     ? `${def.credentialBaseUrl}${urlTemplate}`
     : urlTemplate;
 
-  return tool(
+  return failableTool(
     async (input: Record<string, unknown>) => {
       // 0. Ack (the model-written holding message): required when an ack is configured. The schema
       // already enforces non-empty, so this is a defensive guard — if a provider somehow let an empty
@@ -587,7 +588,13 @@ export function buildHttpTool(
         text.length > maxChars
           ? `${text.slice(0, maxChars)}…[truncated]`
           : text;
-      return `HTTP ${res.status}\n${trimmed}`;
+      // NOTE: For an operator-authored tool EVERY non-2xx is an integration failure worth alerting
+      // on (broken credential, provider outage, rejected payload) — the model still sees the same
+      // "HTTP <status>" body either way (issue #40).
+      const resultText = `HTTP ${res.status}\n${trimmed}`;
+      return res.status >= 200 && res.status < 300
+        ? resultText
+        : toolFailure(resultText);
     },
     {
       name: sanitizeToolName(def.name),

--- a/src/graph/tools/native.ts
+++ b/src/graph/tools/native.ts
@@ -3,6 +3,7 @@ import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
+import { failableTool, toolFailure } from "@/graph/tools/failure";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { xmlAttr, xmlEscape } from "@/lib/xml";
 import type {
@@ -883,7 +884,7 @@ function setVoicePreferenceTool(ctx: ToolCtx) {
 // reacting with the same emoji again removes it. Pair with skip_reply when a reaction is the whole
 // response (e.g. the customer sent just "ok"/👍).
 function reactToMessageTool(ctx: ToolCtx) {
-  return tool(
+  return failableTool(
     async ({ emoji }: { emoji: string }) => {
       const e = emoji.trim();
       if (!e) return "Provide an emoji to react with.";
@@ -902,7 +903,7 @@ function reactToMessageTool(ctx: ToolCtx) {
         await ctx.client.addMessageReaction(ctx.conversationId, latest.id, e);
         return `Reacted with ${e} to the customer's last message.`;
       } catch {
-        return "Could not add the reaction.";
+        return toolFailure("Could not add the reaction.");
       }
     },
     {

--- a/src/modules/integrations/toolpacks/asaas.ts
+++ b/src/modules/integrations/toolpacks/asaas.ts
@@ -313,11 +313,20 @@ function buildCreatePixChargeTool(
           { method: "GET", token },
           ctx,
         );
-        if (found.status >= 200 && found.status < 300) {
-          const data = (found.json ?? {}) as { data?: Array<{ id?: unknown }> };
-          const first = data.data?.[0]?.id;
-          if (typeof first === "string") customerId = first;
+        // NOTE: A rejected lookup must fail the call, not fall through with an empty customerId —
+        // falling through would POST /customers and create a DUPLICATE on a transient provider error.
+        if (found.status < 200 || found.status >= 300) {
+          logger.warn(
+            "asaas: customer lookup returned HTTP %s",
+            String(found.status),
+          );
+          return toolFailure(
+            `The payment provider rejected the customer lookup (HTTP ${found.status}).`,
+          );
         }
+        const data = (found.json ?? {}) as { data?: Array<{ id?: unknown }> };
+        const first = data.data?.[0]?.id;
+        if (typeof first === "string") customerId = first;
       } catch (err) {
         logger.warn({ err, env }, "asaas: customer lookup failed");
         return toolFailure(

--- a/src/modules/integrations/toolpacks/asaas.ts
+++ b/src/modules/integrations/toolpacks/asaas.ts
@@ -324,8 +324,23 @@ function buildCreatePixChargeTool(
             `The payment provider rejected the customer lookup (HTTP ${found.status}).`,
           );
         }
-        const data = (found.json ?? {}) as { data?: Array<{ id?: unknown }> };
-        const first = data.data?.[0]?.id;
+        // NOTE: A malformed 2xx body must also fail the call (asaasFetch yields json: null on an
+        // unparseable body) — only a valid data array may reach the create branch, and a non-empty
+        // one must carry a string id, otherwise a parse glitch would duplicate the customer.
+        const json = found.json as { data?: unknown } | null;
+        if (!json || typeof json !== "object" || !Array.isArray(json.data)) {
+          logger.warn("asaas: customer lookup returned an invalid response");
+          return toolFailure(
+            "The payment provider returned an unexpected response.",
+          );
+        }
+        const first = (json.data as Array<{ id?: unknown }>)[0]?.id;
+        if (json.data.length > 0 && typeof first !== "string") {
+          logger.warn("asaas: customer lookup response missing customer id");
+          return toolFailure(
+            "The payment provider returned an unexpected response.",
+          );
+        }
         if (typeof first === "string") customerId = first;
       } catch (err) {
         logger.warn({ err, env }, "asaas: customer lookup failed");

--- a/src/modules/integrations/toolpacks/asaas.ts
+++ b/src/modules/integrations/toolpacks/asaas.ts
@@ -1,8 +1,9 @@
 import { randomBytes } from "node:crypto";
-import { type StructuredToolInterface, tool } from "@langchain/core/tools";
+import type { StructuredToolInterface } from "@langchain/core/tools";
 import { z } from "zod";
 import type { Prisma } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
+import { failableTool, toolFailure } from "@/graph/tools/failure";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
@@ -173,13 +174,15 @@ function buildCreateLinkTool(
   const base = ASAAS_ORIGINS[env];
   const overrides = (sel.config.paymentLink ?? {}) as Record<string, unknown>;
 
-  return tool(
+  return failableTool(
     async (input: { value: number; description?: string; name?: string }) => {
       const token = sel.credentialRef
         ? await ctx.resolveCredential(sel.credentialRef)
         : null;
       if (!token)
-        return "Asaas credential is not configured for this integration.";
+        return toolFailure(
+          "Asaas credential is not configured for this integration.",
+        );
 
       // Opaque correlation token: sent as externalReference, stored as the ref's externalId, and
       // read back from the payment webhook by the inbound mapper. Never the internal thread id
@@ -208,21 +211,27 @@ function buildCreateLinkTool(
         );
       } catch (err) {
         logger.warn({ err, env }, "asaas: payment link request failed");
-        return "Failed to reach the payment provider. Try again shortly.";
+        return toolFailure(
+          "Failed to reach the payment provider. Try again shortly.",
+        );
       }
       if (res.status < 200 || res.status >= 300) {
         logger.warn(
           "asaas: payment link create returned HTTP %s",
           String(res.status),
         );
-        return `The payment provider rejected the request (HTTP ${res.status}).`;
+        return toolFailure(
+          `The payment provider rejected the request (HTTP ${res.status}).`,
+        );
       }
       const data = (res.json ?? {}) as Record<string, unknown>;
       const linkId = typeof data.id === "string" ? data.id : null;
       const url = typeof data.url === "string" ? data.url : null;
       if (!linkId || !url) {
         logger.warn("asaas: payment link response missing id/url");
-        return "The payment provider returned an unexpected response.";
+        return toolFailure(
+          "The payment provider returned an unexpected response.",
+        );
       }
 
       // Correlation ref (short scoped write, no network — the fetch already happened above).
@@ -274,7 +283,7 @@ function buildCreatePixChargeTool(
   const base = ASAAS_ORIGINS[env];
   const overrides = (sel.config.payment ?? {}) as Record<string, unknown>;
 
-  return tool(
+  return failableTool(
     async (input: {
       value: number;
       customerName: string;
@@ -287,7 +296,9 @@ function buildCreatePixChargeTool(
         ? await ctx.resolveCredential(sel.credentialRef)
         : null;
       if (!token)
-        return "Asaas credential is not configured for this integration.";
+        return toolFailure(
+          "Asaas credential is not configured for this integration.",
+        );
 
       const cpfCnpj = input.cpfCnpj.replace(/\D/g, "");
       if (cpfCnpj.length !== 11 && cpfCnpj.length !== 14)
@@ -309,7 +320,9 @@ function buildCreatePixChargeTool(
         }
       } catch (err) {
         logger.warn({ err, env }, "asaas: customer lookup failed");
-        return "Failed to reach the payment provider. Try again shortly.";
+        return toolFailure(
+          "Failed to reach the payment provider. Try again shortly.",
+        );
       }
 
       if (!customerId) {
@@ -333,21 +346,27 @@ function buildCreatePixChargeTool(
           );
         } catch (err) {
           logger.warn({ err, env }, "asaas: customer create failed");
-          return "Failed to reach the payment provider. Try again shortly.";
+          return toolFailure(
+            "Failed to reach the payment provider. Try again shortly.",
+          );
         }
         if (created.status < 200 || created.status >= 300) {
           logger.warn(
             "asaas: customer create returned HTTP %s",
             String(created.status),
           );
-          return `The payment provider rejected the customer (HTTP ${created.status}).`;
+          return toolFailure(
+            `The payment provider rejected the customer (HTTP ${created.status}).`,
+          );
         }
         const cd = (created.json ?? {}) as Record<string, unknown>;
         if (typeof cd.id === "string") customerId = cd.id;
       }
       if (!customerId) {
         logger.warn("asaas: could not resolve a customer id");
-        return "The payment provider returned an unexpected response.";
+        return toolFailure(
+          "The payment provider returned an unexpected response.",
+        );
       }
 
       // 2) Open the PIX charge. correlationId is opaque (never the internal thread id).
@@ -373,14 +392,18 @@ function buildCreatePixChargeTool(
         );
       } catch (err) {
         logger.warn({ err, env }, "asaas: pix charge request failed");
-        return "Failed to reach the payment provider. Try again shortly.";
+        return toolFailure(
+          "Failed to reach the payment provider. Try again shortly.",
+        );
       }
       if (charge.status < 200 || charge.status >= 300) {
         logger.warn(
           "asaas: pix charge create returned HTTP %s",
           String(charge.status),
         );
-        return `The payment provider rejected the request (HTTP ${charge.status}).`;
+        return toolFailure(
+          `The payment provider rejected the request (HTTP ${charge.status}).`,
+        );
       }
       const cdata = (charge.json ?? {}) as Record<string, unknown>;
       const paymentId = typeof cdata.id === "string" ? cdata.id : null;
@@ -388,7 +411,9 @@ function buildCreatePixChargeTool(
         typeof cdata.invoiceUrl === "string" ? cdata.invoiceUrl : null;
       if (!paymentId) {
         logger.warn("asaas: pix charge response missing id");
-        return "The payment provider returned an unexpected response.";
+        return toolFailure(
+          "The payment provider returned an unexpected response.",
+        );
       }
 
       // Persist the correlation ref (the charge exists; this is what ties a future webhook back to
@@ -457,13 +482,15 @@ function buildStatusTool(
   const env = resolveEnv(sel.config);
   const base = ASAAS_ORIGINS[env];
 
-  return tool(
+  return failableTool(
     async (input: { paymentId?: string; paymentLinkId?: string }) => {
       const token = sel.credentialRef
         ? await ctx.resolveCredential(sel.credentialRef)
         : null;
       if (!token)
-        return "Asaas credential is not configured for this integration.";
+        return toolFailure(
+          "Asaas credential is not configured for this integration.",
+        );
       let paymentId = input.paymentId?.trim() || undefined;
       let linkId = input.paymentLinkId?.trim() || undefined;
       // Defensive: a pay_... id in the link field is a payment id (models mix them up).
@@ -493,14 +520,14 @@ function buildStatusTool(
         res = await asaasFetch(base, path, { method: "GET", token }, ctx);
       } catch (err) {
         logger.warn({ err, env }, "asaas: payment status request failed");
-        return "Failed to reach the payment provider.";
+        return toolFailure("Failed to reach the payment provider.");
       }
       if (res.status < 200 || res.status >= 300) {
         // An invoice-URL SLUG is shape-indistinguishable from a real link id, so it can only be
         // caught here: turn the provider's 404 into recoverable guidance instead of a dead end.
         if (res.status === 404)
           return "The payment provider returned HTTP 404 (id not found). If this value was extracted from an invoice/payment URL, that slug is not a valid id — use the paymentId returned by asaas_create_pix_charge or the paymentLinkId returned by asaas_payment_link_create.";
-        return `The payment provider returned HTTP ${res.status}.`;
+        return toolFailure(`The payment provider returned HTTP ${res.status}.`);
       }
       const d = (res.json ?? {}) as Record<string, unknown>;
       // Bounded projections (no secrets; status-relevant fields only). The payment path skips

--- a/src/modules/integrations/toolpacks/asaas.ts
+++ b/src/modules/integrations/toolpacks/asaas.ts
@@ -335,13 +335,16 @@ function buildCreatePixChargeTool(
           );
         }
         const first = (json.data as Array<{ id?: unknown }>)[0]?.id;
-        if (json.data.length > 0 && typeof first !== "string") {
+        // NOTE: A blank ("" / whitespace) id must count as missing — it would leave customerId
+        // falsy and reach the create branch anyway.
+        const firstId = typeof first === "string" ? first.trim() : "";
+        if (json.data.length > 0 && !firstId) {
           logger.warn("asaas: customer lookup response missing customer id");
           return toolFailure(
             "The payment provider returned an unexpected response.",
           );
         }
-        if (typeof first === "string") customerId = first;
+        if (firstId) customerId = firstId;
       } catch (err) {
         logger.warn({ err, env }, "asaas: customer lookup failed");
         return toolFailure(

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -1,6 +1,7 @@
-import { type StructuredToolInterface, tool } from "@langchain/core/tools";
+import type { StructuredToolInterface } from "@langchain/core/tools";
 import { z } from "zod";
 import logger from "@/api/lib/logger";
+import { failableTool, toolFailure } from "@/graph/tools/failure";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { xmlAttr } from "@/lib/xml";
 import { readAppointmentReminderConfig } from "@/modules/appointments/settings";
@@ -576,7 +577,7 @@ function buildListEventsTool(
 ): StructuredToolInterface {
   const allowed = resolveAllowedCalendarIds(sel.config);
   const labels = resolveCalendarLabels(sel.config);
-  return tool(
+  return failableTool(
     async (input: {
       timeMin?: string;
       timeMax?: string;
@@ -586,7 +587,7 @@ function buildListEventsTool(
       const stamp = contactStamp(ctx);
       if (!stamp) return NO_CONTACT;
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       const pick = pickCalendarId(allowed, labels, input.calendarId);
       if ("error" in pick) return pick.error;
       const calendarId = pick.id;
@@ -610,10 +611,12 @@ function buildListEventsTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: list events request failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (res.status < 200 || res.status >= 300) {
-        return `Google Calendar returned HTTP ${res.status}.`;
+        return toolFailure(`Google Calendar returned HTTP ${res.status}.`);
       }
       const data = (res.json ?? {}) as Record<string, unknown>;
       const items = Array.isArray(data.items) ? data.items : [];
@@ -654,7 +657,7 @@ function buildCheckAvailabilityTool(
   const businessHoursId = resolveBusinessHoursId(sel.config);
   const minLeadMinutes = resolveMinLead(sel.config);
   const blockingIds = resolveBlockingCalendarIds(sel.config);
-  return tool(
+  return failableTool(
     async (input: {
       timeMin: string;
       timeMax: string;
@@ -671,7 +674,7 @@ function buildCheckAvailabilityTool(
         return "Please search at most 24 hours at a time. Narrow the range to a single day and call again for other days.";
       }
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       const pick = pickCalendarId(allowed, labels, input.calendarId);
       if ("error" in pick) return pick.error;
       const calendarId = pick.id;
@@ -690,10 +693,12 @@ function buildCheckAvailabilityTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: freeBusy request failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (res.status < 200 || res.status >= 300) {
-        return `Google Calendar returned HTTP ${res.status}.`;
+        return toolFailure(`Google Calendar returned HTTP ${res.status}.`);
       }
       const data = (res.json ?? {}) as Record<string, unknown>;
       const calendars = (data.calendars ?? {}) as Record<string, unknown>;
@@ -733,11 +738,15 @@ function buildCheckAvailabilityTool(
           );
         } catch (err) {
           logger.warn({ err }, "gcal: blocking calendars request failed");
-          return "Failed to read a blocking calendar (holidays/closures), so availability cannot be verified right now. Try again shortly.";
+          return toolFailure(
+            "Failed to read a blocking calendar (holidays/closures), so availability cannot be verified right now. Try again shortly.",
+          );
         }
         for (const r of blockingRes) {
           if (r.status < 200 || r.status >= 300) {
-            return `Google Calendar returned HTTP ${r.status} for a blocking calendar, so availability cannot be verified right now.`;
+            return toolFailure(
+              `Google Calendar returned HTTP ${r.status} for a blocking calendar, so availability cannot be verified right now.`,
+            );
           }
           const evData = (r.json ?? {}) as Record<string, unknown>;
           // A nextPageToken means the window holds more events than the cap covers; treating the
@@ -802,7 +811,7 @@ function buildCreateEventTool(
   const labels = resolveCalendarLabels(sel.config);
   const timeZone = resolveTimeZone(sel.config);
   const meetEnabled = resolveCreateMeetLink(sel.config);
-  return tool(
+  return failableTool(
     async (input: {
       summary: string;
       start: string;
@@ -813,7 +822,7 @@ function buildCreateEventTool(
       const stamp = contactStamp(ctx);
       if (!stamp) return NO_CONTACT;
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       const pick = pickCalendarId(allowed, labels, input.calendarId);
       if ("error" in pick) return pick.error;
       const calendarId = pick.id;
@@ -848,14 +857,18 @@ function buildCreateEventTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: create event request failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (res.status < 200 || res.status >= 300) {
-        return `Google Calendar rejected the event (HTTP ${res.status}).`;
+        return toolFailure(
+          `Google Calendar rejected the event (HTTP ${res.status}).`,
+        );
       }
       let data = (res.json ?? {}) as Record<string, unknown>;
       if (typeof data.id !== "string") {
-        return "Google Calendar returned an unexpected response.";
+        return toolFailure("Google Calendar returned an unexpected response.");
       }
       const eventId = data.id;
       // NOTE: room creation is usually synchronous, but the API may answer with the createRequest still
@@ -918,7 +931,7 @@ function buildUpdateEventTool(
   const allowed = resolveAllowedCalendarIds(sel.config);
   const labels = resolveCalendarLabels(sel.config);
   const timeZone = resolveTimeZone(sel.config);
-  return tool(
+  return failableTool(
     async (input: {
       eventId: string;
       summary?: string;
@@ -930,7 +943,7 @@ function buildUpdateEventTool(
       const stamp = contactStamp(ctx);
       if (!stamp) return NO_CONTACT;
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       const pick = pickCalendarId(allowed, labels, input.calendarId);
       if ("error" in pick) return pick.error;
       const calendarId = pick.id;
@@ -955,11 +968,13 @@ function buildUpdateEventTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: update ownership check failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (owner.status === 404) return FOREIGN_EVENT;
       if (owner.status < 200 || owner.status >= 300) {
-        return `Google Calendar returned HTTP ${owner.status}.`;
+        return toolFailure(`Google Calendar returned HTTP ${owner.status}.`);
       }
       const ownerEv = (owner.json ?? {}) as Record<string, unknown>;
       if (eventStamp(ownerEv) !== stamp) return FOREIGN_EVENT;
@@ -972,10 +987,14 @@ function buildUpdateEventTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: update event request failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (res.status < 200 || res.status >= 300) {
-        return `Google Calendar rejected the update (HTTP ${res.status}).`;
+        return toolFailure(
+          `Google Calendar rejected the update (HTTP ${res.status}).`,
+        );
       }
       const data = (res.json ?? {}) as Record<string, unknown>;
       // A reschedule (start changed) re-arms reminders against the new time: cancel the old ones, then
@@ -1024,12 +1043,12 @@ function buildCancelEventTool(
 ): StructuredToolInterface {
   const allowed = resolveAllowedCalendarIds(sel.config);
   const labels = resolveCalendarLabels(sel.config);
-  return tool(
+  return failableTool(
     async (input: { eventId: string; calendarId?: string }) => {
       const stamp = contactStamp(ctx);
       if (!stamp) return NO_CONTACT;
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       const pick = pickCalendarId(allowed, labels, input.calendarId);
       if ("error" in pick) return pick.error;
       const calendarId = pick.id;
@@ -1044,11 +1063,13 @@ function buildCancelEventTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: cancel ownership check failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (owner.status === 404) return FOREIGN_EVENT;
       if (owner.status < 200 || owner.status >= 300) {
-        return `Google Calendar returned HTTP ${owner.status}.`;
+        return toolFailure(`Google Calendar returned HTTP ${owner.status}.`);
       }
       const ownerEv = (owner.json ?? {}) as Record<string, unknown>;
       if (eventStamp(ownerEv) !== stamp) return FOREIGN_EVENT;
@@ -1061,12 +1082,16 @@ function buildCancelEventTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: cancel event request failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       // 204 No Content is the success shape; 410 Gone means it was already cancelled (idempotent).
       if (res.status === 410) return "The appointment was already cancelled.";
       if (res.status !== 204 && (res.status < 200 || res.status >= 300)) {
-        return `Google Calendar rejected the cancellation (HTTP ${res.status}).`;
+        return toolFailure(
+          `Google Calendar rejected the cancellation (HTTP ${res.status}).`,
+        );
       }
       // Drop any pending reminders for this appointment (best-effort).
       await ctx.cancelAppointmentReminders?.(input.eventId);
@@ -1089,12 +1114,12 @@ function buildConfirmAppointmentTool(
 ): StructuredToolInterface {
   const allowed = resolveAllowedCalendarIds(sel.config);
   const labels = resolveCalendarLabels(sel.config);
-  return tool(
+  return failableTool(
     async (input: { eventId: string; calendarId?: string }) => {
       const stamp = contactStamp(ctx);
       if (!stamp) return NO_CONTACT;
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       const pick = pickCalendarId(allowed, labels, input.calendarId);
       if ("error" in pick) return pick.error;
       const calendarId = pick.id;
@@ -1108,11 +1133,13 @@ function buildConfirmAppointmentTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: confirm ownership check failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (owner.status === 404) return FOREIGN_EVENT;
       if (owner.status < 200 || owner.status >= 300) {
-        return `Google Calendar returned HTTP ${owner.status}.`;
+        return toolFailure(`Google Calendar returned HTTP ${owner.status}.`);
       }
       const ownerEv = (owner.json ?? {}) as Record<string, unknown>;
       if (eventStamp(ownerEv) !== stamp) return FOREIGN_EVENT;
@@ -1142,10 +1169,14 @@ function buildConfirmAppointmentTool(
         );
       } catch (err) {
         logger.warn({ err }, "gcal: confirm event request failed");
-        return "Failed to reach Google Calendar. Try again shortly.";
+        return toolFailure(
+          "Failed to reach Google Calendar. Try again shortly.",
+        );
       }
       if (res.status < 200 || res.status >= 300) {
-        return `Google Calendar rejected the confirmation (HTTP ${res.status}).`;
+        return toolFailure(
+          `Google Calendar rejected the confirmation (HTTP ${res.status}).`,
+        );
       }
       return "The appointment was marked as confirmed.";
     },

--- a/src/modules/integrations/toolpacks/google-drive.ts
+++ b/src/modules/integrations/toolpacks/google-drive.ts
@@ -1,6 +1,7 @@
-import { type StructuredToolInterface, tool } from "@langchain/core/tools";
+import type { StructuredToolInterface } from "@langchain/core/tools";
 import { z } from "zod";
 import logger from "@/api/lib/logger";
+import { failableTool, toolFailure } from "@/graph/tools/failure";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import {
   type IntegrationSelection,
@@ -173,10 +174,10 @@ function buildFindFileTool(
   ctx: ToolpackCtx,
 ): StructuredToolInterface {
   const folderId = resolveFolderId(sel.config);
-  return tool(
+  return failableTool(
     async (input: { query: string; maxResults?: number }) => {
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       const term = escapeQueryValue(input.query.trim());
       const clauses = [`name contains '${term}'`, "trashed = false"];
       if (folderId) clauses.push(`'${escapeQueryValue(folderId)}' in parents`);
@@ -200,10 +201,10 @@ function buildFindFileTool(
         );
       } catch (err) {
         logger.warn({ err }, "drive: find file request failed");
-        return "Failed to reach Google Drive. Try again shortly.";
+        return toolFailure("Failed to reach Google Drive. Try again shortly.");
       }
       if (res.status < 200 || res.status >= 300) {
-        return `Google Drive returned HTTP ${res.status}.`;
+        return toolFailure(`Google Drive returned HTTP ${res.status}.`);
       }
       const data = (res.json ?? {}) as Record<string, unknown>;
       const files = Array.isArray(data.files) ? data.files : [];
@@ -240,10 +241,10 @@ function buildSendFileTool(
   sel: IntegrationSelection,
   ctx: ToolpackCtx,
 ): StructuredToolInterface {
-  return tool(
+  return failableTool(
     async (input: { fileId: string; caption?: string }) => {
       const token = await resolveToken(sel, ctx);
-      if (!token) return NOT_CONNECTED;
+      if (!token) return toolFailure(NOT_CONNECTED);
       if (!ctx.chatwoot) {
         return "Sending a file to the customer is not available in this context (e.g. the playground). Share the file's link (returned by drive_find_file) instead.";
       }
@@ -258,10 +259,10 @@ function buildSendFileTool(
         );
       } catch (err) {
         logger.warn({ err }, "drive: send file metadata request failed");
-        return "Failed to reach Google Drive. Try again shortly.";
+        return toolFailure("Failed to reach Google Drive. Try again shortly.");
       }
       if (meta.status < 200 || meta.status >= 300) {
-        return `Google Drive returned HTTP ${meta.status}.`;
+        return toolFailure(`Google Drive returned HTTP ${meta.status}.`);
       }
       const m = (meta.json ?? {}) as Record<string, unknown>;
       const name = typeof m.name === "string" ? m.name : "file";
@@ -284,13 +285,17 @@ function buildSendFileTool(
         dl = await driveDownload(downloadPath, token, ctx);
       } catch (err) {
         logger.warn({ err }, "drive: send file download failed");
-        return "Failed to download the file from Google Drive. Try again shortly.";
+        return toolFailure(
+          "Failed to download the file from Google Drive. Try again shortly.",
+        );
       }
       if (dl.tooLarge) {
         return "That file is too large to send here. Share the file's link (returned by drive_find_file) instead.";
       }
       if (dl.status < 200 || dl.status >= 300 || !dl.bytes) {
-        return `Could not download the file from Google Drive (HTTP ${dl.status}).`;
+        return toolFailure(
+          `Could not download the file from Google Drive (HTTP ${dl.status}).`,
+        );
       }
 
       // 3) Deliver to the customer via the live conversation (bot token, multipart).
@@ -304,7 +309,9 @@ function buildSendFileTool(
         );
       } catch (err) {
         logger.warn({ err }, "drive: send file delivery failed");
-        return "Downloaded the file but could not deliver it to the conversation.";
+        return toolFailure(
+          "Downloaded the file but could not deliver it to the conversation.",
+        );
       }
       return `Sent the file "${sendName}" to the customer.`;
     },

--- a/tests/graph/tool-failure.test.ts
+++ b/tests/graph/tool-failure.test.ts
@@ -3,7 +3,7 @@ import { ToolMessage } from "@langchain/core/messages";
 import { z } from "zod";
 import { failableTool, toolFailure } from "@/graph/tools/failure";
 
-// failableTool contract (issue #40): a toolFailure(...) return surfaces to the model as the SAME
+// NOTE: failableTool contract (issue #40): a toolFailure(...) return surfaces to the model as the SAME
 // friendly string, but wrapped in a ToolMessage with status "error" so ToolFlowLogger can log the
 // call as a failure. Without a tool_call in scope it degrades to the plain string (old behavior).
 

--- a/tests/graph/tool-failure.test.ts
+++ b/tests/graph/tool-failure.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { ToolMessage } from "@langchain/core/messages";
+import { z } from "zod";
+import { failableTool, toolFailure } from "@/graph/tools/failure";
+
+// failableTool contract (issue #40): a toolFailure(...) return surfaces to the model as the SAME
+// friendly string, but wrapped in a ToolMessage with status "error" so ToolFlowLogger can log the
+// call as a failure. Without a tool_call in scope it degrades to the plain string (old behavior).
+
+const MSG = "Provider returned HTTP 500.";
+
+const probe = failableTool(
+  async (input: { fail?: boolean }) => (input.fail ? toolFailure(MSG) : "ok"),
+  {
+    name: "probe",
+    description: "failure probe",
+    schema: z.object({ fail: z.boolean().optional() }),
+  },
+);
+
+describe("failableTool", () => {
+  test("a failure invoked as a tool_call becomes a ToolMessage with status error", async () => {
+    const out = await probe.invoke({
+      type: "tool_call",
+      id: "call_1",
+      name: "probe",
+      args: { fail: true },
+    });
+    expect(out).toBeInstanceOf(ToolMessage);
+    const tm = out as ToolMessage;
+    expect(tm.status).toBe("error");
+    expect(tm.content).toBe(MSG);
+    expect(tm.tool_call_id).toBe("call_1");
+    expect(tm.name).toBe("probe");
+  });
+
+  test("a failure invoked with plain args degrades to the plain string", async () => {
+    expect(await probe.invoke({ fail: true })).toBe(MSG);
+  });
+
+  test("the success path is untouched", async () => {
+    expect(await probe.invoke({})).toBe("ok");
+    const wrapped = (await probe.invoke({
+      type: "tool_call",
+      id: "call_2",
+      name: "probe",
+      args: {},
+    })) as ToolMessage;
+    expect(wrapped.status).toBe("success");
+    expect(wrapped.content).toBe("ok");
+  });
+});

--- a/tests/graph/tool-flowlog.test.ts
+++ b/tests/graph/tool-flowlog.test.ts
@@ -215,8 +215,6 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
       },
     );
 
-    // NOTE: The second model call received the failure as a ToolMessage whose content is EXACTLY the
-    // friendly string — the model-facing contract is unchanged by the error marking.
     const second = model.seen[1] ?? [];
     const toolMsg = second.find((m) => m.getType() === "tool") as
       | ToolMessage
@@ -226,7 +224,6 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
     expect(toolMsg?.status).toBe("error");
     expect(toolMsg?.tool_call_id).toBe("call_f1");
 
-    // NOTE: Exactly ONE tool line for the turn, and it is the alertable one.
     const rows = await pollToolRows(flow.turnId, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("warn");

--- a/tests/graph/tool-flowlog.test.ts
+++ b/tests/graph/tool-flowlog.test.ts
@@ -13,7 +13,10 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { buildAgentGraph } from "@/graph/graph";
 import { ToolFlowLogger } from "@/graph/tool-flowlog";
 import { failableTool, toolFailure } from "@/graph/tools/failure";
+import type { TenantContext } from "@/lib/tenancy";
+import { createAlertChannel } from "@/modules/flowlog/channels";
 import type { FlowContext } from "@/modules/flowlog/service";
+import { outboundUrl } from "../utils/outbound";
 
 // The tool line of the execution-flow log must distinguish integration failures from successes:
 // a ToolMessage with status "error" (failableTool) is logged as ONE warn/error line with the
@@ -119,9 +122,15 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
 
   afterAll(async () => {
     if (tenantId) {
-      await suDb.$executeRawUnsafe(
-        `DELETE FROM execution_logs WHERE tenant_id = ${tenantId}`,
-      );
+      for (const table of [
+        "alert_deliveries",
+        "alert_channels",
+        "execution_logs",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
       await suDb.$executeRawUnsafe(
         `DELETE FROM tenants WHERE id = ${tenantId}`,
       );
@@ -223,5 +232,54 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
     expect(rows[0]?.level).toBe("warn");
     expect(rows[0]?.status).toBe("error");
     expect(rows[0]?.errorMessage).toContain("HTTP 503");
+  });
+
+  test("the issue's full loop: a marked failure creates an alert delivery for a minLevel:warn channel", async () => {
+    const ctx: TenantContext = { tenantId, userId: null, role: "TENANT_ADMIN" };
+    const channel = await createAlertChannel(
+      ctx,
+      {
+        name: "Ops",
+        type: "webhook",
+        url: outboundUrl("/hooks/ops"),
+        minLevel: "warn",
+      },
+      appDb,
+    );
+
+    const MSG = "Google Drive returned HTTP 403.";
+    const probe = failableTool(async () => toolFailure(MSG), {
+      name: "probe_alert",
+      description: "always fails",
+      schema: z.object({ fail: z.boolean().optional() }),
+    });
+    const model = new ToolCallThenReplyModel("probe_alert", "ok");
+    const graph = buildAgentGraph({
+      model: model as unknown as BaseChatModel,
+      systemPrompt: "Você é prestativa.",
+      checkpointer: new MemorySaver(),
+      tools: [probe],
+    });
+    const flow = flowCtx();
+    await graph.invoke(
+      { messages: [new HumanMessage("oi")] },
+      {
+        configurable: { thread_id: `tfl-alert-${process.pid}` },
+        callbacks: [new ToolFlowLogger(flow)],
+      },
+    );
+
+    // The delivery row is what the alert worker POSTs from — before this fix the failure was
+    // logged info/ok and no channel could ever produce one (the issue's exact complaint).
+    let delivery: { stage: string | null; level: string | null } | null = null;
+    for (let i = 0; i < 50 && !delivery; i++) {
+      delivery = await suDb.alertDelivery.findFirst({
+        where: { tenantId, channelId: BigInt(channel.id), stage: "tool" },
+        select: { stage: true, level: true },
+      });
+      if (!delivery) await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(delivery).not.toBeNull();
+    expect(delivery?.level).toBe("warn");
   });
 });

--- a/tests/graph/tool-flowlog.test.ts
+++ b/tests/graph/tool-flowlog.test.ts
@@ -18,7 +18,7 @@ import { createAlertChannel } from "@/modules/flowlog/channels";
 import type { FlowContext } from "@/modules/flowlog/service";
 import { outboundUrl } from "../utils/outbound";
 
-// The tool line of the execution-flow log must distinguish integration failures from successes:
+// NOTE: The tool line of the execution-flow log must distinguish integration failures from successes:
 // a ToolMessage with status "error" (failableTool) is logged as ONE warn/error line with the
 // friendly string as errorMessage, so alert channels (minLevel warn) can fire (issue #40).
 
@@ -63,7 +63,7 @@ type LogRow = {
   detail: unknown;
 };
 
-// emitFlowEvent is fire-and-forget; poll until the expected row count lands.
+// NOTE: emitFlowEvent is fire-and-forget; poll until the expected row count lands.
 async function pollToolRows(turnId: string, count: number): Promise<LogRow[]> {
   for (let i = 0; i < 50; i++) {
     const rows = await suDb.executionLog.findMany({
@@ -81,7 +81,7 @@ async function pollToolRows(turnId: string, count: number): Promise<LogRow[]> {
   return [];
 }
 
-// Scripted model: first call emits a tool_call for `toolName`, second call replies with text.
+// NOTE: Scripted model: first call emits a tool_call for `toolName`, second call replies with text.
 // Captures every message list it is invoked with, so the test can assert what the model SAW.
 class ToolCallThenReplyModel {
   seen: BaseMessage[][] = [];
@@ -215,7 +215,7 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
       },
     );
 
-    // The second model call received the failure as a ToolMessage whose content is EXACTLY the
+    // NOTE: The second model call received the failure as a ToolMessage whose content is EXACTLY the
     // friendly string — the model-facing contract is unchanged by the error marking.
     const second = model.seen[1] ?? [];
     const toolMsg = second.find((m) => m.getType() === "tool") as
@@ -226,7 +226,7 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
     expect(toolMsg?.status).toBe("error");
     expect(toolMsg?.tool_call_id).toBe("call_f1");
 
-    // Exactly ONE tool line for the turn, and it is the alertable one.
+    // NOTE: Exactly ONE tool line for the turn, and it is the alertable one.
     const rows = await pollToolRows(flow.turnId, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("warn");
@@ -269,7 +269,7 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
       },
     );
 
-    // The delivery row is what the alert worker POSTs from — before this fix the failure was
+    // NOTE: The delivery row is what the alert worker POSTs from — before this fix the failure was
     // logged info/ok and no channel could ever produce one (the issue's exact complaint).
     let delivery: { stage: string | null; level: string | null } | null = null;
     for (let i = 0; i < 50 && !delivery; i++) {

--- a/tests/graph/tool-flowlog.test.ts
+++ b/tests/graph/tool-flowlog.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import {
+  AIMessage,
+  type BaseMessage,
+  HumanMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { z } from "zod";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { buildAgentGraph } from "@/graph/graph";
+import { ToolFlowLogger } from "@/graph/tool-flowlog";
+import { failableTool, toolFailure } from "@/graph/tools/failure";
+import type { FlowContext } from "@/modules/flowlog/service";
+
+// The tool line of the execution-flow log must distinguish integration failures from successes:
+// a ToolMessage with status "error" (failableTool) is logged as ONE warn/error line with the
+// friendly string as errorMessage, so alert channels (minLevel warn) can fire (issue #40).
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+
+function flowCtx(): FlowContext {
+  return {
+    tenantId,
+    turnId: crypto.randomUUID(),
+    source: "inbox",
+    base: appDb,
+  };
+}
+
+type LogRow = {
+  level: string;
+  status: string | null;
+  errorMessage: string | null;
+  detail: unknown;
+};
+
+// emitFlowEvent is fire-and-forget; poll until the expected row count lands.
+async function pollToolRows(turnId: string, count: number): Promise<LogRow[]> {
+  for (let i = 0; i < 50; i++) {
+    const rows = await suDb.executionLog.findMany({
+      where: { tenantId, turnId, stage: "tool" },
+      select: {
+        level: true,
+        status: true,
+        errorMessage: true,
+        detail: true,
+      },
+    });
+    if (rows.length >= count) return rows;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return [];
+}
+
+// Scripted model: first call emits a tool_call for `toolName`, second call replies with text.
+// Captures every message list it is invoked with, so the test can assert what the model SAW.
+class ToolCallThenReplyModel {
+  seen: BaseMessage[][] = [];
+  constructor(
+    private toolName: string,
+    private reply: string,
+  ) {}
+  async invoke(): Promise<AIMessage> {
+    return new AIMessage(this.reply);
+  }
+  bindTools(_tools: unknown) {
+    const self = this;
+    let n = 0;
+    return {
+      async invoke(messages: BaseMessage[]): Promise<AIMessage> {
+        self.seen.push(messages);
+        n++;
+        return n === 1
+          ? new AIMessage({
+              content: "",
+              tool_calls: [
+                { name: self.toolName, args: { fail: true }, id: "call_f1" },
+              ],
+            })
+          : new AIMessage(self.reply);
+      },
+    };
+  }
+}
+
+describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "TFL", slug: `tfl-${process.pid}` },
+    });
+    tenantId = t.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM execution_logs WHERE tenant_id = ${tenantId}`,
+      );
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  test("a plain string output logs info/ok (regression pin)", async () => {
+    const flow = flowCtx();
+    const logger = new ToolFlowLogger(flow);
+    logger.handleToolStart(
+      {} as never,
+      '{"q":"x"}',
+      "run-ok",
+      undefined,
+      undefined,
+      undefined,
+      "probe",
+    );
+    logger.handleToolEnd("all good", "run-ok");
+    const rows = await pollToolRows(flow.turnId, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("info");
+    expect(rows[0]?.status).toBe("ok");
+    expect(rows[0]?.errorMessage).toBeNull();
+  });
+
+  test("a ToolMessage with status error logs ONE warn/error line carrying the message", async () => {
+    const flow = flowCtx();
+    const logger = new ToolFlowLogger(flow);
+    logger.handleToolStart(
+      {} as never,
+      "{}",
+      "run-fail",
+      undefined,
+      undefined,
+      undefined,
+      "probe",
+    );
+    logger.handleToolEnd(
+      new ToolMessage({
+        status: "error",
+        content: "Google Calendar returned HTTP 500.",
+        tool_call_id: "c1",
+        name: "probe",
+      }),
+      "run-fail",
+    );
+    const rows = await pollToolRows(flow.turnId, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("warn");
+    expect(rows[0]?.status).toBe("error");
+    expect(rows[0]?.errorMessage).toContain(
+      "Google Calendar returned HTTP 500.",
+    );
+    expect((rows[0]?.detail as Record<string, unknown> | null)?.output).toBe(
+      "Google Calendar returned HTTP 500.",
+    );
+  });
+
+  test("e2e through the graph: one warn line AND the model sees the exact friendly string", async () => {
+    const MSG = "The payment provider rejected the request (HTTP 503).";
+    const probe = failableTool(async () => toolFailure(MSG), {
+      name: "probe_fail",
+      description: "always fails",
+      schema: z.object({ fail: z.boolean().optional() }),
+    });
+    const model = new ToolCallThenReplyModel("probe_fail", "entendi");
+    const graph = buildAgentGraph({
+      model: model as unknown as BaseChatModel,
+      systemPrompt: "Você é prestativa.",
+      checkpointer: new MemorySaver(),
+      tools: [probe],
+    });
+    const flow = flowCtx();
+    await graph.invoke(
+      { messages: [new HumanMessage("oi")] },
+      {
+        configurable: { thread_id: `tfl-${process.pid}` },
+        callbacks: [new ToolFlowLogger(flow)],
+      },
+    );
+
+    // The second model call received the failure as a ToolMessage whose content is EXACTLY the
+    // friendly string — the model-facing contract is unchanged by the error marking.
+    const second = model.seen[1] ?? [];
+    const toolMsg = second.find((m) => m.getType() === "tool") as
+      | ToolMessage
+      | undefined;
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg?.content).toBe(MSG);
+    expect(toolMsg?.status).toBe("error");
+    expect(toolMsg?.tool_call_id).toBe("call_f1");
+
+    // Exactly ONE tool line for the turn, and it is the alertable one.
+    const rows = await pollToolRows(flow.turnId, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("warn");
+    expect(rows[0]?.status).toBe("error");
+    expect(rows[0]?.errorMessage).toContain("HTTP 503");
+  });
+});

--- a/tests/graph/tools-http.test.ts
+++ b/tests/graph/tools-http.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { ToolMessage } from "@langchain/core/messages";
 import type { z } from "zod";
 import {
   buildHttpTool,
@@ -1021,5 +1022,42 @@ describe("buildHttpTool — programmatic authoring shapes (JSON-Schema input_sch
     expect(String(out)).toContain("id");
     expect(String(out).toLowerCase()).toContain("error");
     expect(captured.url).toBeUndefined();
+  });
+});
+
+// NOTE: For operator-authored HTTP tools EVERY non-2xx is an integration failure (issue #40):
+// invoked as a tool_call it returns a ToolMessage with status "error" carrying the same
+// "HTTP <status>" body the model already saw; 2xx stays a plain success.
+describe("buildHttpTool — non-2xx marked as integration failure (issue #40)", () => {
+  test("HTTP 500 and HTTP 404 return ToolMessage status error; 200 stays success", async () => {
+    for (const [status, id] of [
+      [500, "call_h1"],
+      [404, "call_h2"],
+    ] as const) {
+      const tool = buildHttpTool(def(), {
+        resolveCredential: async () => null,
+        fetchImpl: stubFetch({}, status, '{"err":true}'),
+      });
+      const out = (await tool.invoke({
+        type: "tool_call",
+        id,
+        name: "thing",
+        args: {},
+      })) as ToolMessage;
+      expect(out.status).toBe("error");
+      expect(String(out.content)).toContain(`HTTP ${status}`);
+    }
+    const ok = buildHttpTool(def(), {
+      resolveCredential: async () => null,
+      fetchImpl: stubFetch({}, 200),
+    });
+    const okOut = (await ok.invoke({
+      type: "tool_call",
+      id: "call_h3",
+      name: "thing",
+      args: {},
+    })) as ToolMessage;
+    expect(okOut.status).toBe("success");
+    expect(String(okOut.content)).toContain("HTTP 200");
   });
 });

--- a/tests/modules/toolpacks-asaas.test.ts
+++ b/tests/modules/toolpacks-asaas.test.ts
@@ -499,6 +499,35 @@ describe("asaas toolpack — integration failures are marked (issue #40)", () =>
     expect(calls).toHaveLength(0);
   });
 
+  test("a rejected customer lookup fails the call — no duplicate customer POST", async () => {
+    const { impl, calls } = scriptedFetch([
+      {
+        match: (u, i) =>
+          u.includes("/customers?cpfCnpj=") && i.method === "GET",
+        status: 500,
+        json: { error: "boom" },
+      },
+    ]);
+    const tool = asaasToolpack.build(
+      sel({
+        enabledTools: ["asaas_create_pix_charge"],
+        config: { environment: "sandbox" },
+      }),
+      baseCtx({ fetchImpl: impl }),
+    )[0];
+    const out = (await tool?.invoke({
+      type: "tool_call",
+      id: "call_as_3",
+      name: "asaas_create_pix_charge",
+      args: { value: 10, customerName: "X", cpfCnpj: "12345678909" },
+    })) as ToolMessage;
+    expect(out.status).toBe("error");
+    expect(String(out.content)).toContain("customer lookup (HTTP 500)");
+    // Exactly ONE request (the lookup): the create branch must never run on a rejected lookup.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.init.method).toBe("GET");
+  });
+
   test("an invalid CPF (model input) is NOT marked as a failure", async () => {
     const { impl, calls } = stubFetch(200, {});
     const tool = asaasToolpack.build(

--- a/tests/modules/toolpacks-asaas.test.ts
+++ b/tests/modules/toolpacks-asaas.test.ts
@@ -529,9 +529,14 @@ describe("asaas toolpack — integration failures are marked (issue #40)", () =>
   });
 
   test("a malformed 2xx lookup body fails the call — no duplicate customer POST", async () => {
-    // NOTE: Two malformed shapes a 2xx can carry: no data array at all, and a non-empty data array
-    // whose first customer has no string id. Either falling through would POST a duplicate customer.
-    for (const body of [{}, { data: [{ nome: "sem id" }] }]) {
+    // NOTE: Malformed shapes a 2xx can carry: no data array at all, a non-empty data array whose
+    // first customer has no string id, and a blank id (customerId would stay falsy and reach the
+    // create branch). Any of them falling through would POST a duplicate customer.
+    for (const body of [
+      {},
+      { data: [{ nome: "sem id" }] },
+      { data: [{ id: "   " }] },
+    ]) {
       const { impl, calls } = scriptedFetch([
         {
           match: (u, i) =>

--- a/tests/modules/toolpacks-asaas.test.ts
+++ b/tests/modules/toolpacks-asaas.test.ts
@@ -523,9 +523,41 @@ describe("asaas toolpack — integration failures are marked (issue #40)", () =>
     })) as ToolMessage;
     expect(out.status).toBe("error");
     expect(String(out.content)).toContain("customer lookup (HTTP 500)");
-    // Exactly ONE request (the lookup): the create branch must never run on a rejected lookup.
+    // NOTE: Exactly ONE request (the lookup): the create branch must never run on a rejected lookup.
     expect(calls).toHaveLength(1);
     expect(calls[0]?.init.method).toBe("GET");
+  });
+
+  test("a malformed 2xx lookup body fails the call — no duplicate customer POST", async () => {
+    // NOTE: Two malformed shapes a 2xx can carry: no data array at all, and a non-empty data array
+    // whose first customer has no string id. Either falling through would POST a duplicate customer.
+    for (const body of [{}, { data: [{ nome: "sem id" }] }]) {
+      const { impl, calls } = scriptedFetch([
+        {
+          match: (u, i) =>
+            u.includes("/customers?cpfCnpj=") && i.method === "GET",
+          status: 200,
+          json: body,
+        },
+      ]);
+      const tool = asaasToolpack.build(
+        sel({
+          enabledTools: ["asaas_create_pix_charge"],
+          config: { environment: "sandbox" },
+        }),
+        baseCtx({ fetchImpl: impl }),
+      )[0];
+      const out = (await tool?.invoke({
+        type: "tool_call",
+        id: "call_as_4",
+        name: "asaas_create_pix_charge",
+        args: { value: 10, customerName: "X", cpfCnpj: "12345678909" },
+      })) as ToolMessage;
+      expect(out.status).toBe("error");
+      expect(String(out.content)).toContain("unexpected response");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.init.method).toBe("GET");
+    }
   });
 
   test("an invalid CPF (model input) is NOT marked as a failure", async () => {

--- a/tests/modules/toolpacks-asaas.test.ts
+++ b/tests/modules/toolpacks-asaas.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { randomBytes } from "node:crypto";
+import type { ToolMessage } from "@langchain/core/messages";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { getMapper } from "@/modules/integrations/mappers";
@@ -474,5 +475,46 @@ describe.skipIf(!dbUp)("asaas toolpack — correlation ref persistence", () => {
     expect((ref?.metadata as Record<string, unknown>)?.paymentId).toBe(
       "pay_db_1",
     );
+  });
+});
+
+// NOTE: Integration failures must reach the flow log as failures (issue #40): invoked as a
+// tool_call, a missing credential returns a ToolMessage with status "error"; bad model input
+// (invalid CPF) stays a plain success — normal operation, not an outage.
+describe("asaas toolpack — integration failures are marked (issue #40)", () => {
+  test("missing credential returns ToolMessage status error", async () => {
+    const { impl, calls } = stubFetch(200, {});
+    const tool = asaasToolpack.build(
+      sel({ enabledTools: ["asaas_payment_status"], credentialRef: null }),
+      baseCtx({ fetchImpl: impl }),
+    )[0];
+    const out = (await tool?.invoke({
+      type: "tool_call",
+      id: "call_as_1",
+      name: "asaas_payment_status",
+      args: { paymentLinkId: "plink_1" },
+    })) as ToolMessage;
+    expect(out.status).toBe("error");
+    expect(String(out.content)).toContain("not configured");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("an invalid CPF (model input) is NOT marked as a failure", async () => {
+    const { impl, calls } = stubFetch(200, {});
+    const tool = asaasToolpack.build(
+      sel({
+        enabledTools: ["asaas_create_pix_charge"],
+        config: { environment: "sandbox" },
+      }),
+      baseCtx({ fetchImpl: impl }),
+    )[0];
+    const out = (await tool?.invoke({
+      type: "tool_call",
+      id: "call_as_2",
+      name: "asaas_create_pix_charge",
+      args: { value: 10, customerName: "X", cpfCnpj: "123" },
+    })) as ToolMessage;
+    expect(out.status).toBe("success");
+    expect(calls).toHaveLength(0);
   });
 });

--- a/tests/modules/toolpacks-google-calendar.test.ts
+++ b/tests/modules/toolpacks-google-calendar.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { ToolMessage } from "@langchain/core/messages";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import { googleCalendarToolpack } from "@/modules/integrations/toolpacks/google-calendar";
 import type {
@@ -1143,5 +1144,57 @@ describe("google calendar toolpack — Meet room on create", () => {
     expect(JSON.parse(out)).toMatchObject({
       meetLink: "https://meet.google.com/abc-defg-hij",
     });
+  });
+});
+
+// NOTE: Integration failures must reach the flow log as failures (issue #40): invoked as a
+// tool_call, a provider/credential failure returns a ToolMessage with status "error" (same friendly
+// content), while bad model input stays a plain success — it is normal operation, not an outage.
+describe("google calendar toolpack — integration failures are marked (issue #40)", () => {
+  test("a non-2xx and a missing credential return ToolMessage status error", async () => {
+    const { impl } = stubFetch(500, { error: "boom" });
+    const http = (await toolFor(
+      "calendar_list_events",
+      {},
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      type: "tool_call",
+      id: "call_cal_1",
+      name: "calendar_list_events",
+      args: {},
+    })) as ToolMessage;
+    expect(http.status).toBe("error");
+    expect(String(http.content)).toContain("500");
+
+    const notConnected = (await toolFor(
+      "calendar_list_events",
+      {},
+      baseCtx({ resolveCredential: async () => null }),
+    )?.invoke({
+      type: "tool_call",
+      id: "call_cal_2",
+      name: "calendar_list_events",
+      args: {},
+    })) as ToolMessage;
+    expect(notConnected.status).toBe("error");
+    expect(String(notConnected.content)).toContain("not connected");
+  });
+
+  test("bad model input (range over 24h) is NOT marked as a failure", async () => {
+    const out = (await toolFor(
+      "calendar_check_availability",
+      {},
+      baseCtx(),
+    )?.invoke({
+      type: "tool_call",
+      id: "call_cal_3",
+      name: "calendar_check_availability",
+      args: {
+        timeMin: "2099-06-22T00:00:00-03:00",
+        timeMax: "2099-06-24T00:00:00-03:00",
+      },
+    })) as ToolMessage;
+    expect(out.status).toBe("success");
+    expect(String(out.content).toLowerCase()).toContain("at most 24 hours");
   });
 });

--- a/tests/modules/toolpacks-google-drive.test.ts
+++ b/tests/modules/toolpacks-google-drive.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { ToolMessage } from "@langchain/core/messages";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { googleDriveToolpack } from "@/modules/integrations/toolpacks/google-drive";
@@ -318,5 +319,43 @@ describe("google drive toolpack — send file", () => {
     const out = (await tool?.invoke({ fileId: "f1" })) as string;
     expect(out).toContain("too large");
     expect(cw.sent).toHaveLength(0);
+  });
+});
+
+// NOTE: Integration failures must reach the flow log as failures (issue #40): invoked as a
+// tool_call, network/credential failures return a ToolMessage with status "error" (same friendly
+// content the model already saw).
+describe("google drive toolpack — integration failures are marked (issue #40)", () => {
+  test("network failure and missing credential return ToolMessage status error", async () => {
+    const boom = (async () => {
+      throw new Error("boom");
+    }) as unknown as typeof fetch;
+    const network = googleDriveToolpack.build(
+      sel({ enabledTools: ["drive_find_file"] }),
+      baseCtx({ fetchImpl: boom }),
+    )[0];
+    const out = (await network?.invoke({
+      type: "tool_call",
+      id: "call_dr_1",
+      name: "drive_find_file",
+      args: { query: "contrato" },
+    })) as ToolMessage;
+    expect(out.status).toBe("error");
+    expect(String(out.content)).toContain("Failed to reach Google Drive");
+
+    const { impl, calls } = routerFetch(() => json(200, {}));
+    const notConnected = googleDriveToolpack.build(
+      sel({ enabledTools: ["drive_find_file"], credentialRef: null }),
+      baseCtx({ fetchImpl: impl }),
+    )[0];
+    const out2 = (await notConnected?.invoke({
+      type: "tool_call",
+      id: "call_dr_2",
+      name: "drive_find_file",
+      args: { query: "x" },
+    })) as ToolMessage;
+    expect(out2.status).toBe("error");
+    expect(String(out2.content)).toContain("not connected");
+    expect(calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Symptom

An integration that fails at runtime is recorded in `execution_logs` as a **successful** tool call — `level: "info"`, `status: "ok"` — with the provider's failure message sitting in `detail.output` as a normal result. Alert channels filter by level, so a channel set to `warn`/`error` never fires on an expired OAuth credential, a provider outage, or a rejected payload. The customer finds out first (issue #40 documents a lead abandoning a conversation after two failed availability checks nobody was alerted about).

## Cause

`ToolFlowLogger.handleToolEnd` stamps every returned output `info`/`ok`; only tools that **throw** reach `handleToolError` (`warn`/`error`). The toolpacks deliberately return friendly strings instead of throwing — correct model-facing behavior (graceful degradation), but the string was doing double duty as the only record of the failure, and the record said nothing went wrong.

## Fix

The model-facing contract is unchanged; the failure is now *marked* on its way out:

- **`src/graph/tools/failure.ts`** (new): `toolFailure(message)` wraps a friendly string as an integration failure; `failableTool(...)` (a `tool()` wrapper) converts it into a `ToolMessage` with `status: "error"` and the same string as content, using LangChain's direct-tool-output passthrough — the message survives intact through `ToolNode` to the model AND reaches `handleToolEnd`. Without a `tool_call` in scope (plain-args invocation, e.g. tests) it degrades to the plain string, exactly today's behavior.
- **`src/graph/tool-flowlog.ts`**: `handleToolEnd` reads `output.status === "error"` → emits the ONE tool line as `level: "warn"`, `status: "error"`, with the string as `errorMessage`. `warn` matches `handleToolError` and the MCP discovery-failure precedent, and passes both the dispatch gate (`warn`/`error` + inbox) and `minLevel` filtering.

### What is marked as a failure

- **google-calendar / google-drive / asaas toolpacks**: network failures, non-2xx provider responses, malformed provider responses, and missing/unresolvable credentials (`NOT_CONNECTED` / "not configured" — operator config, exactly what a channel should surface).
- **Operator-authored HTTP tools**: **every non-2xx** (`HTTP <status>` body unchanged). For a declarative tool, 401/403 mean the operator's credential is broken and 5xx/429 mean the provider is down or throttling — the alert-channel use case. Bursts are contained by the existing coalescing (one pending delivery per channel/stage/level with a `count`). If a deployment's API legitimately uses 404-as-data and this gets noisy, a per-tool "expected statuses" opt-out is the natural follow-up lever — not built now.
- **`react_to_message`**: the `catch` that swallowed a real Chatwoot API failure now marks it.

### What stays `info`/`ok` (deliberately)

Business-level degradation and model input errors are normal operation, not outages: empty availability slots, playground/context gates, invalid ranges, invalid CPF/CNPJ, Asaas id-not-found guidance (recoverable model input), policy limits (blocking-calendar caps, file too large), "already cancelled" idempotency.

MCP tools were already correct (`isError` → `ToolException` → `handleToolError`) and are untouched.

## Tests

- `tests/graph/tool-failure.test.ts`: the wrapper contract (tool_call → `ToolMessage` error with id/name; plain args → plain string; success untouched).
- `tests/graph/tool-flowlog.test.ts`: info/ok pin for plain strings; ONE warn/error line with `errorMessage` for a marked failure; an e2e through `buildAgentGraph` with a scripted model proving the second model call receives the **exact** friendly string (model-facing unchanged) while the flow log records exactly one alertable line; and the issue's full loop — a marked failure produces an `alert_deliveries` row for a `minLevel: warn` channel (before this fix no channel could ever produce one).
- Failure-marking cases per pack (written red-first against the old behavior): calendar HTTP 500 + not-connected, asaas not-configured, drive network + not-connected, HTTP tool 500/404 → error with 200 staying success — plus guards pinning that bad model input (range >24h, invalid CPF) is NOT marked.

## Notes

- Adapter behavior for `ToolMessage.status`: OpenAI-family and Anthropic adapters ignore it (byte-identical requests). `@langchain/google-genai` wraps error-status content as `functionResponse.response.error.details` — same string, semantically coherent framing.
- The playground trace already maps `status === "error"` to its `isError` flag, so marked failures now render as failures there too.
- A sibling class of problems — failures swallowed with a **successful** tool return (orphaned Asaas correlation refs, PIX QR fetch failures, best-effort handoff sends) — needs an explicit extra emit and a `FlowContext` seam into the toolpack context; tracked separately as a follow-up issue.

Fixes #40.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool failures now return clear, helpful messages while preserving relevant details.
  * HTTP, authentication, network, credential, and provider errors are consistently identified as failures.
  * Invalid integration responses are handled safely, avoiding unnecessary follow-up actions.
  * Successful operations and business-level outcomes continue to work normally.
* **Monitoring**
  * Tool-call failures are recorded with appropriate warning or error severity.
  * Warning-level failures can trigger configured alert notifications.
* **Documentation**
  * Added guidance on tool-call logging and integration failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation scope

No live Chatwoot validation in this round: no Chatwoot request changes — the only Chatwoot-facing surface touched is the reaction tool, whose request is unchanged (only its failure return is now marked). Unit + DB-backed e2e close the loop to the observable effect (an `alert_deliveries` row for a `minLevel: warn` channel).
