### PR TITLE
fix(models): run the gpt-5.6 family at reasoning effort none so tools stop rejecting every turn

### DIFF
--- a/src/graph/models.ts
+++ b/src/graph/models.ts
@@ -60,46 +60,61 @@ function openaiTemperature(
 // a transport change rather than part of this fix.
 const TOOL_EFFORT_NONE_RE = /^(?:[\w.-]+\/)?gpt-5\.6(?:-|$)/i;
 
-// NOTE: goes through `modelKwargs` rather than the typed `reasoning` field because
+type OpenAIChatFields = ConstructorParameters<typeof ChatOpenAI>[0];
+
+// Builds an OpenAI-shaped client, pinning the effort ONLY on the tool-bound model.
+//
+// NOTE: the rejection needs tools, so the parameter belongs to the bound model and nowhere else.
+// The raw instance is invoked on purpose when the tool budget runs out (`hardLimit ? model : llm`
+// in graph.ts), and that call is the one that writes the final answer to the customer; the
+// guardrail pass, the TTS normalization and an agent with no grants never bind tools either. All of
+// them are accepted with the provider's default effort (measured: 200 without tools either way), so
+// pinning "none" on the constructor would switch reasoning off exactly where nothing required it.
+//
+// NOTE: the parameter travels via `modelKwargs` rather than the typed `reasoning` field because
 // @langchain/openai gates that field behind its own isReasoningModel(), which tests
 // `model.startsWith("gpt-5")` and therefore DROPS it for a routed id like "openai/gpt-5.6-luna"
-// (OpenRouter). modelKwargs is spread into the request params unconditionally, so the parameter
-// reaches the wire on every OpenAI-shaped client, whatever the id looks like.
-function openaiModelKwargs(model: string): Record<string, unknown> | undefined {
-  return TOOL_EFFORT_NONE_RE.test(model.trim())
-    ? { reasoning_effort: "none" }
-    : undefined;
+// (OpenRouter). modelKwargs is spread into the request params unconditionally.
+function makeOpenAIChat(fields: OpenAIChatFields): ChatOpenAI {
+  const chat = new ChatOpenAI(fields);
+  if (!TOOL_EFFORT_NONE_RE.test(String(fields?.model ?? "").trim()))
+    return chat;
+  const withEffort = new ChatOpenAI({
+    ...fields,
+    modelKwargs: { ...fields?.modelKwargs, reasoning_effort: "none" },
+  });
+  type BindTools = typeof chat.bindTools;
+  const bindTools = withEffort.bindTools.bind(withEffort) as BindTools;
+  chat.bindTools = ((tools, kwargs) => bindTools(tools, kwargs)) as BindTools;
+  return chat;
 }
 
 export function createChatModel(cfg: ResolvedModelConfig): BaseChatModel {
   const { model, apiKey, temperature } = cfg;
   switch (cfg.provider) {
     case "openai":
-      return new ChatOpenAI({
+      return makeOpenAIChat({
         model,
         apiKey,
         temperature: openaiTemperature(model, temperature),
-        modelKwargs: openaiModelKwargs(model),
       });
     case "openai-compatible":
       if (!cfg.baseURL) {
         throw new AppError("openai-compatible provider requires baseURL", 400);
       }
-      return new ChatOpenAI({
+      return makeOpenAIChat({
         // Empty model = "the server's default" (see model-config): send a neutral placeholder so
         // the request is well-formed; llama.cpp-style single-model servers ignore the name.
         model: model.trim() || "default",
         apiKey,
         temperature: openaiTemperature(model, temperature),
-        modelKwargs: openaiModelKwargs(model),
         configuration: { baseURL: cfg.baseURL },
       });
     case "openrouter":
-      return new ChatOpenAI({
+      return makeOpenAIChat({
         model,
         apiKey,
         temperature: openaiTemperature(model, temperature),
-        modelKwargs: openaiModelKwargs(model),
         configuration: { baseURL: cfg.baseURL || OPENROUTER_BASE_URL },
       });
     case "anthropic":

--- a/src/graph/models.ts
+++ b/src/graph/models.ts
@@ -46,6 +46,31 @@ function openaiTemperature(
   return REASONING_MODEL_RE.test(model.trim()) ? undefined : temperature;
 }
 
+// NOTE: OpenAI rejects function tools combined with ANY non-"none" reasoning effort on
+// /v1/chat/completions for the gpt-5.6 family: "Function tools with reasoning_effort are not
+// supported for gpt-5.6-luna in /v1/chat/completions" (issue #66). We never send an effort, so what
+// collides with the tools is the SERVER's own default. Measured against the live API: 400 on luna,
+// sol and terra with tools and no effort, 200 with `reasoning_effort: "none"` on the same call, and
+// 200 without tools either way.
+//
+// The carve-out stays on the family that is actually blocked. gpt-5.5, gpt-5.4, gpt-5.2 and
+// gpt-5-mini all answered 200 with tools and no effort, and gpt-5.4-mini accepts "none" too — so a
+// blanket "none" would silently drop the reasoning those agents get today, trading one regression
+// for another. Reasoning TOGETHER with tools needs /v1/responses (measured working there), which is
+// a transport change rather than part of this fix.
+const TOOL_EFFORT_NONE_RE = /^(?:[\w.-]+\/)?gpt-5\.6(?:-|$)/i;
+
+// NOTE: goes through `modelKwargs` rather than the typed `reasoning` field because
+// @langchain/openai gates that field behind its own isReasoningModel(), which tests
+// `model.startsWith("gpt-5")` and therefore DROPS it for a routed id like "openai/gpt-5.6-luna"
+// (OpenRouter). modelKwargs is spread into the request params unconditionally, so the parameter
+// reaches the wire on every OpenAI-shaped client, whatever the id looks like.
+function openaiModelKwargs(model: string): Record<string, unknown> | undefined {
+  return TOOL_EFFORT_NONE_RE.test(model.trim())
+    ? { reasoning_effort: "none" }
+    : undefined;
+}
+
 export function createChatModel(cfg: ResolvedModelConfig): BaseChatModel {
   const { model, apiKey, temperature } = cfg;
   switch (cfg.provider) {
@@ -54,6 +79,7 @@ export function createChatModel(cfg: ResolvedModelConfig): BaseChatModel {
         model,
         apiKey,
         temperature: openaiTemperature(model, temperature),
+        modelKwargs: openaiModelKwargs(model),
       });
     case "openai-compatible":
       if (!cfg.baseURL) {
@@ -65,6 +91,7 @@ export function createChatModel(cfg: ResolvedModelConfig): BaseChatModel {
         model: model.trim() || "default",
         apiKey,
         temperature: openaiTemperature(model, temperature),
+        modelKwargs: openaiModelKwargs(model),
         configuration: { baseURL: cfg.baseURL },
       });
     case "openrouter":
@@ -72,6 +99,7 @@ export function createChatModel(cfg: ResolvedModelConfig): BaseChatModel {
         model,
         apiKey,
         temperature: openaiTemperature(model, temperature),
+        modelKwargs: openaiModelKwargs(model),
         configuration: { baseURL: cfg.baseURL || OPENROUTER_BASE_URL },
       });
     case "anthropic":

--- a/tests/graph/model-reasoning-effort.test.ts
+++ b/tests/graph/model-reasoning-effort.test.ts
@@ -164,6 +164,37 @@ describe("createChatModel on the gpt-5.6 family", () => {
     const { sent } = await turn("openai/gpt-5.6-luna", "openrouter");
     expect(sent.reasoning_effort).toBe("none");
   });
+
+  // Only the rejection's own precondition (tools) may disable reasoning. graph.ts invokes the RAW
+  // instance once the tool budget runs out — `hardLimit ? model : llm` — and THAT call writes the
+  // final answer to the customer. The guardrail pass, the TTS normalization and an agent with no
+  // grants never bind tools either. All of them are accepted at the provider's default effort.
+  test("a call with no tools keeps the provider's own default", async () => {
+    fake = fakeOpenAI();
+    const chat = createChatModel({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      apiKey: "test",
+      temperature: 0.3,
+    });
+    await chat.invoke([{ role: "user", content: "oi" }]);
+    expect(fake.requests[0]).not.toHaveProperty("reasoning_effort");
+  });
+
+  test("binding tools does not contaminate the raw instance behind it", async () => {
+    fake = fakeOpenAI();
+    const chat = createChatModel({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      apiKey: "test",
+      temperature: 0.3,
+    });
+    const bound = chat.bindTools?.([getCurrentTime]) ?? chat;
+    await bound.invoke([{ role: "user", content: "oi" }]);
+    await chat.invoke([{ role: "user", content: "oi" }]);
+    expect(fake.requests[0]?.reasoning_effort).toBe("none");
+    expect(fake.requests[1]).not.toHaveProperty("reasoning_effort");
+  });
 });
 
 // The carve-out must not spread: gpt-5.5 and older answered 200 with tools and no effort, and

--- a/tests/graph/model-reasoning-effort.test.ts
+++ b/tests/graph/model-reasoning-effort.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { tool } from "@langchain/core/tools";
+import type { ChatOpenAI } from "@langchain/openai";
+import { z } from "zod";
+import { createChatModel } from "@/graph/models";
+
+// Every turn of a gpt-5.6 agent that has tools died on an OpenAI 400 (issue #66). We never send a
+// reasoning effort, so what collides with the tools is the provider's own default: measured against
+// the live API, `gpt-5.6-luna` with tools and no effort answers 400, and the same call with
+// `reasoning_effort: "none"` answers 200 with the tool call. gpt-5.5 and older are unaffected.
+
+interface FakeOpenAI {
+  requests: Record<string, unknown>[];
+  restore: () => void;
+}
+
+// Stands in for /v1/chat/completions. The rule below is transcribed from what the live API did, NOT
+// imported from src — a fake that reuses the implementation's idea of the rule cannot catch that
+// idea being wrong. Measured: the rejection needs BOTH a gpt-5.6 model and function tools, and the
+// only effort it accepts in that combination is "none" (absent counts as the server's default,
+// which is what got rejected).
+function fakeOpenAI(): FakeOpenAI {
+  const requests: Record<string, unknown>[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (_url: string | URL, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<
+      string,
+      unknown
+    >;
+    requests.push(body);
+    const model = String(body.model ?? "");
+    const hasTools = Array.isArray(body.tools) && body.tools.length > 0;
+    const effort = body.reasoning_effort;
+    const isFamily = /^(?:[\w.-]+\/)?gpt-5\.6(?:-|$)/i.test(model);
+    if (isFamily && hasTools && effort !== "none") {
+      return new Response(
+        JSON.stringify({
+          error: {
+            message: `Function tools with reasoning_effort are not supported for ${model} in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.`,
+            type: "invalid_request_error",
+            param: "reasoning_effort",
+            code: null,
+          },
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(
+      JSON.stringify({
+        id: "chatcmpl-test",
+        object: "chat.completion",
+        created: 0,
+        model,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: {
+                    name: "get_current_time",
+                    arguments: '{"timezone":"America/Sao_Paulo"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+  return {
+    requests,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const getCurrentTime = tool(async () => "10:00", {
+  name: "get_current_time",
+  description: "Current time in a timezone",
+  schema: z.object({ timezone: z.string() }),
+});
+
+let fake: FakeOpenAI | null = null;
+afterEach(() => {
+  fake?.restore();
+  fake = null;
+});
+
+async function turn(
+  model: string,
+  provider: "openai" | "openrouter" = "openai",
+) {
+  fake = fakeOpenAI();
+  const chat = createChatModel({
+    provider,
+    model,
+    apiKey: "test",
+    temperature: 0.3,
+  });
+  const bound = chat.bindTools?.([getCurrentTime]) ?? chat;
+  const reply = await bound.invoke([
+    { role: "user", content: "que horas são?" },
+  ]);
+  return { reply, sent: fake.requests[0] ?? {} };
+}
+
+describe("the fake API rejects what OpenAI rejects", () => {
+  test("a gpt-5.6 turn carrying tools and no effort", async () => {
+    fake = fakeOpenAI();
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "gpt-5.6-luna",
+        tools: [{ type: "function" }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.message).toContain(
+      "Function tools with reasoning_effort are not supported",
+    );
+  });
+
+  test("the same turn on gpt-5.4 is accepted", async () => {
+    fake = fakeOpenAI();
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        tools: [{ type: "function" }],
+      }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("createChatModel on the gpt-5.6 family", () => {
+  test("a turn with tools is answered instead of rejected", async () => {
+    const { reply, sent } = await turn("gpt-5.6-luna");
+    expect(sent.reasoning_effort).toBe("none");
+    expect(reply.tool_calls?.[0]?.name).toBe("get_current_time");
+  });
+
+  test("every model of the family carries it", async () => {
+    for (const model of ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]) {
+      const { sent } = await turn(model);
+      expect(sent.reasoning_effort).toBe("none");
+      fake?.restore();
+    }
+  });
+
+  // The typed `reasoning` field would be dropped here: @langchain/openai gates it on its own
+  // isReasoningModel(), which tests model.startsWith("gpt-5") and so misses a routed id.
+  test("a routed OpenRouter id carries it too", async () => {
+    const { sent } = await turn("openai/gpt-5.6-luna", "openrouter");
+    expect(sent.reasoning_effort).toBe("none");
+  });
+});
+
+// The carve-out must not spread: gpt-5.5 and older answered 200 with tools and no effort, and
+// gpt-5.4-mini accepts "none" as well — so sending it there would silently drop the reasoning those
+// agents run with today, trading one regression for another.
+describe("createChatModel leaves every other model alone", () => {
+  test("the generations that already work send no effort at all", async () => {
+    for (const model of [
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.2",
+      "gpt-5-mini",
+      "gpt-5",
+      "o4-mini",
+      "gpt-4o",
+    ]) {
+      const { sent } = await turn(model);
+      expect(sent).not.toHaveProperty("reasoning_effort");
+      fake?.restore();
+    }
+  });
+
+  // "gpt-5.6" must match the family, not any id that merely contains it.
+  test("a model that only looks like the family is untouched", async () => {
+    for (const model of ["gpt-5.60", "gpt-5.6x", "not-gpt-5.6-luna"]) {
+      const { sent } = await turn(model);
+      expect(sent).not.toHaveProperty("reasoning_effort");
+      fake?.restore();
+    }
+  });
+
+  test("temperature stays dropped for the family, as for every reasoning model", () => {
+    const chat = createChatModel({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      apiKey: "test",
+      temperature: 0.3,
+    }) as ChatOpenAI;
+    expect(chat.temperature).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #66.

The report is right that the whole gpt-5.6 generation is unusable with tools, and the 400 is exactly as quoted. The cause is not the one the debugging suggested, and that changes the fix.

## Where `reasoning_effort` comes from

Not from `@langchain/openai`. Its `_getReasoningParams` (`dist/chat_models/base.js`) is:

```js
_getReasoningParams(options) {
  if (!isReasoningModel(this.model)) return;   // early return, not a default
  let reasoning;
  if (this.reasoning !== undefined) reasoning = { ...reasoning, ...this.reasoning };
  ...
  return reasoning;                            // undefined when nobody configured one
}
```

The `isReasoningModel` check is a guard on the way out, not a setter. With nothing configured it returns `undefined`, so `params.reasoning_effort` is never assigned and the field does not reach the wire. The `grep` in the report was correct: we send nothing.

What rejects the call is OpenAI's **own server-side default** for the family. The error message says as much: it asks for `reasoning_effort` to be set to `'none'`, which is only meaningful if the server is applying something else.

## Measured against the live API

Every row below is an actual request, function tool attached, `/v1/chat/completions`:

| model | `reasoning_effort` sent | result |
|---|---|---|
| `gpt-5.6-luna` | none sent (today's behaviour) | **400**, the error from the issue |
| `gpt-5.6-luna` | `"none"` | 200, correct `tool_calls` |
| `gpt-5.6-luna` | `"low"` | **400**, same message |
| `gpt-5.6-luna` | none sent, **no tools** | 200 |
| `gpt-5.6-sol` / `gpt-5.6-terra` | none sent | **400** |
| `gpt-5.5`, `gpt-5.4`, `gpt-5.2`, `gpt-5-mini` | none sent | 200 |
| `gpt-5.4-mini` | `"none"` | 200 |

Two things follow. The rejection needs **both** a 5.6 model and function tools. And the boundary is exactly the 5.6 family: everything older already works.

## The fix

`reasoning_effort: "none"` for the gpt-5.6 family on the OpenAI-shaped clients (`openai`, `openai-compatible`, `openrouter`), in the same place and shape as the existing `temperature` carve-out for reasoning models.

**Why the carve-out stays narrow.** `gpt-5.4-mini` accepts `"none"` too, so a blanket rule would compile. It would also silently switch off the reasoning that every 5.4 agent runs with today, trading this regression for a quieter one.

**Why `modelKwargs` and not the typed `reasoning` field.** That field is gated behind the same `isReasoningModel`, which tests `model.startsWith("gpt-5")` and therefore drops it for a routed id like `openai/gpt-5.6-luna` (OpenRouter). `modelKwargs` is spread into the request params unconditionally, so the parameter reaches the wire whatever the id looks like. There is a test for the routed id.

## What this does NOT do

The issue's related request, exposing `reasoning_effort` in the agent's model configuration, is not here, and the measurement is the reason: on `/v1/chat/completions` the only value that coexists with tools is `"none"`, so a knob would be a control with one legal position and a guaranteed 400 on the others.

Reasoning **together** with tools needs `/v1/responses`, which was measured working (`gpt-5.6-luna`, function tool, `reasoning: { effort: "low" }` → 200 with a `function_call`). That is a transport change with its own message conversion and streaming path, so it is #74 rather than part of this fix. The latency argument in the report is the strongest case for it.

Meanwhile a 5.6 agent runs at effort `none`, which for a WhatsApp customer-service agent is the position the same report argues for: ~7s rather than ~139s to first token.

## Validation scope

**Measured live**, against the real API with a real key, through `createChatModel` + `bindTools` + `invoke`, which is the production path:

- before the change: `gpt-5.6-luna`, `-sol` and `-terra` all fail with the issue's 400, and `gpt-5.4-mini` answers (control);
- after: all four answer with the correct `get_current_time` tool call.

**Proved by test** (red before the change): `tests/graph/model-reasoning-effort.test.ts` stands a fake `/v1/chat/completions` in front of the real client. The fake's rule is transcribed from the measurements above rather than imported from `src`, so a wrong idea in the implementation cannot satisfy it. Covers the turn being answered, all three family members, the routed OpenRouter id, that the generations which already work still send no effort at all, and that a lookalike id (`gpt-5.60`, `not-gpt-5.6-luna`) is untouched.

`bun check` green (2043 tests).
