### PR TITLE
fix(calendar): a single allowed calendar leaves the model no calendarId to invent

### DIFF
--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -33,7 +33,8 @@ import {
 // Security invariants (mirror asaas.ts):
 //   - the set of operable calendars (`calendarIds`) + `timeZone` are bound to the INSTANCE CONFIG; a
 //     tool's optional `calendarId` arg is validated against the allowlist, fail-closed (with a single
-//     allowed calendar it is auto-selected; with several the model picks by name or id IN the set);
+//     allowed calendar the arg is not even exposed and that calendar is used; with several the model
+//     picks by name or id IN the set);
 //   - the per-customer stamp is bound to ctx.contactDbId, never a tool arg;
 //   - the bearer token flows ONLY into the Authorization header;
 //   - the origin is a fixed constant (never interpolated); SSRF-guarded anyway;
@@ -137,19 +138,45 @@ function listAllowed(
   return `Allowed calendars: ${list} (pass calendarId by name or id).`;
 }
 
-// The allowed calendars as an XML block, appended at the END of a tool's description ONLY when several
-// are allowed (with a single calendar it is auto-selected and never needs to be named). Each <calendar>
-// carries the friendly name (when known) and/or the raw id — both are valid values for the calendarId
-// arg. Empty ⇒ "" (no block).
-function allowedCalendarsXml(
+// The calendar the model cannot choose: with EXACTLY ONE allowed calendar the binding is pinned, so
+// there is nothing to pick — the tools drop the calendarId arg (calendarArgSchema) and the context
+// block names the calendar instead of enumerating options (calendarContextXml). Null when the operator
+// allowed none (the tools refuse at invoke time) or several (the model picks, fenced by pickCalendarId).
+function pinnedCalendarId(allowed: string[]): string | null {
+  return allowed.length === 1 ? (allowed[0] as string) : null;
+}
+
+// The calendars as an XML block, appended at the END of a tool's description. Pinned ⇒ the single
+// <active_calendar> the tools operate on, so the agent can NAME it to the customer without a
+// calendarId arg to pass. Several ⇒ the <allowed_calendars> the model picks from, each <calendar>
+// carrying the friendly name (when known) and/or the raw id — both valid values for the arg. None ⇒
+// "" (no block).
+function calendarContextXml(
   allowed: string[],
   labels: Record<string, string>,
 ): string {
-  if (allowed.length <= 1) return "";
+  const pinned = pinnedCalendarId(allowed);
+  if (pinned) {
+    return `<active_calendar${xmlAttr("name", labels[pinned])}${xmlAttr("id", pinned)}/>`;
+  }
+  if (allowed.length === 0) return "";
   const els = allowed.map(
     (id) => `  <calendar${xmlAttr("name", labels[id])}${xmlAttr("id", id)}/>`,
   );
   return `<allowed_calendars>\n${els.join("\n")}\n</allowed_calendars>`;
+}
+
+// A tool's schema as the MODEL sees it. Pinned ⇒ calendarId is REMOVED: an optional arg offered with
+// no valid value in sight is an invitation to invent one (a support report had an agent passing the
+// operator's own wording for the integration, which never reaches the runtime, and the tool refusing
+// on the one calendar it could have used). Zod strips a residual key from an older turn before the
+// body runs, so the pinned calendar is used either way. Several/none ⇒ the arg stays and
+// pickCalendarId fences it.
+function calendarArgSchema(
+  schema: z.ZodObject<z.ZodRawShape>,
+  allowed: string[],
+): z.ZodTypeAny {
+  return pinnedCalendarId(allowed) ? schema.omit({ calendarId: true }) : schema;
 }
 
 // The configured appointment length as an XML element for calendar_check_availability: preset="true"
@@ -447,8 +474,12 @@ const NO_CONTACT =
 const FOREIGN_EVENT =
   "That appointment is not associated with this customer, so it cannot be read or changed here.";
 
+// NOTE: zod-optional but never optional in practice: the arg is only ever EXPOSED when the
+// integration allows several calendars (calendarArgSchema), and then one of them must be named or
+// pickCalendarId refuses. The trailing sentence is for the operator reading the arg list in the
+// console, which is per-catalog and therefore always shows this field.
 const CALENDAR_ID_DESC =
-  "Which calendar to act on. Optional; required only when the integration allows several calendars. Pass an allowed calendar's name or id.";
+  "Which calendar to act on: name or id of one of the calendars in `<allowed_calendars>`. This arg only appears when the integration allows several calendars; with a single one it is used automatically.";
 
 function projectEvent(ev: Record<string, unknown>) {
   return {
@@ -648,9 +679,9 @@ function buildListEventsTool(
       name: "calendar_list_events",
       description: withCalendarContext(
         `List THIS customer's own appointments on the calendar in a time range (each customer only ever sees their own). Holidays, closures, staff events and other customers' bookings are NEVER visible here, so an empty result does NOT mean the calendar is free; use calendar_check_availability to know what is actually bookable. Returns each appointment's id, summary, start and end. Use ISO 8601 timestamps (with offset) for the range.`,
-        allowedCalendarsXml(allowed, labels),
+        calendarContextXml(allowed, labels),
       ),
-      schema: LIST_EVENTS_SCHEMA,
+      schema: calendarArgSchema(LIST_EVENTS_SCHEMA, allowed),
     },
   );
 }
@@ -804,9 +835,9 @@ function buildCheckAvailabilityTool(
       description: withCalendarContext(
         `Return ALL bookable appointment start times within a range, already honoring the service hours, existing bookings and any operator-designated blocking calendars such as holidays or closures (no appointment details are exposed). Each slot has start, end and a human-readable label. Offer these to the customer and confirm one before creating the appointment. Pass ISO 8601 timestamps for the range, and search AT MOST 24 hours per call (one day at a time — call again for other days). The configured appointment length is shown in \`<slot_duration>\` below — when preset="false", choose it yourself per request and pass slotDurationMinutes (e.g. 30 for a standard appointment, 60 for a longer one); when preset="true", pass slotDurationMinutes only to override it.`,
         slotDurationXml(sel.config),
-        allowedCalendarsXml(allowed, labels),
+        calendarContextXml(allowed, labels),
       ),
-      schema: CHECK_AVAILABILITY_SCHEMA,
+      schema: calendarArgSchema(CHECK_AVAILABILITY_SCHEMA, allowed),
     },
   );
 }
@@ -925,9 +956,9 @@ function buildCreateEventTool(
       name: "calendar_create_event",
       description: withCalendarContext(
         `Create an appointment for THIS customer on the calendar (it is automatically tagged to this customer, so only they can later see or change it). Provide a summary plus start and end. Use ISO 8601 with an offset for timed events (e.g. 2026-06-20T14:00:00-03:00) or a bare date (2026-06-20) for an all-day event. Returns the created appointment's id and links${meetEnabled ? "; share meetLink (the Google Meet room) with the customer — htmlLink is only the calendar page" : ""}.`,
-        allowedCalendarsXml(allowed, labels),
+        calendarContextXml(allowed, labels),
       ),
-      schema: CREATE_EVENT_SCHEMA,
+      schema: calendarArgSchema(CREATE_EVENT_SCHEMA, allowed),
     },
   );
 }
@@ -1038,9 +1069,9 @@ function buildUpdateEventTool(
       name: "calendar_update_event",
       description: withCalendarContext(
         `Reschedule or edit THIS customer's appointment (by its id, e.g. from calendar_list_events). Only an appointment belonging to this customer can be changed. Provide ONLY the fields to change. Dates use the same ISO 8601 / all-day format as create.`,
-        allowedCalendarsXml(allowed, labels),
+        calendarContextXml(allowed, labels),
       ),
-      schema: UPDATE_EVENT_SCHEMA,
+      schema: calendarArgSchema(UPDATE_EVENT_SCHEMA, allowed),
     },
   );
 }
@@ -1109,9 +1140,9 @@ function buildCancelEventTool(
       name: "calendar_cancel_event",
       description: withCalendarContext(
         `Cancel (delete) THIS customer's appointment by its id (e.g. from calendar_list_events). Only an appointment belonging to this customer can be cancelled.`,
-        allowedCalendarsXml(allowed, labels),
+        calendarContextXml(allowed, labels),
       ),
-      schema: CANCEL_EVENT_SCHEMA,
+      schema: calendarArgSchema(CANCEL_EVENT_SCHEMA, allowed),
     },
   );
 }
@@ -1192,9 +1223,9 @@ function buildConfirmAppointmentTool(
       name: "calendar_confirm_appointment",
       description: withCalendarContext(
         `Mark THIS customer's appointment as CONFIRMED after they confirm they will attend (by its id, e.g. from calendar_list_events). Prefixes the event title with [CONFIRMADO] and records the confirmation on the event. Only an appointment belonging to this customer can be confirmed.`,
-        allowedCalendarsXml(allowed, labels),
+        calendarContextXml(allowed, labels),
       ),
-      schema: CONFIRM_APPOINTMENT_SCHEMA,
+      schema: calendarArgSchema(CONFIRM_APPOINTMENT_SCHEMA, allowed),
     },
   );
 }

--- a/tests/graph/calendar-pinned-calendar-turn.test.ts
+++ b/tests/graph/calendar-pinned-calendar-turn.test.ts
@@ -1,0 +1,352 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { MemorySaver } from "@langchain/langgraph";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { runAgentTurn } from "@/graph/runtime";
+import type { ChatwootClient } from "@/modules/chatwoot/client";
+import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// A support report, end to end: a Calendar integration with ONE allowed calendar, and the agent
+// calling availability with `calendarId` filled with something that is not a calendar (the model has
+// no valid value in sight, because the block that lists the calendars is suppressed when there is
+// nothing to choose). The tool refused, and the operator only got it working by telling the agent not
+// to send the arg.
+//
+// The unit suite covers the resolver. This one covers the two things only a real turn can show: what
+// the toolset ACTUALLY hands the provider after loadAgentConfig → buildToolpackTools (the arg must not
+// be on the wire at all), and that a model which sends it anyway still gets slots and the customer
+// still gets an answer.
+//
+// NOTE: the turn's SSRF guard is not injectable (prepare.ts builds the toolpack ctx without one), so
+// this test resolves www.googleapis.com for real. Every HTTP response is stubbed; only DNS is live.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const LLM_BASE = "https://llm.example.com/v1";
+const PINNED = "clinic@group.calendar.google.com";
+// What a model fills an optional arg with when nothing tells it a valid value.
+const INVENTED = "My Calendar Integration";
+const REPLY = "Tenho horários livres nesse dia, qual prefere?";
+
+let tenantId = 0n;
+let instanceId = 0n;
+
+interface Call {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+// Personifies both hosts the turn talks to: the OpenAI-shaped provider (tool call first, answer
+// second) and Google Calendar's freeBusy (a day with nothing busy).
+function fakeHosts() {
+  const llm: Call[] = [];
+  const google: Call[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (
+    url: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const href = String(url instanceof Request ? url.url : url);
+    const body = JSON.parse(String(init?.body ?? "{}")) as Record<
+      string,
+      unknown
+    >;
+    if (href.includes("googleapis.com")) {
+      google.push({ url: href, body });
+      return Response.json({ calendars: { [PINNED]: { busy: [] } } });
+    }
+    llm.push({ url: href, body });
+    if (llm.length === 1) {
+      return Response.json({
+        id: "chatcmpl-1",
+        object: "chat.completion",
+        created: 0,
+        model: body.model,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "call_avail",
+                  type: "function",
+                  function: {
+                    name: "calendar_check_availability",
+                    arguments: JSON.stringify({
+                      timeMin: "2099-06-22T00:00:00-03:00",
+                      timeMax: "2099-06-22T23:00:00-03:00",
+                      calendarId: INVENTED,
+                    }),
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+      });
+    }
+    return Response.json({
+      id: "chatcmpl-2",
+      object: "chat.completion",
+      created: 0,
+      model: body.model,
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: REPLY },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 6, total_tokens: 11 },
+    });
+  }) as unknown as typeof fetch;
+  return {
+    llm,
+    google,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+function stubClient(sent: Array<[number, string]>) {
+  const client = {
+    sendMessage: async (conversationId: number, content: string) => {
+      sent.push([conversationId, content]);
+      return {};
+    },
+  } as unknown as ChatwootClient;
+  return async () => client;
+}
+
+const incoming = (conversationId: number): NormalizedChatwootEvent => ({
+  event: "message_created",
+  conversationId,
+  inboxId: 7,
+  status: "pending",
+  assigneeType: null,
+  assigneeId: null,
+  assigneeName: null,
+  contactInboxId: null,
+  message: {
+    id: 1,
+    content: "quais horários vocês têm amanhã?",
+    messageType: "incoming",
+    private: false,
+  },
+});
+
+// The availability tool as the provider received it, by name.
+function toolOnTheWire(call: Call | undefined): Record<string, unknown> | null {
+  const tools = (call?.body.tools ?? []) as Array<Record<string, unknown>>;
+  const match = tools.find(
+    (t) =>
+      (t.function as { name?: string } | undefined)?.name ===
+      "calendar_check_availability",
+  );
+  return (match?.function as Record<string, unknown>) ?? null;
+}
+
+describe.skipIf(!dbUp)("a turn on an integration with one calendar", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "PC", slug: `pc-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 9,
+      baseUrl: "https://chat.example.com",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const llmKey = await suDb.vaultEntry.create({
+      data: { tenantId, name: "llm-key", secret: encryptJson("sk-test") },
+      select: { id: true },
+    });
+    // A connected Google credential whose access token is still fresh, so the turn never attempts a
+    // refresh (that path is a network call of its own).
+    const gcalKey = await suDb.vaultEntry.create({
+      data: {
+        tenantId,
+        name: "gcal-cred",
+        kind: "google_oauth",
+        secret: encryptJson({
+          clientId: "cid",
+          clientSecret: "csecret",
+          accessToken: "gcal-access",
+          refreshToken: "gcal-refresh",
+          expiresAt: Date.now() + 3_600_000,
+        }),
+      },
+      select: { id: true },
+    });
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Atendente",
+        systemPrompt: "Você agenda consultas.",
+        modelConfig: {
+          provider: "openai-compatible",
+          model: "local-model",
+          baseURL: LLM_BASE,
+          credentialRef: `vault:${llmKey.id}`,
+        },
+        settings: { split: { enabled: false } },
+      },
+    });
+    const integration = await suDb.integrationInstance.create({
+      data: {
+        tenantId,
+        catalogType: "GOOGLE_CALENDAR",
+        name: "Agenda",
+        credentialRef: `vault:${gcalKey.id}`,
+        config: {
+          calendarIds: [PINNED],
+          calendarLabels: { [PINNED]: "Clinic" },
+        },
+      },
+      select: { id: true },
+    });
+    await suDb.agentToolSelection.create({
+      data: {
+        tenantId,
+        agentId: agent.id,
+        source: "INTEGRATION",
+        integrationInstanceId: integration.id,
+        enabledTools: ["calendar_check_availability"],
+        knowledgeBaseIds: [],
+      },
+    });
+    await suDb.chatwootAgentBot.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        agentId: agent.id,
+        chatwootAgentBotId: 9,
+        accessToken: encryptJson("BOT"),
+        webhookSecret: encryptJson("S"),
+        webhookRouteTokenHash: `pc-route-${process.pid}`,
+        name: "Atendente",
+      },
+    });
+    await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: 7,
+        name: "Suporte",
+        agentId: agent.id,
+      },
+    });
+    await suDb.conversation.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootConversationId: 801,
+        status: "pending",
+        threadId: `${tenantId}:${instanceId}:801`,
+        lastEventAt: new Date(),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const table of [
+        "execution_logs",
+        "llm_usage",
+        "agent_threads",
+        "conversations",
+        "contacts",
+        "inboxes",
+        "chatwoot_agent_bots",
+        "agent_tool_selections",
+        "integration_instances",
+        "agents",
+        "vault_entries",
+        "chatwoot_instances",
+        "chatwoot_deployments",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  test("the arg never reaches the provider, and an invented one still books nothing but answers", async () => {
+    const fake = fakeHosts();
+    const sent: Array<[number, string]> = [];
+    try {
+      const outcome = await runAgentTurn({
+        tenantId,
+        instanceId,
+        agentBotId: 9,
+        event: incoming(801),
+        base: appDb,
+        deps: {
+          makeClient: stubClient(sent),
+          checkpointer: new MemorySaver(),
+        },
+      });
+      expect(outcome).toBe("posted");
+    } finally {
+      fake.restore();
+    }
+
+    // 1. The model sent a calendarId that is not a calendar, and the pinned one was queried anyway.
+    expect(fake.google).toHaveLength(1);
+    expect(fake.google[0]?.url).toContain("/freeBusy");
+    expect(fake.google[0]?.body).toMatchObject({ items: [{ id: PINNED }] });
+
+    // 2. What the model read back is availability, not a refusal.
+    const followUp = fake.llm[1]?.body.messages as Array<
+      Record<string, unknown>
+    >;
+    const toolReply = followUp?.find((m) => m.role === "tool");
+    expect(String(toolReply?.content)).toContain("slots");
+    expect(String(toolReply?.content)).not.toContain("not allowed");
+
+    // 3. The customer got the answer.
+    expect(sent).toEqual([[801, REPLY]]);
+
+    // 4. And the arg the model filled in was never on the wire to begin with.
+    const fn = toolOnTheWire(fake.llm[0]);
+    expect(fn).not.toBeNull();
+    const params = fn?.parameters as { properties?: Record<string, unknown> };
+    expect(Object.keys(params?.properties ?? {})).not.toContain("calendarId");
+  });
+});

--- a/tests/modules/toolpacks-google-calendar.test.ts
+++ b/tests/modules/toolpacks-google-calendar.test.ts
@@ -242,10 +242,9 @@ describe("google calendar toolpack — credential + calendar binding", () => {
 });
 
 // A support report: an integration with ONE allowed calendar, and the agent calling availability with
-// calendarId set to a string that is not a calendar at all (the operator's own wording for the
-// integration, which never reaches the runtime — the model read it in the prompt). The tool refused,
-// and only omitting the arg worked. The arg was offered with no hint of a valid value, because the
-// <allowed_calendars> block is deliberately suppressed when there is nothing to choose.
+// calendarId set to a string that is not a calendar at all. The tool refused, and only omitting the
+// arg worked. The arg was offered with no hint of a valid value, because the <allowed_calendars> block
+// is deliberately suppressed when there is nothing to choose.
 describe("google calendar toolpack — a single allowed calendar is pinned", () => {
   const PINNED = "clinic@group.calendar.google.com";
   const ONE = {
@@ -279,7 +278,11 @@ describe("google calendar toolpack — a single allowed calendar is pinned", () 
   });
 
   test("availability: an invented calendarId is dropped, not refused", async () => {
-    const { impl, calls } = stubFetch(200, { calendars: {} });
+    // Google keys the freeBusy response by the calendar it was asked about, so the stub answers for
+    // the pinned one: a response keyed by the invented name would be a fixture the API cannot produce.
+    const { impl, calls } = stubFetch(200, {
+      calendars: { [PINNED]: { busy: [] } },
+    });
     const out = (await toolFor(
       "calendar_check_availability",
       ONE,

--- a/tests/modules/toolpacks-google-calendar.test.ts
+++ b/tests/modules/toolpacks-google-calendar.test.ts
@@ -212,11 +212,13 @@ describe("google calendar toolpack — credential + calendar binding", () => {
     );
   });
 
+  // Several allowed calendars is the ONLY case where this boundary exists: with a single one the arg
+  // is not even exposed (see the pinned-calendar suite below), so there is no value to fence.
   test("a calendarId arg outside the allowlist is rejected, no fetch (injection boundary)", async () => {
     const { impl, calls } = stubFetch(200, { items: [] });
     const out = (await toolFor(
       "calendar_list_events",
-      { calendarIds: ["a@g.com"] },
+      { calendarIds: ["a@g.com", "b@g.com"] },
       baseCtx({ fetchImpl: impl }),
     )?.invoke({ calendarId: "evil@g.com" })) as string;
     expect(out).toContain("not allowed");
@@ -236,6 +238,88 @@ describe("google calendar toolpack — credential + calendar binding", () => {
     expect(calls[0]?.url).toContain(
       `/calendars/${encodeURIComponent("a@g.com")}/events`,
     );
+  });
+});
+
+// A support report: an integration with ONE allowed calendar, and the agent calling availability with
+// calendarId set to a string that is not a calendar at all (the operator's own wording for the
+// integration, which never reaches the runtime — the model read it in the prompt). The tool refused,
+// and only omitting the arg worked. The arg was offered with no hint of a valid value, because the
+// <allowed_calendars> block is deliberately suppressed when there is nothing to choose.
+describe("google calendar toolpack — a single allowed calendar is pinned", () => {
+  const PINNED = "clinic@group.calendar.google.com";
+  const ONE = {
+    calendarIds: [PINNED],
+    calendarLabels: { [PINNED]: "Clinic" },
+  };
+  const SEVERAL = {
+    calendarIds: [PINNED, "second@group.calendar.google.com"],
+    calendarLabels: { [PINNED]: "Clinic" },
+  };
+  // What a model with no valid value in sight fills the optional arg with.
+  const INVENTED = "My Calendar Integration";
+  const EVERY_TOOL = googleCalendarToolpack.toolSpecs.map((s) => s.name);
+
+  function argsOf(tool: { schema: unknown } | undefined): string[] {
+    const shape = (tool?.schema as { shape?: Record<string, unknown> })?.shape;
+    return Object.keys(shape ?? {});
+  }
+
+  test("no tool offers a calendarId arg: there is nothing to pick", () => {
+    expect(EVERY_TOOL).toHaveLength(6);
+    for (const name of EVERY_TOOL) {
+      expect(argsOf(toolFor(name, ONE, baseCtx()))).not.toContain("calendarId");
+    }
+  });
+
+  test("with several allowed calendars every tool keeps the arg", () => {
+    for (const name of EVERY_TOOL) {
+      expect(argsOf(toolFor(name, SEVERAL, baseCtx()))).toContain("calendarId");
+    }
+  });
+
+  test("availability: an invented calendarId is dropped, not refused", async () => {
+    const { impl, calls } = stubFetch(200, { calendars: {} });
+    const out = (await toolFor(
+      "calendar_check_availability",
+      ONE,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      timeMin: "2099-06-22T00:00:00-03:00",
+      timeMax: "2099-06-22T23:59:00-03:00",
+      calendarId: INVENTED,
+    })) as string;
+    expect(out).not.toContain("not allowed");
+    expect(calls[0]?.url).toContain("/freeBusy");
+    expect(bodyOf(calls[0] as { init: RequestInit })).toMatchObject({
+      items: [{ id: PINNED }],
+    });
+  });
+
+  test("list: an invented calendarId is dropped, not refused", async () => {
+    const { impl, calls } = stubFetch(200, { items: [] });
+    const out = (await toolFor(
+      "calendar_list_events",
+      ONE,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({ calendarId: INVENTED })) as string;
+    expect(out).not.toContain("not allowed");
+    expect(calls[0]?.url).toContain(
+      `/calendars/${encodeURIComponent(PINNED)}/events`,
+    );
+  });
+
+  test("the description names the pinned calendar instead of listing options", () => {
+    const pinned = toolFor("calendar_check_availability", ONE, baseCtx());
+    expect(pinned?.description).toContain(`<active_calendar name="Clinic"`);
+    expect(pinned?.description).toContain(`id="${PINNED}"`);
+    expect(pinned?.description).not.toContain("<allowed_calendars>");
+  });
+
+  test("with several allowed calendars the description still lists them", () => {
+    const many = toolFor("calendar_check_availability", SEVERAL, baseCtx());
+    expect(many?.description).toContain("<allowed_calendars>");
+    expect(many?.description).not.toContain("<active_calendar");
   });
 });
 


### PR DESCRIPTION
Fixes #97

## What was broken

`calendarIds` with exactly one entry is the common shape (one clinic, one calendar). In that shape the
six Calendar tools kept `calendarId` in the schema handed to the model, while `allowedCalendarsXml`
suppressed the `<allowed_calendars>` block precisely because there was nothing to choose. The model
therefore saw an optional argument and no valid value anywhere in its context, filled it with a
plausible string, and `pickCalendarId` refused on the only calendar it could have used. Omitting the
argument worked, which is how it was diagnosed in the first place.

The refusal was correct by the rules and useless in practice: with a single allowed calendar there is
no second destination to fence, and the auto-selection path was already tested.

## The change

One condition, `allowed.length === 1` (`pinnedCalendarId`), now governs both faces of the interface the
model sees:

| allowed calendars | schema handed to the model | block appended to the description |
| --- | --- | --- |
| 0 | keeps `calendarId` (unchanged) | none; the tool refuses at invoke time (unchanged) |
| 1 | **`calendarId` removed** | **`<active_calendar name id/>`** |
| 2+ | keeps `calendarId` (unchanged) | `<allowed_calendars>` (unchanged) |

`pickCalendarId` is untouched. Two consequences worth stating:

- a residual `calendarId` (a key copied from an earlier turn in the thread, a direct call) is stripped
  by zod before the tool body runs, so the pinned calendar is used either way and there is no second
  tolerance rule to keep in sync;
- the injection boundary now lives only where it means something. The existing test for it was written
  with a **single** allowed calendar, so it proved a refusal that protected nothing; it now uses two.

`CALENDAR_ID_DESC` also stopped claiming the arg is optional. It is only ever exposed when several
calendars are allowed, and then one of them must be named or `pickCalendarId` refuses. The trailing
sentence about the single-calendar case is aimed at the operator reading the arg list in the console,
which is per-catalog and always shows the field.

## Validation scope

**Unit** (`tests/modules/toolpacks-google-calendar.test.ts`, hermetic, runs in CI):

- none of the six tools offers `calendarId` with one allowed calendar; all six keep it with two;
- availability and list with an invented `calendarId` reach the pinned calendar instead of refusing;
- the description names the pinned calendar, and still lists options when there are several.

**Mutation** (the rule, not just the path): dropping `pinnedCalendarId` fails 4 tests, making
`calendarArgSchema` a no-op fails 3, and *widening* the rule to `allowed.length >= 1` fails 5,
including the injection boundary.

**End to end** (`tests/graph/calendar-pinned-calendar-turn.test.ts`, DB-backed, `skipIf` without a
database, so it is skipped in this CI and was run locally): a real turn through
`loadAgentConfig` → `buildToolpackTools`, with a stubbed OpenAI-shaped provider and a stubbed
`freeBusy`. It asserts, in this order, that the pinned calendar was queried, that what the model read
back was slots rather than a refusal, that the customer received the answer, and only then that the
argument was never on the wire. With the rule dead the first assertion already fails: no Google request
happens at all, which is exactly the reported symptom.

**Live** (local instance, real integration rows, one allowed calendar): the tool built from the stored
config offers `timeMin, timeMax, slotDurationMinutes, granularityMinutes` and no `calendarId`, its
description ends with `<active_calendar …/>`, and an invocation carrying an invented `calendarId`
reaches Google (HTTP 401 from the local stub credential) instead of refusing. Reverting the rule on the
same config reproduces the old refusal verbatim.

**Not validated**: no run against a live Google account with several allowed calendars — that path is
unchanged by this PR and covered by unit tests only.
