### PR TITLE
chore(brand): move the wire-format identifiers behind compatibility windows

### DIFF
--- a/docs/api-and-fleet.md
+++ b/docs/api-and-fleet.md
@@ -39,7 +39,7 @@ Every emission is wrapped by `buildOutboundEnvelope(tenantId, event, data)` into
   "occurred_at": "2026-…Z", "tenant_id": "42", "data": { … } }
 ```
 
-`occurred_at` is stamped at emit time (when the event happened), not at delivery. The delivery id (retry dedupe key) is NOT in the envelope — it travels in the `x-secretaria-delivery` header.
+`occurred_at` is stamped at emit time (when the event happened), not at delivery. The delivery id (retry dedupe key) is NOT in the envelope — it travels in the `x-fazerai-delivery` header.
 
 **Emit is best-effort for the domain.** Each seam wraps `emitOutbound` in a try/catch and logs on failure: enqueueing a fan-out row must never break the primary effect (the mirror write, the usage row, the tenant create). When viable the emit runs inside the same scoped tx as that effect.
 
@@ -70,6 +70,8 @@ A single-replica tick (`WEBHOOK_WORKER_ENABLED`, `WEBHOOK_WORKER_INTERVAL_MS`) t
 3. For each, **outside any transaction**: `assertSafeOutboundUrl` (anti-SSRF, https-only, no redirects), resolves the per-tenant signing secret via a **tenant-scoped** read (`runScopedOn`, RLS active — least privilege, not the cross-tenant bypass), signs, and POSTs with a timeout.
 4. **Records the outcome** scoped to the row's tenant: `DELIVERED` (2xx); back to `PENDING` with `nextAttemptAt` from full-jitter backoff (`nextBackoffMs`); or `DEAD` after `MAX_ATTEMPTS`. An SSRF-blocked URL goes straight to `DEAD` (it can never succeed).
 
-Headers: `x-secretaria-delivery` (the delivery id — a **stable dedupe key**, so at-least-once retries are safe for receivers), and when a secret is configured `x-secretaria-signature` (`sha256=` + HMAC-SHA256 over `"{timestamp}.{rawBody}"`, hex) + `x-secretaria-timestamp` (unix seconds). Receivers verify the timestamp window (anti-replay) and recompute over the raw body. See `signing.ts` (`signOutbound`/`verifyOutboundSignature`).
+Headers: `x-fazerai-delivery` (the delivery id — a **stable dedupe key**, so at-least-once retries are safe for receivers), and when a secret is configured `x-fazerai-signature` (`sha256=` + HMAC-SHA256 over `"{timestamp}.{rawBody}"`, hex) + `x-fazerai-timestamp` (unix seconds). Receivers verify the timestamp window (anti-replay) and recompute over the raw body. See `signing.ts` (`signOutbound`/`verifyOutboundSignature`); every emit site builds its headers through `outboundHeaders`.
+
+> **Compatibility window.** These headers were named `x-secretaria-*` before the brand rename. Both sets go out on every delivery, carrying identical values, so a receiver configured against either name keeps working. The legacy trio is dropped at `2.0` — point your receivers at `x-fazerai-*` before then.
 
 **Single-replica invariant.** The worker holds a reentrancy guard (`running`) and an interval on `globalThis` (so `bun --hot` does not stack phantom timers); `stopOutboundWorker` runs on `SIGTERM`/`SIGINT`. `FOR UPDATE SKIP LOCKED` already future-proofs the claim, but scaling the app beyond one replica needs a leader election or durable claim before the worker is enabled on every instance. `WebhookSubscription.onDelete` is `Restrict` (never `Cascade`, which would drop in-flight deliveries).

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -67,6 +67,8 @@ After the deterministic core (resolve → PK correlation → status CAS → mech
 
 One clinic calendar serves MANY WhatsApp contacts, so every event the agent creates is stamped with `extendedProperties.private.secv4Contact = "<tenantId>:<contactDbId>"` — **injected from the trusted context, never a model arg**. Reads/writes are isolated three ways, **fail-closed**:
 
+> The `secv4*` key names predate the brand rename and are **frozen on purpose**: they live on real events in customers' calendars, and the list fence takes exactly one `privateExtendedProperty` filter per request, so a second name would double every listing forever or need a backfill we cannot run. Renaming them is part of the `2.0` cut.
+
 - **List** filters server-side by `privateExtendedProperty=secv4Contact=<stamp>` AND re-verifies each returned event's stamp client-side (`eventStamp(e) === stamp`). The re-verify is defense in depth; when it drops an event the server fence already should have excluded, it logs `gcal: list re-verify dropped events…` (a non-zero `dropped` count is a signal the fence is leaking). With no contact in scope (playground) the per-contact tools refuse outright.
 - **Update / cancel** re-fetch the event (`?fields=extendedProperties`) and refuse with `FOREIGN_EVENT` unless the stamp matches, so an id-guess can never touch another contact's (or a staff-created) appointment.
 - **Availability** is `freeBusy` (busy windows only, zero details) → another contact's bookings count as busy without leaking anything; it returns EVERY bookable slot in a range capped to 24h.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,7 +16,7 @@ Clients fetch `GET /.well-known/oauth-authorization-server` and `.../oauth-prote
 
 ## Access token (`oauth/tokens.ts`) — the security core
 
-- **Fixed algorithm + issuer.** Signed `HS256` with a check on issuer (`secretaria-v4:mcp`) and the `algorithms: ['HS256']` allowlist on verify → anti algorithm/key confusion.
+- **Fixed algorithm + issuer.** Signed `HS256` with a check on issuer (`fazerai:mcp`) and the `algorithms: ['HS256']` allowlist on verify → anti algorithm/key confusion. Verify also accepts the pre-rename issuer `secretaria-v4:mcp` so tokens minted by the previous image survive the deploy; we only ever sign the current one, and the acceptance is dropped at `2.0`.
 - **Separate key from the app cookie JWT** (`config.mcpJwtSecret`, default `${JWT_SECRET}:mcp`). An app-session JWT must not validate as an MCP token and vice-versa.
 - **Audience binding (RFC 8707), enforced.** Every token is minted with `aud` = our canonical resource id (`mcpResourceId()` = `${publicUrl}/api/v1/mcp`, the same `resource` the protected-resource metadata advertises), and `verifyAccessToken` passes `audience` to `jwtVerify`, so a token issued for a different audience does not validate (→ 401). The token is bound to us regardless of whatever `resource` a client sends; the raw `resource` is persisted only for audit. `mcpResourceId` lives in `oauth/metadata.ts` (single source, also used by `protectedResourceMetadata`).
 - **`jti` denylist is mandatory, not optional.** Every access token is persisted (`McpOAuthAccessToken` with `jti` + `revokedAt`). Revocation is **immediate** (a row flip), never "wait ≤15min for expiry" — unacceptable for cross-tenant write tools. Access TTL is 15 min.

--- a/openapi.json
+++ b/openapi.json
@@ -22,14 +22,14 @@
       "sessionCookie": {
         "type": "apiKey",
         "in": "cookie",
-        "name": "secretaria_v4_auth_token",
+        "name": "fazerai_auth_token",
         "description": "Session JWT set by /api/auth/login (HttpOnly cookie)."
       },
       "bearerToken": {
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT",
-        "description": "Bearer token for the API / MCP transport: an MCP OAuth access token, or a per-tenant API key (`secv4_…`) created at /api-keys."
+        "description": "Bearer token for the API / MCP transport: an MCP OAuth access token, or a per-tenant API key (`fazerai_…`) created at /api-keys."
       }
     },
     "schemas": {}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -142,7 +142,7 @@ const api = new Elysia()
             sessionCookie: {
               type: "apiKey",
               in: "cookie",
-              name: "secretaria_v4_auth_token",
+              name: "fazerai_auth_token",
               description:
                 "Session JWT set by /api/auth/login (HttpOnly cookie).",
             },
@@ -151,7 +151,7 @@ const api = new Elysia()
               scheme: "bearer",
               bearerFormat: "JWT",
               description:
-                "Bearer token for the API / MCP transport: an MCP OAuth access token, or a per-tenant API key (`secv4_…`) created at /api-keys.",
+                "Bearer token for the API / MCP transport: an MCP OAuth access token, or a per-tenant API key (`fazerai_…`) created at /api-keys.",
             },
           },
         },

--- a/src/api/lib/auth.ts
+++ b/src/api/lib/auth.ts
@@ -9,8 +9,13 @@ import { ServiceUnavailableError } from "@/lib/errors";
 import { roleAtLeast } from "@/lib/tenancy";
 import { verifyApiKey } from "@/modules/api-keys/verify";
 
-const COOKIE_NAME = "secretaria_v4_auth_token";
+const COOKIE_NAME = "fazerai_auth_token";
+// Compatibility window for the brand rename: sessions minted before it carry the old cookie name.
+// We READ it, then rewrite the same JWT under the new name and drop the old one, so an upgrade logs
+// nobody out and the legacy cookie is gone after one request. Dropped at 2.0.
+const LEGACY_COOKIE_NAME = "secretaria_v4_auth_token";
 const TOKEN_EXPIRY = "7d";
+const COOKIE_MAX_AGE_S = 60 * 60 * 24 * 7; // 7 days, matching TOKEN_EXPIRY
 
 export interface JWTPayload {
   userId: string;
@@ -58,6 +63,18 @@ async function apiKeyAuthUser(
   };
 }
 
+// Single source for the session cookie attributes, so the login path and the legacy-name rewrite
+// below can never drift apart.
+function sessionCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: config.env === "production",
+    sameSite: "lax" as const,
+    maxAge: COOKIE_MAX_AGE_S,
+    path: "/",
+  };
+}
+
 export const authPlugin = new Elysia({ name: "auth" })
   .use(
     jwt({
@@ -75,22 +92,31 @@ export const authPlugin = new Elysia({ name: "auth" })
         tenantId: user.tenantId === null ? null : user.tenantId.toString(),
       });
 
-      cookie[COOKIE_NAME]?.set({
-        value: token,
-        httpOnly: true,
-        secure: config.env === "production",
-        sameSite: "lax",
-        maxAge: 60 * 60 * 24 * 7, // 7 days
-        path: "/",
-      });
+      cookie[COOKIE_NAME]?.set({ value: token, ...sessionCookieOptions() });
+      // A fresh login supersedes any pre-rename cookie; drop it so it can't outlive this session.
+      cookie[LEGACY_COOKIE_NAME]?.remove();
 
       return token;
     },
     clearAuthCookie() {
       cookie[COOKIE_NAME]?.remove();
+      cookie[LEGACY_COOKIE_NAME]?.remove();
     },
     async getAuthUser(): Promise<AuthUser | null> {
-      const token = cookie[COOKIE_NAME]?.value;
+      let token = cookie[COOKIE_NAME]?.value;
+      if (!token || typeof token !== "string") {
+        const legacy = cookie[LEGACY_COOKIE_NAME]?.value;
+        if (legacy && typeof legacy === "string") {
+          // Migrate in place. The token is verified below either way, so copying it under the new
+          // name grants a forged legacy cookie nothing it did not already have.
+          token = legacy;
+          cookie[COOKIE_NAME]?.set({
+            value: legacy,
+            ...sessionCookieOptions(),
+          });
+          cookie[LEGACY_COOKIE_NAME]?.remove();
+        }
+      }
       if (!token || typeof token !== "string") {
         // No session cookie — fall back to a Bearer API key (REST v1 / MCP external clients).
         return apiKeyAuthUser(headers.authorization);

--- a/src/api/v1/mcp.controller.ts
+++ b/src/api/v1/mcp.controller.ts
@@ -16,7 +16,7 @@ import { handleMcpRequest } from "@/modules/mcp/server";
 
 // The MCP transport endpoint. Authenticated by its OWN OAuth Bearer token (NOT the app cookie) —
 // verifyAccessToken re-resolves the principal on every request. As an ALTERNATIVE (OAuth stays the
-// default, discoverable path), a per-tenant API key (Bearer secv4_…) is also accepted: it maps to an
+// default, discoverable path), a per-tenant API key (Bearer fazerai_…) is also accepted: it maps to an
 // MCP principal scoped mcp:read+mcp:write (never mcp:admin). A missing/invalid token returns 401 with
 // the RFC 9728 resource-metadata pointer so a client can discover the OAuth server.
 // This path is exempt from the global per-IP rate limit (isMcpTransport in middlewares/rateLimit);

--- a/src/client/pages/McpPage.tsx
+++ b/src/client/pages/McpPage.tsx
@@ -236,7 +236,7 @@ export function McpPage() {
                 )}
               </p>
               <code className="block w-fit rounded bg-bg-tertiary px-2 py-1 font-mono text-text-secondary text-xs">
-                {"Authorization: Bearer secv4_…"}
+                {"Authorization: Bearer fazerai_…"}
               </code>
             </div>
           </section>

--- a/src/client/pages/resources/AdvancedPanel.tsx
+++ b/src/client/pages/resources/AdvancedPanel.tsx
@@ -22,7 +22,7 @@ const EMBEDDING_MODEL = "text-embedding-3-small";
 // Tenant-level feature config (TENANT_ADMIN): the RAG embedding credential and the Langfuse tracing
 // keys. The embedding provider/model are LOCKED to OpenAI + text-embedding-3-small for now (only the
 // credential is editable); the flexible-embeddings feature (configurable dimension + provider
-// registry, incl. Hugging Face) is deferred — see docs/roadmap.md.
+// registry, incl. Hugging Face) is deferred.
 export function AdvancedPanel() {
   const { t } = useTranslation();
   const tracingId = useId();

--- a/src/modules/api-keys/verify.ts
+++ b/src/modules/api-keys/verify.ts
@@ -4,15 +4,26 @@ import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import { asSuperAdminOn } from "@/lib/tenancy";
 
-// Bearer API key for the REST v1 API and the MCP transport. The plaintext is `secv4_<base64url>`
+// Bearer API key for the REST v1 API and the MCP transport. The plaintext is `fazerai_<base64url>`
 // (256-bit); only its SHA-256 hash is stored (ApiKey.keyHash, unique), so a DB dump never yields a
 // usable key and lookup is a constant-time B-tree probe on the hash. Verified BEFORE the tenant is
 // known, so the hash lookup runs as super admin (the key row carries its own tenantId; RLS still
 // fences every downstream tenant query). `role` is fixed on the key (NOT re-derived from the
 // creator's current role); revocation is the soft `revokedAt`. Never log the plaintext.
 
-export const API_KEY_PREFIX = "secv4_";
+export const API_KEY_PREFIX = "fazerai_";
+// Compatibility window for the brand rename: keys minted before it carry `secv4_`. The stored hash
+// covers the WHOLE token, so an already-issued key keeps verifying byte for byte — only this
+// startsWith guard has to know the old marker. Dropped at 2.0.
+export const LEGACY_API_KEY_PREFIX = "secv4_";
 const LAST_USED_THROTTLE_MS = 60_000;
+
+// A token that carries neither marker cannot be one of ours: reject before touching the DB.
+export function hasApiKeyPrefix(token: string): boolean {
+  return (
+    token.startsWith(API_KEY_PREFIX) || token.startsWith(LEGACY_API_KEY_PREFIX)
+  );
+}
 
 export interface GeneratedApiKey {
   token: string;
@@ -49,7 +60,7 @@ export async function verifyApiKey(
   token: string,
   base: PrismaClient = basePrisma,
 ): Promise<ApiKeyPrincipal | null> {
-  if (!token.startsWith(API_KEY_PREFIX)) return null;
+  if (!hasApiKeyPrefix(token)) return null;
   const keyHash = hashApiKey(token);
   const resolved = await asSuperAdminOn(base, async (db) => {
     const k = await db.apiKey.findUnique({

--- a/src/modules/flowlog/alert-worker.ts
+++ b/src/modules/flowlog/alert-worker.ts
@@ -7,12 +7,7 @@ import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { tryResolveVaultSecret } from "@/modules/vault/service";
 import { nextBackoffMs } from "@/modules/webhooks/outbound/service";
-import {
-  DELIVERY_HEADER,
-  SIGNATURE_HEADER,
-  signOutbound,
-  TIMESTAMP_HEADER,
-} from "@/modules/webhooks/outbound/signing";
+import { outboundHeaders } from "@/modules/webhooks/outbound/signing";
 
 // Alert delivery worker (claim + deliver). Mirrors the outbound-webhook worker: a single-replica
 // tick reaps stale SENDING rows, claims due PENDING deliveries cross-tenant (FOR UPDATE SKIP
@@ -293,14 +288,13 @@ async function deliverClaimed(
 
   const { rawBody, contentType } = buildBody(a);
   const ts = Math.floor(now() / 1000);
-  const headers: Record<string, string> = {
-    "content-type": contentType,
-    [DELIVERY_HEADER]: String(a.id),
-  };
-  if (secret) {
-    headers[SIGNATURE_HEADER] = signOutbound(secret, ts, rawBody);
-    headers[TIMESTAMP_HEADER] = String(ts);
-  }
+  const headers = outboundHeaders({
+    contentType,
+    deliveryId: String(a.id),
+    timestampSeconds: ts,
+    rawBody,
+    secret,
+  });
 
   let status: number;
   try {

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -55,10 +55,18 @@ const DEFAULT_TIME_ZONE = "America/Sao_Paulo";
 
 // The private-event key carrying the owning contact's stamp. Keys in extendedProperties.private are
 // visible/queryable ONLY by our OAuth app, never by other apps or the customer.
+//
+// FROZEN through the brand rename, deliberately. These two keys are stamped on REAL events living
+// in customers' calendars, and the list fence filters server-side by
+// `privateExtendedProperty=secv4Contact=<stamp>` — Google takes ONE such filter per request, so
+// accepting a second key name would mean two listings plus a merge on every read, forever, or a
+// backfill we cannot run on self-hosted instances. They are also the only pre-rename identifiers
+// no human ever sees. Do NOT rename them outside the 2.0 cut.
 const SECV4_CONTACT_KEY = "secv4Contact";
 
 // The private-event key recording the attendance-confirmation timestamp (set by
-// calendar_confirm_appointment, injected from code, never surfaced to the model).
+// calendar_confirm_appointment, injected from code, never surfaced to the model). Frozen for the
+// same reason as SECV4_CONTACT_KEY above.
 const SECV4_CONFIRMED_KEY = "secv4Confirmed";
 // Title prefix that marks a confirmed appointment (applied idempotently).
 const CONFIRMED_PREFIX = "[CONFIRMADO] ";

--- a/src/modules/mcp/oauth/tokens.ts
+++ b/src/modules/mcp/oauth/tokens.ts
@@ -16,10 +16,14 @@ import { mcpResourceId } from "./metadata";
 // The mcp_oauth_* tables are GLOBAL (outside RLS); accessed via the base client, never scoped.
 
 const ALG = "HS256";
-// NOTE: wire-format identifier (the MCP OAuth `iss` claim). Kept as `secretaria-v4:mcp`
-// through the brand rename: renaming it invalidates every issued access/refresh token.
-// Rebrand it only as a deliberate, separate migration (with client re-auth).
-const ISSUER = "secretaria-v4:mcp";
+// NOTE: wire-format identifier (the MCP OAuth `iss` claim).
+const ISSUER = "fazerai:mcp";
+// Compatibility window for the brand rename: verify accepts the pre-rename issuer too, so access
+// tokens minted by the previous image survive the deploy instead of 401-ing in flight. We only ever
+// SIGN the new one. The window that has to be covered is the 15-minute access TTL, not the refresh
+// TTL: refresh tokens are opaque random strings with no issuer (see grant.ts), so a rotation
+// immediately mints under the new issuer. Dropped at 2.0.
+const LEGACY_ISSUER = "secretaria-v4:mcp";
 const ACCESS_TTL_S = 15 * 60;
 
 export const MCP_SCOPES = ["mcp:read", "mcp:write", "mcp:admin"] as const;
@@ -104,7 +108,7 @@ export async function verifyAccessToken(
   try {
     const { payload } = await jwtVerify(token, secretKey(), {
       algorithms: [ALG],
-      issuer: ISSUER,
+      issuer: [ISSUER, LEGACY_ISSUER],
       // RFC 8707: the token MUST have been issued for us (the MCP resource server). jose rejects a
       // missing or divergent `aud`, so an old token with aud=ISSUER no longer verifies (re-auth/refresh).
       audience: mcpResourceId(),

--- a/src/modules/tenant-settings/service.ts
+++ b/src/modules/tenant-settings/service.ts
@@ -15,8 +15,8 @@ import { tryResolveVaultEntry } from "@/modules/vault/service";
 export const embeddingSettingsSchema = z.object({
   // NOTE: provider/model/baseURL are currently PINNED to EMBEDDING_DEFAULTS (OpenAI +
   // text-embedding-3-small) by updateEmbeddingSettings — only the credential is configurable. The
-  // fields stay in the schema so unlocking later (flexible dimensions + provider registry, see
-  // docs/roadmap.md) is purely additive. Dimensionality is the pgvector column width (1536).
+  // fields stay in the schema so unlocking later (flexible dimensions + provider registry) is
+  // purely additive. Dimensionality is the pgvector column width (1536).
   provider: z.enum(["openai", "openai_compatible"]),
   model: z.string().min(1).max(200),
   credentialRef: z.string().min(1).max(200).nullable(),
@@ -145,7 +145,7 @@ export async function updateEmbeddingSettings(
     readEmbeddingSettings(db, tenantId),
   );
   // LOCKED to EMBEDDING_DEFAULTS (OpenAI + text-embedding-3-small) until the flexible-embeddings
-  // feature ships (configurable dimension + provider registry — see docs/roadmap.md). Only the
+  // feature ships (configurable dimension + provider registry). Only the
   // credential is honored; provider/model/baseURL from the patch are ignored. Unlocking = restore
   // the `{ ...current, ...patch }` merge.
   const merged = embeddingSettingsSchema.parse({

--- a/src/modules/webhooks/outbound/signing.ts
+++ b/src/modules/webhooks/outbound/signing.ts
@@ -5,9 +5,17 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 // hex, with the unix-seconds timestamp sent alongside. Receivers verify the timestamp
 // window (anti-replay) and recompute over the raw body.
 
-export const SIGNATURE_HEADER = "x-secretaria-signature";
-export const TIMESTAMP_HEADER = "x-secretaria-timestamp";
-export const DELIVERY_HEADER = "x-secretaria-delivery";
+export const SIGNATURE_HEADER = "x-fazerai-signature";
+export const TIMESTAMP_HEADER = "x-fazerai-timestamp";
+export const DELIVERY_HEADER = "x-fazerai-delivery";
+
+// Compatibility window for the brand rename. These are the only renamed identifiers consumed
+// OUTSIDE our code: operators wired their receivers against the old names, and we only ever EMIT
+// them (nothing here reads them back). So every delivery carries BOTH sets, with identical values,
+// until 2.0 drops the legacy ones.
+export const LEGACY_SIGNATURE_HEADER = "x-secretaria-signature";
+export const LEGACY_TIMESTAMP_HEADER = "x-secretaria-timestamp";
+export const LEGACY_DELIVERY_HEADER = "x-secretaria-delivery";
 
 export function signOutbound(
   secret: string,
@@ -18,6 +26,41 @@ export function signOutbound(
     .update(`${timestampSeconds}.${rawBody}`)
     .digest("hex");
   return `sha256=${mac}`;
+}
+
+export interface OutboundHeaderParams {
+  contentType: string;
+  // Stable dedupe key for the receiver; "test" for the manual test delivery.
+  deliveryId: string;
+  timestampSeconds: number;
+  rawBody: string;
+  // Absent/null → unsigned delivery: no signature and no timestamp go out.
+  secret?: string | null;
+}
+
+// Builds the headers of an outbound POST. Every emit site goes through here, so the dual emission
+// of the compatibility window cannot be forgotten at one of them, and 2.0 removes it in one edit.
+export function outboundHeaders(
+  params: OutboundHeaderParams,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": params.contentType,
+    [DELIVERY_HEADER]: params.deliveryId,
+    [LEGACY_DELIVERY_HEADER]: params.deliveryId,
+  };
+  if (params.secret) {
+    const signature = signOutbound(
+      params.secret,
+      params.timestampSeconds,
+      params.rawBody,
+    );
+    const timestamp = String(params.timestampSeconds);
+    headers[SIGNATURE_HEADER] = signature;
+    headers[TIMESTAMP_HEADER] = timestamp;
+    headers[LEGACY_SIGNATURE_HEADER] = signature;
+    headers[LEGACY_TIMESTAMP_HEADER] = timestamp;
+  }
+  return headers;
 }
 
 export function verifyOutboundSignature(

--- a/src/modules/webhooks/outbound/test.ts
+++ b/src/modules/webhooks/outbound/test.ts
@@ -6,12 +6,7 @@ import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { tryResolveVaultSecret } from "@/modules/vault/service";
 import { OUTBOUND_ENVELOPE_VERSION } from "./events";
-import {
-  DELIVERY_HEADER,
-  SIGNATURE_HEADER,
-  signOutbound,
-  TIMESTAMP_HEADER,
-} from "./signing";
+import { outboundHeaders } from "./signing";
 
 // On-demand "send a sample payload" for a subscription (the Test button). Unlike a real emit, this
 // is SYNCHRONOUS: it POSTs a clearly-marked test envelope to the subscription's URL through the SAME
@@ -113,14 +108,13 @@ export async function sendWebhookTest(
 
   const rawBody = JSON.stringify(buildTestEnvelope(tenantId, sub.events));
   const ts = Math.floor(Date.now() / 1000);
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    [DELIVERY_HEADER]: "test",
-  };
-  if (secret) {
-    headers[SIGNATURE_HEADER] = signOutbound(secret, ts, rawBody);
-    headers[TIMESTAMP_HEADER] = String(ts);
-  }
+  const headers = outboundHeaders({
+    contentType: "application/json",
+    deliveryId: "test",
+    timestampSeconds: ts,
+    rawBody,
+    secret,
+  });
 
   try {
     const res = await fetch(sub.url, {

--- a/src/modules/webhooks/outbound/worker.ts
+++ b/src/modules/webhooks/outbound/worker.ts
@@ -6,19 +6,14 @@ import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { tryResolveVaultSecret } from "@/modules/vault/service";
 import { nextBackoffMs } from "./service";
-import {
-  DELIVERY_HEADER,
-  SIGNATURE_HEADER,
-  signOutbound,
-  TIMESTAMP_HEADER,
-} from "./signing";
+import { outboundHeaders } from "./signing";
 
 // Outbound webhook delivery worker (claim + deliver side). A single-replica tick claims due
 // PENDING deliveries cross-tenant (asSuperAdmin / FOR UPDATE SKIP LOCKED), then for each:
 // resolves the per-tenant signing secret (RLS-scoped), POSTs the signed payload OUTSIDE any
 // transaction (SSRF-checked, no redirects, timeout), and records the outcome — DELIVERED,
 // back to PENDING with full-jitter backoff, or DEAD after MAX_ATTEMPTS. The delivery id is a
-// stable dedupe key (x-secretaria-delivery) so at-least-once retries are safe for receivers.
+// stable dedupe key (x-fazerai-delivery) so at-least-once retries are safe for receivers.
 //
 // Crash safety: the claim flips status to SENDING; a crash between claim and outcome would
 // strand the row, so each tick first reaps stale SENDING rows back to PENDING. The reentrancy
@@ -266,16 +261,15 @@ async function deliverClaimed(
   const ts = Math.floor(now() / 1000);
   // The stored payload IS the versioned envelope (built at emit time by buildOutboundEnvelope):
   // { version, instance_id, event, occurred_at, tenant_id, data }. POST it verbatim — the
-  // delivery id (retry dedupe key) travels in the x-secretaria-delivery header, not the body.
+  // delivery id (retry dedupe key) travels in the x-fazerai-delivery header, not the body.
   const rawBody = JSON.stringify(d.payload ?? {});
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    [DELIVERY_HEADER]: String(d.id),
-  };
-  if (secret) {
-    headers[SIGNATURE_HEADER] = signOutbound(secret, ts, rawBody);
-    headers[TIMESTAMP_HEADER] = String(ts);
-  }
+  const headers = outboundHeaders({
+    contentType: "application/json",
+    deliveryId: String(d.id),
+    timestampSeconds: ts,
+    rawBody,
+    secret,
+  });
 
   let status: number;
   try {

--- a/tests/api/lib/auth.test.ts
+++ b/tests/api/lib/auth.test.ts
@@ -3,6 +3,12 @@ import { Elysia } from "elysia";
 
 import { authPlugin } from "@/api/lib/auth";
 
+// happy-dom's Request drops `Cookie` (a forbidden request header), so a cookie built with the
+// global constructor never reaches the route. Bun's native Request is captured in tests/dom-setup.ts
+// before registration; use it for anything that has to carry a session cookie.
+const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
 const mockUser = {
   id: BigInt(1),
   tenantId: BigInt(1) as bigint | null,
@@ -165,6 +171,106 @@ describe("authPlugin", () => {
 
       const data = await response.json();
       expect(data.user).toBeNull();
+    });
+
+    // Brand rename compatibility window. Sessions minted by the previous image carry
+    // `secretaria_v4_auth_token`; the current one issues and reads `fazerai_auth_token`. Reading
+    // both is what keeps an upgrade from logging every operator out. Dropped at 2.0.
+    describe("session cookie name", () => {
+      // Mints a real session JWT through setAuthCookie, then replays it as a raw Cookie header
+      // under whichever name the caller wants to exercise.
+      async function mintToken(): Promise<string> {
+        const app = new Elysia()
+          .use(authPlugin)
+          .post("/mint", async ({ setAuthCookie }) => ({
+            token: await setAuthCookie(mockUser),
+          }));
+        const res = await app.handle(
+          new Request("http://localhost/mint", { method: "POST" }),
+        );
+        return (await res.json()).token;
+      }
+
+      function readerApp() {
+        return new Elysia()
+          .use(authPlugin)
+          .get("/whoami", async ({ getAuthUser }) => {
+            const user = await getAuthUser();
+            return { id: user ? user.id.toString() : null };
+          });
+      }
+
+      test("resolves a session sent under the current cookie name", async () => {
+        mockPrisma.user.findUnique.mockResolvedValueOnce(mockUser);
+        const token = await mintToken();
+        const res = await readerApp().handle(
+          new BunRequest("http://localhost/whoami", {
+            headers: { Cookie: `fazerai_auth_token=${token}` },
+          }),
+        );
+        expect((await res.json()).id).toBe(mockUser.id.toString());
+      });
+
+      test("resolves a session sent under the pre-rename cookie name", async () => {
+        mockPrisma.user.findUnique.mockResolvedValueOnce(mockUser);
+        const token = await mintToken();
+        const res = await readerApp().handle(
+          new BunRequest("http://localhost/whoami", {
+            headers: { Cookie: `secretaria_v4_auth_token=${token}` },
+          }),
+        );
+        expect((await res.json()).id).toBe(mockUser.id.toString());
+      });
+
+      test("prefers the current name when both cookies are present", async () => {
+        mockPrisma.user.findUnique.mockResolvedValueOnce(mockUser);
+        const token = await mintToken();
+        const res = await readerApp().handle(
+          new BunRequest("http://localhost/whoami", {
+            headers: {
+              Cookie: `fazerai_auth_token=${token}; secretaria_v4_auth_token=not.a.valid.jwt`,
+            },
+          }),
+        );
+        // A garbage legacy cookie must not shadow a good current one.
+        expect((await res.json()).id).toBe(mockUser.id.toString());
+      });
+
+      test("migrates a legacy cookie in place: rewrites it, clears the old name", async () => {
+        mockPrisma.user.findUnique.mockResolvedValueOnce(mockUser);
+        const token = await mintToken();
+        // happy-dom strips `Set-Cookie` off the Response, so assert on Elysia's cookie jar —
+        // the exact state it serializes into the header.
+        const app = new Elysia()
+          .use(authPlugin)
+          .get("/whoami", async ({ getAuthUser, cookie }) => {
+            await getAuthUser();
+            return {
+              current: cookie.fazerai_auth_token?.value ?? null,
+              legacyValue: cookie.secretaria_v4_auth_token?.value ?? null,
+              legacyMaxAge: cookie.secretaria_v4_auth_token?.maxAge ?? null,
+            };
+          });
+        const res = await app.handle(
+          new BunRequest("http://localhost/whoami", {
+            headers: { Cookie: `secretaria_v4_auth_token=${token}` },
+          }),
+        );
+        const jar = await res.json();
+        expect(jar.current).toBe(token);
+        // remove() → empty value + Max-Age 0, i.e. an expiry instruction for the browser.
+        expect(jar.legacyValue).toBe("");
+        expect(jar.legacyMaxAge).toBe(0);
+      });
+
+      test("a legacy cookie carrying garbage is still rejected", async () => {
+        const res = await readerApp().handle(
+          new BunRequest("http://localhost/whoami", {
+            headers: { Cookie: "secretaria_v4_auth_token=not.a.valid.jwt" },
+          }),
+        );
+        expect((await res.json()).id).toBeNull();
+      });
     });
   });
 

--- a/tests/dom-setup.ts
+++ b/tests/dom-setup.ts
@@ -12,17 +12,22 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 // reorder them anyway. Splitting the two into separate preloads is what makes
 // the ordering explicit and enforceable.
 
-// NOTE: Bun's native WebSocket and Response constructors are captured before
-// happy-dom replaces them globally. Backend tests that run a real Bun.serve
-// need the native Response (the spec one from happy-dom is not recognized by
-// Bun's TCP socket layer); WebSocket tests need the Bun-only `{ headers }`
-// option that the spec WebSocket rejects. Reach for them via
-// `globalThis.BunWebSocket` / `globalThis.BunResponse`.
+// NOTE: Bun's native WebSocket, Response and Request constructors are captured
+// before happy-dom replaces them globally. Backend tests that run a real
+// Bun.serve need the native Response (the spec one from happy-dom is not
+// recognized by Bun's TCP socket layer); WebSocket tests need the Bun-only
+// `{ headers }` option that the spec WebSocket rejects; and happy-dom's Request
+// silently DROPS forbidden request headers, `Cookie` among them — so any test
+// that drives a cookie-authenticated route through `app.handle()` must build
+// its Request with the native constructor or the header never arrives. Reach
+// for them via `globalThis.BunWebSocket` / `BunResponse` / `BunRequest`.
 const __nativeBunGlobals = globalThis as {
   BunWebSocket?: typeof WebSocket;
   BunResponse?: typeof Response;
+  BunRequest?: typeof Request;
 };
 __nativeBunGlobals.BunWebSocket = WebSocket;
 __nativeBunGlobals.BunResponse = Response;
+__nativeBunGlobals.BunRequest = Request;
 
 GlobalRegistrator.register();

--- a/tests/modules/api-keys.test.ts
+++ b/tests/modules/api-keys.test.ts
@@ -10,7 +10,9 @@ import {
 import {
   API_KEY_PREFIX,
   generateApiKey,
+  hasApiKeyPrefix,
   hashApiKey,
+  LEGACY_API_KEY_PREFIX,
   verifyApiKey,
 } from "@/modules/api-keys/verify";
 
@@ -26,6 +28,20 @@ describe("api key token generation", () => {
 
   test("two keys never collide", () => {
     expect(generateApiKey().token).not.toBe(generateApiKey().token);
+  });
+
+  // Brand rename compatibility window: new keys are minted `fazerai_`, keys minted before it carry
+  // `secv4_`. The prefix guard has to admit both; the DB lookup then decides. Dropped at 2.0.
+  test("the mint prefix is the current brand marker", () => {
+    expect(API_KEY_PREFIX).toBe("fazerai_");
+    expect(generateApiKey().token.startsWith("fazerai_")).toBe(true);
+  });
+
+  test("the prefix guard admits both markers and nothing else", () => {
+    expect(hasApiKeyPrefix(`${API_KEY_PREFIX}abc`)).toBe(true);
+    expect(hasApiKeyPrefix(`${LEGACY_API_KEY_PREFIX}abc`)).toBe(true);
+    expect(hasApiKeyPrefix("sk_live_abc")).toBe(false);
+    expect(hasApiKeyPrefix("")).toBe(false);
   });
 });
 
@@ -130,9 +146,36 @@ describe.skipIf(!dbUp)("api key service + verify (RLS)", () => {
     expect(principal?.userId).toBe(USER_A);
   });
 
+  // The load-bearing half of the compatibility window: a key an operator is already using was
+  // minted under the old marker and lives in their DB. It has to keep authenticating unchanged —
+  // we cannot reach a self-hosted instance to rewrite it.
+  test("verify still resolves a key minted under the pre-rename prefix", async () => {
+    const legacyToken = `${LEGACY_API_KEY_PREFIX}${"l".repeat(32)}`;
+    await su?.apiKey.create({
+      data: {
+        tenantId: tenantA,
+        displayName: "pre-rename key",
+        // The stored hash covers the WHOLE token, prefix included — this is why no data migration
+        // is needed for the rename.
+        keyHash: hashApiKey(legacyToken),
+        keyPrefix: legacyToken.slice(0, LEGACY_API_KEY_PREFIX.length + 6),
+        role: "TENANT_ADMIN",
+        createdByUserId: USER_A,
+      },
+    });
+    const principal = await verifyApiKey(legacyToken, appDb);
+    expect(principal).not.toBeNull();
+    expect(principal?.tenantId).toBe(tenantA);
+    expect(principal?.role).toBe("TENANT_ADMIN");
+    expect(principal?.userId).toBe(USER_A);
+  });
+
   test("verify rejects a malformed or unknown key", async () => {
     expect(await verifyApiKey("not-a-key", appDb)).toBeNull();
     expect(await verifyApiKey(`${API_KEY_PREFIX}deadbeef`, appDb)).toBeNull();
+    expect(
+      await verifyApiKey(`${LEGACY_API_KEY_PREFIX}deadbeef`, appDb),
+    ).toBeNull();
   });
 
   test("list is RLS-scoped: a tenant sees only its own keys", async () => {

--- a/tests/modules/mcp-oauth-tokens.test.ts
+++ b/tests/modules/mcp-oauth-tokens.test.ts
@@ -99,6 +99,54 @@ describe.skipIf(!dbUp)("mcp oauth access tokens", () => {
     expect(decodeJwt(token).aud).toBe(mcpResourceId());
   });
 
+  // Brand rename compatibility window. We SIGN only the current issuer, but verify accepts the
+  // pre-rename one so access tokens minted by the previous image do not 401 mid-deploy. The window
+  // that has to be covered is the 15-minute access TTL — refresh tokens are opaque (no issuer), so
+  // the first rotation after the upgrade already mints under the current one. Dropped at 2.0.
+  test("we sign the current issuer", async () => {
+    const { token } = await issue();
+    expect(decodeJwt(token).iss).toBe("fazerai:mcp");
+  });
+
+  test("a token carrying the pre-rename issuer still verifies", async () => {
+    // Reuse a real jti so the denylist lookup finds its row; only the `iss` claim differs from
+    // what we mint today.
+    const { jti } = await issue(["mcp:read"]);
+    const legacy = await new SignJWT({
+      tenant_id: tenantId.toString(),
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:read"],
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject(String(userId))
+      .setJti(jti)
+      .setIssuer("secretaria-v4:mcp")
+      .setAudience(mcpResourceId())
+      .setExpirationTime("15m")
+      .sign(new TextEncoder().encode(config.mcpJwtSecret));
+    const v = await verifyAccessToken(legacy, suDb);
+    expect(v).not.toBeNull();
+    expect(v?.userId).toBe(userId);
+    expect(v?.jti).toBe(jti);
+  });
+
+  test("an unknown issuer is still rejected", async () => {
+    const { jti } = await issue(["mcp:read"]);
+    const foreign = await new SignJWT({
+      tenant_id: tenantId.toString(),
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:read"],
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject(String(userId))
+      .setJti(jti)
+      .setIssuer("evil:mcp")
+      .setAudience(mcpResourceId())
+      .setExpirationTime("15m")
+      .sign(new TextEncoder().encode(config.mcpJwtSecret));
+    expect(await verifyAccessToken(foreign, suDb)).toBeNull();
+  });
+
   test("a token bound to a different audience is rejected (RFC 8707)", async () => {
     // Signed with OUR mcp secret, correct issuer/alg, but a foreign aud → must not verify.
     const forged = await new SignJWT({
@@ -109,7 +157,7 @@ describe.skipIf(!dbUp)("mcp oauth access tokens", () => {
       .setProtectedHeader({ alg: "HS256" })
       .setSubject(String(userId))
       .setJti("forged-aud")
-      .setIssuer("secretaria-v4:mcp")
+      .setIssuer("fazerai:mcp")
       .setAudience("https://evil.example.com/api/v1/mcp")
       .setExpirationTime("15m")
       .sign(new TextEncoder().encode(config.mcpJwtSecret));
@@ -124,7 +172,7 @@ describe.skipIf(!dbUp)("mcp oauth access tokens", () => {
       .setProtectedHeader({ alg: "HS256" })
       .setSubject(String(userId))
       .setJti("forged")
-      .setIssuer("secretaria-v4:mcp")
+      .setIssuer("fazerai:mcp")
       .setExpirationTime("15m")
       .sign(new TextEncoder().encode(config.jwtSecret));
     expect(await verifyAccessToken(appToken, suDb)).toBeNull();

--- a/tests/modules/mcp-write-resources.test.ts
+++ b/tests/modules/mcp-write-resources.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(!dbUp)("MCP resource-write tools (DB)", () => {
         tenantId: tenantA,
         displayName: "k1",
         keyHash: `hash-${process.pid}`,
-        keyPrefix: "secv4_aaa",
+        keyPrefix: "fazerai_aaa",
         role: "TENANT_ADMIN",
       },
       select: { id: true },

--- a/tests/modules/webhooks-outbound-worker.test.ts
+++ b/tests/modules/webhooks-outbound-worker.test.ts
@@ -4,6 +4,9 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import {
   DELIVERY_HEADER,
+  LEGACY_DELIVERY_HEADER,
+  LEGACY_SIGNATURE_HEADER,
+  LEGACY_TIMESTAMP_HEADER,
   SIGNATURE_HEADER,
   TIMESTAMP_HEADER,
   verifyOutboundSignature,
@@ -180,6 +183,38 @@ describe.skipIf(!dbUp)("outbound delivery worker", () => {
       ),
     ).toBe(true);
     expect(await readDelivery(id)).toMatchObject({ status: "DELIVERED" });
+  });
+
+  // Brand rename compatibility window, asserted on what actually leaves the worker: an operator's
+  // receiver is keyed on the pre-rename header names and we cannot reach it to reconfigure. Both
+  // sets must be on the wire, with identical values. Dropped at 2.0.
+  test("puts both the current and the pre-rename header names on the wire", async () => {
+    const id = await seedDelivery({ subscriptionId: signedSubId });
+    const { fetchImpl, calls } = stubFetch(200);
+    await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl,
+      assertSafe: passthroughSafe,
+    });
+    const call = calls.find(
+      (c) =>
+        (c.init?.headers as Record<string, string>)?.[DELIVERY_HEADER] ===
+        String(id),
+    );
+    const headers = call?.init?.headers as Record<string, string>;
+    expect(headers[LEGACY_DELIVERY_HEADER]).toBe(String(id));
+    expect(headers[LEGACY_SIGNATURE_HEADER]).toBe(headers[SIGNATURE_HEADER]);
+    expect(headers[LEGACY_TIMESTAMP_HEADER]).toBe(headers[TIMESTAMP_HEADER]);
+    // A receiver still verifying under the old names gets a signature that checks out.
+    expect(
+      verifyOutboundSignature(
+        SECRET,
+        Number(headers[LEGACY_TIMESTAMP_HEADER]),
+        call?.init?.body as string,
+        headers[LEGACY_SIGNATURE_HEADER] ?? "",
+      ),
+    ).toBe(true);
   });
 
   test("retries a non-2xx response with backoff", async () => {

--- a/tests/modules/webhooks-outbound.test.ts
+++ b/tests/modules/webhooks-outbound.test.ts
@@ -4,7 +4,14 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { runScopedOn, type ScopedDb } from "@/lib/tenancy";
 import { emitOutbound } from "@/modules/webhooks/outbound/service";
 import {
+  DELIVERY_HEADER,
+  LEGACY_DELIVERY_HEADER,
+  LEGACY_SIGNATURE_HEADER,
+  LEGACY_TIMESTAMP_HEADER,
+  outboundHeaders,
+  SIGNATURE_HEADER,
   signOutbound,
+  TIMESTAMP_HEADER,
   verifyOutboundSignature,
 } from "@/modules/webhooks/outbound/signing";
 import { outboundUrl } from "../utils/outbound";
@@ -24,6 +31,66 @@ describe("outbound webhook signing", () => {
     expect(verifyOutboundSignature("wrong", ts, body, sig)).toBe(false);
     expect(verifyOutboundSignature("secret", ts + 1, body, sig)).toBe(false);
     expect(verifyOutboundSignature("secret", ts, `${body} `, sig)).toBe(false);
+  });
+});
+
+// Brand rename compatibility window. These headers are the only renamed identifiers consumed
+// OUTSIDE our code — an operator's receiver is already keyed on the pre-rename names — so every
+// delivery carries both sets with identical values. Dropped at 2.0.
+describe("outbound webhook headers", () => {
+  const ts = 1700000000;
+  const body = '{"event":"conversation.created"}';
+
+  test("emits the current names", () => {
+    const h = outboundHeaders({
+      contentType: "application/json",
+      deliveryId: "42",
+      timestampSeconds: ts,
+      rawBody: body,
+      secret: "s3cr3t",
+    });
+    expect(h[DELIVERY_HEADER]).toBe("42");
+    expect(h[TIMESTAMP_HEADER]).toBe(String(ts));
+    expect(
+      verifyOutboundSignature("s3cr3t", ts, body, h[SIGNATURE_HEADER] ?? ""),
+    ).toBe(true);
+    expect(DELIVERY_HEADER).toBe("x-fazerai-delivery");
+    expect(SIGNATURE_HEADER).toBe("x-fazerai-signature");
+    expect(TIMESTAMP_HEADER).toBe("x-fazerai-timestamp");
+  });
+
+  test("mirrors every header under its pre-rename name, byte for byte", () => {
+    const h = outboundHeaders({
+      contentType: "application/json",
+      deliveryId: "42",
+      timestampSeconds: ts,
+      rawBody: body,
+      secret: "s3cr3t",
+    });
+    expect(h[LEGACY_DELIVERY_HEADER]).toBe(h[DELIVERY_HEADER]);
+    expect(h[LEGACY_SIGNATURE_HEADER]).toBe(h[SIGNATURE_HEADER]);
+    expect(h[LEGACY_TIMESTAMP_HEADER]).toBe(h[TIMESTAMP_HEADER]);
+  });
+
+  test("an unsigned delivery carries no signature under either name", () => {
+    const h = outboundHeaders({
+      contentType: "application/json",
+      deliveryId: "42",
+      timestampSeconds: ts,
+      rawBody: body,
+      secret: null,
+    });
+    // The delivery id still goes out under both names — it is the dedupe key, not a credential.
+    expect(h[DELIVERY_HEADER]).toBe("42");
+    expect(h[LEGACY_DELIVERY_HEADER]).toBe("42");
+    for (const name of [
+      SIGNATURE_HEADER,
+      TIMESTAMP_HEADER,
+      LEGACY_SIGNATURE_HEADER,
+      LEGACY_TIMESTAMP_HEADER,
+    ]) {
+      expect(h[name]).toBeUndefined();
+    }
   });
 });
 


### PR DESCRIPTION
Second beat of the brand rename. #93 moved every identifier that carries neither persistence nor a wire format. This moves the four that do, and each one keeps accepting its pre-rename form, so upgrading an existing instance breaks nothing.

The product is self-hosted: we cannot reach anyone's database or anyone's webhook receiver. So the exit is backward compatibility in code, never a data migration.

## The four windows

| Identifier | Emitted now | Still accepted | What bounds the window |
| --- | --- | --- | --- |
| Auth cookie | `fazerai_auth_token` | `secretaria_v4_auth_token` | one request: the session is rewritten under the new name and the old cookie is expired |
| API key prefix | `fazerai_` | `secv4_` | forever, in practice: keys already issued are never re-minted |
| MCP OAuth issuer | `fazerai:mcp` | `secretaria-v4:mcp` | the 15-minute access TTL |
| Outbound webhook headers | `x-fazerai-signature` / `-timestamp` / `-delivery` | the `x-secretaria-*` trio, emitted alongside | until `2.0` |

Notes on each:

- **Cookie.** `getAuthUser` reads the new name, falls back to the old one, and on that fallback rewrites the same JWT under the new name while expiring the old cookie. Nobody is logged out, and the legacy cookie is gone after a single request. Logout clears both.
- **API key.** The stored hash covers the whole token, prefix included, which is exactly why no data migration is needed: a key sitting in an operator's database keeps verifying byte for byte. Only the `startsWith` guard had to learn the old marker.
- **MCP issuer.** We sign only the new one; verify takes both (`jose` accepts `issuer: string[]`). The window is bounded by the access token's 15 minutes, not by the 30-day refresh: refresh tokens are opaque random strings carrying no issuer, so the first rotation after the upgrade already mints under the new issuer. What the acceptance buys is that tokens in flight do not 401 mid-deploy.
- **Webhook headers.** The only renamed identifiers consumed **outside** this codebase. Operators configured their receivers against the old names and we only ever emit these, never read them back, so every delivery now carries both sets with identical values. The three emit sites (the outbound worker, the alert worker, the Test button) each had a copy-pasted header block; they now share `outboundHeaders`, so the dual emission cannot be forgotten at one of them.

## If you consume our webhooks

Point your receiver at `x-fazerai-signature` / `x-fazerai-timestamp` / `x-fazerai-delivery`. The old names keep arriving with identical values until `2.0`. The signature payload and algorithm are unchanged.

## Left alone on purpose

The Google Calendar stamps (`extendedProperties.private.secv4Contact` / `secv4Confirmed`). They live on real events in customers' calendars, and the list fence filters server-side by `privateExtendedProperty=secv4Contact=<stamp>` — Google takes exactly one such filter per request, so accepting a second key name would mean two listings plus a merge on every read, permanently, or a backfill nobody can run across self-hosted instances. They are also the only renamed identifiers no human ever sees. `2.0` renames them along with dropping all four acceptances above.

## Test infrastructure

happy-dom drops `Cookie` from a `Request` as a forbidden header, so no test in the suite had ever driven the cookie path of `getAuthUser` — the existing "invalid cookie" cases were passing because the header never arrived at all. `tests/dom-setup.ts` now also captures Bun's native `Request`, alongside the `Response` and `WebSocket` it already kept, and the cookie tests build their requests with it.

## Also

Five comment pointers to files that do not ship in this repo were removed (they pointed at paths a reader here cannot open). The comments keep their substance and lose the dead path. Found by sweeping every internal file path mentioned in the tree against what the tree actually contains.

## Validation

- `bun check` green with Postgres up: **2449 pass, 0 fail**.
- In this repo's CI there is no database, so the DB-backed assertions skip (`1770 pass, 807 skip, 0 fail` in that shape). The three that matter most here are among them and were verified locally against a real Postgres: a key minted with the old prefix still resolving to its principal, an access token carrying the old issuer still verifying through the jti denylist, and the outbound worker putting both header sets on the wire with a signature that checks out under the old names.
- Every new assertion was mutation-checked against the code it covers. Reverting the cookie name, the legacy cookie fallback, the issuer rename, the dual issuer, the legacy prefix acceptance and the legacy header mirror each turns the corresponding tests red.
