### PR TITLE
fix(followups): the follow-up indicator trusts a pending job the handler will drop, so a human-owned conversation still counts down

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -70,3 +70,18 @@ src/modules/chatwoot/mirror.ts: Guard the watermark during rolling deploys
 # message stays bot-owned until the next conversation event repairs it. The supported deployments
 # ship our fork (4.11.x), where the version exists and decides.
 src/modules/chatwoot/mirror.ts: Preserve human-message handoffs without a version stamp
+
+# PR #83 (issue #72), round 3. Real, and it predates this PR: once the scheduler claims the dead job
+# and the handler drops it, `abandoned` goes back to false and the console draws its completion
+# marker. That is exactly what it drew in the same state BEFORE this change (with no pending row the
+# estimate branch already yielded nextStep null, and the marker only needs lastFollowUpAt). What this
+# PR removes is the window where a LIVE COUNTDOWN was displayed for a follow-up that was going to be
+# dropped, which is the defect #72 reports.
+#
+# Telling "the sequence finished" from "the sequence was cut short" after the job is gone needs a fact
+# nothing stores: which step last fired, against the configured total. `Conversation.lastFollowUpAt`
+# is a timestamp, not an index, and the job row that carried `stepIndex` is precisely what just
+# disappeared. So the honest fix is a persisted marker (an aborted-at stamp, or the last step index),
+# a schema change with its own migration and its own UI copy — a separate change, not a round of this
+# one.
+src/modules/conversations/service.ts: Persist abandonment after the scheduler consumes the job

--- a/src/client/pages/ConversationDetailPage.tsx
+++ b/src/client/pages/ConversationDetailPage.tsx
@@ -1381,11 +1381,11 @@ export function ConversationDetailPage() {
     conv.followUp.lastFollowUpAt != null &&
     conv.followUp.nextStep == null &&
     // NOTE: a paused sequence also has no next step, and it is not complete — it resumes once the
-    // appointment passes. Neither is a sequence that stopped being eligible (a human took the
-    // conversation, the agent was disabled, follow-up was switched off): the armed job will be
-    // dropped, so nothing is pending, but nothing completed either.
+    // appointment passes. Neither is a sequence with a step still queued that the handler is going to
+    // drop (a human took the conversation, the agent was disabled, follow-up was switched off):
+    // nothing is pending, but nothing completed either.
     conv.followUp.pausedByAppointment !== true &&
-    conv.followUp.live !== false;
+    conv.followUp.abandoned !== true;
 
   // Caller passes the already-translated success message (static t() at the call
   // site, so the extractor sees the key).

--- a/src/client/pages/ConversationDetailPage.tsx
+++ b/src/client/pages/ConversationDetailPage.tsx
@@ -1381,8 +1381,11 @@ export function ConversationDetailPage() {
     conv.followUp.lastFollowUpAt != null &&
     conv.followUp.nextStep == null &&
     // NOTE: a paused sequence also has no next step, and it is not complete — it resumes once the
-    // appointment passes.
-    conv.followUp.pausedByAppointment !== true;
+    // appointment passes. Neither is a sequence that stopped being eligible (a human took the
+    // conversation, the agent was disabled, follow-up was switched off): the armed job will be
+    // dropped, so nothing is pending, but nothing completed either.
+    conv.followUp.pausedByAppointment !== true &&
+    conv.followUp.live !== false;
 
   // Caller passes the already-translated success message (static t() at the call
   // site, so the extractor sees the key).

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -354,6 +354,12 @@ export interface ConversationDetail {
     // an indicator that promises a follow-up the sweep suppresses is indistinguishable from a broken
     // scheduler, which is the worst failure mode for an indicator whose whole job is to be trusted.
     pausedByAppointment: boolean;
+    // Whether a follow-up is alive AT ALL for this conversation, by the same predicate the handler
+    // re-checks when it claims a job (isFollowUpLive): agent enabled, follow-up on, not redirect-
+    // managed, not test-silenced, bot still owns the conversation. False suppresses the countdown —
+    // and has to be distinguishable from a finished sequence, because "nothing is pending" reads as
+    // "the sequence completed" otherwise, which is a different wrong answer for the same shape.
+    live: boolean;
   } | null;
   // Pending appointment reminders for THIS conversation (deterministic Calendar-booked reminders), for
   // an operator-facing "a reminder is scheduled" indicator. One entry per pending scheduler job, soonest
@@ -830,6 +836,7 @@ export async function getConversationDetail(
       managedByRedirect,
       redirectNext,
       pausedByAppointment,
+      live: followUpLive,
     };
   }
 

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -5,7 +5,6 @@ import basePrisma from "@/api/lib/prisma";
 import { modelConfigSchema } from "@/graph/model-config";
 import { AppError, NotFoundError } from "@/lib/errors";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
-import { isTestSilenced } from "@/modules/agents/test-mode";
 import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
   isOutOfHoursNow,
@@ -18,7 +17,7 @@ import {
   loadAgentBot,
   loadChatwootClient,
 } from "@/modules/chatwoot/instance";
-import { shouldBotHandle } from "@/modules/chatwoot/normalize";
+import { isFollowUpLive } from "@/modules/followups/eligibility";
 import type { FollowUpDelayUnit } from "@/modules/followups/settings";
 import {
   isNewFollowUpEpisode,
@@ -606,6 +605,7 @@ export async function getConversationDetail(
             where: { id: agentId },
             select: {
               name: true,
+              enabled: true,
               mode: true,
               settings: true,
               modelConfig: true,
@@ -633,6 +633,18 @@ export async function getConversationDetail(
       inboxCwId != null &&
       (redirectCfg.widgetInboxId === inboxCwId ||
         redirectCfg.entryInboxId === inboxCwId);
+    // Whether a follow-up for this conversation is alive AT ALL, by the same predicate the handler
+    // re-checks when it claims the job. Both branches below are gated on it: the estimate because the
+    // sweep would never enqueue it, and the armed job because the handler would drop it (issue #72).
+    const followUpLive = isFollowUpLive({
+      agentEnabled: agent?.enabled ?? false,
+      followUpEnabled: cfg.enabled,
+      managedByRedirect,
+      agentMode: agent?.mode ?? "production",
+      testActivatedAt: conv.testActivatedAt,
+      status: conv.status,
+      assigneeType: conv.assigneeType,
+    });
     const isRedirectWidgetConv =
       redirectCfg.enabled &&
       inboxCwId != null &&
@@ -682,7 +694,7 @@ export async function getConversationDetail(
       (agent?.followUpArmedAt == null ||
         conv.lastInboundAt == null ||
         conv.lastInboundAt < agent.followUpArmedAt);
-    if (job && !fencedStep0Job) {
+    if (job && !fencedStep0Job && followUpLive) {
       const stepIndex = jobStepIndex;
       nextStep = stepIndex + 1;
       // job.runAt is NOT the firing time yet — the sweep enqueues step 0 with runAt=now (and re-arms
@@ -714,8 +726,7 @@ export async function getConversationDetail(
       // test-silenced, and we know when the conversation last moved. The episode predicate MUST match
       // the sweep/handler (isNewFollowUpEpisode) or the indicator disagrees with what actually fires.
       // (managedByRedirect already forces job=null; guard the estimate too so it stays suppressed.)
-      !managedByRedirect &&
-      cfg.enabled &&
+      followUpLive &&
       firstStep &&
       isNewFollowUpEpisode(conv.lastFollowUpAt, conv.lastInboundAt) &&
       // NOTE: Activation fence (mirrors the sweep SQL): no estimate for an episode that began before
@@ -723,12 +734,7 @@ export async function getConversationDetail(
       agent?.followUpArmedAt != null &&
       conv.lastInboundAt != null &&
       conv.lastInboundAt >= agent.followUpArmedAt &&
-      conv.lastEventAt &&
-      shouldBotHandle({
-        status: conv.status,
-        assigneeType: conv.assigneeType,
-      }) &&
-      !isTestSilenced(agent?.mode ?? "production", conv.testActivatedAt)
+      conv.lastEventAt
     ) {
       nextStep = 1;
       let dueAt = new Date(

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -354,12 +354,16 @@ export interface ConversationDetail {
     // an indicator that promises a follow-up the sweep suppresses is indistinguishable from a broken
     // scheduler, which is the worst failure mode for an indicator whose whole job is to be trusted.
     pausedByAppointment: boolean;
-    // Whether a follow-up is alive AT ALL for this conversation, by the same predicate the handler
-    // re-checks when it claims a job (isFollowUpLive): agent enabled, follow-up on, not redirect-
-    // managed, not test-silenced, bot still owns the conversation. False suppresses the countdown —
-    // and has to be distinguishable from a finished sequence, because "nothing is pending" reads as
-    // "the sequence completed" otherwise, which is a different wrong answer for the same shape.
-    live: boolean;
+    // A follow-up job IS armed for this conversation and the handler will drop it when it claims it
+    // (isFollowUpLive: agent enabled, follow-up on, not redirect-managed, not test-silenced, bot
+    // still owns the conversation). Nothing is coming, but nothing completed either — so the console
+    // must show neither a countdown nor the "sequence complete" marker.
+    //
+    // It is keyed on a job EXISTING, not on liveness alone, because the two look identical from the
+    // outside and mean opposite things: a sequence whose last step is configured to resolve the
+    // conversation ends with the bot no longer owning it, which is a completed sequence, not an
+    // abandoned one. What separates them is whether a step is still queued.
+    abandoned: boolean;
   } | null;
   // Pending appointment reminders for THIS conversation (deterministic Calendar-booked reminders), for
   // an operator-facing "a reminder is scheduled" indicator. One entry per pending scheduler job, soonest
@@ -836,7 +840,7 @@ export async function getConversationDetail(
       managedByRedirect,
       redirectNext,
       pausedByAppointment,
-      live: followUpLive,
+      abandoned: job !== null && !followUpLive,
     };
   }
 

--- a/src/modules/followups/eligibility.ts
+++ b/src/modules/followups/eligibility.ts
@@ -1,0 +1,46 @@
+import { isTestSilenced } from "@/modules/agents/test-mode";
+import { shouldBotHandle } from "@/modules/chatwoot/normalize";
+
+// Whether a follow-up for this conversation is still live, meaning: if `followUpHandler` claimed its
+// job right now, would it send, or would it drop the job?
+//
+// The handler re-reads all of this at claim time and returns `done` (dropping the job silently) on
+// any of it, because a job can outlive the state it was armed under: a multi-step sequence leaves a
+// PENDING row whose runAt is hours or days out (`handlers.ts` reschedules the SAME row after each
+// step), and nothing cancels it when a human takes the conversation, when the agent is disabled, or
+// when follow-up is switched off. Only /teste, /reset and a new inbound message cancel it.
+//
+// It lives here as one predicate because it has two readers that MUST agree. The handler acts on it;
+// the console's follow-up indicator reads it to decide whether to promise a countdown. Issue #72 was
+// the second reader not having it: the indicator trusted the pending row and counted down for a
+// follow-up the handler was going to drop, telling the operator the customer would be re-engaged when
+// nobody was.
+//
+// NOT included, on purpose: whether the episode is fresh, the activation fence, and the cadence.
+// Those decide WHICH step is next rather than whether the sequence is alive at all, and they differ
+// between an armed job (a later step legitimately has `lastFollowUpAt` set) and an estimate.
+export interface FollowUpLiveness {
+  // Agent.enabled — a disabled agent sends nothing.
+  agentEnabled: boolean;
+  // followUp.enabled from the agent's settings.
+  followUpEnabled: boolean;
+  // This conversation's inbox is the entry or widget side of a channelRedirect, which owns
+  // re-engagement itself; the generic follow-up stays out of it.
+  managedByRedirect: boolean;
+  // Agent.mode + Conversation.testActivatedAt: a test agent is silent until /teste.
+  agentMode: string;
+  testActivatedAt: Date | null;
+  // The bot only follows up while it still owns the conversation (pending, no human assignee).
+  status: string | null;
+  assigneeType: string | null;
+}
+
+export function isFollowUpLive(s: FollowUpLiveness): boolean {
+  return (
+    s.agentEnabled &&
+    s.followUpEnabled &&
+    !s.managedByRedirect &&
+    !isTestSilenced(s.agentMode, s.testActivatedAt) &&
+    shouldBotHandle({ status: s.status, assigneeType: s.assigneeType })
+  );
+}

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -5,7 +5,6 @@ import { isTurnInFlight } from "@/graph/inflight";
 import { parseThreadId, runAgentNudge } from "@/graph/nudge";
 import type { RuntimeDeps } from "@/graph/runtime";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
-import { isTestSilenced } from "@/modules/agents/test-mode";
 import { hasLiveAppointment } from "@/modules/appointments/reminders";
 import {
   isOpenAt,
@@ -13,7 +12,7 @@ import {
   parseWindows,
 } from "@/modules/business-hours/hours";
 import { readChannelRedirectConfig } from "@/modules/channel-redirect/service";
-import { shouldBotHandle } from "@/modules/chatwoot/normalize";
+import { isFollowUpLive } from "@/modules/followups/eligibility";
 import { type ClaimedJob, enqueueJob } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import {
@@ -255,25 +254,34 @@ export async function followUpHandler(
         followUpArmedAt: true,
       },
     });
-    if (!agent?.enabled) return null;
-    // Test-mode gate: a "test" agent must not send proactive follow-ups in a conversation that
-    // hasn't been activated with /teste (defense in depth — the sweep's SQL already filters these).
-    if (isTestSilenced(agent.mode, conv.testActivatedAt)) return null;
-    // Anti double follow-up: this conversation is managed by a channelRedirect this agent runs — its
-    // WIDGET inbox gets the dedicated REDIRECT_FOLLOWUP job, and its WhatsApp ENTRY inbox is owned by
-    // the redirect's own re-send + cross-channel stage. Either way the generic follow-up stays out.
-    // Defense in depth — the sweep's SQL already filters these; this catches a FOLLOWUP job enqueued
-    // BEFORE the redirect config changed underneath it.
+    if (!agent) return null;
+    // Everything that can have changed since the job was armed: the agent disabled, follow-up switched
+    // off, the conversation taken by a human or resolved, a test agent's conversation never activated,
+    // or a channelRedirect taking over re-engagement (its WIDGET inbox gets the dedicated
+    // REDIRECT_FOLLOWUP job and its ENTRY inbox is owned by the redirect's own stage, so the generic
+    // follow-up stays out of both). The sweep's SQL already filters most of these; this catches a job
+    // enqueued BEFORE the config changed underneath it.
+    //
+    // Shared with the console's follow-up indicator, which must promise a countdown only for a job
+    // that would survive this check — see the predicate's header and issue #72.
     const redirectCfg = readChannelRedirectConfig(agent.settings);
+    const followUpCfg = readFollowUpConfig(agent.settings);
     if (
-      redirectCfg.enabled &&
-      (redirectCfg.widgetInboxId === inbox.chatwootInboxId ||
-        redirectCfg.entryInboxId === inbox.chatwootInboxId)
+      !isFollowUpLive({
+        agentEnabled: agent.enabled,
+        followUpEnabled: followUpCfg.enabled,
+        managedByRedirect:
+          redirectCfg.enabled &&
+          (redirectCfg.widgetInboxId === inbox.chatwootInboxId ||
+            redirectCfg.entryInboxId === inbox.chatwootInboxId),
+        agentMode: agent.mode,
+        testActivatedAt: conv.testActivatedAt,
+        status: conv.status,
+        assigneeType: conv.assigneeType,
+      })
     ) {
       return null;
     }
-    const followUpCfg = readFollowUpConfig(agent.settings);
-    if (!followUpCfg.enabled) return null;
 
     // Business hours gate: prefer followUpHoursId; fall back to businessHoursId; neither → no gate.
     const hoursId = agent.followUpHoursId ?? agent.businessHoursId;
@@ -342,16 +350,6 @@ export async function followUpHandler(
   } else if (newEpisode) {
     // A later step but the client spoke (or the watermark vanished): the episode is over. The inbound
     // webhook already cancels the PENDING job; a new period of silence restarts at step 0.
-    return { outcome: "done" };
-  }
-
-  // Gate: only follow up while the bot still owns the conversation (pending, no human).
-  if (
-    !shouldBotHandle({
-      assigneeType: ctx.conv.assigneeType,
-      status: ctx.conv.status,
-    })
-  ) {
     return { outcome: "done" };
   }
 

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -51,6 +51,9 @@ let convAppointmentCancelled = 0n;
 let convAppointmentOptOut = 0n;
 let convAppointmentResolved = 0n;
 let convAppointmentDone = 0n;
+let convHandedOffMidSequence = 0n;
+let convDisabledAgentArmed = 0n;
+let convFollowUpOffArmed = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
 const REDIRECT_JOB_RUN_AT = new Date("2026-06-18T23:30:00Z");
@@ -74,6 +77,9 @@ const BH_WINDOWS = Array.from({ length: 7 }, (_, day) => ({
 }));
 const BH_LAST_EVENT_AT = new Date("2026-06-15T20:00:00Z"); // dueAt = +2min = 20:02 UTC (closed)
 const BH_EXPECTED_RUN_AT = "2026-06-16T09:00:00.000Z";
+
+// A step-1 job armed two days out — the window in which the ground can shift under it.
+const ARMED_STEP1_RUN_AT = new Date("2026-06-20T23:18:45Z");
 
 describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
   beforeAll(async () => {
@@ -463,6 +469,122 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     convAppointmentOptOut = await seedAppointmentConv(313, optOutInbox.id, {
       startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
     });
+
+    // ── A PENDING job the handler will drop at claim time (issue #72). A multi-step sequence leaves
+    //    one armed between steps with runAt days out, and nothing cancels it when the ground shifts.
+    const twoStepSettings = {
+      followUp: {
+        enabled: true,
+        steps: [
+          { delayValue: 2, delayUnit: "minutes", instructions: "" },
+          { delayValue: 2, delayUnit: "days", instructions: "" },
+        ],
+      },
+    };
+    const armedAgent = await suDb.agent.create({
+      data: {
+        tenantId: tenant,
+        name: "FU Armed",
+        systemPrompt: "x",
+        followUpArmedAt: new Date("2026-01-01T00:00:00Z"),
+        mode: "production",
+        settings: twoStepSettings,
+      },
+    });
+    const armedInbox = await suDb.inbox.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootInboxId: 90,
+        name: "Sup armado",
+        agentId: armedAgent.id,
+      },
+    });
+    const disabledAgent = await suDb.agent.create({
+      data: {
+        tenantId: tenant,
+        name: "FU Disabled",
+        systemPrompt: "x",
+        enabled: false,
+        followUpArmedAt: new Date("2026-01-01T00:00:00Z"),
+        mode: "production",
+        settings: twoStepSettings,
+      },
+    });
+    const disabledInbox = await suDb.inbox.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootInboxId: 91,
+        name: "Sup desligado",
+        agentId: disabledAgent.id,
+      },
+    });
+    const offAgent = await suDb.agent.create({
+      data: {
+        tenantId: tenant,
+        name: "FU Off",
+        systemPrompt: "x",
+        followUpArmedAt: new Date("2026-01-01T00:00:00Z"),
+        mode: "production",
+        settings: {
+          followUp: { enabled: false, steps: twoStepSettings.followUp.steps },
+        },
+      },
+    });
+    const offInbox = await suDb.inbox.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootInboxId: 92,
+        name: "Sup sem follow-up",
+        agentId: offAgent.id,
+      },
+    });
+
+    // Mid-sequence: step 0 fired, the job was rescheduled for step 1, and only THEN a human took the
+    // conversation. The row is still PENDING with runAt two days out.
+    async function seedArmedConv(
+      chatwootId: number,
+      inboxId: bigint,
+      conv: { assigneeType?: string | null; assigneeId?: number } = {},
+    ): Promise<bigint> {
+      const c = await suDb.conversation.create({
+        data: {
+          tenantId: tenant,
+          chatwootInstanceId: inst,
+          chatwootConversationId: chatwootId,
+          inboxId,
+          status: "pending",
+          assigneeType: conv.assigneeType ?? null,
+          ...(conv.assigneeId != null ? { assigneeId: conv.assigneeId } : {}),
+          threadId: `${tenant}:${inst}:${chatwootId}`,
+          lastEventAt: LAST_EVENT_AT,
+          lastInboundAt: REPLY_AT,
+          lastFollowUpAt: FOLLOW_UP_AT,
+        },
+      });
+      await suDb.schedulerJob.create({
+        data: {
+          tenantId: tenant,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${tenant}:${inst}:${chatwootId}`,
+          status: "PENDING",
+          runAt: ARMED_STEP1_RUN_AT,
+          payload: {
+            threadId: `${tenant}:${inst}:${chatwootId}`,
+            stepIndex: 1,
+          },
+        },
+      });
+      return c.id;
+    }
+    convHandedOffMidSequence = await seedArmedConv(320, armedInbox.id, {
+      assigneeType: "User",
+      assigneeId: 5,
+    });
+    convDisabledAgentArmed = await seedArmedConv(321, disabledInbox.id);
+    convFollowUpOffArmed = await seedArmedConv(322, offInbox.id);
   });
 
   // A live appointment is the sweep's own fence (followUp.pauseWhileAppointment, on by default): it
@@ -736,5 +858,41 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     );
     expect(d.followUp?.pausedByAppointment).toBe(false);
     expect(d.followUp?.nextStep).toBe(1);
+  });
+
+  // Issue #72: the pending-job branch reported whatever the row said, while the handler re-checks all
+  // of this at claim time and drops the job. The countdown told the operator the customer would be
+  // re-engaged when nobody was going to be.
+  test("a human took the conversation mid-sequence → no countdown for a job that will be dropped", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convHandedOffMidSequence,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
+    // Not the appointment's doing, and the sequence is not "complete" either — nothing is coming.
+    expect(d.followUp?.pausedByAppointment).toBe(false);
+  });
+
+  test("the agent was disabled with a job already armed → no countdown", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convDisabledAgentArmed,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
+  });
+
+  test("follow-up was switched off with a job already armed → no countdown", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convFollowUpOffArmed,
+      appDb,
+    );
+    expect(d.followUp?.enabled).toBe(false);
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
   });
 });

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -871,8 +871,12 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     );
     expect(d.followUp?.nextStep).toBeNull();
     expect(d.followUp?.nextRunAt).toBeNull();
-    // Not the appointment's doing, and the sequence is not "complete" either — nothing is coming.
+    // Not the appointment's doing, and not a finished sequence either: `lastFollowUpAt` is set and
+    // nothing is pending, which is exactly the shape the console draws the "sequence complete" marker
+    // for. `live: false` is what keeps it from doing that.
     expect(d.followUp?.pausedByAppointment).toBe(false);
+    expect(d.followUp?.lastFollowUpAt).not.toBeNull();
+    expect(d.followUp?.live).toBe(false);
   });
 
   test("the agent was disabled with a job already armed → no countdown", async () => {
@@ -894,5 +898,12 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     expect(d.followUp?.enabled).toBe(false);
     expect(d.followUp?.nextStep).toBeNull();
     expect(d.followUp?.nextRunAt).toBeNull();
+    expect(d.followUp?.live).toBe(false);
+  });
+
+  test("a conversation the bot still owns reports the sequence as live", async () => {
+    const d = await getConversationDetail(ctx(tenant), convNewEpisode, appDb);
+    expect(d.followUp?.live).toBe(true);
+    expect(d.followUp?.nextStep).toBe(1);
   });
 });

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -54,6 +54,7 @@ let convAppointmentDone = 0n;
 let convHandedOffMidSequence = 0n;
 let convDisabledAgentArmed = 0n;
 let convFollowUpOffArmed = 0n;
+let convFinishedByResolve = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
 const REDIRECT_JOB_RUN_AT = new Date("2026-06-18T23:30:00Z");
@@ -585,6 +586,23 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     });
     convDisabledAgentArmed = await seedArmedConv(321, disabledInbox.id);
     convFollowUpOffArmed = await seedArmedConv(322, offInbox.id);
+    // The sequence ran to its end and its last step resolved the conversation: no job left, the bot
+    // no longer owns it, and it is COMPLETE.
+    const finished = await suDb.conversation.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootConversationId: 323,
+        inboxId: armedInbox.id,
+        status: "resolved",
+        assigneeType: null,
+        threadId: `${tenant}:${inst}:323`,
+        lastEventAt: LAST_EVENT_AT,
+        lastInboundAt: REPLY_AT,
+        lastFollowUpAt: FOLLOW_UP_AT,
+      },
+    });
+    convFinishedByResolve = finished.id;
   });
 
   // A live appointment is the sweep's own fence (followUp.pauseWhileAppointment, on by default): it
@@ -876,7 +894,7 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     // for. `live: false` is what keeps it from doing that.
     expect(d.followUp?.pausedByAppointment).toBe(false);
     expect(d.followUp?.lastFollowUpAt).not.toBeNull();
-    expect(d.followUp?.live).toBe(false);
+    expect(d.followUp?.abandoned).toBe(true);
   });
 
   test("the agent was disabled with a job already armed → no countdown", async () => {
@@ -898,12 +916,26 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     expect(d.followUp?.enabled).toBe(false);
     expect(d.followUp?.nextStep).toBeNull();
     expect(d.followUp?.nextRunAt).toBeNull();
-    expect(d.followUp?.live).toBe(false);
+    expect(d.followUp?.abandoned).toBe(true);
   });
 
-  test("a conversation the bot still owns reports the sequence as live", async () => {
+  test("a conversation the bot still owns is not abandoned", async () => {
     const d = await getConversationDetail(ctx(tenant), convNewEpisode, appDb);
-    expect(d.followUp?.live).toBe(true);
+    expect(d.followUp?.abandoned).toBe(false);
     expect(d.followUp?.nextStep).toBe(1);
+  });
+
+  // The distinction the flag exists for: a sequence whose last step is configured to resolve the
+  // conversation ends with the bot no longer owning it. That is a COMPLETED sequence, and the console
+  // still has to draw its completion marker — liveness alone cannot tell it from an abandoned one.
+  test("a sequence that finished by resolving the conversation is complete, not abandoned", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convFinishedByResolve,
+      appDb,
+    );
+    expect(d.followUp?.abandoned).toBe(false);
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.lastFollowUpAt).not.toBeNull();
   });
 });

--- a/tests/modules/followup-eligibility.test.ts
+++ b/tests/modules/followup-eligibility.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type FollowUpLiveness,
+  isFollowUpLive,
+} from "@/modules/followups/eligibility";
+
+// Decision table: one row per reason the handler drops a claimed follow-up job. The console indicator
+// reads the same predicate, so a row that flips here flips in both places at once — which is the
+// whole point of the predicate existing (issue #72).
+
+const LIVE: FollowUpLiveness = {
+  agentEnabled: true,
+  followUpEnabled: true,
+  managedByRedirect: false,
+  agentMode: "production",
+  testActivatedAt: null,
+  status: "pending",
+  assigneeType: null,
+};
+
+const cases: Array<{
+  name: string;
+  patch: Partial<FollowUpLiveness>;
+  live: boolean;
+}> = [
+  { name: "nothing in the way", patch: {}, live: true },
+  {
+    name: "the agent is disabled",
+    patch: { agentEnabled: false },
+    live: false,
+  },
+  {
+    name: "follow-up is switched off",
+    patch: { followUpEnabled: false },
+    live: false,
+  },
+  {
+    name: "a channelRedirect owns re-engagement",
+    patch: { managedByRedirect: true },
+    live: false,
+  },
+  {
+    name: "a test agent whose conversation was never activated",
+    patch: { agentMode: "test" },
+    live: false,
+  },
+  {
+    name: "a test agent whose conversation WAS activated",
+    patch: { agentMode: "test", testActivatedAt: new Date() },
+    live: true,
+  },
+  {
+    name: "a human took the conversation",
+    patch: { assigneeType: "User" },
+    live: false,
+  },
+  {
+    name: "the conversation was resolved",
+    patch: { status: "resolved" },
+    live: false,
+  },
+  {
+    name: "the conversation was reopened but is not pending",
+    patch: { status: "open" },
+    live: false,
+  },
+  {
+    // Without the instance bot id there is no way to tell OUR bot from another one; the handler
+    // and the estimate both call shouldBotHandle without it, so this stays live in both.
+    name: "a bot holds it",
+    patch: { assigneeType: "AgentBot" },
+    live: true,
+  },
+];
+
+describe("isFollowUpLive", () => {
+  for (const c of cases) {
+    test(`${c.live ? "live" : "dead"}: ${c.name}`, () => {
+      expect(isFollowUpLive({ ...LIVE, ...c.patch })).toBe(c.live);
+    });
+  }
+});


### PR DESCRIPTION
The console's follow-up indicator had two branches with two different ideas of when a follow-up is coming. The estimate branch mirrored the sweep's eligibility; the pending-job branch reported whatever the row said, gated only on the step-0 activation fence. Everything else that makes `followUpHandler` drop a claimed job was invisible to it.

The reachable case is a multi-step sequence. It reschedules the SAME row after each step, so between steps there is a PENDING job with `runAt` hours or days out. Nothing cancels it when a human takes the conversation (only `/teste`, `/reset` and a new inbound message do), the handler drops it on claim because the bot no longer owns the conversation, and meanwhile the console counts down for a re-engagement that will never happen. Same for an agent that gets disabled or follow-up switched off with a job already armed.

That is the same complaint as #60, from a different cause: the indicator exists so an operator can decide whether to step in, and it was telling them the customer would be chased when nobody was.

## What changed

**One predicate, `isFollowUpLive`** (`src/modules/followups/eligibility.ts`), answering exactly one question: if the handler claimed this job right now, would it send or would it drop it? Agent enabled, follow-up enabled, not redirect-managed, not test-silenced, bot still owns the conversation.

Both readers now use it: `followUpHandler` (which acts on it) and `getConversationDetail` (which must not promise a countdown that contradicts it). Copying the estimate branch's conditions onto the job branch would have created a third copy of the same gates and a third thing to drift; there were already two, and they had drifted twice.

What is deliberately NOT in the predicate: the fresh-episode check, the activation fence and the cadence. Those decide WHICH step comes next rather than whether the sequence is alive, and they legitimately differ between an armed job (a later step has `lastFollowUpAt` set by design) and a first-step estimate.

**One behavior change worth naming.** In the handler, the ownership check used to run after the appointment suppression; folding it into the predicate moves it before. A human-owned conversation with a live appointment used to be rescheduled until the appointment passed and only then dropped; now it is dropped on the first claim. Same end state, sooner, and it stops a dead row from being rescheduled for days.

## The decision the issue left open

The issue asks whether a handoff should cancel the pending job outright. **It should not**, and this PR does not.

A handoff is not always permanent: when the human unassigns, the conversation returns to the bot and the armed sequence should still be there. Cancelling would destroy it. The row costs one claim that returns `done`, whereas cancelling costs a write on every handoff and loses recoverable state. The display problem, which is what the issue is actually about, is fixed by the predicate.

## Validation scope

**Proved by test.** Three DB-backed cases added to the existing estimate suite, each seeding a step-1 job with `runAt` two days out and then changing the ground under it: a human takes the conversation, the agent is disabled, follow-up is switched off. All three reported `nextStep: 2` with a live `nextRunAt` before the change and report nothing after it. The human-owned case also asserts `pausedByAppointment` stays false, so the suppression is not misattributed to an appointment that is not there.

A decision table (`tests/modules/followup-eligibility.test.ts`) covers the predicate itself, one row per reason the handler drops a job, plus the two cases that must stay live (an activated test conversation, a bot-held conversation).

**Not validated live.** No live Chatwoot exercised; every case here is our own state, read back from the database.

`bun check`: 2161 pass, 0 fail, 0 skipped.

Fixes #72
