### PR TITLE
fix(chatwoot): pino de localização do WhatsApp chega ao modelo com coordenadas

### DIFF
--- a/docs/stt.md
+++ b/docs/stt.md
@@ -43,6 +43,7 @@ The OpenAI `/audio/transcriptions` multipart shape is a de-facto standard, so `o
 - **text** → as-is.
 - **audio** → `<mensagem-de-audio>{transcription}</mensagem-de-audio>`, or a "não audível; peça texto" marker when transcription is empty/failed.
 - **image** → marker asking the customer to send text/audio (no vision yet).
+- **location** (a WhatsApp pin) → `<localização latitude="…" longitude="…" titulo="…">` — coordinates + place title from the attachment (`coordinates_lat`/`coordinates_long`/`fallback_title`); the model forwards them as ordinary tool args. `(0,0)` is the column default, treated as "no coordinates"; a pin with neither coordinates nor title falls back to the generic marker.
 - **other file** → `<usuário enviou um arquivo do tipo '{type}'>`.
 - **quoted/replied-to** (`content_attributes.in_reply_to`) → prefixed with the referenced snippet, resolved from the re-fetched page (flush) — omitted on the direct path (no page).
 

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "@/modules/chatwoot/messages";
 import {
   firstAudioAttachment,
+  firstLocationAttachment,
   isIncomingMessage,
   shouldBotHandle,
 } from "@/modules/chatwoot/normalize";
@@ -578,6 +579,7 @@ export async function runAgentTurn(
     attachmentTypes: (n.message?.attachments ?? [])
       .map((a) => a.fileType)
       .filter((t): t is string => t !== null),
+    location: firstLocationAttachment(n.message?.attachments),
     inReplyTo: n.message?.inReplyTo,
     isReaction: n.message?.isReaction,
   };

--- a/src/modules/chatwoot/messages.ts
+++ b/src/modules/chatwoot/messages.ts
@@ -1,4 +1,9 @@
-import { cleanTranscription, type RenderableMessage } from "./render";
+import { firstLocationAttachment } from "./normalize";
+import {
+  cleanTranscription,
+  type RenderableLocation,
+  type RenderableMessage,
+} from "./render";
 
 // Pure parser for the Chatwoot conversation-messages REST response (admin-token getMessages). The
 // list endpoint returns `{ meta, payload: [...] }` (or, defensively, a bare array). Each message
@@ -24,6 +29,9 @@ export interface ChatwootMessageRow {
   extractedText: string | null;
   // Best-effort first-attachment file name (from the data_url basename), for the unsupported marker.
   attachmentName: string | null;
+  // The first usable location attachment's content (coordinates/title), for the <localização>
+  // marker — mirrors the direct webhook path (issue #45). Null when absent/unusable.
+  location: RenderableLocation | null;
   // content_attributes.in_reply_to — the quoted/replied-to message id, if any.
   inReplyTo: number | null;
   // content_attributes.is_reaction — true when this message is an emoji reaction (content = emoji).
@@ -82,6 +90,29 @@ function fileNameFrom(attachments: unknown): string | null {
   return null;
 }
 
+// Raw REST attachments → the shared location extractor (the same fields the webhook mapper reads:
+// coordinates_lat / coordinates_long / fallback_title).
+function locationFrom(attachments: unknown): RenderableLocation | null {
+  if (!Array.isArray(attachments)) return null;
+  return firstLocationAttachment(
+    attachments.filter(isRecord).map((a) => ({
+      fileType: typeof a.file_type === "string" ? a.file_type : null,
+      latitude:
+        typeof a.coordinates_lat === "number" &&
+        Number.isFinite(a.coordinates_lat)
+          ? a.coordinates_lat
+          : null,
+      longitude:
+        typeof a.coordinates_long === "number" &&
+        Number.isFinite(a.coordinates_long)
+          ? a.coordinates_long
+          : null,
+      fallbackTitle:
+        typeof a.fallback_title === "string" ? a.fallback_title : null,
+    })),
+  );
+}
+
 function attachmentTypesFrom(attachments: unknown): string[] {
   if (!Array.isArray(attachments)) return [];
   const out: string[] = [];
@@ -117,6 +148,7 @@ export function parseChatwootMessages(raw: unknown): ChatwootMessageRow[] {
       imageDescription: metaStringFrom(item.attachments, "image_description"),
       extractedText: metaStringFrom(item.attachments, "extracted_text"),
       attachmentName: fileNameFrom(item.attachments),
+      location: locationFrom(item.attachments),
       inReplyTo: ca ? num(ca.in_reply_to) : null,
       isReaction: ca?.is_reaction === true,
     });
@@ -148,6 +180,7 @@ export function toRenderable(row: ChatwootMessageRow): RenderableMessage {
     extractedText: row.extractedText,
     attachmentTypes: row.attachmentTypes,
     attachmentName: row.attachmentName,
+    location: row.location,
     inReplyTo: row.inReplyTo,
     isReaction: row.isReaction,
   };

--- a/src/modules/chatwoot/messages.ts
+++ b/src/modules/chatwoot/messages.ts
@@ -29,8 +29,8 @@ export interface ChatwootMessageRow {
   extractedText: string | null;
   // Best-effort first-attachment file name (from the data_url basename), for the unsupported marker.
   attachmentName: string | null;
-  // The first usable location attachment's content (coordinates/title), for the <localização>
-  // marker — mirrors the direct webhook path (issue #45). Null when absent/unusable.
+  // NOTE: The first usable location attachment's content (coordinates/title), for the
+  // <localização> marker — mirrors the direct webhook path (issue #45). Null when absent/unusable.
   location: RenderableLocation | null;
   // content_attributes.in_reply_to — the quoted/replied-to message id, if any.
   inReplyTo: number | null;
@@ -90,8 +90,8 @@ function fileNameFrom(attachments: unknown): string | null {
   return null;
 }
 
-// Raw REST attachments → the shared location extractor (the same fields the webhook mapper reads:
-// coordinates_lat / coordinates_long / fallback_title).
+// NOTE: Raw REST attachments → the shared location extractor (the same fields the webhook mapper
+// reads: coordinates_lat / coordinates_long / fallback_title).
 function locationFrom(attachments: unknown): RenderableLocation | null {
   if (!Array.isArray(attachments)) return null;
   return firstLocationAttachment(

--- a/src/modules/chatwoot/normalize.ts
+++ b/src/modules/chatwoot/normalize.ts
@@ -98,8 +98,8 @@ export function normalizeChatwootEvent(
             // Audio attachments ship `transcribed_text` (empty until our write-back lands); empty
             // string normalizes to null so callers can treat "no transcription" uniformly.
             transcribedText: str(a.transcribed_text) || null,
-            // Location attachments ship coordinates + place name (location_metadata); null-ish on
-            // every other file_type.
+            // NOTE: Location attachments ship coordinates + place name (location_metadata);
+            // null-ish on every other file_type.
             latitude: float(a.coordinates_lat),
             longitude: float(a.coordinates_long),
             fallbackTitle: str(a.fallback_title) || null,
@@ -294,11 +294,12 @@ export function firstAudioAttachment(e: NormalizedChatwootEvent): {
   return null;
 }
 
-// The first USABLE location attachment (a WhatsApp pin): real coordinates and/or a human title, or
-// null. Chatwoot's coordinate columns default to 0.0, so an exact (0,0) — the null island — means
-// the provider sent no coordinates, not a pin in the Gulf of Guinea; such a pin can still carry a
-// usable fallback_title (place name + address). Neither ⇒ null, and the render falls back to the
-// generic attachment marker. Shared by the direct webhook path and the debounce re-fetch (issue #45).
+// NOTE: The first USABLE location attachment (a WhatsApp pin): real coordinates and/or a human
+// title, or null. Chatwoot's coordinate columns default to 0.0, so an exact (0,0) — the null
+// island — means the provider sent no coordinates, not a pin in the Gulf of Guinea; such a pin can
+// still carry a usable fallback_title (place name + address). Neither ⇒ null, and the render falls
+// back to the generic attachment marker. Shared by the direct webhook path and the debounce
+// re-fetch (issue #45).
 export function firstLocationAttachment(
   attachments:
     | Array<
@@ -313,8 +314,16 @@ export function firstLocationAttachment(
     if (a.fileType !== "location") continue;
     const lat = a.latitude ?? null;
     const long = a.longitude ?? null;
+    // NOTE: Out-of-range values (|lat| > 90, |long| > 180) are provider garbage, not coordinates —
+    // they would flow into tool args. Same fail-safe as (0,0): drop the coords, keep the title.
     const hasCoords =
-      lat !== null && long !== null && !(lat === 0 && long === 0);
+      lat !== null &&
+      long !== null &&
+      lat >= -90 &&
+      lat <= 90 &&
+      long >= -180 &&
+      long <= 180 &&
+      !(lat === 0 && long === 0);
     const title = a.fallbackTitle?.replace(/\s+/g, " ").trim() || null;
     if (hasCoords || title) {
       return {

--- a/src/modules/chatwoot/normalize.ts
+++ b/src/modules/chatwoot/normalize.ts
@@ -1,4 +1,8 @@
-import type { NormalizedChatwootEvent } from "./types";
+import type { RenderableLocation } from "./render";
+import type {
+  NormalizedChatwootAttachment,
+  NormalizedChatwootEvent,
+} from "./types";
 
 // Pure normalization of an (untrusted) Chatwoot Agent Bot webhook payload into the fields we
 // act on, tolerant of the two payload shapes. No DB, no network — the receiver verifies HMAC,
@@ -16,6 +20,12 @@ function num(v: unknown): number | null {
 
 function str(v: unknown): string | null {
   return typeof v === "string" ? v : null;
+}
+
+// NOTE: Coordinates arrive as JSON floats (possibly negative) — num() deliberately rejects those
+// (it parses ids). Numbers only: the fork's serializer never sends coordinates as strings.
+function float(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
 
 // NOTE: undefined means "this payload said nothing", so the mirror keeps the stored bag instead of
@@ -88,6 +98,11 @@ export function normalizeChatwootEvent(
             // Audio attachments ship `transcribed_text` (empty until our write-back lands); empty
             // string normalizes to null so callers can treat "no transcription" uniformly.
             transcribedText: str(a.transcribed_text) || null,
+            // Location attachments ship coordinates + place name (location_metadata); null-ish on
+            // every other file_type.
+            latitude: float(a.coordinates_lat),
+            longitude: float(a.coordinates_long),
+            fallbackTitle: str(a.fallback_title) || null,
           }))
         : undefined,
       inReplyTo: ca ? num(ca.in_reply_to) : null,
@@ -273,6 +288,39 @@ export function firstAudioAttachment(e: NormalizedChatwootEvent): {
         id: a.id,
         dataUrl: a.dataUrl,
         transcribedText: a.transcribedText ?? null,
+      };
+    }
+  }
+  return null;
+}
+
+// The first USABLE location attachment (a WhatsApp pin): real coordinates and/or a human title, or
+// null. Chatwoot's coordinate columns default to 0.0, so an exact (0,0) — the null island — means
+// the provider sent no coordinates, not a pin in the Gulf of Guinea; such a pin can still carry a
+// usable fallback_title (place name + address). Neither ⇒ null, and the render falls back to the
+// generic attachment marker. Shared by the direct webhook path and the debounce re-fetch (issue #45).
+export function firstLocationAttachment(
+  attachments:
+    | Array<
+        Pick<
+          NormalizedChatwootAttachment,
+          "fileType" | "latitude" | "longitude" | "fallbackTitle"
+        >
+      >
+    | undefined,
+): RenderableLocation | null {
+  for (const a of attachments ?? []) {
+    if (a.fileType !== "location") continue;
+    const lat = a.latitude ?? null;
+    const long = a.longitude ?? null;
+    const hasCoords =
+      lat !== null && long !== null && !(lat === 0 && long === 0);
+    const title = a.fallbackTitle?.replace(/\s+/g, " ").trim() || null;
+    if (hasCoords || title) {
+      return {
+        latitude: hasCoords ? lat : null,
+        longitude: hasCoords ? long : null,
+        title,
       };
     }
   }

--- a/src/modules/chatwoot/render.ts
+++ b/src/modules/chatwoot/render.ts
@@ -8,6 +8,15 @@
 //   * a quoted/replied-to message → prefixed with the referenced snippet when resolvable.
 // Pure: no DB, no network. Shared by the direct (webhook) path and the debounce flush.
 
+// A location attachment's usable content (issue #45): coordinates and/or the provider's place
+// title ("Padaria do Zé, Rua X, 123"). Coordinate-less pins keep the title; see
+// firstLocationAttachment for the (0,0) null-island rule.
+export interface RenderableLocation {
+  latitude: number | null;
+  longitude: number | null;
+  title: string | null;
+}
+
 export interface RenderableMessage {
   text: string;
   transcribedText?: string | null;
@@ -18,6 +27,9 @@ export interface RenderableMessage {
   attachmentTypes: string[];
   // Best-effort file name of the first attachment (for the "could not extract" marker).
   attachmentName?: string | null;
+  // The first usable location attachment's content (coordinates/title), or null/absent. Rendered
+  // as a <localização …> marker so the model can pass the coordinates on as ordinary tool args.
+  location?: RenderableLocation | null;
   inReplyTo?: number | null;
   // True when this message is an emoji reaction (content = the emoji). Rendered as a context marker so
   // the agent understands the customer reacted (vs sent the emoji as a message) and can decide whether
@@ -76,6 +88,17 @@ export function renderInboundMessage(
     body = withText(
       "<usuário enviou uma imagem; peça que envie a informação por texto ou áudio>",
     );
+  } else if (m.location) {
+    // A WhatsApp location pin: surfaced as attributes (mirroring the reaction marker) so the model
+    // reads the coordinates and forwards them as ordinary tool arguments (issue #45). A pin with
+    // neither coordinates nor title never gets here (location is null) and falls through to the
+    // generic marker below.
+    const coords =
+      m.location.latitude !== null && m.location.longitude !== null
+        ? ` latitude="${m.location.latitude}" longitude="${m.location.longitude}"`
+        : "";
+    const title = m.location.title ? ` titulo="${m.location.title}"` : "";
+    body = withText(`<localização${coords}${title}>`);
   } else if (text) {
     body = text;
   } else if (types.size > 0) {

--- a/src/modules/chatwoot/render.ts
+++ b/src/modules/chatwoot/render.ts
@@ -8,7 +8,7 @@
 //   * a quoted/replied-to message → prefixed with the referenced snippet when resolvable.
 // Pure: no DB, no network. Shared by the direct (webhook) path and the debounce flush.
 
-// A location attachment's usable content (issue #45): coordinates and/or the provider's place
+// NOTE: A location attachment's usable content (issue #45): coordinates and/or the provider's place
 // title ("Padaria do Zé, Rua X, 123"). Coordinate-less pins keep the title; see
 // firstLocationAttachment for the (0,0) null-island rule.
 export interface RenderableLocation {
@@ -27,8 +27,8 @@ export interface RenderableMessage {
   attachmentTypes: string[];
   // Best-effort file name of the first attachment (for the "could not extract" marker).
   attachmentName?: string | null;
-  // The first usable location attachment's content (coordinates/title), or null/absent. Rendered
-  // as a <localização …> marker so the model can pass the coordinates on as ordinary tool args.
+  // NOTE: The first usable location attachment's content (coordinates/title), or null/absent.
+  // Rendered as a <localização …> marker so the model can pass the coordinates on as tool args.
   location?: RenderableLocation | null;
   inReplyTo?: number | null;
   // True when this message is an emoji reaction (content = the emoji). Rendered as a context marker so
@@ -89,15 +89,20 @@ export function renderInboundMessage(
       "<usuário enviou uma imagem; peça que envie a informação por texto ou áudio>",
     );
   } else if (m.location) {
-    // A WhatsApp location pin: surfaced as attributes (mirroring the reaction marker) so the model
-    // reads the coordinates and forwards them as ordinary tool arguments (issue #45). A pin with
-    // neither coordinates nor title never gets here (location is null) and falls through to the
-    // generic marker below.
+    // NOTE: A WhatsApp location pin: surfaced as attributes (mirroring the reaction marker) so the
+    // model reads the coordinates and forwards them as ordinary tool arguments (issue #45). A pin
+    // with neither coordinates nor title never gets here (location is null) and falls through to
+    // the generic marker below.
     const coords =
       m.location.latitude !== null && m.location.longitude !== null
         ? ` latitude="${m.location.latitude}" longitude="${m.location.longitude}"`
         : "";
-    const title = m.location.title ? ` titulo="${m.location.title}"` : "";
+    // NOTE: The title is provider/user text inside a quoted pseudo-attribute — a double quote in it
+    // would read as closing the attribute early; swap for single quotes (no full XML escaping, per
+    // this file's marker convention).
+    const title = m.location.title
+      ? ` titulo="${m.location.title.replace(/"/g, "'")}"`
+      : "";
     body = withText(`<localização${coords}${title}>`);
   } else if (text) {
     body = text;

--- a/src/modules/chatwoot/types.ts
+++ b/src/modules/chatwoot/types.ts
@@ -42,6 +42,14 @@ export interface NormalizedChatwootAttachment {
   // message_created; populated once our STT write-back lands (which the fork re-dispatches as a
   // message_updated). Read to make eager STT idempotent and to render the transcription in the UI.
   transcribedText?: string | null;
+  // Location attachments (a WhatsApp pin) also ship their coordinates + human-readable place name
+  // in the payload (Attachment#push_event_data → location_metadata: coordinates_lat /
+  // coordinates_long / fallback_title). The columns default to 0.0, so an exact (0,0) means "the
+  // provider sent no coordinates", not a real pin (see firstLocationAttachment). Absent on every
+  // other file_type.
+  latitude?: number | null;
+  longitude?: number | null;
+  fallbackTitle?: string | null;
 }
 
 export interface NormalizedChatwootMessage {

--- a/src/modules/chatwoot/types.ts
+++ b/src/modules/chatwoot/types.ts
@@ -42,8 +42,8 @@ export interface NormalizedChatwootAttachment {
   // message_created; populated once our STT write-back lands (which the fork re-dispatches as a
   // message_updated). Read to make eager STT idempotent and to render the transcription in the UI.
   transcribedText?: string | null;
-  // Location attachments (a WhatsApp pin) also ship their coordinates + human-readable place name
-  // in the payload (Attachment#push_event_data → location_metadata: coordinates_lat /
+  // NOTE: Location attachments (a WhatsApp pin) also ship their coordinates + human-readable place
+  // name in the payload (Attachment#push_event_data → location_metadata: coordinates_lat /
   // coordinates_long / fallback_title). The columns default to 0.0, so an exact (0,0) means "the
   // provider sent no coordinates", not a real pin (see firstLocationAttachment). Absent on every
   // other file_type.

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -56,6 +56,7 @@ import {
   type ControlCommand,
   controlCommand,
   firstAudioAttachment,
+  firstLocationAttachment,
   firstVisualAttachment,
   isHumanAgentMessage,
   isIncomingMessage,
@@ -525,6 +526,7 @@ async function ingestUnhandledMessage(args: {
     attachmentTypes: (n.message.attachments ?? [])
       .map((a) => a.fileType)
       .filter((t): t is string => t !== null),
+    location: firstLocationAttachment(n.message.attachments),
     inReplyTo: n.message.inReplyTo,
   });
   if (!text.trim()) return;

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { AIMessage } from "@langchain/core/messages";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
 import { MemorySaver } from "@langchain/langgraph";
 import { PrismaPg } from "@prisma/adapter-pg";
@@ -53,6 +54,20 @@ type JsonValue =
 
 function fakeModel() {
   return new FakeListChatModel({ responses: [REPLY] });
+}
+
+// NOTE: Captures every message list the model is invoked with, so a test can assert what the model
+// actually SAW (issue #45: the rendered location marker).
+class CaptureReplyModel {
+  seen: unknown[][] = [];
+  constructor(private reply: string) {}
+  async invoke(messages: unknown[]) {
+    this.seen.push(messages);
+    return new AIMessage(this.reply);
+  }
+  bindTools(_tools: unknown) {
+    return { invoke: (messages: unknown[]) => this.invoke(messages) };
+  }
 }
 
 function makeStubClient(sent: Array<[number, string]>) {
@@ -221,6 +236,54 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     });
     expect(outcome).toBe("posted");
     expect(sent).toEqual([[900, REPLY]]);
+  });
+
+  // NOTE: Issue #45 end-to-end (direct path): a WhatsApp location pin must reach the model as the
+  // rendered <localização> marker — before the fix it arrived as an unusable "unsupported file".
+  test("a location pin reaches the model as a <localização> marker", async () => {
+    await seedConversation(960, null);
+    const model = new CaptureReplyModel(REPLY);
+    const sent: Array<[number, string]> = [];
+    const outcome = await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: incoming({
+        conversationId: 960,
+        message: {
+          id: 2,
+          content: "",
+          messageType: "incoming",
+          private: false,
+          attachments: [
+            {
+              id: 5,
+              fileType: "location",
+              dataUrl: "https://maps.google.com/maps?q=-23.5505,-46.6333",
+              latitude: -23.5505,
+              longitude: -46.6333,
+              fallbackTitle: "Padaria do Zé",
+            },
+          ],
+        },
+      }),
+      base: appDb,
+      deps: {
+        makeModel: () => model as never,
+        makeClient: makeStubClient(sent),
+        checkpointer: new MemorySaver(),
+      },
+    });
+    expect(outcome).toBe("posted");
+    const first = model.seen[0] ?? [];
+    const human = [...first]
+      .reverse()
+      .find((m) => (m as { getType(): string }).getType() === "human") as
+      | { content: unknown }
+      | undefined;
+    expect(String(human?.content ?? "")).toContain(
+      '<localização latitude="-23.5505" longitude="-46.6333" titulo="Padaria do Zé">',
+    );
   });
 
   test("memory is per-contact-inbox: a new conversation reuses the thread with a divider", async () => {

--- a/tests/modules/chatwoot-messages.test.ts
+++ b/tests/modules/chatwoot-messages.test.ts
@@ -3,7 +3,9 @@ import {
   buildQuoteResolver,
   parseChatwootMessages,
   pendingIncoming,
+  toRenderable,
 } from "@/modules/chatwoot/messages";
+import { renderInboundMessage } from "@/modules/chatwoot/render";
 
 describe("parseChatwootMessages", () => {
   test("parses { payload } with integer message_type, sorted by id", () => {
@@ -24,6 +26,7 @@ describe("parseChatwootMessages", () => {
       imageDescription: null,
       extractedText: null,
       attachmentName: null,
+      location: null,
       inReplyTo: null,
       isReaction: false,
     });
@@ -83,6 +86,43 @@ describe("parseChatwootMessages", () => {
     expect(rows[0]?.attachmentTypes).toEqual(["audio"]);
     expect(rows[0]?.transcribedText).toBe("oi tudo bem");
     expect(rows[0]?.inReplyTo).toBe(7);
+  });
+
+  // NOTE: Issue #45 — the debounce re-fetch path must carry the pin the same way the direct path
+  // does, and the maps-URL basename ("maps") must stop leaking as a fake file name.
+  test("location attachment: coordinates ride the REST row into the renderable", () => {
+    const rows = parseChatwootMessages({
+      payload: [
+        {
+          id: 11,
+          content: "",
+          message_type: 0,
+          attachments: [
+            {
+              id: 2,
+              file_type: "location",
+              coordinates_lat: -23.5505,
+              coordinates_long: -46.6333,
+              fallback_title: "Padaria do Zé",
+              data_url: "https://maps.google.com/maps?q=-23.5505,-46.6333",
+            },
+          ],
+        },
+      ],
+    });
+    const row = rows[0];
+    expect(row).toBeDefined();
+    if (!row) return;
+    const renderable = toRenderable(row);
+    expect(renderable.location).toEqual({
+      latitude: -23.5505,
+      longitude: -46.6333,
+      title: "Padaria do Zé",
+    });
+    const out = renderInboundMessage(renderable);
+    expect(out).toBe(
+      '<localização latitude="-23.5505" longitude="-46.6333" titulo="Padaria do Zé">',
+    );
   });
 });
 

--- a/tests/modules/chatwoot-render.test.ts
+++ b/tests/modules/chatwoot-render.test.ts
@@ -116,3 +116,61 @@ describe("renderInboundMessage", () => {
     expect(out).toBe('<reação do cliente emoji="👍">');
   });
 });
+
+// NOTE: Issue #45 — a WhatsApp location pin must reach the model as coordinates, not as an
+// unusable "unsupported file" marker. The marker style mirrors the reaction marker (pt-BR
+// pseudo-tag with attributes).
+describe("location markers (issue #45)", () => {
+  test("coordinates + title render as a <localização> marker", () => {
+    const out = renderInboundMessage({
+      text: "",
+      attachmentTypes: ["location"],
+      location: {
+        latitude: -23.5505,
+        longitude: -46.6333,
+        title: "Padaria do Zé, Rua X, 123",
+      },
+    });
+    expect(out).toBe(
+      '<localização latitude="-23.5505" longitude="-46.6333" titulo="Padaria do Zé, Rua X, 123">',
+    );
+  });
+
+  test("coordinates without a title omit the titulo attribute", () => {
+    const out = renderInboundMessage({
+      text: "",
+      attachmentTypes: ["location"],
+      location: { latitude: 48.7484, longitude: 30.2216, title: null },
+    });
+    expect(out).toBe('<localização latitude="48.7484" longitude="30.2216">');
+  });
+
+  test("a title-only pin (provider sent no coordinates) still renders", () => {
+    const out = renderInboundMessage({
+      text: "",
+      attachmentTypes: ["location"],
+      location: { latitude: null, longitude: null, title: "Praça da Sé" },
+    });
+    expect(out).toBe('<localização titulo="Praça da Sé">');
+  });
+
+  test("text alongside the pin keeps the text and appends the marker", () => {
+    const out = renderInboundMessage({
+      text: "estou aqui",
+      attachmentTypes: ["location"],
+      location: { latitude: -1.5, longitude: -48.2, title: null },
+    });
+    expect(out).toBe(
+      'estou aqui\n<localização latitude="-1.5" longitude="-48.2">',
+    );
+  });
+
+  test("a location without usable content falls back to the generic file marker", () => {
+    const out = renderInboundMessage({
+      text: "",
+      attachmentTypes: ["location"],
+      location: null,
+    });
+    expect(out).toContain("arquivo do tipo 'location'");
+  });
+});

--- a/tests/modules/chatwoot-render.test.ts
+++ b/tests/modules/chatwoot-render.test.ts
@@ -165,6 +165,21 @@ describe("location markers (issue #45)", () => {
     );
   });
 
+  test("double quotes in the title become single quotes (the attribute stays intact)", () => {
+    const out = renderInboundMessage({
+      text: "",
+      attachmentTypes: ["location"],
+      location: {
+        latitude: -23.5,
+        longitude: -46.6,
+        title: 'Bar do "Zé"',
+      },
+    });
+    expect(out).toBe(
+      '<localização latitude="-23.5" longitude="-46.6" titulo="Bar do \'Zé\'">',
+    );
+  });
+
   test("a location without usable content falls back to the generic file marker", () => {
     const out = renderInboundMessage({
       text: "",

--- a/tests/modules/chatwoot-webhook.test.ts
+++ b/tests/modules/chatwoot-webhook.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/modules/chatwoot/management";
 import {
   firstAudioAttachment,
+  firstLocationAttachment,
   isHumanAgentMessage,
   isIncomingMessage,
   isNewIncomingMessage,
@@ -184,6 +185,81 @@ describe("normalizeChatwootEvent", () => {
   test("returns null for a non-object or eventless payload", () => {
     expect(normalizeChatwootEvent(null)).toBeNull();
     expect(normalizeChatwootEvent({ foo: 1 })).toBeNull();
+  });
+
+  // NOTE: Issue #45 — the fork ships coordinates_lat/coordinates_long/fallback_title on location
+  // attachments (Attachment#location_metadata); the mapper used to drop all three.
+  test("location attachment: coordinates + fallback title survive normalization", () => {
+    const e = normalizeChatwootEvent({
+      event: "message_created",
+      id: 1002,
+      content: "",
+      message_type: "incoming",
+      private: false,
+      attachments: [
+        {
+          id: 31,
+          file_type: "location",
+          coordinates_lat: -23.5505,
+          coordinates_long: -46.6333,
+          fallback_title: "Padaria do Zé, Rua X, 123",
+          data_url: "https://maps.google.com/maps?q=-23.5505,-46.6333",
+        },
+      ],
+      conversation: { id: 42, inbox_id: 7, status: "pending" },
+    });
+    expect(e?.message?.attachments?.[0]).toMatchObject({
+      fileType: "location",
+      latitude: -23.5505,
+      longitude: -46.6333,
+      fallbackTitle: "Padaria do Zé, Rua X, 123",
+    });
+  });
+});
+
+describe("firstLocationAttachment (issue #45)", () => {
+  const loc = (over: Record<string, unknown> = {}) => ({
+    id: 1,
+    fileType: "location",
+    dataUrl: null,
+    latitude: null as number | null,
+    longitude: null as number | null,
+    fallbackTitle: null as string | null,
+    ...over,
+  });
+
+  test("the null island (0,0) without a title is unusable — column defaults, not a real pin", () => {
+    expect(
+      firstLocationAttachment([loc({ latitude: 0, longitude: 0 })]),
+    ).toBeNull();
+  });
+
+  test("(0, non-zero) is a real coordinate", () => {
+    expect(
+      firstLocationAttachment([loc({ latitude: 0, longitude: 9.4 })]),
+    ).toEqual({ latitude: 0, longitude: 9.4, title: null });
+  });
+
+  test("an empty-string title normalizes to null; coordinates stay usable", () => {
+    expect(
+      firstLocationAttachment([
+        loc({ latitude: -23.5, longitude: -46.6, fallbackTitle: "  " }),
+      ]),
+    ).toEqual({ latitude: -23.5, longitude: -46.6, title: null });
+  });
+
+  test("a title-only pin is usable; non-location attachments are skipped", () => {
+    expect(
+      firstLocationAttachment([
+        loc({ fileType: "image" }),
+        loc({ fallbackTitle: "Praça da Sé" }),
+      ]),
+    ).toEqual({ latitude: null, longitude: null, title: "Praça da Sé" });
+  });
+
+  test("no attachments → null", () => {
+    expect(firstLocationAttachment(undefined)).toBeNull();
+    expect(firstLocationAttachment([])).toBeNull();
   });
 });
 

--- a/tests/modules/chatwoot-webhook.test.ts
+++ b/tests/modules/chatwoot-webhook.test.ts
@@ -261,6 +261,27 @@ describe("firstLocationAttachment (issue #45)", () => {
     expect(firstLocationAttachment(undefined)).toBeNull();
     expect(firstLocationAttachment([])).toBeNull();
   });
+
+  test("boundary coordinates are accepted; out-of-range values are dropped", () => {
+    expect(
+      firstLocationAttachment([loc({ latitude: 90, longitude: 180 })]),
+    ).toEqual({ latitude: 90, longitude: 180, title: null });
+    expect(
+      firstLocationAttachment([loc({ latitude: -90, longitude: -180 })]),
+    ).toEqual({ latitude: -90, longitude: -180, title: null });
+    // Provider garbage: no coordinate survives, the title (when present) still does.
+    expect(
+      firstLocationAttachment([loc({ latitude: 91, longitude: 10 })]),
+    ).toBeNull();
+    expect(
+      firstLocationAttachment([loc({ latitude: 10, longitude: 181 })]),
+    ).toBeNull();
+    expect(
+      firstLocationAttachment([
+        loc({ latitude: -91, longitude: 10, fallbackTitle: "Praça da Sé" }),
+      ]),
+    ).toEqual({ latitude: null, longitude: null, title: "Praça da Sé" });
+  });
 });
 
 describe("isHumanAgentMessage (continuous-ingestion role gate)", () => {


### PR DESCRIPTION
Fixes #45.

When a WhatsApp user shares a location pin, Chatwoot stores `coordinates_lat` / `coordinates_long` / `fallback_title` on the attachment and ships all three in both the webhook payload and the REST messages list (`Attachment#location_metadata`, same serializer on both paths). The agent's normalization dropped all of them, so the model received only `<usuário enviou um arquivo do tipo 'location'; não foi possível extrair o conteúdo>` — and on the debounce path the maps-URL basename even leaked as a fake file name (`chamado 'maps'`).

## What changed

Additive, scoped to the ingestion path exactly as proposed in the issue — no tool or context-var plumbing:

- `NormalizedChatwootAttachment` gains `latitude` / `longitude` / `fallbackTitle`; the webhook mapper reads them (new `float()` helper — `num()` deliberately rejects negative floats, it parses ids).
- New `firstLocationAttachment` (`normalize.ts`) extracts the first **usable** pin. Chatwoot's coordinate columns default to `0.0`, so an exact `(0,0)` — the null island — is treated as "provider sent no coordinates", never as a real pin; a coordinate-less pin can still carry a usable `fallback_title`. Neither ⇒ null ⇒ the generic marker, as before.
- `renderInboundMessage` renders the pin before the generic fallback, in the reaction-marker style:
  `<localização latitude="-23.5505" longitude="-46.6333" titulo="Padaria do Zé, Rua X, 123">`
  (attributes omitted when absent; message text, when present, is kept above the marker).
- The debounce re-fetch path matches the direct path: `ChatwootMessageRow` carries `location` (extracted from the raw REST attachments through the same shared helper) and `toRenderable` forwards it. Both direct assembly points (`runtime.ts`, `webhook.ts` unhandled-ingest) pass `location` too.
- `docs/stt.md` marker list updated.

## Validation scope

- Unit: marker rendering (coords+title / coords-only / title-only / text alongside / unusable pin falls back), `firstLocationAttachment` edge cases (null island, `(0, non-zero)`, empty-string title, non-location attachments skipped), webhook mapper normalization, REST row → renderable (including that `'maps'` no longer leaks as a file name).
- End-to-end (DB-backed, local — the public CI has no Postgres service, so DB suites skip there): `runAgentTurn` with a location event → the model's first invocation contains the exact `<localização …>` marker.
- Payload shapes verified against the fork source (`Attachment#location_metadata`, `Message#webhook_data`, and the conversations/messages jbuilder — webhook and REST serialize attachments through the same `push_event_data`). No Chatwoot-facing request changes in this PR, so no live Chatwoot validation was run.

## Notes

- The issue's vCard remark is only partially right: contact messages arrive with non-empty `content` (Baileys builds "Name - +55…" per contact; Cloud API sends `name.formatted_name`), so they hit the text branch, not the generic fallback. The real vCard gap is Cloud API losing the phone (it lives only in `fallback_title`) — out of scope here.
- The operator console also drops location attachments today (`ConversationDetailPage` skips attachments without `data_url`); worth a small follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WhatsApp location attachments are now supported in inbound messages.
  * Location details, including available coordinates and titles, are preserved for agent processing.
  * Location markers can appear alongside message text.

* **Bug Fixes**
  * Invalid or incomplete location data now falls back gracefully to a generic marker or title-only location.

* **Tests**
  * Added coverage for location coordinates, titles, accompanying text, and invalid attachment data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->