### PR TITLE
ci(docs): publish the API reference from the release tag

### DIFF
--- a/.codex-review-waived
+++ b/.codex-review-waived
@@ -103,3 +103,17 @@ src/modules/conversations/service.ts: Persist abandonment after the scheduler co
 # our own checkpointer. That is a mechanism justified by a hypothesis; if a measurable quality gap
 # shows up on multi-step tool loops, it earns its own change.
 src/graph/models.ts: Include encrypted reasoning in stateless tool loops
+
+# PR #91. The window is real and can be long (the image job is a multi-arch matrix and its runner
+# queue has held a job for hours), but the conclusion does not follow. At the instant `released`
+# fires, the version is already public: the GitHub Release exists, with its notes and its source
+# tarball. The reference tracks the RELEASE, which is the announcement of the version, not the
+# container artifact, so a GHCR image lagging its own release is a gap between the image and the
+# release, and putting the docs inside that gap does not close it. The remedy costs real mechanism:
+# `workflow_run` runs in the default branch's context and carries none of the release payload (the
+# tag would have to be re-resolved from the triggering run), `publish_github_package.yml` also has a
+# `workflow_dispatch` trigger so the docs would fire on builds that are not releases, and it adds a
+# failure mode that does not exist today (image published, docs silently not). A release whose image
+# never builds is a broken release: repair the build or cut another tag. `workflow_dispatch` already
+# covers repairing the page by hand.
+.github/workflows/deploy-swagger.yml: Wait for image publication before deploying the docs

--- a/.github/workflows/deploy-swagger.yml
+++ b/.github/workflows/deploy-swagger.yml
@@ -5,17 +5,21 @@ name: Deploy Swagger UI to GitHub Pages
 # tooling drops THIS WORKFLOW from the Pro tree (openapi.json itself ships in both), and the job is
 # additionally guarded to the public Free repo so it no-ops if it ever reaches the master or a fork.
 #
+# It publishes from the RELEASE TAG, not from main. Publishing on every push to main documented
+# endpoints nobody could call yet: the newest image an operator can run is the last release, so the
+# page ran ahead of every deployed instance. Publishing from the tag also makes the version real:
+# the committed spec carries the 0.0.0 placeholder (info.version reads package.json, which this repo
+# keeps at 0.0.0 by design), so the number is stamped here from the tag, exactly like
+# publish_github_package.yml does to package.json when it builds the image.
+#
 # NOTE: Pages must be enabled on the repo with "GitHub Actions" as the source, or `configure-pages`
 # fails with "Get Pages site failed". It cannot self-enable: the action's `enablement` input needs a
 # token other than GITHUB_TOKEN. Pages on a private repo also requires a paid plan, which is why
 # this job only ever succeeded after fazer-ai/agents went public.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "openapi.json"
-      - ".github/workflows/deploy-swagger.yml"
+  release:
+    types: [published]
+  # Republishes the latest release: use it to repair the page without cutting a release.
   workflow_dispatch:
 
 # Serialize Pages deploys; never cancel an in-flight publish.
@@ -26,7 +30,9 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.repository == 'fazer-ai/agents'
+    # A prerelease (rc/beta) is not what operators run, so it must not become the public docs.
+    # On workflow_dispatch there is no release payload and the expression reads null, i.e. falsy.
+    if: github.repository == 'fazer-ai/agents' && !github.event.release.prerelease
 
     permissions:
       contents: read
@@ -38,8 +44,26 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Resolve the release to publish
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # workflow_dispatch carries no release payload: republish whatever the latest release is.
+          TAG="${TAG:-}"
+          if [ -z "$TAG" ]; then
+            TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Publishing the spec from $TAG as ${TAG#v}"
+
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release.outputs.tag }}
 
       - name: Create Swagger UI index.html
         run: |
@@ -85,7 +109,13 @@ jobs:
           </body>
           </html>
           EOL
-          cp openapi.json ./public/openapi.json
+
+      - name: Stamp the released version into the spec
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          jq --arg v "$VERSION" '.info.version = $v' openapi.json > ./public/openapi.json
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/.github/workflows/deploy-swagger.yml
+++ b/.github/workflows/deploy-swagger.yml
@@ -24,8 +24,16 @@ on:
   # need a prerelease guard of its own.
   release:
     types: [released]
-  # Republishes the latest release: use it to repair the page without cutting a release.
+  # Repairs the page without cutting a release. `tag` is worth naming explicitly whenever the
+  # intended release is not the latest one: `releases/latest` sorts by the TAGGED COMMIT's date,
+  # not by publication time, so a release cut from an older commit (a promoted prerelease, a
+  # late-published draft) is not the one it returns, and a blind repair could move the page back.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish. Defaults to the latest release."
+        required: false
+        type: string
 
 # Serialize Pages deploys; never cancel an in-flight publish.
 concurrency:
@@ -51,12 +59,12 @@ jobs:
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
           set -euo pipefail
-          # workflow_dispatch carries no release payload: republish the latest release. The REST
-          # `releases/latest` is the most recent non-prerelease, non-draft release, which is the
-          # same thing the `released` trigger above would have published.
+          # A release carries its own tag; a dispatch may name one. With neither, fall back to the
+          # latest release: REST `releases/latest` is the most recent non-prerelease, non-draft
+          # release, the same thing the `released` trigger above would have published.
           TAG="${TAG:-}"
           if [ -z "$TAG" ]; then
             TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)

--- a/.github/workflows/deploy-swagger.yml
+++ b/.github/workflows/deploy-swagger.yml
@@ -17,8 +17,13 @@ name: Deploy Swagger UI to GitHub Pages
 # token other than GITHUB_TOKEN. Pages on a private repo also requires a paid plan, which is why
 # this job only ever succeeded after fazer-ai/agents went public.
 on:
+  # The same event publish_github_package.yml uses to build the image this documents. `released`
+  # fires when a release is published as stable AND when a prerelease is promoted in place, and
+  # never for a prerelease on its own, so the reference and the image always move together.
+  # `published` would miss the promotion (no second `published` event is emitted for it) and would
+  # need a prerelease guard of its own.
   release:
-    types: [published]
+    types: [released]
   # Republishes the latest release: use it to repair the page without cutting a release.
   workflow_dispatch:
 
@@ -30,9 +35,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # A prerelease (rc/beta) is not what operators run, so it must not become the public docs.
-    # On workflow_dispatch there is no release payload and the expression reads null, i.e. falsy.
-    if: github.repository == 'fazer-ai/agents' && !github.event.release.prerelease
+    if: github.repository == 'fazer-ai/agents'
 
     permissions:
       contents: read
@@ -51,10 +54,12 @@ jobs:
           TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          # workflow_dispatch carries no release payload: republish whatever the latest release is.
+          # workflow_dispatch carries no release payload: republish the latest release. The REST
+          # `releases/latest` is the most recent non-prerelease, non-draft release, which is the
+          # same thing the `released` trigger above would have published.
           TAG="${TAG:-}"
           if [ -z "$TAG" ]; then
-            TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)
+            TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What was wrong

The published API reference (Swagger UI on GitHub Pages) shows `0.0.0` as the API version, and it documents `main` rather than any released version. Both come from the same place.

`info.version` is wired to `config.packageInfo.version` (`src/api/index.ts`), which reads `package.json`. This repo keeps `package.json` at `0.0.0` by design: the real number is injected from the release tag at image-build time (`npm version "$TAG_VERSION" --no-git-tag-version`, `publish_github_package.yml`) and is never committed. `scripts/build-openapi.ts` boots the app to generate the committed `openapi.json`, so the placeholder is baked into the file, and this workflow copied that file verbatim. Measured on the committed spec:

```
$ jq -r .info.version openapi.json
0.0.0
```

The version was only the visible half. The workflow triggered on every push to `main` that touched `openapi.json`, so the published reference described endpoints nobody could call yet: the newest image an operator can run is the last release, so the page ran permanently ahead of every deployed instance.

Correcting `info.version` in the committed file is not an option: `bun openapi:check` compares it byte for byte against the freshly generated document (wired into `bun check` and CI), so a real version stored there is permanent drift.

## What changed

Publish from the release tag instead of from `main`, and stamp the version at publish time, which is what `publish_github_package.yml` already does to `package.json` when it builds the image.

- **Trigger**: `on: push` becomes `on: release: types: [released]`, the same event `publish_github_package.yml` uses to build the image this documents. `released` fires when a release is published as stable and when a prerelease is promoted in place, and never for a prerelease on its own, so the reference and the image always move together. (`published` would have missed the promotion: GitHub emits no second `published` event for it.)
- **Checkout**: the job resolves the tag and checks that ref out, so the spec published is the released spec.
- **Stamp**: `cp openapi.json ./public/openapi.json` becomes `jq '.info.version = $v'`, with the leading `v` stripped from the tag.
- **Manual repair**: `workflow_dispatch` stays and takes an optional `tag` input. Without it, the job falls back to `repos/<repo>/releases/latest`, documented as the most recent non-prerelease, non-draft release. The input exists because that endpoint sorts by the *tagged commit's* date, not by publication time, so a release cut from an older commit is not the one it returns.

`src/api/index.ts` is untouched. The `0.0.0` in the committed spec stays a placeholder, consistent with `package.json`, and the `openapi:check` drift guard is unaffected.

## Validation scope

Proven locally by extracting the `run:` blocks from the workflow itself (never retyped) and executing them against a fake `gh` and the real committed `openapi.json`:

- the trigger is `release: [released]`, and it is the same trigger `publish_github_package.yml` declares;
- release payload `v1.6.0` resolves `tag=v1.6.0`, `version=1.6.0`;
- a dispatch naming `v1.4.1` resolves `1.4.1`, winning over the latest-release lookup;
- a dispatch naming nothing falls back to `repos/<repo>/releases/latest` and resolves `1.6.0`;
- the stamped artifact carries `info.version: 1.6.0` while the committed file still reads `0.0.0`;
- the published document differs from the committed one in `info.version` and in nothing else;
- red: the previous `cp` path reproduces `0.0.0` on the artifact.

Every check was mutation-tested, one mutation at a time, and each mutation fails the checks it should: reverting the trigger to `published`, re-adding a prerelease guard, dropping the `v` strip, removing the dispatch fallback, pointing the fallback at `releases` instead of `releases/latest`, ignoring `inputs.tag`, making the input required, restoring `cp`, and making `jq` overwrite the rest of `info`.

The stamp was additionally run against this repo's own `openapi.json` (155 paths): `info.version` changes, the rest of the document is byte-identical. `jq 1.7` and `GitHub CLI 2.97.0` are both in the `ubuntu-24.04` runner image (checked against `actions/runner-images`).

**Not validated:** the workflow has not run on GitHub. The trigger change, the `ref:` checkout and the dispatch input are only exercised by a real `release: released` event or a manual dispatch, so the first proof in production is the next release cut.

**Review:** three codex rounds (`gpt-5.6-sol`, effort `high`), converging to `0 findings` on the current head. The reviewer bot's token was unreadable throughout, so the rounds are recorded as comments on this PR rather than as reviews. One finding is waived rather than fixed (gating the docs deploy on the image build), with the reasoning in `.codex-review-waived`.
