### PR TITLE
fix(guardrails): run the configured guardrail instead of failing open on an empty model

### DIFF
--- a/src/client/components/ModelPicker.tsx
+++ b/src/client/components/ModelPicker.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "@/client/lib/api";
+import { PROVIDER_DEFAULT_MODEL } from "@/graph/model-defaults";
 import { ComboBox, type ComboItem } from "./ComboBox";
 
 interface ProviderModel {
@@ -73,12 +74,19 @@ export function ModelPicker({
   credentialRef,
   baseURL,
   capability = "chat",
-  placeholder = "gpt-5.4-mini",
+  placeholder,
   disabled,
   "aria-label": ariaLabel,
 }: Props) {
   const { t } = useTranslation();
   const key = cacheKey(provider, credentialRef, baseURL, capability);
+  // An empty field still shows this text, so it has to be the model the runtime would actually use.
+  // It used to be the literal "gpt-5.4-mini" for every provider, which read as "Anthropic will run
+  // gpt-5.4-mini". Only chat has a per-provider default; elsewhere the honest hint is that nobody
+  // picked, and the provider's own default applies.
+  const shown =
+    placeholder ??
+    (capability === "chat" ? PROVIDER_DEFAULT_MODEL[provider] : undefined);
 
   const loader = useCallback(async (): Promise<ComboItem[]> => {
     const cached = readCache(key);
@@ -106,7 +114,9 @@ export function ModelPicker({
       loaderKey={key}
       eager
       needsCredential={!credentialRef}
-      placeholder={placeholder}
+      placeholder={
+        shown || t("editor.modelPickerProviderDefault", "Provider default")
+      }
       searchPlaceholder={t("editor.modelPickerSearch", "Search models…")}
       disabled={disabled}
       aria-label={ariaLabel ?? t("editor.model", "Model")}

--- a/src/client/components/ModelPicker.tsx
+++ b/src/client/components/ModelPicker.tsx
@@ -82,11 +82,23 @@ export function ModelPicker({
   const key = cacheKey(provider, credentialRef, baseURL, capability);
   // An empty field still shows this text, so it has to be the model the runtime would actually use.
   // It used to be the literal "gpt-5.4-mini" for every provider, which read as "Anthropic will run
-  // gpt-5.4-mini". Only chat has a per-provider default; elsewhere the honest hint is that nobody
-  // picked, and the provider's own default applies.
+  // gpt-5.4-mini" under Anthropic. Only chat has a per-provider table here.
+  //
+  // NOTE: A caller's placeholder wins even when it is the empty string, which is a deliberate value
+  // and not an omission: the vision and STT tabs pass `X_DEFAULT_MODEL[provider] ?? ""`, and for
+  // openai-compatible those tables hold "" precisely because no default exists and the endpoint
+  // needs a named model. Promising "provider default" there would invite an empty field the request
+  // cannot satisfy. Hence `!== undefined` rather than a truthiness fallback.
+  const providerDefault = t(
+    "editor.modelPickerProviderDefault",
+    "Provider default",
+  );
   const shown =
-    placeholder ??
-    (capability === "chat" ? PROVIDER_DEFAULT_MODEL[provider] : undefined);
+    placeholder !== undefined
+      ? placeholder
+      : capability === "chat"
+        ? PROVIDER_DEFAULT_MODEL[provider] || providerDefault
+        : providerDefault;
 
   const loader = useCallback(async (): Promise<ComboItem[]> => {
     const cached = readCache(key);
@@ -114,9 +126,7 @@ export function ModelPicker({
       loaderKey={key}
       eager
       needsCredential={!credentialRef}
-      placeholder={
-        shown || t("editor.modelPickerProviderDefault", "Provider default")
-      }
+      placeholder={shown}
       searchPlaceholder={t("editor.modelPickerSearch", "Search models…")}
       disabled={disabled}
       aria-label={ariaLabel ?? t("editor.model", "Model")}

--- a/src/client/lib/providerLabels.ts
+++ b/src/client/lib/providerLabels.ts
@@ -19,16 +19,3 @@ export function providerLabel(p: string, t: TFunction): string {
   }
   return PROVIDER_LABELS[p] ?? p;
 }
-
-// Sensible per-provider default, auto-applied when the operator switches provider so the form
-// never sits on a model id that belongs to another provider. openai-compatible has no guessable
-// default (empty clears the field; the picker lists the endpoint's models). Ids age with provider
-// releases — revisit alongside DEFAULT_MODEL_CONFIG in src/graph/model-config.ts.
-export const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
-  openai: "gpt-5.4-mini",
-  anthropic: "claude-sonnet-4-6",
-  google: "gemini-3.5-flash",
-  deepseek: "deepseek-chat",
-  openrouter: "openai/gpt-5.4-mini",
-  "openai-compatible": "",
-};

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -856,6 +856,7 @@
     "mode": "Mode",
     "modeHint": "A test agent stays silent in a conversation until the customer sends /teste; production answers normally.",
     "model": "Model",
+    "modelPickerProviderDefault": "Provider default",
     "modelPickerSearch": "Search models…",
     "modelRequired": "Pick a model for this provider before saving.",
     "modelSection": "Model",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -858,6 +858,7 @@
     "mode": "Modo",
     "modeHint": "Um agente em teste fica em silêncio na conversa até o cliente enviar /teste; em produção responde normalmente.",
     "model": "Modelo",
+    "modelPickerProviderDefault": "Padrão do provedor",
     "modelPickerSearch": "Buscar modelos…",
     "modelRequired": "Escolha um modelo para este provedor antes de salvar.",
     "modelSection": "Modelo",

--- a/src/client/pages/agents/GeneralTab.tsx
+++ b/src/client/pages/agents/GeneralTab.tsx
@@ -14,12 +14,10 @@ import {
 } from "@/client/components";
 import { useActiveTenantName } from "@/client/hooks/useActiveTenantName";
 import { credentialCompat } from "@/client/lib/credentialCompat";
-import {
-  PROVIDER_DEFAULT_MODEL,
-  providerLabel,
-} from "@/client/lib/providerLabels";
+import { providerLabel } from "@/client/lib/providerLabels";
 import { cn } from "@/client/lib/utils";
 import { isValidHttpUrl } from "@/client/lib/validation";
+import { PROVIDER_DEFAULT_MODEL } from "@/graph/model-defaults";
 import { REASONING_EFFORTS } from "@/graph/openai-reasoning";
 import { CapabilityMap } from "./CapabilityMap";
 import { PromptPanel } from "./PromptPanel";

--- a/src/client/pages/agents/GuardrailsTab.tsx
+++ b/src/client/pages/agents/GuardrailsTab.tsx
@@ -9,10 +9,8 @@ import {
   Textarea,
 } from "@/client/components";
 import { credentialCompat } from "@/client/lib/credentialCompat";
-import {
-  PROVIDER_DEFAULT_MODEL,
-  providerLabel,
-} from "@/client/lib/providerLabels";
+import { providerLabel } from "@/client/lib/providerLabels";
+import { PROVIDER_DEFAULT_MODEL } from "@/graph/model-defaults";
 import type {
   GuardrailAction,
   GuardrailChecks,

--- a/src/graph/model-defaults.ts
+++ b/src/graph/model-defaults.ts
@@ -1,0 +1,19 @@
+// The model assumed when a provider that requires one was picked and no model was. Three places
+// read it and they must agree, or the operator is told one thing and the runtime does another: the
+// editor applies it when the provider select changes, the model picker shows it as the placeholder
+// of an empty field, and the guardrails reader resolves an empty stored model through it.
+//
+// openai-compatible maps to "" on purpose. There, empty is a real choice (single-model servers
+// ignore the requested name), which is why it is the only provider `modelConfigSchema` lets through
+// empty. Everywhere else an empty model reaches the provider verbatim and the call is refused.
+//
+// Deliberately import-free: the client bundle reads this table too, and must not pull server code
+// in to get it. Ids age with provider releases; revisit alongside DEFAULT_MODEL_CONFIG.
+export const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
+  openai: "gpt-5.4-mini",
+  anthropic: "claude-sonnet-4-6",
+  google: "gemini-3.5-flash",
+  deepseek: "deepseek-chat",
+  openrouter: "openai/gpt-5.4-mini",
+  "openai-compatible": "",
+};

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -404,6 +404,18 @@ export async function runLoadedTurn(
       generationPrompt:
         dir.action === "generated" ? dir.generationPrompt : undefined,
     });
+    // A guardrail that could not run reads exactly like one that ran and approved, so without this
+    // line an expired credential is silent moderation for as long as nobody notices. The turn is
+    // NOT blocked (fail-open stays), only recorded.
+    if (verdict.error) {
+      emitFlowEvent(flow, {
+        stage: "guardrail",
+        status: "error",
+        level: "warn",
+        detail: { direction, outcome: "analysis_failed" },
+        errorMessage: verdict.error,
+      });
+    }
     if (!verdict.violated) return null;
     emitFlowEvent(flow, {
       stage: "guardrail",

--- a/src/modules/guardrails/analyze.ts
+++ b/src/modules/guardrails/analyze.ts
@@ -19,6 +19,10 @@ export interface GuardrailVerdict {
   rationale: string;
   // A safe replacement reply the model proposed (used when the direction's action is "generated").
   suggestedReply: string | null;
+  // Set when the analysis could not be performed (model error, timeout, unusable output). The
+  // verdict is still non-violating — fail-open is the policy — but the caller must be able to tell
+  // "screened and approved" from "never screened", which are the same value without this.
+  error?: string;
 }
 
 const CLEAN: GuardrailVerdict = {
@@ -44,11 +48,14 @@ function messageText(content: BaseMessage["content"]): string {
   return "";
 }
 
+const unanalyzed = (error: string): GuardrailVerdict => ({ ...CLEAN, error });
+
 // Extract the first balanced JSON object from a model response (tolerates ```json fences / prose).
 function parseVerdict(raw: string): GuardrailVerdict {
   const start = raw.indexOf("{");
   const end = raw.lastIndexOf("}");
-  if (start < 0 || end <= start) return CLEAN;
+  if (start < 0 || end <= start)
+    return unanalyzed("no JSON object in response");
   try {
     const obj = JSON.parse(raw.slice(start, end + 1)) as Record<
       string,
@@ -68,7 +75,7 @@ function parseVerdict(raw: string): GuardrailVerdict {
           : null,
     };
   } catch {
-    return CLEAN;
+    return unanalyzed("unparseable verdict JSON");
   }
 }
 
@@ -92,6 +99,6 @@ export async function analyzeGuardrail(
       { err },
       "guardrails analysis failed (fail-open, message not blocked)",
     );
-    return CLEAN;
+    return unanalyzed(err instanceof Error ? err.message : String(err));
   }
 }

--- a/src/modules/guardrails/analyze.ts
+++ b/src/modules/guardrails/analyze.ts
@@ -50,17 +50,15 @@ function messageText(content: BaseMessage["content"]): string {
 
 const unanalyzed = (error: string): GuardrailVerdict => ({ ...CLEAN, error });
 
-// The first BALANCED object, not everything up to the last "}": a verdict followed by prose that
-// happens to contain a brace ("...}, as required.") would otherwise be sliced together with that
-// prose and fail to parse, discarding a perfectly good verdict — which, for a violation, means
-// silently approving it. Braces inside strings don't count, and \" doesn't close one.
-function firstJsonObject(raw: string): string | null {
-  const start = raw.indexOf("{");
-  if (start < 0) return null;
+// Every TOP-LEVEL balanced object in the response, in order. Nested objects are not returned (they
+// belong to their parent), braces inside strings do not count, and \" does not close one.
+function topLevelObjects(raw: string): string[] {
+  const out: string[] = [];
+  let start = -1;
   let depth = 0;
   let inString = false;
   let escaped = false;
-  for (let i = start; i < raw.length; i++) {
+  for (let i = 0; i < raw.length; i++) {
     const c = raw[i];
     if (escaped) {
       escaped = false;
@@ -75,40 +73,58 @@ function firstJsonObject(raw: string): string | null {
       continue;
     }
     if (inString) continue;
-    if (c === "{") depth++;
-    else if (c === "}" && --depth === 0) return raw.slice(start, i + 1);
+    if (c === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (c === "}" && depth > 0 && --depth === 0) {
+      out.push(raw.slice(start, i + 1));
+    }
   }
-  return null;
+  return out;
 }
 
-// Extract the verdict object from a model response (tolerates ```json fences / prose around it).
+// The response must contain EXACTLY ONE verdict, and anything else is "we did not get an answer".
+// One rule, because three rounds of review found three ways to read a non-answer as an approval, and
+// they were all the same mistake: for a moderation feature, ambiguity has to fail towards "unknown",
+// never towards "clean". What it settles, in order of how they were found:
+//
+//   * a verdict followed by prose that carries braces ("the policy {toxicity} applies") — the prose
+//     is not a parseable verdict, so it drops out and the real one is still found;
+//   * `{}` or `{"violated": "true"}` — parseable and unusable, so neither of them is a candidate;
+//   * a self-correction (`{"violated": true}` … `Correction: {"violated": false}`) — two candidates,
+//     and picking either one is a guess about which the model meant.
+//
+// The alternative for the last case, taking the last object, is a guess in the other direction: the
+// same shape would silently approve a real violation whenever the trailing object is the stale one.
 function parseVerdict(raw: string): GuardrailVerdict {
-  const slice = firstJsonObject(raw);
-  if (slice === null) return unanalyzed("no JSON object in response");
-  try {
-    const obj = JSON.parse(slice) as Record<string, unknown>;
-    // Only a literal boolean is a verdict. `{}` or `{"violated":"true"}` are parseable and unusable,
-    // and reading them as `false` is the same silent approval this whole path exists to end: the
-    // guardrail would report neither a violation nor a failure to analyze.
-    if (obj.violated === false) return CLEAN;
-    if (obj.violated !== true) {
-      return unanalyzed("verdict has no boolean `violated` field");
+  const candidates: Record<string, unknown>[] = [];
+  for (const slice of topLevelObjects(raw)) {
+    try {
+      const obj = JSON.parse(slice) as Record<string, unknown>;
+      if (typeof obj.violated === "boolean") candidates.push(obj);
+    } catch {
+      // Not a verdict; prose and half-written objects are expected here.
     }
-    const categories = Array.isArray(obj.categories)
-      ? obj.categories.filter((c): c is string => typeof c === "string")
-      : [];
-    return {
-      violated: true,
-      categories,
-      rationale: typeof obj.rationale === "string" ? obj.rationale : "",
-      suggestedReply:
-        typeof obj.suggestedReply === "string" && obj.suggestedReply.trim()
-          ? obj.suggestedReply.trim()
-          : null,
-    };
-  } catch {
-    return unanalyzed("unparseable verdict JSON");
   }
+  if (candidates.length === 0)
+    return unanalyzed("no usable verdict in response");
+  if (candidates.length > 1) {
+    return unanalyzed(`${candidates.length} conflicting verdicts in response`);
+  }
+  const obj = candidates[0] as Record<string, unknown>;
+  if (obj.violated === false) return CLEAN;
+  const categories = Array.isArray(obj.categories)
+    ? obj.categories.filter((c): c is string => typeof c === "string")
+    : [];
+  return {
+    violated: true,
+    categories,
+    rationale: typeof obj.rationale === "string" ? obj.rationale : "",
+    suggestedReply:
+      typeof obj.suggestedReply === "string" && obj.suggestedReply.trim()
+        ? obj.suggestedReply.trim()
+        : null,
+  };
 }
 
 // Run the guardrails agent over `text`. Best-effort and FAIL-OPEN: any model/timeout/parse error

--- a/src/modules/guardrails/analyze.ts
+++ b/src/modules/guardrails/analyze.ts
@@ -87,7 +87,13 @@ function parseVerdict(raw: string): GuardrailVerdict {
   if (slice === null) return unanalyzed("no JSON object in response");
   try {
     const obj = JSON.parse(slice) as Record<string, unknown>;
-    if (obj.violated !== true) return CLEAN;
+    // Only a literal boolean is a verdict. `{}` or `{"violated":"true"}` are parseable and unusable,
+    // and reading them as `false` is the same silent approval this whole path exists to end: the
+    // guardrail would report neither a violation nor a failure to analyze.
+    if (obj.violated === false) return CLEAN;
+    if (obj.violated !== true) {
+      return unanalyzed("verdict has no boolean `violated` field");
+    }
     const categories = Array.isArray(obj.categories)
       ? obj.categories.filter((c): c is string => typeof c === "string")
       : [];

--- a/src/modules/guardrails/analyze.ts
+++ b/src/modules/guardrails/analyze.ts
@@ -50,17 +50,43 @@ function messageText(content: BaseMessage["content"]): string {
 
 const unanalyzed = (error: string): GuardrailVerdict => ({ ...CLEAN, error });
 
-// Extract the first balanced JSON object from a model response (tolerates ```json fences / prose).
-function parseVerdict(raw: string): GuardrailVerdict {
+// The first BALANCED object, not everything up to the last "}": a verdict followed by prose that
+// happens to contain a brace ("...}, as required.") would otherwise be sliced together with that
+// prose and fail to parse, discarding a perfectly good verdict — which, for a violation, means
+// silently approving it. Braces inside strings don't count, and \" doesn't close one.
+function firstJsonObject(raw: string): string | null {
   const start = raw.indexOf("{");
-  const end = raw.lastIndexOf("}");
-  if (start < 0 || end <= start)
-    return unanalyzed("no JSON object in response");
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < raw.length; i++) {
+    const c = raw[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c === "\\") {
+      if (inString) escaped = true;
+      continue;
+    }
+    if (c === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return raw.slice(start, i + 1);
+  }
+  return null;
+}
+
+// Extract the verdict object from a model response (tolerates ```json fences / prose around it).
+function parseVerdict(raw: string): GuardrailVerdict {
+  const slice = firstJsonObject(raw);
+  if (slice === null) return unanalyzed("no JSON object in response");
   try {
-    const obj = JSON.parse(raw.slice(start, end + 1)) as Record<
-      string,
-      unknown
-    >;
+    const obj = JSON.parse(slice) as Record<string, unknown>;
     if (obj.violated !== true) return CLEAN;
     const categories = Array.isArray(obj.categories)
       ? obj.categories.filter((c): c is string => typeof c === "string")

--- a/src/modules/guardrails/settings.ts
+++ b/src/modules/guardrails/settings.ts
@@ -1,4 +1,5 @@
 import { MODEL_PROVIDERS, type ModelConfig } from "@/graph/model-config";
+import { PROVIDER_DEFAULT_MODEL } from "@/graph/model-defaults";
 
 // Per-agent guardrails (input/output moderation) config, read from `agent.settings.guardrails`. A
 // dedicated LLM "guardrails agent" (its OWN selectable chat model, separate from the main agent's)
@@ -42,7 +43,9 @@ export interface GuardrailsConfig {
   enabled: boolean;
   // The guardrails agent's own chat model (separate from the main agent's model).
   provider: ModelConfig["provider"];
-  model: string; // "" → provider default (only valid for openai-compatible)
+  // Always a usable model name after the reader: an empty stored value resolves to
+  // PROVIDER_DEFAULT_MODEL, and stays "" only for openai-compatible, where the server picks.
+  model: string;
   credentialRef: string | null; // `vault:<id>` ref of the entry holding the API key
   baseURL: string | null; // for openai-compatible / self-hosted endpoints
   // Configurable competitor names for the competitorMentions check.
@@ -158,14 +161,26 @@ export function readGuardrailsConfig(settings: unknown): GuardrailsConfig {
       : undefined;
   if (!s || typeof s !== "object") return structuredClone(GUARDRAILS_DEFAULTS);
   const bag = s as Record<string, unknown>;
-  const provider = str(bag.provider);
+  const rawProvider = str(bag.provider);
+  const provider =
+    rawProvider && (MODEL_PROVIDERS as readonly string[]).includes(rawProvider)
+      ? (rawProvider as ModelConfig["provider"])
+      : GUARDRAILS_DEFAULTS.provider;
   return {
     enabled: bool(bag.enabled, GUARDRAILS_DEFAULTS.enabled),
-    provider:
-      provider && (MODEL_PROVIDERS as readonly string[]).includes(provider)
-        ? (provider as ModelConfig["provider"])
-        : GUARDRAILS_DEFAULTS.provider,
-    model: str(bag.model) ?? "",
+    provider,
+    // NOTE: An empty model is stored by the editor whenever the operator enables guardrails without
+    // opening the provider select, and the model field shows the provider default anyway. Sending it
+    // through is not a soft failure: the name goes on the wire verbatim, the provider refuses the
+    // call, and analyzeGuardrail fails open, so the guardrail reads as enabled and screens nothing.
+    // Resolving it here is what makes the runtime send the model the editor displayed.
+    //
+    // The agent's own model answers the same question the other way (`guardModelBeforeSave` refuses
+    // to save it empty), and the asymmetry is deliberate. That one is the operator's core choice and
+    // has no defensible default; this one is a supporting choice whose default the editor already
+    // shows. A save-time refusal here would also leave every already-saved empty value broken, and
+    // those are exactly the installs running unprotected today.
+    model: str(bag.model) ?? PROVIDER_DEFAULT_MODEL[provider] ?? "",
     credentialRef: str(bag.credentialRef),
     baseURL: str(bag.baseURL),
     competitors: readCompetitors(bag.competitors),

--- a/tests/client/components/ModelPicker.test.tsx
+++ b/tests/client/components/ModelPicker.test.tsx
@@ -1,0 +1,56 @@
+/// <reference lib="dom" />
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ModelPicker } from "@/client/components/ModelPicker";
+
+// An empty model field still displays text, and the operator reads that text as "the model this
+// will use". It used to be the literal "gpt-5.4-mini" for every provider, so an Anthropic guardrail
+// with nothing selected showed an OpenAI model, which is how a whole config could look configured
+// and screen nothing. The placeholder now has to name the model the runtime would actually fall
+// back to. No credentialRef here, so the picker's loader returns [] without touching the network.
+//
+// NOTE: The assertion reduces to a string BEFORE expect. A failing expectation that holds a DOM node
+// serializes a cyclic happy-dom tree and stalls the runner.
+function shownFor(
+  provider: string,
+  capability?: "chat" | "transcription" | "vision",
+): string {
+  render(
+    <ModelPicker
+      value=""
+      onChange={() => {}}
+      provider={provider}
+      capability={capability}
+      aria-label="model"
+    />,
+  );
+  return screen.getByLabelText("model").textContent ?? "";
+}
+
+describe("ModelPicker placeholder", () => {
+  afterEach(() => cleanup());
+
+  test("names the provider's own default, not OpenAI's", () => {
+    expect(shownFor("anthropic")).toContain("claude-sonnet-4-6");
+  });
+
+  test("names the OpenAI default on OpenAI", () => {
+    expect(shownFor("openai")).toContain("gpt-5.4-mini");
+  });
+
+  // Empty is a real choice here (single-model servers ignore the requested name), so naming a model
+  // would be the lie in the other direction.
+  test("promises no model where the server picks one", () => {
+    const shown = shownFor("openai-compatible");
+    expect([shown.includes("gpt"), shown.length > 0]).toEqual([false, true]);
+  });
+
+  // PROVIDER_DEFAULT_MODEL is a chat table; showing a chat model where a transcription model goes
+  // would name something that will never be sent.
+  test("promises no chat model for a non-chat capability", () => {
+    expect(shownFor("openai", "transcription").includes("gpt-5.4-mini")).toBe(
+      false,
+    );
+  });
+});

--- a/tests/client/components/ModelPicker.test.tsx
+++ b/tests/client/components/ModelPicker.test.tsx
@@ -15,6 +15,7 @@ import { ModelPicker } from "@/client/components/ModelPicker";
 function shownFor(
   provider: string,
   capability?: "chat" | "transcription" | "vision",
+  placeholder?: string,
 ): string {
   render(
     <ModelPicker
@@ -22,6 +23,7 @@ function shownFor(
       onChange={() => {}}
       provider={provider}
       capability={capability}
+      placeholder={placeholder}
       aria-label="model"
     />,
   );
@@ -52,5 +54,16 @@ describe("ModelPicker placeholder", () => {
     expect(shownFor("openai", "transcription").includes("gpt-5.4-mini")).toBe(
       false,
     );
+  });
+
+  // The vision and STT tabs pass `X_DEFAULT_MODEL[provider] ?? ""`, and for openai-compatible those
+  // tables hold "" on purpose: no default exists and the endpoint needs a named model. An empty
+  // placeholder from a caller is a decision, not an omission, so it must survive verbatim.
+  test("keeps a caller's empty placeholder instead of promising a default", () => {
+    expect(shownFor("openai-compatible", "vision", "")).toBe("");
+  });
+
+  test("keeps a caller's non-empty placeholder", () => {
+    expect(shownFor("openai", "vision", "gpt-4o")).toContain("gpt-4o");
   });
 });

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -1654,5 +1654,136 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       expect(sent).toEqual([]);
       expect(toggles).toEqual([]);
     });
+
+    // The SHIPPED DEFAULT is the broken case: provider "openai" with an empty model is what the
+    // editor persists when the operator enables guardrails and never opens the provider select (the
+    // per-provider default is applied only on that select's change), while the model field shows a
+    // model name it never saved. Measured on the dependency we ship: `new ChatOpenAI({ model: "" })`
+    // puts `model: ""` on the wire verbatim, so the provider refuses the call and `analyzeGuardrail`
+    // fails open. What the operator sees is a guardrail that is on and never trips.
+    test("an enabled guardrail with no model configured still screens the reply", async () => {
+      await setGuardrails({
+        enabled: true,
+        provider: "openai",
+        model: "",
+        credentialRef: gVaultRef,
+        input: { enabled: false },
+        output: {
+          enabled: true,
+          action: "template",
+          checks: {
+            toxicity: true,
+            unsafeContent: false,
+            competitorMentions: false,
+            promptAdherence: false,
+          },
+          templateMessage: "TEMPLATE-NO-MODEL",
+        },
+      });
+      await seedConv(951);
+      const sent: Array<[number, string]> = [];
+      const notes: Array<[number, string]> = [];
+      const verdict = JSON.stringify({
+        violated: true,
+        categories: ["toxicity"],
+        rationale: "rude",
+        suggestedReply: null,
+      });
+      // Stands in for the PROVIDER, not for a generic model: a request that carries an empty model
+      // name is refused instead of being quietly answered, which is the behaviour that turns a
+      // misconfigured guardrail into a silent one.
+      const providerLike = (cfg: ResolvedModelConfig): BaseChatModel =>
+        cfg.model === "gpt-4o-mini"
+          ? new FakeListChatModel({ responses: [REPLY] })
+          : ({
+              invoke: async () => {
+                if (!cfg.model.trim()) {
+                  throw new Error("400 invalid value for 'model': ''");
+                }
+                return { content: verdict };
+              },
+            } as unknown as BaseChatModel);
+      const outcome = await runAgentTurn({
+        tenantId: gTenantId,
+        instanceId: gInstanceId,
+        agentBotId: G_BOT,
+        event: incoming({ conversationId: 951, inboxId: G_INBOX }),
+        base: appDb,
+        deps: {
+          makeModel: providerLike,
+          makeClient: guardStub(sent, notes),
+          checkpointer: new MemorySaver(),
+        },
+      });
+      expect(outcome).toBe("posted");
+      expect(sent).toEqual([[951, "TEMPLATE-NO-MODEL"]]);
+    });
+
+    // Fail-open stays fail-open: a guardrail that cannot run must never cost the customer the reply.
+    // But it also must not be indistinguishable from a guardrail that ran and approved, or an
+    // operator whose credential expired reads "no violations" forever. Same argument that put
+    // `retriedEmptyResponse` in the trail on #63.
+    test("a guardrail that cannot run leaves a line in the turn trail", async () => {
+      await setGuardrails({
+        enabled: true,
+        provider: "openai",
+        model: GUARD_MODEL,
+        credentialRef: gVaultRef,
+        input: { enabled: false },
+        output: {
+          enabled: true,
+          action: "template",
+          checks: {
+            toxicity: true,
+            unsafeContent: false,
+            competitorMentions: false,
+            promptAdherence: false,
+          },
+          templateMessage: "TEMPLATE-UNREACHABLE",
+        },
+      });
+      await seedConv(952);
+      const sent: Array<[number, string]> = [];
+      const notes: Array<[number, string]> = [];
+      const unreachable = (cfg: ResolvedModelConfig): BaseChatModel =>
+        cfg.model === GUARD_MODEL
+          ? ({
+              invoke: async () => {
+                throw new Error("401 incorrect api key provided");
+              },
+            } as unknown as BaseChatModel)
+          : new FakeListChatModel({ responses: [REPLY] });
+      const outcome = await runAgentTurn({
+        tenantId: gTenantId,
+        instanceId: gInstanceId,
+        agentBotId: G_BOT,
+        event: incoming({ conversationId: 952, inboxId: G_INBOX }),
+        base: appDb,
+        deps: {
+          makeModel: unreachable,
+          makeClient: guardStub(sent, notes),
+          checkpointer: new MemorySaver(),
+        },
+      });
+      expect(outcome).toBe("posted");
+      // The customer still gets answered: moderation failing is not the customer's problem.
+      expect(sent).toEqual([[952, REPLY]]);
+
+      // emitFlowEvent is fire-and-forget, so poll briefly.
+      let failureLogged = false;
+      for (let i = 0; i < 30 && !failureLogged; i++) {
+        const rows = await suDb.executionLog.findMany({
+          where: { tenantId: gTenantId, stage: "guardrail", level: "warn" },
+          select: { detail: true },
+        });
+        failureLogged = rows.some(
+          (r) =>
+            (r.detail as Record<string, unknown> | null)?.outcome ===
+            "analysis_failed",
+        );
+        if (!failureLogged) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(failureLogged).toBe(true);
+    });
   });
 });

--- a/tests/modules/guardrails.test.ts
+++ b/tests/modules/guardrails.test.ts
@@ -75,6 +75,57 @@ describe("readGuardrailsConfig", () => {
     });
     expect(c.input.generationPrompt).toBe("be warm");
   });
+
+  // An empty model is what the editor persists when the operator enables guardrails and never
+  // touches the provider select (the per-provider default is only applied on that select's change),
+  // and the model field then SHOWS a model name it never saved. Reaching the provider with `model: ""`
+  // fails the call, and `analyzeGuardrail` fails open, so the guardrail reads as enabled and silently
+  // screens nothing. Resolved here because this reader is the single source of defaults + clamping.
+  // The literals are deliberately spelled out instead of imported: a test that reads the same table
+  // as the code proves nothing about which model is actually sent.
+  test("an empty model resolves to the provider's default", () => {
+    const cases: [string, string][] = [
+      ["openai", "gpt-5.4-mini"],
+      ["anthropic", "claude-sonnet-4-6"],
+      ["google", "gemini-3.5-flash"],
+      ["deepseek", "deepseek-chat"],
+      ["openrouter", "openai/gpt-5.4-mini"],
+    ];
+    for (const [provider, expected] of cases) {
+      const c = readGuardrailsConfig({
+        guardrails: { enabled: true, provider, model: "" },
+      });
+      expect([provider, c.model]).toEqual([provider, expected]);
+    }
+  });
+
+  test("whitespace counts as empty", () => {
+    const c = readGuardrailsConfig({
+      guardrails: { enabled: true, provider: "openai", model: "   " },
+    });
+    expect(c.model).toBe("gpt-5.4-mini");
+  });
+
+  test("openai-compatible keeps the empty model, where it means the server's own", () => {
+    const c = readGuardrailsConfig({
+      guardrails: { enabled: true, provider: "openai-compatible", model: "" },
+    });
+    expect(c.model).toBe("");
+  });
+
+  test("an explicit model is never replaced", () => {
+    const c = readGuardrailsConfig({
+      guardrails: { enabled: true, provider: "openai", model: "gpt-4o-mini" },
+    });
+    expect(c.model).toBe("gpt-4o-mini");
+  });
+
+  // The default provider is already "openai", so the default config is the broken case: nothing in
+  // the editor has to be misused for it to happen.
+  test("the shipped default provider resolves to a usable model", () => {
+    const c = readGuardrailsConfig({ guardrails: { enabled: true } });
+    expect([c.provider, c.model]).toEqual(["openai", "gpt-5.4-mini"]);
+  });
 });
 
 describe("buildGuardrailSystemPrompt", () => {
@@ -158,5 +209,47 @@ describe("analyzeGuardrail", () => {
   test("fail-open on unparseable output", async () => {
     const v = await analyzeGuardrail(fakeModel("not json at all"), base);
     expect(v.violated).toBe(false);
+  });
+
+  // Fail-open is the right policy and it is also indistinguishable, from the outside, from a
+  // guardrail that ran and approved. The verdict has to say which one happened, or an operator whose
+  // credential expired keeps reading "no violations" forever. Same argument as `onModelRetry` (#63).
+  test("a model error is reported as a failure to analyze, not as approval", async () => {
+    const v = await analyzeGuardrail(throwingModel, base);
+    expect(v.error).toContain("boom");
+  });
+
+  // Two different ways the output can be unusable, and they leave by different branches: no JSON
+  // object at all never reaches the parser, while a malformed one throws inside it. A single case
+  // covers only the first, which is how the second branch stayed untested (caught by mutation).
+  test("output with no JSON object at all is reported", async () => {
+    const v = await analyzeGuardrail(fakeModel("not json at all"), base);
+    expect(typeof v.error).toBe("string");
+  });
+
+  test("output with a malformed JSON object is reported", async () => {
+    const v = await analyzeGuardrail(
+      fakeModel('Sure: {"violated": true, categories: [oops}'),
+      base,
+    );
+    expect([v.violated, typeof v.error]).toEqual([false, "string"]);
+  });
+
+  test("a genuine clean verdict is not reported as a failure", async () => {
+    const v = await analyzeGuardrail(
+      fakeModel('{"violated": false, "categories": [], "rationale": ""}'),
+      base,
+    );
+    expect(v.error).toBeUndefined();
+  });
+
+  test("a violation is not reported as a failure", async () => {
+    const v = await analyzeGuardrail(
+      fakeModel(
+        '{"violated": true, "categories": ["toxicity"], "rationale": "x", "suggestedReply": null}',
+      ),
+      base,
+    );
+    expect(v.error).toBeUndefined();
   });
 });

--- a/tests/modules/guardrails.test.ts
+++ b/tests/modules/guardrails.test.ts
@@ -255,6 +255,30 @@ describe("analyzeGuardrail", () => {
     expect([v.violated, v.rationale]).toEqual([true, 'said "} bye" rudely']);
   });
 
+  // Parseable is not the same as usable. A verdict with no boolean `violated` says nothing, and
+  // reading it as "false" is the same silent approval the error field exists to end.
+  test("an object with no boolean verdict is reported, not read as approval", async () => {
+    for (const body of [
+      "{}",
+      '{"violated": "false"}',
+      '{"violated": "true"}',
+      '{"violated": null}',
+      '{"categories": ["toxicity"]}',
+    ]) {
+      const v = await analyzeGuardrail(fakeModel(body), base);
+      expect([body, v.violated, typeof v.error]).toEqual([
+        body,
+        false,
+        "string",
+      ]);
+    }
+  });
+
+  test("an explicit false is a real approval, with no error", async () => {
+    const v = await analyzeGuardrail(fakeModel('{"violated": false}'), base);
+    expect([v.violated, v.error]).toEqual([false, undefined]);
+  });
+
   test("output with a malformed JSON object is reported", async () => {
     const v = await analyzeGuardrail(
       fakeModel('Sure: {"violated": true, categories: [oops}'),

--- a/tests/modules/guardrails.test.ts
+++ b/tests/modules/guardrails.test.ts
@@ -227,6 +227,34 @@ describe("analyzeGuardrail", () => {
     expect(typeof v.error).toBe("string");
   });
 
+  // A verdict followed by prose that happens to carry a brace used to be sliced together with that
+  // prose and fail to parse, so a real violation came back as an approval. For a moderation feature
+  // that is the expensive direction of the mistake.
+  test("reads a verdict that is followed by prose containing braces", async () => {
+    const v = await analyzeGuardrail(
+      fakeModel(
+        '{"violated": true, "categories": ["toxicity"], "rationale": "x", "suggestedReply": null}\n' +
+          "I flagged it because the policy {toxicity} applies here.",
+      ),
+      base,
+    );
+    expect([v.violated, v.categories, v.error]).toEqual([
+      true,
+      ["toxicity"],
+      undefined,
+    ]);
+  });
+
+  test("a brace inside a string never ends the object early", async () => {
+    const v = await analyzeGuardrail(
+      fakeModel(
+        '{"violated": true, "categories": ["toxicity"], "rationale": "said \\"} bye\\" rudely", "suggestedReply": null}',
+      ),
+      base,
+    );
+    expect([v.violated, v.rationale]).toEqual([true, 'said "} bye" rudely']);
+  });
+
   test("output with a malformed JSON object is reported", async () => {
     const v = await analyzeGuardrail(
       fakeModel('Sure: {"violated": true, categories: [oops}'),

--- a/tests/modules/guardrails.test.ts
+++ b/tests/modules/guardrails.test.ts
@@ -279,6 +279,30 @@ describe("analyzeGuardrail", () => {
     expect([v.violated, v.error]).toEqual([false, undefined]);
   });
 
+  // A model that answers twice has not answered: picking the first ignores a self-correction, and
+  // picking the last would approve a real violation whenever the trailing object is the stale one.
+  test("two conflicting verdicts are unanalyzed, not resolved by guessing", async () => {
+    const v = await analyzeGuardrail(
+      fakeModel(
+        '{"violated": true, "categories": ["toxicity"], "rationale": "x", "suggestedReply": null}\n' +
+          'Correction: {"violated": false, "categories": [], "rationale": "", "suggestedReply": null}',
+      ),
+      base,
+    );
+    expect([v.violated, typeof v.error]).toEqual([false, "string"]);
+  });
+
+  // A nested object belongs to its parent and must not read as a second answer.
+  test("a nested object is not a second verdict", async () => {
+    const v = await analyzeGuardrail(
+      fakeModel(
+        '{"violated": true, "categories": ["toxicity"], "rationale": "x", "suggestedReply": null, "meta": {"score": 1}}',
+      ),
+      base,
+    );
+    expect([v.violated, v.error]).toEqual([true, undefined]);
+  });
+
   test("output with a malformed JSON object is reported", async () => {
     const v = await analyzeGuardrail(
       fakeModel('Sure: {"violated": true, categories: [oops}'),


### PR DESCRIPTION
Found by @DrWallx in #53, where the fix rides along inside a larger change. It is worth its own PR: it is a silent failure on the **default** configuration, and it is unrelated to the feature that PR is about.

## What was wrong

An enabled guardrail could screen nothing, report nothing, and still read as enabled everywhere the operator looks.

The chain, verified end to end:

1. `GUARDRAILS_DEFAULTS` ships `{ provider: "openai", model: "" }`.
2. The editor writes the per-provider default only in the provider select's `onChange`. The provider already **is** `openai`, so an operator who enables guardrails and never opens that dropdown saves `model: ""`.
3. Meanwhile the model field is not blank: `ModelPicker` had `placeholder = "gpt-5.4-mini"` hardcoded, and `ComboBox` renders the placeholder in the closed trigger. The form displays a model that was never saved, for every provider.
4. An empty model is not defaulted by the SDK. Measured on the version in `package.json`:

   ```
   new ChatOpenAI({ model: "" }).invocationParams({})  →  { model: "", … }
   ```

   It goes on the wire verbatim and the provider refuses the call.
5. `analyzeGuardrail` is fail-open, which is the right policy, and it returned the same `CLEAN` verdict it returns after a real approval. The only trace was a `logger.warn` in the process log, so nothing reached the Logs page, the turn trail, or an alert channel.

The result is the worst shape a safety feature can take: the operator believes messages are being moderated, every verdict comes back clean, and there is nothing to notice.

## What changed

**The empty model resolves in `readGuardrailsConfig`**, which the module header already declares as "the single source of defaults + clamping, so a malformed value never breaks the webhook". It resolves against one `PROVIDER_DEFAULT_MODEL` table that the editor, the model picker and the runtime all read, so the model the field displays is the model the runtime sends. `openai-compatible` still keeps `""`, where empty is a real choice (single-model servers ignore the requested name) and the only case `modelConfigSchema` lets through empty.

That table moved out of `src/client/lib/providerLabels.ts` into `src/graph/model-defaults.ts`, deliberately import-free so the client can read it without pulling server code in.

**The verdict now distinguishes "could not analyze" from "analyzed and approved"** (`GuardrailVerdict.error`), and the runtime writes a `guardrail` warn line on the turn when it is set. Fail-open is unchanged: the customer still gets the reply. This is the same argument that put `retriedEmptyResponse` in the trail on #63, one subsystem over.

**The model picker's placeholder follows the provider** and the capability, instead of naming an OpenAI model under Anthropic, or a chat model where a transcription model goes.

### Why not the fallback in #53

That PR reads `gr.model.trim() || loaded.mc.model`, in the runtime. The guardrails agent carries its own provider and its own credential precisely so it can be a different vendor, so borrowing the agent's model name crosses that boundary: guardrails on `openai` with an agent on `gemini-3.5-flash` sends a Google model id to OpenAI and fails the same way, with a different error. Resolving against the provider's own default keeps the two configurations independent, and putting it in the reader means every consumer of the config gets it, not just this one call site.

The agent's own model answers the same question the other way: `guardModelBeforeSave` refuses to save it empty. The asymmetry is deliberate and noted in the code. That one is the operator's core choice with no defensible default; this one is a supporting choice whose default the editor already displays. A save-time refusal here would also leave every already-saved empty value broken, and those are exactly the installs running unprotected right now.

## Validation scope

**Proven by test**, red before the change and green after:

- unit, `readGuardrailsConfig`: an empty model resolves to the default of each of the five providers that require one; whitespace counts as empty; `openai-compatible` keeps `""`; an explicit model is never replaced; and the shipped default config resolves to a usable model;
- unit, `analyzeGuardrail`: a model error and both flavours of unusable output are reported as failures to analyze, while a genuine clean verdict and a genuine violation are not;
- component, `ModelPicker`: the placeholder names the provider's own default, promises no model where the server picks one, and never shows a chat model for a non-chat capability;
- **e2e, DB-backed, through `runAgentTurn`** with a fake that stands in for the provider (it refuses a request carrying an empty model name, the way the endpoint does) rather than a generic model: an agent whose guardrail has no model configured now has its reply **replaced by the configured template** in front of the customer. Before the change the violating reply was delivered.
- **e2e, DB-backed**: a guardrail whose model call fails still delivers the reply (fail-open preserved) **and** leaves an `analysis_failed` line in `execution_logs`.

Every rule was mutation-tested, one at a time, and each mutation fails the tests it should: dropping the fallback (3 unit + 1 e2e), giving `openai-compatible` a model (1), swallowing the analysis failure (2), swallowing only the malformed-JSON branch (1), removing the trail line (1 e2e), restoring the hardcoded placeholder (3), dropping the capability guard (1), dropping the empty-placeholder fallback (1). The malformed-JSON branch was found untested by exactly this pass and has a test now.

`bun check` is green with the test Postgres up (2426 pass, 0 fail).

**Not validated:** no live call to a provider with an empty model name. Step 4 above measures what our dependency puts on the wire, and the refusal itself is personified by the test fake, not observed against the real endpoint in this round.

Co-authored-by: DrWallx <drwallx@users.noreply.github.com>
