### PR TITLE
fix(conversations): the follow-up indicator respects the live-appointment pause

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -1,0 +1,10 @@
+# Findings adjudicated and rejected, with the reason. One `<path>: <title>` per line.
+
+# PR #69 (issue #60). Half of this does not hold: `followUpComplete` already requires
+# `nextStep == null`, so a stale PENDING job blocks the completion marker on its own, with or
+# without the paused flag. The other half is real but predates this PR and is independent of
+# appointments: the job branch of the estimate does not mirror the handler's gates (agent.enabled,
+# isTestSilenced, step existence, the episode check, shouldBotHandle), so a stale job shows a
+# phantom countdown even with no appointment anywhere. That is a separate defect in the estimate
+# itself and belongs in its own change, not folded into the appointment flag.
+src/modules/conversations/service.ts: Validate pending jobs before marking the sequence paused

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -362,6 +362,8 @@
       "done": "Follow-up sequence complete",
       "imminent": "any moment now",
       "imminentHint": "The estimated time has passed; it runs on a background worker, so the follow-up will be sent at any moment.",
+      "pausedAppointment": "Follow-up paused · appointment booked",
+      "pausedAppointmentHint": "The contact has an appointment booked, and this agent pauses re-engagement until it passes or is cancelled. The sequence resumes on its own after that.",
       "redirectHint": "This conversation's channel is managed by the redirect, so the standard follow-up does not run here. The redirect re-engages the lead across WhatsApp and the website chat.",
       "redirectManaged": "Re-engagement handled by Redirect",
       "redirectScheduled": "Redirect follow-up · {{stage}} · {{when}} · {{at}}",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -363,6 +363,8 @@
       "done": "Sequência de follow-up concluída",
       "imminent": "a qualquer momento",
       "imminentHint": "O horário estimado já passou; o envio roda em segundo plano, então o follow-up será enviado a qualquer momento.",
+      "pausedAppointment": "Follow-up pausado · compromisso agendado",
+      "pausedAppointmentHint": "O contato tem um compromisso agendado, e este agente pausa a reativação até ele passar ou ser cancelado. Depois disso a sequência volta sozinha.",
       "redirectHint": "O canal desta conversa é gerenciado pelo redirecionamento, então o follow-up padrão não roda aqui. O redirecionamento reengaja o lead entre o WhatsApp e o chat do site.",
       "redirectManaged": "Reengajamento gerenciado pelo Redirecionamento",
       "redirectScheduled": "Follow-up do redirecionamento · {{stage}} · {{when}} · {{at}}",

--- a/src/client/pages/ConversationDetailPage.tsx
+++ b/src/client/pages/ConversationDetailPage.tsx
@@ -741,7 +741,16 @@ function FollowUpLine({
   let label: string;
   let imminent = false;
   let imminentHint: string | null = null;
-  if (followUp.nextStep != null && followUp.nextRunAt) {
+  // A booked appointment pauses the sequence (the sweep skips the conversation and the handler
+  // reschedules an armed job), so there is no time to count down to. Say WHY instead of hiding the
+  // line: an empty indicator here reads exactly like a broken scheduler.
+  const paused = followUp.pausedByAppointment;
+  if (paused) {
+    label = t(
+      "conversation.followUp.pausedAppointment",
+      "Follow-up paused · appointment booked",
+    );
+  } else if (followUp.nextStep != null && followUp.nextRunAt) {
     const deltaSec = (Date.parse(followUp.nextRunAt) - Date.now()) / 1000;
     let when: string;
     if (deltaSec <= 0) {
@@ -777,6 +786,20 @@ function FollowUpLine({
         <div className="flex items-start gap-1.5 rounded bg-warning/15 px-2 py-1.5 text-warning">
           <Clock className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
           <span>{imminentHint}</span>
+        </div>
+      )}
+      {paused && (
+        <div className="flex items-start gap-1.5 rounded bg-bg-tertiary px-2 py-1.5 text-text-secondary">
+          <CalendarClock
+            className="mt-0.5 h-3 w-3 shrink-0"
+            aria-hidden="true"
+          />
+          <span>
+            {t(
+              "conversation.followUp.pausedAppointmentHint",
+              "The contact has an appointment booked, and this agent pauses re-engagement until it passes or is cancelled. The sequence resumes on its own after that.",
+            )}
+          </span>
         </div>
       )}
       {!imminent && followUp.nextRunAtDeferred && (
@@ -1356,7 +1379,10 @@ export function ConversationDetailPage() {
     conv?.followUp?.enabled === true &&
     conv.followUp.managedByRedirect !== true &&
     conv.followUp.lastFollowUpAt != null &&
-    conv.followUp.nextStep == null;
+    conv.followUp.nextStep == null &&
+    // NOTE: a paused sequence also has no next step, and it is not complete — it resumes once the
+    // appointment passes.
+    conv.followUp.pausedByAppointment !== true;
 
   // Caller passes the already-translated success message (static t() at the call
   // site, so the extractor sees the key).

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -6,6 +6,7 @@ import { modelConfigSchema } from "@/graph/model-config";
 import { AppError, NotFoundError } from "@/lib/errors";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { isTestSilenced } from "@/modules/agents/test-mode";
+import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
   isOutOfHoursNow,
   nextOpenAt,
@@ -348,6 +349,12 @@ export interface ConversationDetail {
     // conversation carries one (the entry/WhatsApp side is re-engaged by the gate re-sending the link on
     // the next inbound, not a scheduled job). null = none pending (or not the widget side).
     redirectNext: { stage: "chat" | "whatsapp"; runAt: string } | null;
+    // The agent pauses re-engagement while the contact has a live appointment
+    // (followUp.pauseWhileAppointment, on by default), so the sweep skips this conversation and the
+    // handler reschedules an already-armed job. Surfaced instead of a countdown that never fires:
+    // an indicator that promises a follow-up the sweep suppresses is indistinguishable from a broken
+    // scheduler, which is the worst failure mode for an indicator whose whole job is to be trusted.
+    pausedByAppointment: boolean;
   } | null;
   // Pending appointment reminders for THIS conversation (deterministic Calendar-booked reminders), for
   // an operator-facing "a reminder is scheduled" indicator. One entry per pending scheduler job, soonest
@@ -588,7 +595,7 @@ export async function getConversationDetail(
   id: bigint,
   base: PrismaClient = basePrisma,
 ): Promise<ConversationDetail> {
-  requireTenant(ctx);
+  const tenantId = requireTenant(ctx);
   const conv = await loadConvRef(ctx, id, base);
   // Resolve the bound persona's name (separate read — Inbox carries only agentId, no relation).
   const agentId = conv.inbox?.agentId ?? null;
@@ -644,6 +651,20 @@ export async function getConversationDetail(
           )
         : null;
     const hoursWindows = hoursRow ? parseWindows(hoursRow.windows) : [];
+    // NOTE: the sweep's live-appointment fence, read from the SAME source the handler uses
+    // (loadAppointmentContext via hasLiveAppointment), instead of a third hand-kept copy of the
+    // predicate. The estimate and the sweep have now drifted twice — the suppression itself in #39,
+    // and this indicator in #60 — so anything else here would be the third.
+    const pausedByAppointment =
+      cfg.enabled && cfg.pauseWhileAppointment && !managedByRedirect
+        ? await runScopedOn(
+            base,
+            ctx,
+            async (db) =>
+              (await loadAppointmentContext(db, tenantId, conv.threadId))
+                .length > 0,
+          )
+        : false;
     const job = managedByRedirect
       ? null
       : await runScopedOn(base, ctx, (db) =>
@@ -737,6 +758,15 @@ export async function getConversationDetail(
       if (dueAt.getTime() > ungated) nextRunAtDeferred = true;
       nextRunAt = dueAt.toISOString();
     }
+    // A live appointment suppresses BOTH shapes: the sweep never enqueues the estimated step, and an
+    // already-armed job is rescheduled by the handler for as long as the appointment stands, so its
+    // countdown would just slip an hour at a time. Show the reason instead of a time that never comes.
+    if (pausedByAppointment) {
+      nextStep = null;
+      nextRunAt = null;
+      nextRunAtDeferred = false;
+    }
+
     // The pending redirect follow-up, keyed to the WIDGET conversation's thread (the entry/WhatsApp
     // side has no job of its own). Surfaced in place of the — suppressed — generic estimate.
     let redirectNext: { stage: "chat" | "whatsapp"; runAt: string } | null =
@@ -783,6 +813,7 @@ export async function getConversationDetail(
           : null,
       managedByRedirect,
       redirectNext,
+      pausedByAppointment,
     };
   }
 

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -651,20 +651,6 @@ export async function getConversationDetail(
           )
         : null;
     const hoursWindows = hoursRow ? parseWindows(hoursRow.windows) : [];
-    // NOTE: the sweep's live-appointment fence, read from the SAME source the handler uses
-    // (loadAppointmentContext via hasLiveAppointment), instead of a third hand-kept copy of the
-    // predicate. The estimate and the sweep have now drifted twice — the suppression itself in #39,
-    // and this indicator in #60 — so anything else here would be the third.
-    const pausedByAppointment =
-      cfg.enabled && cfg.pauseWhileAppointment && !managedByRedirect
-        ? await runScopedOn(
-            base,
-            ctx,
-            async (db) =>
-              (await loadAppointmentContext(db, tenantId, conv.threadId))
-                .length > 0,
-          )
-        : false;
     const job = managedByRedirect
       ? null
       : await runScopedOn(base, ctx, (db) =>
@@ -761,6 +747,30 @@ export async function getConversationDetail(
     // A live appointment suppresses BOTH shapes: the sweep never enqueues the estimated step, and an
     // already-armed job is rescheduled by the handler for as long as the appointment stands, so its
     // countdown would just slip an hour at a time. Show the reason instead of a time that never comes.
+    //
+    // NOTE: read from the SAME source the handler uses (loadAppointmentContext via
+    // hasLiveAppointment), instead of a third hand-kept copy of the predicate. The estimate and the
+    // sweep have now drifted twice — the suppression itself in #39, and this indicator in #60 — so
+    // anything else here would be the third.
+    //
+    // The `nextStep` guard is what makes the flag mean "the appointment is hiding something": every
+    // OTHER reason the follow-up will not run (conversation resolved or taken by a human, episode
+    // older than the arming, agent test-silenced, sequence already finished) leaves nextStep null on
+    // its own, and announcing "paused by appointment" there would state a reason that is not the
+    // reason — and, because the completion marker yields to this flag, would hide a finished sequence
+    // behind it. It also skips the query on every conversation with nothing to suppress.
+    const pausedByAppointment =
+      nextStep !== null &&
+      cfg.enabled &&
+      cfg.pauseWhileAppointment &&
+      !managedByRedirect &&
+      (await runScopedOn(
+        base,
+        ctx,
+        async (db) =>
+          (await loadAppointmentContext(db, tenantId, conv.threadId)).length >
+          0,
+      ));
     if (pausedByAppointment) {
       nextStep = null;
       nextRunAt = null;

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -49,6 +49,8 @@ let convAppointmentLive = 0n;
 let convAppointmentPast = 0n;
 let convAppointmentCancelled = 0n;
 let convAppointmentOptOut = 0n;
+let convAppointmentResolved = 0n;
+let convAppointmentDone = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
 const REDIRECT_JOB_RUN_AT = new Date("2026-06-18T23:30:00Z");
@@ -412,6 +414,24 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
       startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
       cancelledAt: new Date(Date.now() - 60_000).toISOString(),
     });
+    // Live appointment on conversations the sweep would skip anyway: a human owns this one, and the
+    // next one already ran its whole sequence (same episode, no reply since).
+    convAppointmentResolved = await seedAppointmentConv(
+      315,
+      inbox.id,
+      { startISO: new Date(Date.now() + 2 * 3_600_000).toISOString() },
+      { status: "resolved" },
+    );
+    convAppointmentDone = await seedAppointmentConv(
+      316,
+      inbox.id,
+      { startISO: new Date(Date.now() + 2 * 3_600_000).toISOString() },
+      {
+        lastEventAt: FOLLOW_UP_AT,
+        lastInboundAt: new Date("2026-06-18T23:00:00Z"),
+        lastFollowUpAt: FOLLOW_UP_AT,
+      },
+    );
 
     // A second persona that opted OUT of the pause, on its own inbox.
     const optOutAgent = await suDb.agent.create({
@@ -452,6 +472,12 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     chatwootId: number,
     inboxId: bigint,
     reminder: { startISO: string; cancelledAt?: string } | null,
+    conv: {
+      status?: string;
+      lastEventAt?: Date;
+      lastInboundAt?: Date;
+      lastFollowUpAt?: Date;
+    } = {},
   ): Promise<bigint> {
     const c = await suDb.conversation.create({
       data: {
@@ -459,11 +485,12 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
         chatwootInstanceId: inst,
         chatwootConversationId: chatwootId,
         inboxId,
-        status: "pending",
+        status: conv.status ?? "pending",
         assigneeType: null,
         threadId: `${tenant}:${inst}:${chatwootId}`,
-        lastEventAt: LAST_EVENT_AT,
-        lastInboundAt: REPLY_AT,
+        lastEventAt: conv.lastEventAt ?? LAST_EVENT_AT,
+        lastInboundAt: conv.lastInboundAt ?? REPLY_AT,
+        ...(conv.lastFollowUpAt ? { lastFollowUpAt: conv.lastFollowUpAt } : {}),
       },
     });
     if (reminder) {
@@ -676,6 +703,29 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     );
     expect(d.followUp?.pausedByAppointment).toBe(false);
     expect(d.followUp?.nextStep).toBe(1);
+  });
+
+  // The flag has to name the reason the follow-up is not coming, and on these two the appointment is
+  // not it. Saying "paused" here also costs the completion marker, which yields to this flag.
+  test("a human already owns the conversation → not attributed to the appointment", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convAppointmentResolved,
+      appDb,
+    );
+    expect(d.followUp?.pausedByAppointment).toBe(false);
+    expect(d.followUp?.nextStep).toBeNull();
+  });
+
+  test("the sequence already finished → still reads as complete, not paused", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convAppointmentDone,
+      appDb,
+    );
+    expect(d.followUp?.pausedByAppointment).toBe(false);
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.lastFollowUpAt).toBe(FOLLOW_UP_AT.toISOString());
   });
 
   test("an agent that opted out of the pause still gets its estimate", async () => {

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -45,6 +45,10 @@ let convTestPostActivation = 0n;
 let convRedirectWidget = 0n;
 let convRedirectWidgetJob = 0n;
 let convRedirectEntry = 0n;
+let convAppointmentLive = 0n;
+let convAppointmentPast = 0n;
+let convAppointmentCancelled = 0n;
+let convAppointmentOptOut = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
 const REDIRECT_JOB_RUN_AT = new Date("2026-06-18T23:30:00Z");
@@ -395,7 +399,103 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
       },
     });
     convRedirectEntry = c9.id;
+
+    // Same shape as the fresh-episode conversation (so an estimate WOULD be produced), differing
+    // only in whether an appointment is live.
+    convAppointmentLive = await seedAppointmentConv(310, inbox.id, {
+      startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+    });
+    convAppointmentPast = await seedAppointmentConv(311, inbox.id, {
+      startISO: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+    });
+    convAppointmentCancelled = await seedAppointmentConv(312, inbox.id, {
+      startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+      cancelledAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+
+    // A second persona that opted OUT of the pause, on its own inbox.
+    const optOutAgent = await suDb.agent.create({
+      data: {
+        tenantId: tenant,
+        name: "FU No Pause",
+        systemPrompt: "x",
+        followUpArmedAt: new Date("2026-01-01T00:00:00Z"),
+        mode: "production",
+        modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        settings: {
+          followUp: {
+            enabled: true,
+            pauseWhileAppointment: false,
+            steps: [{ delayValue: 2, delayUnit: "minutes", instructions: "" }],
+          },
+        },
+      },
+    });
+    const optOutInbox = await suDb.inbox.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootInboxId: 79,
+        name: "Sup sem pausa",
+        agentId: optOutAgent.id,
+      },
+    });
+    convAppointmentOptOut = await seedAppointmentConv(313, optOutInbox.id, {
+      startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+    });
   });
+
+  // A live appointment is the sweep's own fence (followUp.pauseWhileAppointment, on by default): it
+  // skips the conversation, and the handler reschedules an already-armed job. The indicator has to
+  // agree, or the operator reads a countdown for a follow-up that never fires (issue #60).
+  async function seedAppointmentConv(
+    chatwootId: number,
+    inboxId: bigint,
+    reminder: { startISO: string; cancelledAt?: string } | null,
+  ): Promise<bigint> {
+    const c = await suDb.conversation.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootConversationId: chatwootId,
+        inboxId,
+        status: "pending",
+        assigneeType: null,
+        threadId: `${tenant}:${inst}:${chatwootId}`,
+        lastEventAt: LAST_EVENT_AT,
+        lastInboundAt: REPLY_AT,
+      },
+    });
+    if (reminder) {
+      await suDb.schedulerJob.create({
+        data: {
+          tenantId: tenant,
+          kind: "APPOINTMENT_REMINDER",
+          dedupeKey: `reminder:ev_${chatwootId}:1`,
+          // DONE on purpose: anchoring on PENDING rows alone went blind after the last reminder
+          // fired, which is what #39 fixed in the sweep. The indicator reads the same projection.
+          status: "DONE",
+          runAt: new Date(Date.now() - 3_600_000),
+          payload: {
+            threadId: `${tenant}:${inst}:${chatwootId}`,
+            eventId: `ev_${chatwootId}`,
+            calendarId: "cal_x@group.calendar.google.com",
+            credentialRef: null,
+            startISO: reminder.startISO,
+            offsetHours: 1,
+            isLast: true,
+            askConfirmation: false,
+            summary: "Consulta",
+            calendarLabel: "Agenda",
+            ...(reminder.cancelledAt
+              ? { cancelledAt: reminder.cancelledAt }
+              : {}),
+          },
+        },
+      });
+    }
+    return c.id;
+  }
 
   afterAll(async () => {
     if (tenant) {
@@ -543,5 +643,48 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     expect(d.followUp?.nextRunAt).toBeNull();
     // The entry side is re-engaged by the gate re-sending the link, not a scheduled job.
     expect(d.followUp?.redirectNext).toBeNull();
+  });
+
+  test("a live appointment suppresses the estimate and says why", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convAppointmentLive,
+      appDb,
+    );
+    expect(d.followUp?.enabled).toBe(true);
+    expect(d.followUp?.pausedByAppointment).toBe(true);
+    // The whole point: no countdown for a follow-up the sweep will not enqueue.
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
+  });
+
+  test("an appointment already past does not suppress anything", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convAppointmentPast,
+      appDb,
+    );
+    expect(d.followUp?.pausedByAppointment).toBe(false);
+    expect(d.followUp?.nextStep).toBe(1);
+  });
+
+  test("a cancelled appointment does not suppress anything", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convAppointmentCancelled,
+      appDb,
+    );
+    expect(d.followUp?.pausedByAppointment).toBe(false);
+    expect(d.followUp?.nextStep).toBe(1);
+  });
+
+  test("an agent that opted out of the pause still gets its estimate", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convAppointmentOptOut,
+      appDb,
+    );
+    expect(d.followUp?.pausedByAppointment).toBe(false);
+    expect(d.followUp?.nextStep).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #60.

The conversation page could show a live countdown for a follow-up the sweep will never enqueue. For a contact who has an appointment booked, that is indistinguishable from a broken scheduler, which is the worst failure mode for an indicator whose entire job is to be trusted.

## What was missing

`getConversationDetail` deliberately mirrors the sweep's eligibility so the indicator agrees with what fires, and it already mirrors the redirect-managed case, the `followUpArmedAt` activation fence, `isNewFollowUpEpisode`, `shouldBotHandle`, the test-mode silence, and the business-hours gate. It did not mirror the **live-appointment suppression**: the sweep skips a conversation when the agent has `followUp.pauseWhileAppointment` on (the default) and the thread has a live `APPOINTMENT_REMINDER`.

## The fix

The detail read now consults `loadAppointmentContext` — **the same function the handler reaches through `hasLiveAppointment`**, not a third hand-kept copy of the predicate. That matters more than the missing check itself: the estimate and the sweep have now drifted twice, in #39 (the suppression) and here (the indicator), so the fix is to share the source rather than re-derive it.

Two things follow from it:

- **The suppression covers both shapes, not just the estimate.** The issue frames this as an estimate problem, but an already-armed job is rescheduled by the handler for as long as the appointment stands, so its countdown just slips an hour at a time. Both are suppressed.
- **The reason is shown, not the absence.** `followUp.pausedByAppointment` reaches the console, and the indicator renders "Follow-up paused · appointment booked" with a tooltip saying the sequence resumes on its own, instead of rendering nothing. An empty indicator reads exactly like the broken scheduler this is meant to rule out. The "sequence complete" marker is guarded too: a paused sequence also has no next step, and it is not finished.

## On the issue's open question

The question was whether any other sweep fence the estimate does not mirror is still out there, and whether the predicate can have one source instead of a SQL copy and a TypeScript copy kept in step by comment.

This change removes the JavaScript-side duplication (the estimate and the handler now read the same function), but the sweep's own SQL copy in `src/modules/followups/handlers.ts` remains a second expression of the same rule. Collapsing that one is a larger change than this fix warrants and is not attempted here.

## Validation scope

- **Automated, DB-backed.** Four scenarios added to the existing suite, all on conversations seeded identically to the fresh-episode case so an estimate *would* be produced, differing only in the appointment: a live one suppresses and flags the reason; one already past does not; a cancelled one does not; and an agent with `pauseWhileAppointment: false` keeps its estimate. The reminder rows are seeded `DONE` with a future start on purpose, since anchoring on `PENDING` alone is exactly what went blind in #39.
- **Red confirmed.** Without the service change, those four fail and the other nine pass.
- **Not covered.** No browser check of the rendered indicator: the change to `FollowUpLine` is a new branch on a field the tests assert directly, and the copy is behind the usual i18n keys (pt-BR translated, not left as the English default).
- `bun check` green with the test database up.
