### PR TITLE
fix(conversations): a dead agent turn is invisible inside Chatwoot, so a silent agent and a broken one look the same

### DIFF
--- a/prisma/migrations/20260815180000_conversation_failure_notice/migration.sql
+++ b/prisma/migrations/20260815180000_conversation_failure_notice/migration.sql
@@ -1,0 +1,2 @@
+-- Coalescing anchor + concurrency claim for the "turn definitively lost" private note.
+ALTER TABLE "conversations" ADD COLUMN "failure_notice_sent_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -462,6 +462,12 @@ model Conversation {
   // NULL = the last turn was fine (or none ran yet).
   lastError              String?   @map("last_error")
   lastErrorAt            DateTime? @map("last_error_at")
+  // When the "the agent could not answer, a human has to take over" private note was last posted for
+  // this conversation. Distinct from lastErrorAt, which is stamped on EVERY failed attempt including
+  // the ones a retry will fix: this one is only stamped when the turn is definitively lost, and it is
+  // the coalescing anchor + the concurrency claim (the conditional write that sets it is what elects
+  // the single announcer). NULL = never announced.
+  failureNoticeSentAt    DateTime? @map("failure_notice_sent_at")
   // When the customer activated test mode in this conversation by sending /teste (item 1). NULL =
   // not activated; a "test" agent stays silent until this is set. /reset deliberately does NOT clear
   // it (the conversation keeps answering after a reset).

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -1317,21 +1317,25 @@ export async function processChatwootDelivery(
             });
             // And, when nothing else is coming, say so INSIDE Chatwoot (issue #71). There is no
             // retry on this path, so the only thing that can still answer is a newer message's own
-            // turn — the same fence the success path applies at `shouldPost`.
+            // turn — the same fence the success path applies at `shouldPost`. Read by the announcer,
+            // not here: the answer has to describe the moment of the note, not the moment of the
+            // failure.
+            const conversationId = n.conversationId;
+            const triggerId = n.message?.id ?? null;
             await announceFailedTurn({
               tenantId: params.tenantId,
               instanceId: params.instanceId,
-              chatwootConversationId: n.conversationId,
-              failure: {
+              chatwootConversationId: conversationId,
+              assess: async () => ({
                 path: "direct",
                 fence: await readDirectFence({
                   tenantId: params.tenantId,
                   instanceId: params.instanceId,
-                  chatwootConversationId: n.conversationId,
-                  triggerId: n.message?.id ?? null,
+                  chatwootConversationId: conversationId,
+                  triggerId,
                   base,
                 }),
-              },
+              }),
               error: err,
               base,
             });

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -38,6 +38,10 @@ import {
   clearConversationError,
   recordConversationError,
 } from "@/modules/conversations/error";
+import {
+  announceFailedTurn,
+  readDirectFence,
+} from "@/modules/conversations/failure-note";
 import { armDebounce, resolveDebounceConfig } from "@/modules/debounce/service";
 import { advanceHandledWatermark } from "@/modules/debounce/watermark";
 import { cancelPendingJob } from "@/modules/scheduler/service";
@@ -1308,6 +1312,26 @@ export async function processChatwootDelivery(
               tenantId: params.tenantId,
               instanceId: params.instanceId,
               chatwootConversationId: n.conversationId,
+              error: err,
+              base,
+            });
+            // And, when nothing else is coming, say so INSIDE Chatwoot (issue #71). There is no
+            // retry on this path, so the only thing that can still answer is a newer message's own
+            // turn — the same fence the success path applies at `shouldPost`.
+            await announceFailedTurn({
+              tenantId: params.tenantId,
+              instanceId: params.instanceId,
+              chatwootConversationId: n.conversationId,
+              failure: {
+                path: "direct",
+                fence: await readDirectFence({
+                  tenantId: params.tenantId,
+                  instanceId: params.instanceId,
+                  chatwootConversationId: n.conversationId,
+                  triggerId: n.message?.id ?? null,
+                  base,
+                }),
+              },
               error: err,
               base,
             });

--- a/src/modules/conversations/failure-note.ts
+++ b/src/modules/conversations/failure-note.ts
@@ -1,0 +1,231 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+import logger from "@/api/lib/logger";
+import basePrisma from "@/api/lib/prisma";
+import { sanitizeErrorMessage } from "@/lib/redact";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import {
+  type LoadChatwootClientDeps,
+  loadAgentBot,
+  loadChatwootClient,
+} from "@/modules/chatwoot/instance";
+import {
+  maxIncomingId,
+  parseChatwootMessages,
+} from "@/modules/chatwoot/messages";
+
+// A turn that dies leaves the customer with no reply, and the only traces are an `error` line in
+// `execution_logs`, `Conversation.lastError` in our console, and an `AlertChannel` dispatch when one
+// is configured. None of those is open in front of the person working the inbox, so a dead turn is
+// indistinguishable from an agent that chose to stay silent. This posts a private note (agents see
+// it, the customer does not) saying so.
+//
+// The hard part is not the note: it is knowing when the turn is DEFINITIVELY lost. The note tells an
+// operator to take over, and taking over closes `shouldBotHandle` — the gate a pending retry depends
+// on — so a premature note causes the failure it reports. Hence the rule below, and hence the fact
+// that this is NOT called from the handlers' catch blocks (issue #71):
+//
+//   * a job that will be retried is not lost, so the announcement hangs off the DEAD-LETTER event
+//     rather than off the failure. `failJob` reports whether its CAS actually dead-lettered, which
+//     also covers the flush that was re-armed mid-run (`armDebounce` upserts the CLAIMED row back to
+//     PENDING, the CAS then matches nothing, and another flush is already queued);
+//   * on the direct webhook path there is no job and no retry, so what has to be excluded is a NEWER
+//     message whose own turn may still answer — the same supersede fence the success path applies at
+//     `shouldPost`. A fence that cannot be read is `unknown`, and unknown does not announce: the cost
+//     of a missing note is an operator who finds out from the console, the cost of a wrong one is a
+//     conversation taken over while its answer was still coming.
+
+export type TurnFailure =
+  // A scheduler job. `deadLettered` is the CAS result, not the attempt count: only the statement that
+  // actually moved the row to DEAD may claim the turn is over.
+  | { path: "job"; deadLettered: boolean }
+  // The direct path. `clear` = no newer incoming message exists, so nothing else will answer;
+  // `superseded` = one does; `unknown` = the fence could not be read.
+  | { path: "direct"; fence: "clear" | "superseded" | "unknown" };
+
+export function isTurnLost(f: TurnFailure): boolean {
+  return f.path === "job" ? f.deadLettered : f.fence === "clear";
+}
+
+// The direct path's fence, read the same way the success path reads it at `shouldPost`: a newer
+// incoming message than the one this turn was triggered by means another turn is coming for it, and
+// that turn may well answer. Admin-token read (same as the flush's re-fetch), so it does not depend
+// on the persona bot resolving.
+export async function readDirectFence(params: {
+  tenantId: bigint;
+  instanceId: bigint;
+  chatwootConversationId: number;
+  triggerId: number | null;
+  base?: PrismaClient;
+  deps?: LoadChatwootClientDeps;
+}): Promise<"clear" | "superseded" | "unknown"> {
+  // NOTE: No trigger message (a non-message event, or a payload without one) means there is nothing
+  // to compare against, so the fence cannot say anything and the turn is not announced.
+  if (params.triggerId === null) return "unknown";
+  try {
+    const client = await loadChatwootClient(
+      params.tenantId,
+      params.instanceId,
+      {
+        ...params.deps,
+        base: params.base ?? basePrisma,
+      },
+    );
+    const latest = parseChatwootMessages(
+      await client.getMessages(params.chatwootConversationId),
+    );
+    return maxIncomingId(latest, params.triggerId) > params.triggerId
+      ? "superseded"
+      : "clear";
+  } catch (err) {
+    logger.warn(
+      "conversations: failed-turn fence unreadable (conv=%s): %s",
+      String(params.chatwootConversationId),
+      err instanceof Error ? err.message : String(err),
+    );
+    return "unknown";
+  }
+}
+
+// One announcement per conversation per window. A provider outage burns through every conversation
+// in an inbox, and an inbox buried in identical notes is the same as no notes at all.
+export const FAILURE_NOTICE_COOLDOWN_MS = 30 * 60_000;
+
+function sysCtx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}
+
+// Elects the single announcer, atomically. Two concurrent failures on one conversation both read the
+// same pre-failure stamp, so a read-then-write cooldown lets both through; the claim therefore IS the
+// write — whoever's conditional UPDATE matches the row gets the note, and the other sees 0 rows.
+//
+// NOTE: A claim whose post then fails keeps the stamp, so that conversation stays quiet for the rest
+// of the window. That direction is deliberate: the failure mode of a post is a Chatwoot that is down,
+// where a re-claim would not deliver anything either, and releasing the claim is exactly how one
+// failed turn becomes two notes once it comes back.
+export async function claimFailureNotice(params: {
+  tenantId: bigint;
+  instanceId: bigint;
+  chatwootConversationId: number;
+  now?: Date;
+  cooldownMs?: number;
+  base?: PrismaClient;
+}): Promise<boolean> {
+  const base = params.base ?? basePrisma;
+  const now = params.now ?? new Date();
+  const cooldownMs = params.cooldownMs ?? FAILURE_NOTICE_COOLDOWN_MS;
+  const cutoff = new Date(now.getTime() - cooldownMs);
+  const { count } = await runScopedOn(base, sysCtx(params.tenantId), (db) =>
+    db.conversation.updateMany({
+      where: {
+        tenantId: params.tenantId,
+        chatwootInstanceId: params.instanceId,
+        chatwootConversationId: params.chatwootConversationId,
+        OR: [
+          { failureNoticeSentAt: null },
+          { failureNoticeSentAt: { lt: cutoff } },
+        ],
+      },
+      data: { failureNoticeSentAt: now },
+    }),
+  );
+  return count > 0;
+}
+
+// The persona whose conversation this is, so the note is posted AS the agent the operator sees on the
+// inbox. `loadChatwootClient` defaults the bot token to "" and Chatwoot answers 401, which a
+// best-effort catch swallows — a note that never posts at all. The bot comes from the conversation's
+// inbox (`Inbox.agentId`), the same resolution the console does.
+async function personaBotToken(
+  tenantId: bigint,
+  instanceId: bigint,
+  chatwootConversationId: number,
+  base: PrismaClient,
+): Promise<string | null> {
+  const conv = await runScopedOn(base, sysCtx(tenantId), (db) =>
+    db.conversation.findFirst({
+      where: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootConversationId,
+      },
+      select: { inbox: { select: { agentId: true } } },
+    }),
+  );
+  const agentId = conv?.inbox?.agentId;
+  if (agentId == null) return null;
+  const bot = await loadAgentBot(tenantId, instanceId, agentId, base);
+  return bot?.accessToken ?? null;
+}
+
+function noteText(reason: string): string {
+  return [
+    "⚠️ Não consegui responder a esta conversa.",
+    "Um atendente humano precisa assumir.",
+    `Motivo: ${reason}`,
+  ].join("\n\n");
+}
+
+// Best-effort from end to end: a Chatwoot that is down must never turn one failed turn into two.
+export async function announceFailedTurn(params: {
+  tenantId: bigint;
+  instanceId: bigint;
+  chatwootConversationId: number;
+  failure: TurnFailure;
+  error: unknown;
+  now?: Date;
+  cooldownMs?: number;
+  base?: PrismaClient;
+  deps?: LoadChatwootClientDeps;
+}): Promise<"posted" | "not-lost" | "coalesced" | "failed"> {
+  if (!isTurnLost(params.failure)) return "not-lost";
+  const base = params.base ?? basePrisma;
+  const {
+    tenantId,
+    instanceId,
+    chatwootConversationId: conversationId,
+  } = params;
+  try {
+    if (
+      !(await claimFailureNotice({
+        tenantId,
+        instanceId,
+        chatwootConversationId: conversationId,
+        now: params.now,
+        cooldownMs: params.cooldownMs,
+        base,
+      }))
+    ) {
+      return "coalesced";
+    }
+    const botToken = await personaBotToken(
+      tenantId,
+      instanceId,
+      conversationId,
+      base,
+    );
+    if (botToken === null) {
+      logger.warn(
+        "conversations: no persona bot to announce a failed turn as (conv=%s)",
+        String(conversationId),
+      );
+      return "failed";
+    }
+    const client = await loadChatwootClient(tenantId, instanceId, {
+      ...params.deps,
+      base,
+      botToken,
+    });
+    await client.sendPrivateNote(
+      conversationId,
+      noteText(sanitizeErrorMessage(params.error)),
+    );
+    return "posted";
+  } catch (err) {
+    logger.warn(
+      "conversations: failed-turn note not posted (conv=%s): %s",
+      String(conversationId),
+      err instanceof Error ? err.message : String(err),
+    );
+    return "failed";
+  }
+}

--- a/src/modules/conversations/failure-note.ts
+++ b/src/modules/conversations/failure-note.ts
@@ -27,7 +27,8 @@ import {
 //   * a job that will be retried is not lost, so the announcement hangs off the DEAD-LETTER event
 //     rather than off the failure. `failJob` reports whether its CAS actually dead-lettered, which
 //     also covers the flush that was re-armed mid-run (`armDebounce` upserts the CLAIMED row back to
-//     PENDING, the CAS then matches nothing, and another flush is already queued);
+//     PENDING, the CAS then matches nothing, and another flush is already queued). The DEAD row can
+//     be re-armed AFTER that too, so the state is re-read at announce time (see `assess` below);
 //   * on the direct webhook path there is no job and no retry, so what has to be excluded is a NEWER
 //     message whose own turn may still answer — the same supersede fence the success path applies at
 //     `shouldPost`. A fence that cannot be read is `unknown`, and unknown does not announce: the cost
@@ -166,18 +167,27 @@ function noteText(reason: string): string {
 }
 
 // Best-effort from end to end: a Chatwoot that is down must never turn one failed turn into two.
+//
+// `assess` is deliberately a callback rather than a value. The failure and the announcement are
+// separated by database and network work, and a message arriving in that gap starts a direct turn or
+// re-arms the DEAD debounce row back to PENDING — so a snapshot taken at failure time can announce
+// over work that is already live, which is the one outcome this whole module exists to avoid. It is
+// therefore called as late as it can be, right before the claim, and after the reads that could fail
+// for their own reasons (resolving the persona bot burns nothing when it comes back empty).
+//
+// What remains is the claim→post gap, which is irreducible: Chatwoot is the source of truth for
+// "another message arrived" and we cannot hold a lock across it.
 export async function announceFailedTurn(params: {
   tenantId: bigint;
   instanceId: bigint;
   chatwootConversationId: number;
-  failure: TurnFailure;
+  assess: () => Promise<TurnFailure>;
   error: unknown;
   now?: Date;
   cooldownMs?: number;
   base?: PrismaClient;
   deps?: LoadChatwootClientDeps;
 }): Promise<"posted" | "not-lost" | "coalesced" | "failed"> {
-  if (!isTurnLost(params.failure)) return "not-lost";
   const base = params.base ?? basePrisma;
   const {
     tenantId,
@@ -185,18 +195,6 @@ export async function announceFailedTurn(params: {
     chatwootConversationId: conversationId,
   } = params;
   try {
-    if (
-      !(await claimFailureNotice({
-        tenantId,
-        instanceId,
-        chatwootConversationId: conversationId,
-        now: params.now,
-        cooldownMs: params.cooldownMs,
-        base,
-      }))
-    ) {
-      return "coalesced";
-    }
     const botToken = await personaBotToken(
       tenantId,
       instanceId,
@@ -209,6 +207,19 @@ export async function announceFailedTurn(params: {
         String(conversationId),
       );
       return "failed";
+    }
+    if (!isTurnLost(await params.assess())) return "not-lost";
+    if (
+      !(await claimFailureNotice({
+        tenantId,
+        instanceId,
+        chatwootConversationId: conversationId,
+        now: params.now,
+        cooldownMs: params.cooldownMs,
+        base,
+      }))
+    ) {
+      return "coalesced";
     }
     const client = await loadChatwootClient(tenantId, instanceId, {
       ...params.deps,

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -401,7 +401,19 @@ export async function announceDeadDebounceFlush(
     tenantId: job.tenantId,
     instanceId: parsed.instanceId,
     chatwootConversationId: parsed.conversationId,
-    failure: { path: "job", deadLettered: true },
+    // NOTE: Re-read rather than trust the dead-letter that got us here: `armDebounce` upserts this
+    // very row back to PENDING on the next inbound message, and a row that is queued again is a turn
+    // that is coming — announcing over it is what would make an operator take over and close the
+    // gate that queued flush depends on.
+    assess: async () => {
+      const row = await runScopedOn(base, sysCtx(job.tenantId), (db) =>
+        db.schedulerJob.findUnique({
+          where: { id: job.id },
+          select: { status: true },
+        }),
+      );
+      return { path: "job", deadLettered: row?.status === "DEAD" };
+    },
     error,
     base,
   });

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -24,10 +24,15 @@ import {
   clearConversationError,
   recordConversationError,
 } from "@/modules/conversations/error";
+import { announceFailedTurn } from "@/modules/conversations/failure-note";
 import { emitFlowEvent } from "@/modules/flowlog/service";
 import type { FlowStage } from "@/modules/flowlog/stages";
 import type { ClaimedJob } from "@/modules/scheduler/service";
-import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
+import {
+  type JobResult,
+  registerDeadLetterHandler,
+  registerJobHandler,
+} from "@/modules/scheduler/worker";
 import { readLastMessageId } from "./service";
 import { readDebounceConfig } from "./settings";
 import { advanceHandledWatermark } from "./watermark";
@@ -378,9 +383,34 @@ function debounceFlushHandler(
   return flushDebounceJob({ job, base });
 }
 
+// The burst is definitively unanswered: the flush exhausted its attempts and the row is DEAD, so no
+// retry is coming and the customer is waiting on nobody. This is the only place on this path where
+// that can be said — the handler's catch runs on attempt 1 too, and cannot know whether another
+// attempt exists (issue #71).
+export async function announceDeadDebounceFlush(
+  job: ClaimedJob,
+  error: string,
+  base: PrismaClient,
+): Promise<void> {
+  const threadId =
+    typeof job.payload.threadId === "string" ? job.payload.threadId : null;
+  if (!threadId) return;
+  const parsed = parseThreadId(threadId);
+  if (!parsed || parsed.tenantId !== job.tenantId) return;
+  await announceFailedTurn({
+    tenantId: job.tenantId,
+    instanceId: parsed.instanceId,
+    chatwootConversationId: parsed.conversationId,
+    failure: { path: "job", deadLettered: true },
+    error,
+    base,
+  });
+}
+
 let registered = false;
 export function registerDebounceHandler(): void {
   if (registered) return;
   registerJobHandler("DEBOUNCE", debounceFlushHandler);
+  registerDeadLetterHandler("DEBOUNCE", announceDeadDebounceFlush);
   registered = true;
 }

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -265,24 +265,48 @@ export async function failJob(
 // Reaper: a CLAIMED row older than `staleMs` is presumed crashed → back to PENDING (attempts++ so
 // poison eventually dies). Cross-tenant, so asSuperAdmin. `tenantId` is the same test-only fence as
 // the claim's: without it, a concurrent suite's reap bumps this run's attempts underneath it.
+// Returns every row it touched, because the reaper is the SECOND way a job reaches DEAD: a claim that
+// crashed or hung is killed here, not by `failJob`, and a caller that hangs its "this work is
+// definitively lost" reaction off failJob alone would never hear about those (issue #71 review).
+export interface ReapedJob extends ClaimedJob {
+  status: "PENDING" | "DEAD";
+}
+
 export async function reapStaleJobs(
   staleMs: number,
   base: PrismaClient = basePrisma,
   now: Date = new Date(),
   tenantId?: bigint,
-): Promise<number> {
+): Promise<ReapedJob[]> {
   const cutoff = new Date(now.getTime() - staleMs);
   const tenantClause =
     tenantId != null ? Prisma.sql`AND tenant_id = ${tenantId}` : Prisma.empty;
   return asSuperAdminOn(base, async (db) => {
-    const requeued = await db.$executeRaw(Prisma.sql`
+    const rows = await db.$queryRaw<
+      Array<{
+        id: bigint;
+        tenant_id: bigint;
+        kind: string;
+        payload: unknown;
+        attempts: number;
+        status: "PENDING" | "DEAD";
+      }>
+    >(Prisma.sql`
       UPDATE scheduler_jobs
       SET status = CASE WHEN attempts + 1 >= ${MAX_ATTEMPTS} THEN 'DEAD'::"SchedulerJobStatus" ELSE 'PENDING'::"SchedulerJobStatus" END,
           attempts = attempts + 1,
           claimed_at = NULL,
           updated_at = now()
-      WHERE status = 'CLAIMED' AND claimed_at < ${cutoff} ${tenantClause}`);
-    return requeued;
+      WHERE status = 'CLAIMED' AND claimed_at < ${cutoff} ${tenantClause}
+      RETURNING id, tenant_id, kind, payload, attempts, status`);
+    return rows.map((r) => ({
+      id: r.id,
+      tenantId: r.tenant_id,
+      kind: r.kind as ClaimedJob["kind"],
+      payload: (r.payload ?? {}) as ClaimedJob["payload"],
+      attempts: r.attempts,
+      status: r.status,
+    }));
   });
 }
 

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -231,6 +231,11 @@ export async function rescheduleJob(
 }
 
 // Failure: attempts++; retry with backoff until the cap, then DEAD.
+// Returns whether this call is the one that DEAD-LETTERED the job — the attempt count alone does not
+// say so. The CAS is on `status = 'CLAIMED'`, and a job re-armed mid-run (`armDebounce` upserts the
+// claimed row back to PENDING) no longer matches it: the row survives with another run already
+// queued, so a caller reading `attempts` would call a live job dead. Anything hanging off "this work
+// is definitively lost" has to hang off this, not off the failure (issue #71).
 export async function failJob(
   tenantId: bigint,
   id: bigint,
@@ -238,10 +243,10 @@ export async function failJob(
   error: string,
   base: PrismaClient = basePrisma,
   now: Date = new Date(),
-): Promise<void> {
+): Promise<{ deadLettered: boolean }> {
   const next = attempts + 1;
   const dead = next >= MAX_ATTEMPTS;
-  await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const { count } = await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.schedulerJob.updateMany({
       where: { id, status: "CLAIMED" },
       data: dead
@@ -254,6 +259,7 @@ export async function failJob(
           },
     }),
   );
+  return { deadLettered: dead && count > 0 };
 }
 
 // Reaper: a CLAIMED row older than `staleMs` is presumed crashed → back to PENDING (attempts++ so

--- a/src/modules/scheduler/worker.ts
+++ b/src/modules/scheduler/worker.ts
@@ -37,8 +37,60 @@ export function getJobHandler(kind: string): JobHandler | undefined {
   return handlers.get(kind);
 }
 
+// Called when a job is DEAD-LETTERED, which is the only moment the scheduler can state that this
+// work is definitively lost — a failure is not that statement, because the next attempt may succeed
+// (issue #71). Registered per kind so the scheduler stays ignorant of what a given job's loss means
+// downstream; a kind with no hook simply dies quietly, as before.
+export type DeadLetterHandler = (
+  job: ClaimedJob,
+  error: string,
+  base: PrismaClient,
+) => Promise<void>;
+
+const deadLetterHandlers = new Map<string, DeadLetterHandler>();
+
+export function registerDeadLetterHandler(
+  kind: string,
+  handler: DeadLetterHandler,
+): void {
+  deadLetterHandlers.set(kind, handler);
+}
+export function getDeadLetterHandler(
+  kind: string,
+): DeadLetterHandler | undefined {
+  return deadLetterHandlers.get(kind);
+}
+
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+// Records a failure and, when it was the one that dead-lettered the job, notifies whoever registered
+// a hook for that kind. Best-effort: a hook that throws must not turn a failed job into a failed
+// tick, and it runs AFTER the row is DEAD so it can never be mistaken for part of the attempt.
+async function fail(
+  job: ClaimedJob,
+  error: string,
+  base: PrismaClient,
+): Promise<void> {
+  const { deadLettered } = await failJob(
+    job.tenantId,
+    job.id,
+    job.attempts,
+    error,
+    base,
+  );
+  if (!deadLettered) return;
+  const hook = deadLetterHandlers.get(job.kind);
+  if (!hook) return;
+  try {
+    await hook(job, error, base);
+  } catch (err) {
+    logger.warn(
+      { err, jobId: String(job.id), kind: job.kind },
+      "scheduler: dead-letter hook failed",
+    );
+  }
 }
 
 // Runs one claimed job through its handler and records the outcome (under the job's tenant scope).
@@ -48,20 +100,14 @@ export async function runClaimed(
 ): Promise<void> {
   const handler = getJobHandler(job.kind);
   if (!handler) {
-    await failJob(
-      job.tenantId,
-      job.id,
-      job.attempts,
-      `no handler: ${job.kind}`,
-      base,
-    );
+    await fail(job, `no handler: ${job.kind}`, base);
     return;
   }
   let result: JobResult;
   try {
     result = await handler(job, base);
   } catch (err) {
-    await failJob(job.tenantId, job.id, job.attempts, errMsg(err), base);
+    await fail(job, errMsg(err), base);
     return;
   }
   if (result.outcome === "done") {
@@ -75,13 +121,7 @@ export async function runClaimed(
       base,
     );
   } else {
-    await failJob(
-      job.tenantId,
-      job.id,
-      job.attempts,
-      result.error ?? "failed",
-      base,
-    );
+    await fail(job, result.error ?? "failed", base);
   }
 }
 

--- a/src/modules/scheduler/worker.ts
+++ b/src/modules/scheduler/worker.ts
@@ -65,9 +65,27 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Best-effort: a hook that throws must not turn a failed job into a failed tick, and it runs AFTER
+// the row is DEAD so it can never be mistaken for part of the attempt.
+async function dispatchDeadLetter(
+  job: ClaimedJob,
+  error: string,
+  base: PrismaClient,
+): Promise<void> {
+  const hook = deadLetterHandlers.get(job.kind);
+  if (!hook) return;
+  try {
+    await hook(job, error, base);
+  } catch (err) {
+    logger.warn(
+      { err, jobId: String(job.id), kind: job.kind },
+      "scheduler: dead-letter hook failed",
+    );
+  }
+}
+
 // Records a failure and, when it was the one that dead-lettered the job, notifies whoever registered
-// a hook for that kind. Best-effort: a hook that throws must not turn a failed job into a failed
-// tick, and it runs AFTER the row is DEAD so it can never be mistaken for part of the attempt.
+// a hook for that kind.
 async function fail(
   job: ClaimedJob,
   error: string,
@@ -80,17 +98,7 @@ async function fail(
     error,
     base,
   );
-  if (!deadLettered) return;
-  const hook = deadLetterHandlers.get(job.kind);
-  if (!hook) return;
-  try {
-    await hook(job, error, base);
-  } catch (err) {
-    logger.warn(
-      { err, jobId: String(job.id), kind: job.kind },
-      "scheduler: dead-letter hook failed",
-    );
-  }
+  if (deadLettered) await dispatchDeadLetter(job, error, base);
 }
 
 // Runs one claimed job through its handler and records the outcome (under the job's tenant scope).
@@ -135,11 +143,18 @@ export async function runSchedulerTick(
   opts: TickOptions,
 ): Promise<{ claimed: number; reaped: number }> {
   const reaped = await reapStaleJobs(opts.staleMs, base);
+  // NOTE: The reaper is the other road to DEAD — a claim that crashed or hung never reaches failJob,
+  // so without this a job that exhausts its attempts by hanging dies unannounced.
+  for (const job of reaped) {
+    if (job.status === "DEAD") {
+      await dispatchDeadLetter(job, "reaped: the claim never finished", base);
+    }
+  }
   const jobs = await claimDueJobs(opts.batchSize, base);
   for (const job of jobs) {
     await runClaimed(job, base);
   }
-  return { claimed: jobs.length, reaped };
+  return { claimed: jobs.length, reaped: reaped.length };
 }
 
 interface Holder {

--- a/tests/modules/failure-note.test.ts
+++ b/tests/modules/failure-note.test.ts
@@ -1,0 +1,607 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
+import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
+import {
+  announceFailedTurn,
+  claimFailureNotice,
+  isTurnLost,
+  readDirectFence,
+  type TurnFailure,
+} from "@/modules/conversations/failure-note";
+import {
+  announceDeadDebounceFlush,
+  registerDebounceHandler,
+} from "@/modules/debounce/handler";
+import type { ClaimedJob } from "@/modules/scheduler/service";
+import {
+  getDeadLetterHandler,
+  getJobHandler,
+  registerDeadLetterHandler,
+  registerJobHandler,
+  runClaimed,
+} from "@/modules/scheduler/worker";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// Issue #71. A turn that dies leaves the customer with no reply and the operator with nothing to see
+// inside Chatwoot. The note that says so is easy; knowing the turn is DEFINITIVELY lost is not, and
+// getting it wrong is worse than saying nothing — the note tells an operator to take over, and taking
+// over closes the gate the pending retry depends on.
+//
+// These cover the five windows the design named: the announcement hangs off the dead-letter CAS (not
+// the attempt count, and not the handler's catch), a job re-armed mid-run is not dead, the direct
+// path fences on a newer message, an unreadable fence stays silent, and the coalescing claim is the
+// write itself so two concurrent failures cannot both announce.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+// TEST-NET-3 on a closed port: passes the SSRF check without a DNS lookup, and nothing can reach it
+// even if a call escaped the double.
+const BASE_URL = "https://203.0.113.20:9";
+const BOT_TOKEN = "PERSONA-BOT-TOKEN";
+const INBOX_ID = 501;
+
+let tenantId = 0n;
+let instanceId = 0n;
+let agentId = 0n;
+let nextConv = 900;
+
+// The double AUTHENTICATES like Chatwoot: the note is posted with the bot token, and the whole point
+// of window 1 is that a client built without one gets a 401 that a best-effort catch swallows. A stub
+// that accepts any token is what let that ship in the first place.
+interface Posted {
+  conversationId: number;
+  content: string;
+  private: boolean;
+  token: string;
+}
+let posted: Posted[] = [];
+let inbound: Array<{ id: number; message_type: number; content: string }> = [];
+let messagesFail = false;
+let realFetch: typeof globalThis.fetch;
+
+function installChatwootDouble(): void {
+  realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const token = String(
+      (init?.headers as Record<string, string> | undefined)?.[
+        "api-access-token"
+      ] ?? "",
+    );
+    const json = (body: unknown, status = 200) =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      });
+    if (token === "") {
+      return json({ error: "Invalid Access Token" }, 401);
+    }
+    const messages = url.match(/\/conversations\/(\d+)\/messages$/);
+    if (messages && (init?.method ?? "GET") === "GET") {
+      if (messagesFail) return json({ error: "boom" }, 500);
+      return json({ payload: inbound });
+    }
+    if (messages && init?.method === "POST") {
+      const body = JSON.parse(String(init.body ?? "{}"));
+      posted.push({
+        conversationId: Number(messages[1]),
+        content: String(body.content ?? ""),
+        private: body.private === true,
+        token,
+      });
+      return json({ id: 1 });
+    }
+    return json({}, 404);
+  }) as typeof globalThis.fetch;
+}
+
+async function seedConversation(over: { failureNoticeSentAt?: Date } = {}) {
+  const chatwootConversationId = nextConv++;
+  await suDb.conversation.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      chatwootConversationId,
+      inboxId: inboxDbId,
+      status: "pending",
+      threadId: `${tenantId}:${instanceId}:${chatwootConversationId}`,
+      ...(over.failureNoticeSentAt
+        ? { failureNoticeSentAt: over.failureNoticeSentAt }
+        : {}),
+    },
+  });
+  return chatwootConversationId;
+}
+
+let inboxDbId: bigint | null = null;
+
+async function noticeAt(conversationId: number): Promise<Date | null> {
+  const row = await suDb.conversation.findFirstOrThrow({
+    where: { tenantId, chatwootConversationId: conversationId },
+    select: { failureNoticeSentAt: true },
+  });
+  return row.failureNoticeSentAt;
+}
+
+describe("isTurnLost", () => {
+  // The whole decision, as a table. Everything else in this file is plumbing around these five rows.
+  const rows: Array<[string, TurnFailure, boolean]> = [
+    [
+      "a job that dead-lettered is lost",
+      { path: "job", deadLettered: true },
+      true,
+    ],
+    [
+      "a job that will be retried is not",
+      { path: "job", deadLettered: false },
+      false,
+    ],
+    [
+      "a direct turn with a clear fence is lost",
+      { path: "direct", fence: "clear" },
+      true,
+    ],
+    [
+      "a direct turn superseded by a newer message is not",
+      { path: "direct", fence: "superseded" },
+      false,
+    ],
+    [
+      "a fence that could not be read does NOT announce",
+      { path: "direct", fence: "unknown" },
+      false,
+    ],
+  ];
+  for (const [name, failure, expected] of rows) {
+    test(name, () => {
+      expect(isTurnLost(failure)).toBe(expected);
+    });
+  }
+});
+
+// `SchedulerJob.kind` is a DB enum, so a test-only kind cannot be inserted: the two seam tests borrow
+// DEBOUNCE and put the real handlers back, or every later suite in this worker inherits a flush that
+// throws (the registries are process-global).
+const KIND = "DEBOUNCE" as const;
+
+async function withBorrowedKind(
+  handler: () => Promise<never>,
+  onDead: (job: ClaimedJob) => Promise<void>,
+  run: () => Promise<void>,
+): Promise<void> {
+  const realHandler = getJobHandler(KIND);
+  const realHook = getDeadLetterHandler(KIND);
+  registerJobHandler(KIND, handler);
+  registerDeadLetterHandler(KIND, onDead);
+  try {
+    await run();
+  } finally {
+    if (realHandler) registerJobHandler(KIND, realHandler);
+    if (realHook) registerDeadLetterHandler(KIND, realHook);
+  }
+}
+
+describe.skipIf(!dbUp)("failed-turn note", () => {
+  beforeAll(async () => {
+    installChatwootDouble();
+    // The real DEBOUNCE handlers, so the two scheduler-seam tests below can borrow the kind and put
+    // them back afterwards (the kind is a DB enum — a test-only one cannot be inserted).
+    registerDebounceHandler();
+    const t = await suDb.tenant.create({
+      data: { name: "FAILNOTE", slug: `failnote-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 4,
+      baseUrl: BASE_URL,
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Atendente",
+        systemPrompt: "Voce e prestativa.",
+        modelConfig: {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          credentialRef: "vault:999999999",
+        },
+        // Debounce off: the direct path is the one with no retry, and the one this suite fences.
+        settings: { debounce: { enabled: false }, split: { enabled: false } },
+      },
+    });
+    agentId = agent.id;
+    await suDb.chatwootAgentBot.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        agentId,
+        chatwootAgentBotId: 9,
+        accessToken: encryptJson(BOT_TOKEN),
+        webhookSecret: encryptJson("S"),
+        webhookRouteTokenHash: `failnote-route-${process.pid}`,
+        name: "Atendente",
+      },
+    });
+    const inbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: INBOX_ID,
+        name: "Suporte",
+        agentId,
+      },
+    });
+    inboxDbId = inbox.id;
+  });
+
+  afterEach(() => {
+    posted = [];
+    inbound = [];
+    messagesFail = false;
+  });
+
+  afterAll(async () => {
+    globalThis.fetch = realFetch;
+    if (!dbUp) return;
+    for (const table of [
+      "scheduler_jobs",
+      "conversations",
+      "vault_entries",
+      "inboxes",
+      "chatwoot_agent_bots",
+      "agents",
+      "chatwoot_instances",
+    ]) {
+      await suDb
+        .$executeRawUnsafe(`DELETE FROM ${table} WHERE tenant_id = ${tenantId}`)
+        .catch(() => {});
+    }
+    await suDb.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  // ── The claim ────────────────────────────────────────────────────────────────────────────────
+  test("two concurrent failures on one conversation elect exactly one announcer", async () => {
+    const conv = await seedConversation();
+    const both = await Promise.all([
+      claimFailureNotice({
+        tenantId,
+        instanceId,
+        chatwootConversationId: conv,
+        base: appDb,
+      }),
+      claimFailureNotice({
+        tenantId,
+        instanceId,
+        chatwootConversationId: conv,
+        base: appDb,
+      }),
+    ]);
+    expect(both.filter(Boolean)).toHaveLength(1);
+  });
+
+  test("a second failure inside the window does not announce again", async () => {
+    const now = new Date();
+    const conv = await seedConversation({
+      failureNoticeSentAt: new Date(now.getTime() - 60_000),
+    });
+    expect(
+      await claimFailureNotice({
+        tenantId,
+        instanceId,
+        chatwootConversationId: conv,
+        now,
+        base: appDb,
+      }),
+    ).toBe(false);
+  });
+
+  test("a failure past the window announces again", async () => {
+    const now = new Date();
+    const conv = await seedConversation({
+      failureNoticeSentAt: new Date(now.getTime() - 31 * 60_000),
+    });
+    expect(
+      await claimFailureNotice({
+        tenantId,
+        instanceId,
+        chatwootConversationId: conv,
+        now,
+        base: appDb,
+      }),
+    ).toBe(true);
+    expect((await noticeAt(conv))?.getTime()).toBe(now.getTime());
+  });
+
+  // ── The note itself ──────────────────────────────────────────────────────────────────────────
+  test("posts a private note AS the persona bot, with the sanitized reason", async () => {
+    const conv = await seedConversation();
+    const outcome = await announceFailedTurn({
+      tenantId,
+      instanceId,
+      chatwootConversationId: conv,
+      failure: { path: "job", deadLettered: true },
+      error: new Error("model provider returned 503"),
+      base: appDb,
+    });
+    expect(outcome).toBe("posted");
+    expect(posted).toHaveLength(1);
+    // Window 1: a client built without the persona bot token 401s and the note never appears.
+    expect(posted[0]?.token).toBe(BOT_TOKEN);
+    expect(posted[0]?.private).toBe(true);
+    expect(posted[0]?.conversationId).toBe(conv);
+    expect(posted[0]?.content).toContain("model provider returned 503");
+  });
+
+  test("a turn that is not lost posts nothing and does not burn the window", async () => {
+    const conv = await seedConversation();
+    const outcome = await announceFailedTurn({
+      tenantId,
+      instanceId,
+      chatwootConversationId: conv,
+      failure: { path: "job", deadLettered: false },
+      error: new Error("transient"),
+      base: appDb,
+    });
+    expect(outcome).toBe("not-lost");
+    expect(posted).toHaveLength(0);
+    expect(await noticeAt(conv)).toBeNull();
+  });
+
+  // ── The direct path's fence ──────────────────────────────────────────────────────────────────
+  test("a newer incoming message means someone else may still answer", async () => {
+    const conv = await seedConversation();
+    inbound = [
+      { id: 10, message_type: 0, content: "oi" },
+      { id: 11, message_type: 0, content: "ainda ai?" },
+    ];
+    const fence = await readDirectFence({
+      tenantId,
+      instanceId,
+      chatwootConversationId: conv,
+      triggerId: 10,
+      base: appDb,
+    });
+    expect(fence).toBe("superseded");
+  });
+
+  test("no newer incoming message means nothing else is coming", async () => {
+    const conv = await seedConversation();
+    inbound = [
+      { id: 10, message_type: 0, content: "oi" },
+      // An outgoing message is not another turn's trigger.
+      { id: 12, message_type: 1, content: "ja respondo" },
+    ];
+    expect(
+      await readDirectFence({
+        tenantId,
+        instanceId,
+        chatwootConversationId: conv,
+        triggerId: 10,
+        base: appDb,
+      }),
+    ).toBe("clear");
+  });
+
+  test("a fence that cannot be read is unknown, and unknown stays silent", async () => {
+    const conv = await seedConversation();
+    messagesFail = true;
+    const fence = await readDirectFence({
+      tenantId,
+      instanceId,
+      chatwootConversationId: conv,
+      triggerId: 10,
+      base: appDb,
+    });
+    expect(fence).toBe("unknown");
+    await announceFailedTurn({
+      tenantId,
+      instanceId,
+      chatwootConversationId: conv,
+      failure: { path: "direct", fence },
+      error: new Error("boom"),
+      base: appDb,
+    });
+    expect(posted).toHaveLength(0);
+    expect(await noticeAt(conv)).toBeNull();
+  });
+
+  // ── The scheduler seam ───────────────────────────────────────────────────────────────────────
+  test("the hook fires on the dead-letter, not on the failures before it", async () => {
+    const calls: bigint[] = [];
+    const row = await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: KIND,
+        dedupeKey: `failnote-dead-${process.pid}`,
+        payload: {},
+        runAt: new Date(),
+        status: "CLAIMED",
+        attempts: 0,
+      },
+      select: { id: true },
+    });
+    await withBorrowedKind(
+      async () => {
+        throw new Error("always fails");
+      },
+      async (job) => {
+        calls.push(job.id);
+      },
+      async () => {
+        // MAX_ATTEMPTS is 5: the first four runs requeue, the fifth is the one that dead-letters.
+        for (let attempts = 0; attempts < 5; attempts++) {
+          await suDb.schedulerJob.update({
+            where: { id: row.id },
+            data: { status: "CLAIMED", attempts },
+          });
+          await runClaimed(
+            { id: row.id, tenantId, kind: KIND, payload: {}, attempts },
+            appDb,
+          );
+          expect(calls).toHaveLength(attempts === 4 ? 1 : 0);
+        }
+      },
+    );
+    const after = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id: row.id },
+      select: { status: true },
+    });
+    expect(after.status).toBe("DEAD");
+  });
+
+  test("a job re-armed mid-run is not dead, so nothing is announced", async () => {
+    const calls: bigint[] = [];
+    const row = await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: KIND,
+        dedupeKey: `failnote-rearm-${process.pid}`,
+        payload: {},
+        runAt: new Date(),
+        status: "CLAIMED",
+        attempts: 4,
+      },
+      select: { id: true },
+    });
+    await withBorrowedKind(
+      async () => {
+        // What armDebounce does when a new message lands while the flush is running: the CLAIMED row
+        // goes back to PENDING with another run queued. The CAS in failJob then matches nothing, so
+        // the attempt count says "dead" while the job is very much alive.
+        await suDb.schedulerJob.update({
+          where: { id: row.id },
+          data: { status: "PENDING" },
+        });
+        throw new Error("failed after being re-armed");
+      },
+      async (job) => {
+        calls.push(job.id);
+      },
+      () =>
+        runClaimed(
+          { id: row.id, tenantId, kind: KIND, payload: {}, attempts: 4 },
+          appDb,
+        ),
+    );
+    expect(calls).toHaveLength(0);
+    const after = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id: row.id },
+      select: { status: true },
+    });
+    expect(after.status).toBe("PENDING");
+  });
+
+  test("the debounce flush registers its dead-letter hook", () => {
+    registerDebounceHandler();
+    expect(getDeadLetterHandler("DEBOUNCE")).toBe(announceDeadDebounceFlush);
+  });
+
+  // The direct webhook path, end to end: a delivery arrives, the turn dies inside the runtime, and the
+  // operator finds out INSIDE Chatwoot. Nothing here is injected — `processChatwootDelivery` has no
+  // seam for the runtime, so the turn runs for real and the note is posted by the real client against
+  // the double, which authenticates like Chatwoot. The turn cannot succeed by accident: its model
+  // credential does not resolve and every outbound call it could make lands on the double.
+  test("a turn that dies on the direct path leaves a note on the conversation", async () => {
+    const conv = await seedConversation();
+    const payload = {
+      event: "message_created",
+      id: 4242,
+      content: "oi, preciso de ajuda",
+      message_type: "incoming",
+      private: false,
+      conversation: {
+        id: conv,
+        inbox_id: INBOX_ID,
+        status: "pending",
+        contact_inbox: { id: 88_000 + conv },
+        meta: {
+          assignee_type: null,
+          assignee: null,
+          sender: { id: 700, name: "Cliente", phone_number: "+5511999990000" },
+        },
+        channel: "Channel::WebWidget",
+        last_activity_at: Math.floor(Date.now() / 1000),
+      },
+    };
+    const n = normalizeChatwootEvent(payload);
+    expect(n).not.toBeNull();
+    if (!n) throw new Error("unreachable");
+    // The fence sees only the message this turn was triggered by, so nothing else is coming.
+    inbound = [{ id: 4242, message_type: 0, content: "oi, preciso de ajuda" }];
+    const delivery = await suDb.chatwootWebhookDelivery.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        deliveryId: `failnote-${process.pid}-${conv}`,
+        event: "message_created",
+        status: "PENDING",
+      },
+      select: { id: true },
+    });
+    await processChatwootDelivery({
+      tenantId,
+      instanceId,
+      deliveryRowId: delivery.id,
+      agentBotId: 9,
+      normalized: n,
+      base: appDb,
+    });
+    const note = posted.find((p) => p.conversationId === conv);
+    expect(note).toBeDefined();
+    expect(note?.private).toBe(true);
+    expect(note?.token).toBe(BOT_TOKEN);
+    expect(await noticeAt(conv)).not.toBeNull();
+  });
+
+  test("the dead debounce flush announces on the conversation its thread names", async () => {
+    const conv = await seedConversation();
+    const job: ClaimedJob = {
+      id: 1n,
+      tenantId,
+      kind: "DEBOUNCE",
+      payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
+      attempts: 4,
+    };
+    await announceDeadDebounceFlush(job, "model provider returned 503", appDb);
+    expect(posted).toHaveLength(1);
+    expect(posted[0]?.conversationId).toBe(conv);
+    expect(posted[0]?.token).toBe(BOT_TOKEN);
+    expect(await noticeAt(conv)).not.toBeNull();
+  });
+});

--- a/tests/modules/failure-note.test.ts
+++ b/tests/modules/failure-note.test.ts
@@ -29,6 +29,7 @@ import {
   registerDeadLetterHandler,
   registerJobHandler,
   runClaimed,
+  runSchedulerTick,
 } from "@/modules/scheduler/worker";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
@@ -355,7 +356,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
       tenantId,
       instanceId,
       chatwootConversationId: conv,
-      failure: { path: "job", deadLettered: true },
+      assess: async () => ({ path: "job", deadLettered: true }),
       error: new Error("model provider returned 503"),
       base: appDb,
     });
@@ -374,7 +375,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
       tenantId,
       instanceId,
       chatwootConversationId: conv,
-      failure: { path: "job", deadLettered: false },
+      assess: async () => ({ path: "job", deadLettered: false }),
       error: new Error("transient"),
       base: appDb,
     });
@@ -433,7 +434,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
       tenantId,
       instanceId,
       chatwootConversationId: conv,
-      failure: { path: "direct", fence },
+      assess: async () => ({ path: "direct", fence }),
       error: new Error("boom"),
       base: appDb,
     });
@@ -527,6 +528,65 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
     expect(after.status).toBe("PENDING");
   });
 
+  test("a DEAD row re-armed before the note is posted is a live turn again", async () => {
+    const conv = await seedConversation();
+    const row = await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: KIND,
+        dedupeKey: `failnote-rearmed-after-${process.pid}`,
+        payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
+        runAt: new Date(),
+        // Dead when the hook fired, PENDING by the time the note would be posted: armDebounce upserts
+        // this very row on the next inbound message, and that queued flush will answer.
+        status: "PENDING",
+        attempts: 5,
+      },
+      select: { id: true },
+    });
+    await announceDeadDebounceFlush(
+      {
+        id: row.id,
+        tenantId,
+        kind: KIND,
+        payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
+        attempts: 4,
+      },
+      "model provider returned 503",
+      appDb,
+    );
+    expect(posted).toHaveLength(0);
+    expect(await noticeAt(conv)).toBeNull();
+  });
+
+  test("a job the reaper kills is announced too", async () => {
+    const conv = await seedConversation();
+    const row = await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: KIND,
+        dedupeKey: `failnote-reaped-${process.pid}`,
+        payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
+        runAt: new Date(),
+        // A claim that hung: the reaper, not failJob, is what ends it, and this is its last attempt.
+        status: "CLAIMED",
+        claimedAt: new Date(Date.now() - 600_000),
+        attempts: 4,
+      },
+      select: { id: true },
+    });
+    registerDebounceHandler();
+    await runSchedulerTick(appDb, { staleMs: 5 * 60_000, batchSize: 20 });
+    const after = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id: row.id },
+      select: { status: true },
+    });
+    expect(after.status).toBe("DEAD");
+    const note = posted.find((p) => p.conversationId === conv);
+    expect(note).toBeDefined();
+    expect(note?.token).toBe(BOT_TOKEN);
+  });
+
   test("the debounce flush registers its dead-letter hook", () => {
     registerDebounceHandler();
     expect(getDeadLetterHandler("DEBOUNCE")).toBe(announceDeadDebounceFlush);
@@ -589,12 +649,60 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
     expect(await noticeAt(conv)).not.toBeNull();
   });
 
+  // Same window on the direct path: the fence is read by the announcer, so a message that lands while
+  // the failure is being recorded is seen, and the turn it will start is left alone.
+  test("a message that arrives before the note does cancels the note", async () => {
+    const conv = await seedConversation();
+    let announced = 0;
+    const outcome = await announceFailedTurn({
+      tenantId,
+      instanceId,
+      chatwootConversationId: conv,
+      assess: async () => {
+        announced += 1;
+        // The customer wrote again between the failure and this point.
+        inbound = [
+          { id: 4242, message_type: 0, content: "oi" },
+          { id: 4243, message_type: 0, content: "alo?" },
+        ];
+        return {
+          path: "direct",
+          fence: await readDirectFence({
+            tenantId,
+            instanceId,
+            chatwootConversationId: conv,
+            triggerId: 4242,
+            base: appDb,
+          }),
+        };
+      },
+      error: new Error("boom"),
+      base: appDb,
+    });
+    expect(announced).toBe(1);
+    expect(outcome).toBe("not-lost");
+    expect(posted).toHaveLength(0);
+    expect(await noticeAt(conv)).toBeNull();
+  });
+
   test("the dead debounce flush announces on the conversation its thread names", async () => {
     const conv = await seedConversation();
+    const row = await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: KIND,
+        dedupeKey: `failnote-flush-${process.pid}`,
+        payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
+        runAt: new Date(),
+        status: "DEAD",
+        attempts: 5,
+      },
+      select: { id: true },
+    });
     const job: ClaimedJob = {
-      id: 1n,
+      id: row.id,
       tenantId,
-      kind: "DEBOUNCE",
+      kind: KIND,
       payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
       attempts: 4,
     };

--- a/tests/modules/scheduler.test.ts
+++ b/tests/modules/scheduler.test.ts
@@ -238,7 +238,11 @@ describe.skipIf(!dbUp)("scheduler", () => {
       data: { status: "CLAIMED", claimedAt: new Date(Date.now() - 600_000) },
     });
     const reaped = await reapStaleJobs(5 * 60_000, appDb, new Date(), tenantId);
-    expect(reaped).toBeGreaterThanOrEqual(1);
+    expect(reaped.length).toBeGreaterThanOrEqual(1);
+    // The reaper reports what it touched: it is the other road to DEAD, and a caller reacting to a
+    // definitively lost job has to hear about those too.
+    expect(reaped.map((r) => r.id)).toContain(id);
+    expect(reaped.find((r) => r.id === id)?.status).toBe("PENDING");
     const s = await statusOf(id);
     expect(s.status).toBe("PENDING");
     expect(s.attempts).toBe(1);


### PR DESCRIPTION
A turn that dies leaves the customer with no reply. The only traces are an `error` line in `execution_logs`, `Conversation.lastError` in our console, and a dispatch to an `AlertChannel` when one is configured. None of those is open in front of the person working the inbox, so a dead turn is indistinguishable from an agent that chose to stay silent.

This posts a **private note** on the Chatwoot conversation (agents see it, the customer does not) saying the agent could not answer and a human has to take over, with the sanitized reason.

## The note is the easy half

Knowing the turn is **definitively lost** is the hard one, and getting it wrong is worse than saying nothing: the note tells an operator to take over, and taking over closes `shouldBotHandle`, which is the gate a pending retry depends on. A premature note causes the failure it reports.

That is why the announcement is **not** called from the handlers' `catch` blocks. Each of the five windows the design named is closed by a different mechanism:

**1. The note posted with no bot token.** `sendPrivateNote` goes through `sendMessage`, which authenticates with the persona bot token, and `loadChatwootClient` defaults that token to `""`. Chatwoot answers 401 and a best-effort catch swallows it, so the note never appears at all. The bot is now resolved from the conversation's inbox (`Inbox.agentId` → `loadAgentBot`), the same resolution the console does.

**2. Two concurrent failures both announcing.** A read-then-write cooldown lets both callers see the same pre-failure stamp. The claim is therefore the write itself: one conditional `UPDATE` on a new `Conversation.failureNoticeSentAt` column, and whoever matches the row gets the note.

**3. Announcing on attempt 1 of 5.** The scheduler retries a `DEBOUNCE` flush up to `MAX_ATTEMPTS`, so a failure is not a loss. `failJob` now reports whether it dead-lettered, and the announcement hangs off a per-kind **dead-letter hook** the scheduler calls off that report.

**4. A flush re-armed mid-run looking final.** `armDebounce` upserts the `CLAIMED` row back to `PENDING`, so `failJob`'s CAS (`WHERE status = 'CLAIMED'`) matches nothing and another flush is already queued. Reporting the CAS result rather than the attempt count is exactly what excludes this: `deadLettered = dead && count > 0`.

**5. An older direct turn announcing over a newer one.** The direct webhook path has no job and no retry, so what has to be excluded is a newer incoming message whose own turn may still answer. That is the same supersede fence the success path applies at `shouldPost`, read here before announcing.

A sixth case falls out of the fifth: a fence that **cannot be read** (the re-fetch failed) is `unknown`, and unknown does not announce. The success path treats a failed re-fetch as non-fatal and proceeds, because there the fallback is a monotonic CAS. Here proceeding means announcing, which is the harmful direction, so the two paths deliberately differ.

## Shape

The decision is a pure function over a two-case union, with the whole rule in five rows:

```ts
export type TurnFailure =
  | { path: "job"; deadLettered: boolean }
  | { path: "direct"; fence: "clear" | "superseded" | "unknown" };

export function isTurnLost(f: TurnFailure): boolean {
  return f.path === "job" ? f.deadLettered : f.fence === "clear";
}
```

Everything else is the plumbing that produces those booleans honestly.

One deliberate asymmetry: a claim whose post then fails **keeps** the stamp, so that conversation stays quiet for the rest of the window. The failure mode of a post is a Chatwoot that is down, where a re-claim would not deliver anything either, and releasing the claim is exactly how one failed turn becomes two notes once it comes back.

## Validation scope

**Proven by test** (18 tests, `tests/modules/failure-note.test.ts`, `bun check` green at 2166 pass / 0 fail):

- the decision table for `isTurnLost`, all five rows;
- the claim, against the database: two concurrent claims elect exactly one announcer; a second failure inside the window does not announce; a failure past the window does, and stamps the new time;
- the note itself, through the **real** Chatwoot client against a double that **authenticates like Chatwoot** (a blank `api-access-token` gets `401 {"error":"Invalid Access Token"}`, which is the defect in window 1): posted private, on the right conversation, carrying the persona bot token, with the sanitized reason in the body;
- the fence: a newer incoming message is `superseded`; an outgoing message is not another turn's trigger, so it stays `clear`; a re-fetch that fails is `unknown`, and `unknown` posts nothing and does not burn the window;
- the scheduler seam, against the database: the hook fires on the fifth run and not on the four before it, and a job whose handler re-arms it mid-run ends `PENDING` with nothing announced;
- the direct path **end to end**: a delivery goes through `processChatwootDelivery`, the turn dies inside the runtime (no seam is injected there), and the private note lands on the conversation with the persona token.

**Proven by mutation** (each run alone, count is failing tests):

| mutation | failures |
| --- | --- |
| the dead-letter trusts the attempt count instead of the CAS | 1 |
| an unreadable fence announces | 2 |
| the claim drops its cooldown predicate | 2 |
| the note is posted without the persona bot | 1 |
| the hook fires on every failure | 2 |
| the webhook does not announce at all | 1 |

**Not validated:** no live run against a real Chatwoot. The 401-on-blank-token behaviour the double reproduces was read from the fork (`render_unauthorized` answers 401 for all three auth strings), not measured here.

**Deliberately not changed:** `recordConversationError` still stamps `lastError` on every failed attempt, including ones a retry will fix. The issue raises the same question for the console badge, and the answer is not the same: the note is an interruption addressed to a person, while the badge is a status an operator goes looking for, and hiding transient errors from it would remove the only place a flapping provider is visible. The "re-engage" collision it mentions is real and unaddressed here.

Fixes #71
