### PR TITLE
fix(graph): declare Gemini tools as JSON Schema so a numeric bound stops rejecting every turn

### DIFF
--- a/src/graph/gemini-tools.ts
+++ b/src/graph/gemini-tools.ts
@@ -57,12 +57,26 @@ function normalizeTupleItems(node: unknown, depth = 0): unknown {
     return node.map((v) => normalizeTupleItems(v, depth + 1));
   if (!node || typeof node !== "object") return node;
   const source = node as Record<string, unknown>;
+  const isTuple = Array.isArray(source.items);
   const hasPrefixItems = "prefixItems" in source;
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(source)) {
     if (key === "items" && Array.isArray(value)) {
       if (!hasPrefixItems) {
         out.prefixItems = value.map((v) => normalizeTupleItems(v, depth + 1));
+      }
+      continue;
+    }
+    if (key === "additionalItems") {
+      // The other half of the same translation: what draft-07 spelled `additionalItems` is the
+      // single-schema form of `items` in 2020-12. Dropping it would silently widen the contract —
+      // `additionalItems: false` means "nothing past the tuple", and losing it lets the model send
+      // extra elements. Outside a tuple the keyword has no meaning in either draft, so it goes.
+      if (isTuple) {
+        out.items =
+          typeof value === "boolean"
+            ? value
+            : normalizeTupleItems(value, depth + 1);
       }
       continue;
     }

--- a/src/graph/gemini-tools.ts
+++ b/src/graph/gemini-tools.ts
@@ -1,0 +1,115 @@
+import { isLangChainTool } from "@langchain/core/utils/function_calling";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
+
+// Gemini tool declarations. @langchain/google-genai declares a tool's parameters in
+// `FunctionDeclaration.parameters`, which generativelanguage parses as the OpenAPI 3.03 subset: a
+// CLOSED set of 22 fields (the API's own discovery document lists them under `.schemas.Schema
+// .properties` at https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta). One
+// field outside that set makes the API reject the ENTIRE request with `Invalid JSON payload
+// received. Unknown name "<key>"`, before the model is ever reached — issue #64. Two of our own
+// generators trip it on every turn: `z.number().int().positive()` emits `exclusiveMinimum` (the
+// native `get_current_time`, the Calendar/Drive/Asaas toolpacks) and `z.record(...)` emits
+// `propertyNames` (every HTTP tool with an object parameter).
+//
+// `FunctionDeclaration.parametersJsonSchema` takes a FULL JSON Schema instead, and is mutually
+// exclusive with `parameters`. Declaring tools that way sends the schema exactly as authored, so
+// nothing is dropped and no bound is approximated. Measured against the live API on
+// gemini-3.5-flash, gemini-2.5-flash and gemini-flash-latest: `exclusiveMinimum`, `propertyNames`,
+// `additionalProperties`, `$schema`, `$defs`/`$ref`, `const`, `uniqueItems`, `multipleOf`,
+// `oneOf`/`allOf`, an object with no properties, a `type` array and a non-string `enum` all pass,
+// and the model still answers with correct arguments.
+//
+// The alternative (rewrite each schema into the subset) was measured working too, but it is lossy
+// by construction: `exclusiveMinimum: 0` on a money field can only become `minimum: 0`, which tells
+// the model that zero is a legal amount.
+
+// A Gemini FunctionDeclaration as we build it. NOTE: the SDK's own types predate
+// `parametersJsonSchema` (@google/generative-ai is the legacy client and stopped being updated),
+// but the field is in the API's discovery document and the request body is JSON.stringify'd
+// straight through, so it reaches the wire regardless of the local type.
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description?: string;
+  parametersJsonSchema?: unknown;
+}
+
+export interface GeminiFunctionTool {
+  functionDeclarations: GeminiFunctionDeclaration[];
+}
+
+// NOTE: guards against a hostile schema from a third-party MCP server; JSON-derived data cannot be
+// cyclic, so this only caps absurd nesting instead of preventing a loop. Past the cap the subtree
+// travels untransformed, which is exactly what shipped before this module existed.
+const MAX_DEPTH = 64;
+
+// The ONE construct the JSON Schema path still rejects (measured: `schema at properties.X.items
+// must be a boolean or an object`). Draft-07 writes a tuple as an `items` ARRAY; 2020-12 writes it
+// `prefixItems`, and Gemini implements 2020-12. Zod never emits the old form, but an MCP server
+// written against draft-07 does and @langchain/mcp-adapters passes it through untouched. The rename
+// is the exact 2020-12 translation, so the tuple keeps its meaning.
+//
+// Always returns fresh objects: `toJsonSchema` memoizes per schema and hands back the SAME object
+// on every call, so editing in place would corrupt what the other providers declare for the rest of
+// the process.
+function normalizeTupleItems(node: unknown, depth = 0): unknown {
+  if (depth > MAX_DEPTH) return node;
+  if (Array.isArray(node))
+    return node.map((v) => normalizeTupleItems(v, depth + 1));
+  if (!node || typeof node !== "object") return node;
+  const source = node as Record<string, unknown>;
+  const hasPrefixItems = "prefixItems" in source;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (key === "items" && Array.isArray(value)) {
+      if (!hasPrefixItems) {
+        out.prefixItems = value.map((v) => normalizeTupleItems(v, depth + 1));
+      }
+      continue;
+    }
+    out[key] = normalizeTupleItems(value, depth + 1);
+  }
+  return out;
+}
+
+// A tool whose object schema declares no property is sent WITHOUT parameters, the same shape
+// @langchain/google-genai produces today for `z.object({})` (`resolve_conversation`). An empty
+// schema is accepted either way; keeping the omission means parameterless tools go on the wire
+// exactly as they did before this change.
+function declaredParameters(schema: unknown): unknown | undefined {
+  if (!schema || typeof schema !== "object") return undefined;
+  const properties = (schema as { properties?: unknown }).properties;
+  const declared =
+    !!properties &&
+    typeof properties === "object" &&
+    Object.keys(properties).length > 0;
+  return declared ? normalizeTupleItems(schema) : undefined;
+}
+
+// Rewrites a bindTools argument list into Gemini's own tool shape. LangChain tools become function
+// declarations carrying their JSON Schema; anything else (a search or code-execution tool, or an
+// already-converted declaration coming back through `invocationParams`) is passed through as is.
+export function toGeminiTools<T>(
+  tools: readonly T[],
+): (T | GeminiFunctionTool)[] {
+  const declarations: GeminiFunctionDeclaration[] = [];
+  const passthrough: T[] = [];
+  for (const candidate of tools) {
+    if (!isLangChainTool(candidate)) {
+      passthrough.push(candidate);
+      continue;
+    }
+    const parameters = candidate.schema
+      ? declaredParameters(toJsonSchema(candidate.schema))
+      : undefined;
+    declarations.push({
+      name: candidate.name,
+      description: candidate.description,
+      ...(parameters === undefined ? {} : { parametersJsonSchema: parameters }),
+    });
+  }
+  // NOTE: one entry holding every declaration, never one entry per tool — Gemini refuses a request
+  // with multiple tool entries unless they are all search tools.
+  return declarations.length > 0
+    ? [...passthrough, { functionDeclarations: declarations }]
+    : [...passthrough];
+}

--- a/src/graph/gemini-tools.ts
+++ b/src/graph/gemini-tools.ts
@@ -71,18 +71,41 @@ function normalizeTupleItems(node: unknown, depth = 0): unknown {
   return out;
 }
 
-// A tool whose object schema declares no property is sent WITHOUT parameters, the same shape
-// @langchain/google-genai produces today for `z.object({})` (`resolve_conversation`). An empty
-// schema is accepted either way; keeping the omission means parameterless tools go on the wire
+// Keywords that describe arguments without listing a single property, so a schema carrying any of
+// them is NOT parameterless even though `properties` is empty.
+const ARGUMENT_KEYWORDS = [
+  "$ref",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "patternProperties",
+  "propertyNames",
+];
+
+// A tool that takes no parameters is declared WITHOUT `parametersJsonSchema`, the same shape
+// @langchain/google-genai already sends today for `z.object({})` (`resolve_conversation`); an empty
+// schema is accepted either way, and keeping the omission means parameterless tools go on the wire
 // exactly as they did before this change.
-function declaredParameters(schema: unknown): unknown | undefined {
-  if (!schema || typeof schema !== "object") return undefined;
-  const properties = (schema as { properties?: unknown }).properties;
-  const declared =
+//
+// NOTE: "no properties" alone is NOT the test. A third-party MCP server can describe its arguments
+// with an `additionalProperties` map, a root `$ref`, or a union, and omitting those would hand the
+// model a tool it then has to call with no arguments at all. What makes a schema parameterless is
+// that it can accept nothing: no properties, closed to extras, and no keyword that admits any.
+function acceptsNoArguments(source: Record<string, unknown>): boolean {
+  const properties = source.properties;
+  const listsProperties =
     !!properties &&
     typeof properties === "object" &&
     Object.keys(properties).length > 0;
-  return declared ? normalizeTupleItems(schema) : undefined;
+  if (listsProperties || source.additionalProperties !== false) return false;
+  return !ARGUMENT_KEYWORDS.some((keyword) => keyword in source);
+}
+
+function declaredParameters(schema: unknown): unknown | undefined {
+  if (!schema || typeof schema !== "object") return undefined;
+  return acceptsNoArguments(schema as Record<string, unknown>)
+    ? undefined
+    : normalizeTupleItems(schema);
 }
 
 // Rewrites a bindTools argument list into Gemini's own tool shape. LangChain tools become function

--- a/src/graph/gemini-tools.ts
+++ b/src/graph/gemini-tools.ts
@@ -52,20 +52,39 @@ const MAX_DEPTH = 64;
 // on every call, so editing in place would corrupt what the other providers declare for the rest of
 // the process.
 //
-// Keywords whose value is a MAP OF SCHEMAS keyed by a name the tool author chose, not a schema. The
-// walk has to change mode there: inside `properties` the key `additionalItems` is a parameter called
-// "additionalItems", and translating it as the draft-07 keyword deletes the parameter while
-// `required` goes on demanding it — a declaration the model cannot satisfy.
+// Where a schema may legally sit. The walk descends ONLY into these, because "every object is a
+// schema" is wrong three different ways: inside `properties` the keys are parameter NAMES chosen by
+// the tool author (a parameter called "additionalItems" would be translated away while `required`
+// still demanded it), and `enum`/`const`/`default`/`examples` hold INSTANCE DATA, so an enum value
+// that happens to contain `items: [...]` would be rewritten into a different allowed value. Anything
+// not listed here travels verbatim, which is also the safe default for a keyword we do not know.
 const SCHEMA_MAP_KEYWORDS = new Set([
   "properties",
   "patternProperties",
   "$defs",
   "definitions",
+  "dependentSchemas",
+]);
+const SCHEMA_LIST_KEYWORDS = new Set([
+  "prefixItems",
+  "allOf",
+  "anyOf",
+  "oneOf",
+]);
+const SCHEMA_KEYWORDS = new Set([
+  "not",
+  "if",
+  "then",
+  "else",
+  "contains",
+  "propertyNames",
+  "additionalProperties",
+  "unevaluatedItems",
+  "unevaluatedProperties",
 ]);
 
 function normalizeSchemaMap(node: unknown, depth: number): unknown {
-  if (!node || typeof node !== "object" || Array.isArray(node))
-    return normalizeTupleItems(node, depth);
+  if (!node || typeof node !== "object" || Array.isArray(node)) return node;
   const out: Record<string, unknown> = Object.create(null);
   for (const [name, schema] of Object.entries(
     node as Record<string, unknown>,
@@ -77,9 +96,7 @@ function normalizeSchemaMap(node: unknown, depth: number): unknown {
 
 function normalizeTupleItems(node: unknown, depth = 0): unknown {
   if (depth > MAX_DEPTH) return node;
-  if (Array.isArray(node))
-    return node.map((v) => normalizeTupleItems(v, depth + 1));
-  if (!node || typeof node !== "object") return node;
+  if (!node || typeof node !== "object" || Array.isArray(node)) return node;
   const source = node as Record<string, unknown>;
   const isTuple = Array.isArray(source.items);
   const hasPrefixItems = "prefixItems" in source;
@@ -92,7 +109,21 @@ function normalizeTupleItems(node: unknown, depth = 0): unknown {
       out[key] = normalizeSchemaMap(value, depth + 1);
       continue;
     }
-    if (key === "items" && Array.isArray(value)) {
+    if (SCHEMA_LIST_KEYWORDS.has(key)) {
+      out[key] = Array.isArray(value)
+        ? value.map((v) => normalizeTupleItems(v, depth + 1))
+        : normalizeTupleItems(value, depth + 1);
+      continue;
+    }
+    if (SCHEMA_KEYWORDS.has(key)) {
+      out[key] = normalizeTupleItems(value, depth + 1);
+      continue;
+    }
+    if (key === "items") {
+      if (!Array.isArray(value)) {
+        out.items = normalizeTupleItems(value, depth + 1);
+        continue;
+      }
       if (!hasPrefixItems) {
         out.prefixItems = value.map((v) => normalizeTupleItems(v, depth + 1));
       }
@@ -111,7 +142,9 @@ function normalizeTupleItems(node: unknown, depth = 0): unknown {
       }
       continue;
     }
-    out[key] = normalizeTupleItems(value, depth + 1);
+    // Not a schema position: instance data (`enum`, `const`, `default`, `examples`) or a plain
+    // annotation. Copied by reference, never walked — and never mutated, here or downstream.
+    out[key] = value;
   }
   return out;
 }

--- a/src/graph/gemini-tools.ts
+++ b/src/graph/gemini-tools.ts
@@ -51,6 +51,30 @@ const MAX_DEPTH = 64;
 // Always returns fresh objects: `toJsonSchema` memoizes per schema and hands back the SAME object
 // on every call, so editing in place would corrupt what the other providers declare for the rest of
 // the process.
+//
+// Keywords whose value is a MAP OF SCHEMAS keyed by a name the tool author chose, not a schema. The
+// walk has to change mode there: inside `properties` the key `additionalItems` is a parameter called
+// "additionalItems", and translating it as the draft-07 keyword deletes the parameter while
+// `required` goes on demanding it — a declaration the model cannot satisfy.
+const SCHEMA_MAP_KEYWORDS = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+]);
+
+function normalizeSchemaMap(node: unknown, depth: number): unknown {
+  if (!node || typeof node !== "object" || Array.isArray(node))
+    return normalizeTupleItems(node, depth);
+  const out: Record<string, unknown> = Object.create(null);
+  for (const [name, schema] of Object.entries(
+    node as Record<string, unknown>,
+  )) {
+    out[name] = normalizeTupleItems(schema, depth + 1);
+  }
+  return out;
+}
+
 function normalizeTupleItems(node: unknown, depth = 0): unknown {
   if (depth > MAX_DEPTH) return node;
   if (Array.isArray(node))
@@ -59,8 +83,15 @@ function normalizeTupleItems(node: unknown, depth = 0): unknown {
   const source = node as Record<string, unknown>;
   const isTuple = Array.isArray(source.items);
   const hasPrefixItems = "prefixItems" in source;
-  const out: Record<string, unknown> = {};
+  // NOTE: null prototype because the keys come from a third-party schema. `out.__proto__ = x` on a
+  // normal object runs the prototype setter instead of creating an own key, so a parameter legally
+  // named `__proto__` would vanish from the declaration while `required` still demanded it.
+  const out: Record<string, unknown> = Object.create(null);
   for (const [key, value] of Object.entries(source)) {
+    if (SCHEMA_MAP_KEYWORDS.has(key)) {
+      out[key] = normalizeSchemaMap(value, depth + 1);
+      continue;
+    }
     if (key === "items" && Array.isArray(value)) {
       if (!hasPrefixItems) {
         out.prefixItems = value.map((v) => normalizeTupleItems(v, depth + 1));

--- a/src/graph/gemini-tools.ts
+++ b/src/graph/gemini-tools.ts
@@ -122,6 +122,21 @@ function declaredParameters(schema: unknown): unknown | undefined {
     : normalizeTupleItems(schema);
 }
 
+// An entry the caller already handed over in Gemini's own shape. Upstream's `processTools` folds the
+// LangChain declarations INTO the first of these instead of appending a second entry, precisely
+// because Gemini refuses a request carrying more than one. Converting every tool ourselves leaves
+// upstream's accumulator empty by the time it checks, so the fold has to happen here or the mixed
+// case regresses into `Multiple tools are supported only when they are all search tools`.
+function isDeclarationTool(
+  candidate: unknown,
+): candidate is GeminiFunctionTool {
+  return (
+    !!candidate &&
+    typeof candidate === "object" &&
+    "functionDeclarations" in candidate
+  );
+}
+
 // Rewrites a bindTools argument list into Gemini's own tool shape. LangChain tools become function
 // declarations carrying their JSON Schema; anything else (a search or code-execution tool, or an
 // already-converted declaration coming back through `invocationParams`) is passed through as is.
@@ -145,8 +160,22 @@ export function toGeminiTools<T>(
     });
   }
   // NOTE: one entry holding every declaration, never one entry per tool — Gemini refuses a request
-  // with multiple tool entries unless they are all search tools.
-  return declarations.length > 0
-    ? [...passthrough, { functionDeclarations: declarations }]
-    : [...passthrough];
+  // with multiple tool entries unless they are all search tools. Same reason the fold below exists:
+  // a declaration entry the caller already passed has to absorb ours instead of sitting beside it.
+  if (declarations.length === 0) return [...passthrough];
+  const foldInto = passthrough.findIndex(isDeclarationTool);
+  if (foldInto < 0)
+    return [...passthrough, { functionDeclarations: declarations }];
+  return passthrough.map((tool, index) => {
+    if (index !== foldInto) return tool;
+    const existing = tool as GeminiFunctionTool;
+    return {
+      ...existing,
+      // Caller's declarations first, matching the order upstream produced before this module existed.
+      functionDeclarations: [
+        ...(existing.functionDeclarations ?? []),
+        ...declarations,
+      ],
+    };
+  });
 }

--- a/src/graph/models.ts
+++ b/src/graph/models.ts
@@ -4,6 +4,7 @@ import { ChatDeepSeek } from "@langchain/deepseek";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { ChatOpenAI } from "@langchain/openai";
 import { AppError } from "@/lib/errors";
+import { toGeminiTools } from "./gemini-tools";
 import type { ModelConfig } from "./model-config";
 
 // Per-agent/per-node model factory. The config SCHEMA lives in ./model-config (LangChain-free, so
@@ -75,8 +76,24 @@ export function createChatModel(cfg: ResolvedModelConfig): BaseChatModel {
       });
     case "anthropic":
       return new ChatAnthropic({ model, apiKey, temperature });
-    case "google":
-      return new ChatGoogleGenerativeAI({ model, apiKey, temperature });
+    case "google": {
+      const gemini = new ChatGoogleGenerativeAI({ model, apiKey, temperature });
+      // NOTE: the adapter declares tool parameters in the OpenAPI subset, whose closed field set
+      // rejects the whole request over a single unknown key (issue #64). Redeclaring them as JSON
+      // Schema is the carve-out; see ./gemini-tools for the field set and what was measured.
+      // Patched on the INSTANCE rather than by subclassing: LangChain derives the serialized model
+      // id from the constructor name, so a subclass renames the model to itself in every payload
+      // that reaches Langfuse (measured: the lc_id tail becomes the subclass name). An own property
+      // also shadows the prototype for the adapter's own internal `this.bindTools(...)` calls.
+      type BindTools = typeof gemini.bindTools;
+      const bindTools = gemini.bindTools.bind(gemini) as BindTools;
+      gemini.bindTools = ((tools, kwargs) =>
+        bindTools(
+          toGeminiTools(tools) as Parameters<BindTools>[0],
+          kwargs,
+        )) as BindTools;
+      return gemini;
+    }
     case "deepseek":
       return new ChatDeepSeek({ model, apiKey, temperature });
     default:

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -1,0 +1,365 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { tool } from "@langchain/core/tools";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
+import { z } from "zod";
+import { type GeminiFunctionTool, toGeminiTools } from "@/graph/gemini-tools";
+import { createChatModel } from "@/graph/models";
+
+// Gemini rejected EVERY turn of an agent whose tools carry a numeric bound or a free-form object
+// parameter (issue #64): `parameters` is parsed as the OpenAPI 3.03 subset, whose field set is
+// closed, and an unknown field kills the whole request before the model is reached. The fix declares
+// tools with `parametersJsonSchema` instead, which takes a full JSON Schema.
+//
+// NOTE: the allowlist below is transcribed from the API's own discovery document
+// (https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta, .schemas.Schema
+// .properties) and is DELIBERATELY not imported from src — a test that reuses the implementation's
+// idea of what the API accepts cannot catch that idea being wrong.
+const OPENAPI_SUBSET_FIELDS = new Set([
+  "anyOf",
+  "default",
+  "description",
+  "enum",
+  "example",
+  "format",
+  "items",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+  "minItems",
+  "minLength",
+  "minProperties",
+  "minimum",
+  "nullable",
+  "pattern",
+  "properties",
+  "propertyOrdering",
+  "required",
+  "title",
+  "type",
+]);
+
+interface GeminiReject {
+  message: string;
+}
+
+// Walks a `parameters` schema the way the API's proto3 parser does: the first field outside the
+// subset aborts the request. Returns the rejection, or null when the schema is acceptable.
+function rejectOpenApiSubset(node: unknown, path: string): GeminiReject | null {
+  if (Array.isArray(node)) {
+    for (const [i, v] of node.entries()) {
+      const bad = rejectOpenApiSubset(v, `${path}[${i}]`);
+      if (bad) return bad;
+    }
+    return null;
+  }
+  if (!node || typeof node !== "object") return null;
+  for (const [key, value] of Object.entries(node)) {
+    if (!OPENAPI_SUBSET_FIELDS.has(key)) {
+      return {
+        message: `Invalid JSON payload received. Unknown name "${key}" at '${path}': Cannot find field.`,
+      };
+    }
+    // `Schema.items` is a single Schema in the proto, so the draft-07 tuple form is a type error
+    // rather than an unknown field.
+    if (key === "items" && Array.isArray(value)) {
+      return {
+        message: `Invalid value at '${path}.items' (TYPE_MESSAGE), ${JSON.stringify(value)}`,
+      };
+    }
+    if (key === "properties" && value && typeof value === "object") {
+      for (const [prop, sub] of Object.entries(value)) {
+        const bad = rejectOpenApiSubset(sub, `${path}.properties[${prop}]`);
+        if (bad) return bad;
+      }
+      continue;
+    }
+    const bad = rejectOpenApiSubset(value, `${path}.${key}`);
+    if (bad) return bad;
+  }
+  return null;
+}
+
+// The JSON Schema path accepts what the subset does not ($defs/$ref, const, exclusiveMinimum,
+// additionalProperties, propertyNames, uniqueItems, multipleOf, oneOf/allOf, a `type` array and a
+// non-string `enum` were all measured passing against the live API). The one construct it still
+// rejects is a draft-07 tuple, because Gemini implements 2020-12, where `items` must be a schema.
+function rejectJsonSchema(node: unknown, path: string): GeminiReject | null {
+  if (Array.isArray(node)) {
+    for (const [i, v] of node.entries()) {
+      const bad = rejectJsonSchema(v, `${path}[${i}]`);
+      if (bad) return bad;
+    }
+    return null;
+  }
+  if (!node || typeof node !== "object") return null;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "items" && Array.isArray(value)) {
+      return {
+        message: `Invalid value at 'tools[0].function_declarations[0].parameters_json_schema': schema at ${path}.items must be a boolean or an object`,
+      };
+    }
+    if (key === "properties" && value && typeof value === "object") {
+      for (const [prop, sub] of Object.entries(value)) {
+        const bad = rejectJsonSchema(sub, `${path}.properties.${prop}`);
+        if (bad) return bad;
+      }
+      continue;
+    }
+    const bad = rejectJsonSchema(value, `${path}.${key}`);
+    if (bad) return bad;
+  }
+  return null;
+}
+
+interface FakeGemini {
+  requests: unknown[];
+  restore: () => void;
+}
+
+// Stands in for generativelanguage: validates the declared tools exactly as the API does, so a
+// payload that would 400 in production 400s here too.
+function fakeGemini(): FakeGemini {
+  const requests: unknown[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_url: string | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      tools?: { functionDeclarations?: Record<string, unknown>[] }[];
+    };
+    requests.push(body);
+    const declarations = (body.tools ?? []).flatMap(
+      (t) => t.functionDeclarations ?? [],
+    );
+    for (const [i, decl] of declarations.entries()) {
+      const at = `tools[0].function_declarations[${i}].parameters`;
+      const bad = decl.parameters
+        ? rejectOpenApiSubset(decl.parameters, at)
+        : decl.parametersJsonSchema
+          ? rejectJsonSchema(decl.parametersJsonSchema, "")
+          : null;
+      if (bad) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 400,
+              message: bad.message,
+              status: "INVALID_ARGUMENT",
+            },
+          }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        );
+      }
+    }
+    return new Response(
+      JSON.stringify({
+        candidates: [
+          {
+            content: { parts: [{ text: "ok" }], role: "model" },
+            finishReason: "STOP",
+            index: 0,
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+  return {
+    requests,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+// The three shapes that reach bindTools in production: a native tool with a numeric bound, an HTTP
+// tool with a free-form object parameter (src/graph/tools/http.ts builds one per object field), and
+// an MCP tool carrying a third-party JSON Schema.
+const getCurrentTime = tool(async () => "10:00", {
+  name: "get_current_time",
+  description: "Current time in a timezone",
+  schema: z.object({
+    timezone: z.string().optional(),
+    roundToMinutes: z.number().int().positive().optional(),
+  }),
+});
+
+const callApi = tool(async () => "ok", {
+  name: "call_api",
+  description: "Call an API",
+  schema: z.object({ body: z.record(z.string(), z.unknown()) }),
+});
+
+const resolveConversation = tool(async () => "ok", {
+  name: "resolve_conversation",
+  description: "Resolve the conversation",
+  schema: z.object({}),
+});
+
+const mcpTool = tool(async () => "ok", {
+  name: "mcp__crm__lookup",
+  description: "Look a customer up",
+  schema: {
+    type: "object",
+    $defs: {
+      Addr: { type: "object", properties: { city: { type: "string" } } },
+    },
+    properties: {
+      addr: { $ref: "#/$defs/Addr" },
+      kind: { const: "person" },
+      tags: { type: "array", items: { type: "string" }, uniqueItems: true },
+    },
+    additionalProperties: false,
+  },
+});
+
+const googleModel = () =>
+  createChatModel({
+    provider: "google",
+    model: "gemini-3.5-flash",
+    apiKey: "test",
+    temperature: 0.7,
+  });
+
+let gemini: FakeGemini | null = null;
+afterEach(() => {
+  gemini?.restore();
+  gemini = null;
+});
+
+describe("Gemini tool declarations", () => {
+  test("a turn with the production toolset is not rejected", async () => {
+    gemini = fakeGemini();
+    const reply = await googleModel()
+      .bindTools?.([getCurrentTime, callApi, resolveConversation, mcpTool])
+      .invoke([{ role: "user", content: "que horas são?" }]);
+    expect(reply?.content).toBe("ok");
+  });
+
+  test("declarations travel as JSON Schema, never as the OpenAPI subset", async () => {
+    gemini = fakeGemini();
+    await googleModel()
+      .bindTools?.([getCurrentTime])
+      .invoke([{ role: "user", content: "oi" }]);
+    const [sent] = gemini.requests as {
+      tools: { functionDeclarations: Record<string, unknown>[] }[];
+    }[];
+    const decl = sent?.tools[0]?.functionDeclarations[0];
+    expect(decl?.parameters).toBeUndefined();
+    expect(decl?.parametersJsonSchema).toBeDefined();
+  });
+
+  test("the schema reaches the model exactly as authored", () => {
+    const [entry] = toGeminiTools([getCurrentTime]) as {
+      functionDeclarations: { parametersJsonSchema: unknown }[];
+    }[];
+    // The bound `roundToMinutes` survives instead of being approximated: `exclusiveMinimum` is what
+    // the OpenAPI subset has no way to express, and losing it would let the model pass 0.
+    expect(entry?.functionDeclarations[0]?.parametersJsonSchema).toEqual(
+      toJsonSchema(getCurrentTime.schema) as object,
+    );
+  });
+
+  test("every tool lands in ONE declarations entry", () => {
+    const out = toGeminiTools([getCurrentTime, callApi, mcpTool]) as {
+      functionDeclarations: { name: string }[];
+    }[];
+    expect(out).toHaveLength(1);
+    expect(out[0]?.functionDeclarations.map((d) => d.name)).toEqual([
+      "get_current_time",
+      "call_api",
+      "mcp__crm__lookup",
+    ]);
+  });
+
+  test("a parameterless tool declares no parameters at all", () => {
+    const [entry] = toGeminiTools([
+      resolveConversation,
+    ]) as GeminiFunctionTool[];
+    const decl = entry?.functionDeclarations[0];
+    expect(decl?.name).toBe("resolve_conversation");
+    expect(decl).not.toHaveProperty("parametersJsonSchema");
+    expect(decl).not.toHaveProperty("parameters");
+  });
+
+  test("a draft-07 tuple is translated instead of rejected", async () => {
+    const tupleTool = tool(async () => "ok", {
+      name: "mcp__legacy__pair",
+      description: "Takes a pair",
+      schema: {
+        type: "object",
+        properties: {
+          pair: {
+            type: "array",
+            items: [{ type: "string" }, { type: "number" }],
+          },
+        },
+      },
+    });
+    gemini = fakeGemini();
+    const reply = await googleModel()
+      .bindTools?.([tupleTool])
+      .invoke([{ role: "user", content: "oi" }]);
+    expect(reply?.content).toBe("ok");
+    const [entry] = toGeminiTools([tupleTool]) as {
+      functionDeclarations: {
+        parametersJsonSchema: { properties: { pair: Record<string, unknown> } };
+      }[];
+    }[];
+    const pair =
+      entry?.functionDeclarations[0]?.parametersJsonSchema.properties.pair;
+    expect(pair?.prefixItems).toEqual([{ type: "string" }, { type: "number" }]);
+    expect(pair).not.toHaveProperty("items");
+  });
+
+  test("an explicit prefixItems is not overwritten by the items rename", () => {
+    const both = tool(async () => "ok", {
+      name: "mcp__legacy__both",
+      description: "d",
+      schema: {
+        type: "object",
+        properties: {
+          pair: {
+            type: "array",
+            prefixItems: [{ type: "boolean" }],
+            items: [{ type: "string" }],
+          },
+        },
+      },
+    });
+    const [entry] = toGeminiTools([both]) as {
+      functionDeclarations: {
+        parametersJsonSchema: { properties: { pair: Record<string, unknown> } };
+      }[];
+    }[];
+    const pair =
+      entry?.functionDeclarations[0]?.parametersJsonSchema.properties.pair;
+    expect(pair?.prefixItems).toEqual([{ type: "boolean" }]);
+  });
+
+  test("what is not a LangChain tool is passed through untouched", () => {
+    const search = { googleSearchRetrieval: {} };
+    const out = toGeminiTools([search, getCurrentTime]);
+    expect(out[0]).toBe(search);
+    expect(out[1]).toHaveProperty("functionDeclarations");
+  });
+
+  test("the shared schema is not mutated, so other providers keep theirs", () => {
+    // NOTE: toJsonSchema memoizes per schema and hands back the SAME object every time, so an
+    // in-place edit here would corrupt what ChatOpenAI/ChatAnthropic declare for the rest of the
+    // process — a cross-provider break that no Gemini test would ever show.
+    const before = structuredClone(
+      toJsonSchema(getCurrentTime.schema) as object,
+    );
+    toGeminiTools([getCurrentTime]);
+    expect(toJsonSchema(getCurrentTime.schema)).toEqual(before);
+  });
+
+  test("only the Google provider is patched", () => {
+    const openai = createChatModel({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      apiKey: "test",
+    });
+    expect(Object.hasOwn(openai, "bindTools")).toBe(false);
+  });
+});

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -416,11 +416,10 @@ describe("Gemini tool declarations", () => {
         } as never,
       });
       const [entry] = toGeminiTools([legacy]) as GeminiFunctionTool[];
-      const pair = (
-        entry?.functionDeclarations[0]?.parametersJsonSchema as {
-          properties: { pair: Record<string, unknown> };
-        }
-      ).properties.pair;
+      const declared = entry?.functionDeclarations[0]?.parametersJsonSchema as {
+        properties: { pair: Record<string, unknown> };
+      };
+      const pair = declared.properties.pair;
       expect(pair.prefixItems).toEqual([
         { type: "string" },
         { type: "number" },
@@ -446,11 +445,10 @@ describe("Gemini tool declarations", () => {
       } as never,
     });
     const [entry] = toGeminiTools([stray]) as GeminiFunctionTool[];
-    const list = (
-      entry?.functionDeclarations[0]?.parametersJsonSchema as {
-        properties: { list: Record<string, unknown> };
-      }
-    ).properties.list;
+    const declared = entry?.functionDeclarations[0]?.parametersJsonSchema as {
+      properties: { list: Record<string, unknown> };
+    };
+    const list = declared.properties.list;
     expect(list.items).toEqual({ type: "string" });
     expect(list).not.toHaveProperty("additionalItems");
   });

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -127,9 +127,25 @@ function fakeGemini(): FakeGemini {
       tools?: { functionDeclarations?: Record<string, unknown>[] }[];
     };
     requests.push(body);
-    const declarations = (body.tools ?? []).flatMap(
-      (t) => t.functionDeclarations ?? [],
+    // Gemini refuses a request carrying more than one tool entry unless they are all search tools,
+    // so a regression that emits one entry per tool has to fail here, not just in a unit assertion.
+    const entries = (body.tools ?? []).filter(
+      (t) => (t.functionDeclarations ?? []).length > 0,
     );
+    if (entries.length > 1) {
+      return new Response(
+        JSON.stringify({
+          error: {
+            code: 400,
+            message:
+              "Multiple tools are supported only when they are all search tools",
+            status: "INVALID_ARGUMENT",
+          },
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+    }
+    const declarations = entries.flatMap((t) => t.functionDeclarations ?? []);
     for (const [i, decl] of declarations.entries()) {
       const at = `tools[0].function_declarations[${i}].parameters`;
       const bad = decl.parameters
@@ -334,6 +350,62 @@ describe("Gemini tool declarations", () => {
     const pair =
       entry?.functionDeclarations[0]?.parametersJsonSchema.properties.pair;
     expect(pair?.prefixItems).toEqual([{ type: "boolean" }]);
+  });
+
+  // An MCP server can describe its arguments without listing a single property. Treating "no
+  // properties" as "no parameters" would declare those tools parameterless, and the model would
+  // then call them with nothing.
+  test.each([
+    [
+      "an additionalProperties map",
+      { type: "object", additionalProperties: { type: "string" } },
+    ],
+    [
+      "a root $ref",
+      { $ref: "#/$defs/Input", $defs: { Input: { type: "object" } } },
+    ],
+    ["a union", { anyOf: [{ type: "object" }, { type: "string" }] }],
+  ])(
+    "a schema that describes arguments through %s is still declared",
+    (_label, schema) => {
+      const mcp = tool(async () => "ok", {
+        name: "mcp__srv__thing",
+        description: "d",
+        schema: schema as never,
+      });
+      const [entry] = toGeminiTools([mcp]) as GeminiFunctionTool[];
+      expect(entry?.functionDeclarations[0]?.parametersJsonSchema).toEqual(
+        schema,
+      );
+    },
+  );
+
+  test("nesting past the depth cap travels untransformed instead of throwing", () => {
+    // NOTE: pins the documented degradation. Past MAX_DEPTH the subtree is left exactly as it
+    // arrived, which is what shipped before this module existed, rather than a stack overflow on a
+    // hostile schema.
+    let deep: Record<string, unknown> = {
+      type: "array",
+      items: [{ type: "string" }],
+    };
+    for (let i = 0; i < 70; i++) {
+      deep = { type: "object", properties: { next: deep } };
+    }
+    const hostile = tool(async () => "ok", {
+      name: "mcp__srv__deep",
+      description: "d",
+      schema: deep as never,
+    });
+    const [entry] = toGeminiTools([hostile]) as GeminiFunctionTool[];
+    const declared = entry?.functionDeclarations[0]?.parametersJsonSchema as
+      | Record<string, unknown>
+      | undefined;
+    let node = declared;
+    for (let i = 0; i < 70; i++) {
+      node = (node?.properties as { next?: Record<string, unknown> })?.next;
+    }
+    expect(node).toHaveProperty("items");
+    expect(node).not.toHaveProperty("prefixItems");
   });
 
   test("what is not a LangChain tool is passed through untouched", () => {

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -392,6 +392,69 @@ describe("Gemini tool declarations", () => {
     expect(pair).not.toHaveProperty("items");
   });
 
+  // `additionalItems` is the other half of the same draft-07 tuple. Leaving it behind would widen
+  // the contract, because `false` means "nothing past the tuple" and 2020-12 spells that `items:
+  // false` — measured accepted by the live API.
+  test.each([
+    ["a closed tuple", false, false],
+    ["an open tuple with a type", { type: "string" }, { type: "string" }],
+  ])(
+    "%s keeps its bound on the extras",
+    (_label, additionalItems, expected) => {
+      const legacy = tool(async () => "ok", {
+        name: "mcp__legacy__bounded",
+        description: "d",
+        schema: {
+          type: "object",
+          properties: {
+            pair: {
+              type: "array",
+              items: [{ type: "string" }, { type: "number" }],
+              additionalItems,
+            },
+          },
+        } as never,
+      });
+      const [entry] = toGeminiTools([legacy]) as GeminiFunctionTool[];
+      const pair = (
+        entry?.functionDeclarations[0]?.parametersJsonSchema as {
+          properties: { pair: Record<string, unknown> };
+        }
+      ).properties.pair;
+      expect(pair.prefixItems).toEqual([
+        { type: "string" },
+        { type: "number" },
+      ]);
+      expect(pair.items).toEqual(expected);
+      expect(pair).not.toHaveProperty("additionalItems");
+    },
+  );
+
+  test("additionalItems outside a tuple is dropped, as both drafts ignore it", () => {
+    const stray = tool(async () => "ok", {
+      name: "mcp__legacy__stray",
+      description: "d",
+      schema: {
+        type: "object",
+        properties: {
+          list: {
+            type: "array",
+            items: { type: "string" },
+            additionalItems: { type: "number" },
+          },
+        },
+      } as never,
+    });
+    const [entry] = toGeminiTools([stray]) as GeminiFunctionTool[];
+    const list = (
+      entry?.functionDeclarations[0]?.parametersJsonSchema as {
+        properties: { list: Record<string, unknown> };
+      }
+    ).properties.list;
+    expect(list.items).toEqual({ type: "string" });
+    expect(list).not.toHaveProperty("additionalItems");
+  });
+
   test("an explicit prefixItems is not overwritten by the items rename", () => {
     const both = tool(async () => "ok", {
       name: "mcp__legacy__both",

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -151,7 +151,7 @@ function fakeGemini(): FakeGemini {
       const bad = decl.parameters
         ? rejectOpenApiSubset(decl.parameters, at)
         : decl.parametersJsonSchema
-          ? rejectJsonSchema(decl.parametersJsonSchema, "")
+          ? rejectJsonSchema(decl.parametersJsonSchema, at)
           : null;
       if (bad) {
         return new Response(
@@ -240,6 +240,71 @@ let gemini: FakeGemini | null = null;
 afterEach(() => {
   gemini?.restore();
   gemini = null;
+});
+
+// The whole suite leans on the fake rejecting what the real API rejects. If a branch of that
+// validator silently stopped firing, every positive test below would still pass and the regression
+// guard would be decorative, so the validator is driven into each of its rejections directly.
+describe("the fake API rejects what generativelanguage rejects", () => {
+  const post = (tools: unknown) =>
+    fetch(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+      { method: "POST", body: JSON.stringify({ tools }) },
+    );
+
+  test("a field outside the OpenAPI subset", async () => {
+    gemini = fakeGemini();
+    const res = await post([
+      {
+        functionDeclarations: [
+          {
+            name: "t",
+            parameters: {
+              type: "object",
+              properties: { n: { type: "integer", exclusiveMinimum: 0 } },
+            },
+          },
+        ],
+      },
+    ]);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toContain(
+      'Unknown name "exclusiveMinimum"',
+    );
+  });
+
+  test("a draft-07 tuple declared as JSON Schema", async () => {
+    gemini = fakeGemini();
+    const res = await post([
+      {
+        functionDeclarations: [
+          {
+            name: "t",
+            parametersJsonSchema: {
+              type: "object",
+              properties: {
+                pair: { type: "array", items: [{ type: "string" }] },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toContain(
+      "must be a boolean or an object",
+    );
+  });
+
+  test("more than one tool entry", async () => {
+    gemini = fakeGemini();
+    const res = await post([
+      { functionDeclarations: [{ name: "a" }] },
+      { functionDeclarations: [{ name: "b" }] },
+    ]);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toContain("Multiple tools");
+  });
 });
 
 describe("Gemini tool declarations", () => {

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -486,6 +486,47 @@ describe("Gemini tool declarations", () => {
     expect(list).not.toHaveProperty("additionalItems");
   });
 
+  // Inside `properties` the keys are parameter NAMES chosen by whoever wrote the tool, so the
+  // draft-07 translation must not run there: it would delete a parameter the schema still requires.
+  test("a parameter NAMED additionalItems is not mistaken for the keyword", () => {
+    const collides = tool(async () => "ok", {
+      name: "mcp__legacy__collides",
+      description: "d",
+      schema: {
+        type: "object",
+        properties: { additionalItems: { type: "string" } },
+        required: ["additionalItems"],
+      } as never,
+    });
+    const [entry] = toGeminiTools([collides]) as GeminiFunctionTool[];
+    const declared = entry?.functionDeclarations[0]?.parametersJsonSchema as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(Object.keys(declared.properties)).toEqual(["additionalItems"]);
+    expect(declared.required).toEqual(["additionalItems"]);
+  });
+
+  // Built through JSON.parse on purpose: an object literal would set the prototype instead of
+  // creating the key, which is exactly the trap on the output side.
+  test("a parameter named __proto__ still reaches the wire", () => {
+    const proto = tool(async () => "ok", {
+      name: "mcp__legacy__proto",
+      description: "d",
+      schema: JSON.parse(
+        '{"type":"object","properties":{"__proto__":{"type":"string"}},"required":["__proto__"]}',
+      ),
+    });
+    const [entry] = toGeminiTools([proto]) as GeminiFunctionTool[];
+    const declared = entry?.functionDeclarations[0]?.parametersJsonSchema as {
+      properties: Record<string, unknown>;
+    };
+    // Own key, and present in the serialized body — NOT `toContain("__proto__")` on the whole
+    // schema, which `required: ["__proto__"]` satisfies whether or not the parameter survived.
+    expect(Object.keys(declared.properties)).toEqual(["__proto__"]);
+    expect(JSON.stringify(declared.properties)).toContain('"__proto__"');
+  });
+
   test("an explicit prefixItems is not overwritten by the items rename", () => {
     const both = tool(async () => "ok", {
       name: "mcp__legacy__both",

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -507,6 +507,33 @@ describe("Gemini tool declarations", () => {
     expect(declared.required).toEqual(["additionalItems"]);
   });
 
+  // `enum`/`const`/`default`/`examples` hold instance DATA. Rewriting an `items` array inside one of
+  // them changes which values the model is allowed to send, which is a different contract, not a
+  // translation.
+  test("instance data is never rewritten as if it were a schema", () => {
+    const dataTool = tool(async () => "ok", {
+      name: "mcp__legacy__data",
+      description: "d",
+      schema: {
+        type: "object",
+        properties: {
+          shape: {
+            type: "object",
+            enum: [{ items: ["a", "b"], additionalItems: false }],
+            default: { items: ["a", "b"], additionalItems: false },
+          },
+        },
+      } as never,
+    });
+    const [entry] = toGeminiTools([dataTool]) as GeminiFunctionTool[];
+    const declared = entry?.functionDeclarations[0]?.parametersJsonSchema as {
+      properties: { shape: { enum: unknown[]; default: unknown } };
+    };
+    const preserved = { items: ["a", "b"], additionalItems: false };
+    expect(declared.properties.shape.enum).toEqual([preserved]);
+    expect(declared.properties.shape.default).toEqual(preserved);
+  });
+
   // Built through JSON.parse on purpose: an object literal would set the prototype instead of
   // creating the key, which is exactly the trap on the output side.
   test("a parameter named __proto__ still reaches the wire", () => {

--- a/tests/graph/gemini-tool-schema.test.ts
+++ b/tests/graph/gemini-tool-schema.test.ts
@@ -352,6 +352,39 @@ describe("Gemini tool declarations", () => {
     ]);
   });
 
+  // Regression: the upstream adapter folds ITS conversions into a declaration entry the caller
+  // already passed, exactly so the request never carries two. Ours arrive pre-converted, which
+  // leaves that accumulator empty, so a mixed bindTools call would ship both entries.
+  test("a declarations entry from the caller absorbs ours instead of sitting beside it", () => {
+    const preConverted = {
+      functionDeclarations: [{ name: "already_there", description: "Given" }],
+    };
+    const out = toGeminiTools([
+      preConverted,
+      getCurrentTime,
+    ]) as GeminiFunctionTool[];
+    expect(out).toHaveLength(1);
+    expect(out[0]?.functionDeclarations.map((d) => d.name)).toEqual([
+      "already_there",
+      "get_current_time",
+    ]);
+    // The caller's object is left alone: the fold builds a new entry.
+    expect(preConverted.functionDeclarations).toHaveLength(1);
+  });
+
+  test("a mixed bindTools call is not rejected as multiple tools", async () => {
+    gemini = fakeGemini();
+    const reply = await googleModel()
+      .bindTools?.([
+        { functionDeclarations: [{ name: "already_there" }] },
+        getCurrentTime,
+      ])
+      .invoke([{ role: "user", content: "que horas são?" }]);
+    expect(reply?.content).toBe("ok");
+    const [sent] = gemini.requests as { tools: unknown[] }[];
+    expect(sent?.tools).toHaveLength(1);
+  });
+
   test("a parameterless tool declares no parameters at all", () => {
     const [entry] = toGeminiTools([
       resolveConversation,


### PR DESCRIPTION
Fixes #64.

An agent on `provider: google` failed on **every** turn, before the model was reached. The report is correct, and the cause is one layer below where it looked.

## What was happening

`@langchain/google-genai` declares a tool's parameters in `FunctionDeclaration.parameters`, which `generativelanguage` parses as the **OpenAPI 3.03 subset**. That subset has a closed set of 22 fields, listed in the API's own discovery document (`.schemas.Schema.properties` at `https://generativelanguage.googleapis.com/$discovery/rest?version=v1beta`). One field outside it rejects the whole request.

Two of our own generators emit fields outside it on every turn:

| Zod | emits | reaches |
| --- | --- | --- |
| `z.number().int().positive()` | `exclusiveMinimum` | native `get_current_time`, Calendar/Drive/Asaas toolpacks |
| `z.record(z.string(), z.unknown())` | `propertyNames` | **every** HTTP tool with an object parameter |

Sending the real payload to the live API returns both at once:

```
Unknown name "exclusiveMinimum" at 'tools[0].function_declarations[0].parameters.properties[1].value'
Unknown name "propertyNames"    at 'tools[0].function_declarations[1].parameters.properties[0].value'
```

So the blast radius is wider than "remove `get_current_time`": any agent with an HTTP tool taking an object parameter was equally dead, with no native tool involved.

## The fix

`FunctionDeclaration` also accepts **`parametersJsonSchema`**, which takes a full JSON Schema and is mutually exclusive with `parameters`. Declaring tools that way sends the schema **exactly as authored** — nothing dropped, no bound approximated.

Measured against the live API on `gemini-3.5-flash`, `gemini-2.5-flash` and `gemini-flash-latest`, all of these now pass and the model still answers with correct arguments: `exclusiveMinimum`, `propertyNames`, `additionalProperties`, `$schema`, `$defs`/`$ref` (resolved by the API), `const`, `uniqueItems`, `multipleOf`, `oneOf`/`allOf`, an object with no properties, a `type` array, and a non-string `enum`.

The narrower alternative suggested in the issue (rewrite each schema into the subset) was implemented and measured working too, but it is lossy by construction: `exclusiveMinimum: 0` on `asaas_payment_link.value` can only become `minimum: 0`, which tells the model that a R$ 0,00 charge is legal. It also needs perpetual maintenance as third-party MCP schemas bring new keywords. This approach needs neither.

One construct still had to be handled: a **draft-07 tuple** (`items` as an array) is rejected even by the JSON Schema path, because Gemini implements 2020-12, where a tuple is `prefixItems`. Zod never emits the old form, but an MCP server written against draft-07 does, and `@langchain/mcp-adapters` passes it through. The rename is the exact 2020-12 translation, so nothing is lost.

The hook is patched on the model instance rather than by subclassing: LangChain derives the serialized model id from the constructor name, so a subclass would rename the model to itself in every payload that reaches Langfuse.

## What in the report does not hold

Two details, both harmless to the diagnosis but worth correcting for anyone reading this later:

- **`$schema` and `additionalProperties` were never going to be the next failure.** `@langchain/google-genai` already strips both (`utils/zod_to_genai_parameters.js`), along with `strict`.
- **A parameterless tool was not at risk.** For `z.object({})` (`resolve_conversation`) the adapter already omits `parameters` entirely, so nothing was sent to reject.

The rest of the report is accurate, including the identification of `function_declarations[9]` as `get_current_time` and the observation that fixing only `native.ts` would move the failure rather than remove it. That last point is exactly why this fixes the class instead of the instance.

## Validation scope

- **Live, against the real API.** The unfixed payload returns the reporter's 400; the fixed one returns 200 with a correct `tool_call` (`asaas_create_charge` with `value: 199.9`, `dueDate: "2026-09-01"`). Repeated on three models. The hostile-schema battery above was measured the same way.
- **Automated, offline.** `tests/graph/gemini-tool-schema.test.ts` stands a fake `generativelanguage` up that validates declarations exactly as the API does: the 22-field allowlist is **transcribed into the test from the discovery document**, deliberately not imported from `src`, so a wrong idea in the implementation cannot make the test agree with it. Three tests are red without the fix and green with it.
- **Not covered.** The API's behaviour on models Google has already retired (`gemini-2.0-flash`, `gemini-2.5-flash-lite` answer 404 to any request now, so they cannot be reached at all). No production traffic was exercised: the fix is on the request-building path, and CI has no API key, which is why the offline mockup carries the regression guard.
- `bun check` green (2006 pass, 0 fail, 0 skip) with the test database up.

## Worth doing upstream

The right long-term home for this is `@langchain/google-genai` itself: `parametersJsonSchema` makes its `removeAdditionalProperties` workaround unnecessary and fixes the same class of bug for every consumer. Happy to take that upstream if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Google Gemini tool integration with compatible function declarations.
  - Added support for full JSON Schema parameters, including tuple-style schemas and parameterless tools.
  - Multiple tools are now grouped into a single Gemini function-tool configuration.

- **Bug Fixes**
  - Improved compatibility with third-party and non-native tools while preserving unsupported definitions unchanged.
  - Prevented invalid or empty parameter schemas from being sent to Gemini.
  - Preserved tool binding behavior and existing provider functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->