### PR TITLE
fix(followups): re-arm the agents the RLS-blocked backfill missed

### DIFF
--- a/prisma/migrations/20260818120000_followup_armed_at_backfill_rls/migration.sql
+++ b/prisma/migrations/20260818120000_followup_armed_at_backfill_rls/migration.sql
@@ -1,0 +1,25 @@
+-- Re-arm the agents the 20260807032257 backfill silently missed.
+--
+-- That migration ended in a bare `UPDATE "agents" SET "follow_up_armed_at" = NOW()`. `agents`
+-- carries FORCE ROW LEVEL SECURITY, so `tenant_isolation` applies to the table OWNER as well; only
+-- a superuser (or a BYPASSRLS role) is exempt. docs/deploy.md allows MIGRATION_DATABASE_URL to be
+-- "superuser OR DB owner", and on managed Postgres the administrative role is typically the owner
+-- WITHOUT rolsuper. There the statement matched zero rows and reported success: no error, no
+-- warning, migrate deploy green. Every agent that existed before that deploy kept a null watermark,
+-- which conversations/service.ts reads as "not armed", and since the column gates sequence STARTS,
+-- no follow-up ever fires on that install (issue #106).
+--
+-- The GUC is the same escape hatch the app's own asSuperAdmin() path uses, and docs/deploy.md
+-- (#105) makes it the rule for any DATA migration over a tenant-scoped table. Plain SET rather than
+-- SET LOCAL: outside a transaction SET LOCAL is a no-op with only a warning, which would reproduce
+-- the very failure this migration exists to repair.
+SET app.is_super_admin = 'on';
+
+-- Idempotent by construction. An install where the original backfill DID work is untouched, and so
+-- is any agent armed since by the app's OFF→ON transition. Re-arming an already-armed agent would
+-- move its watermark forward, and the watermark is what keeps the sweep off the historical backlog.
+-- NOW() (transaction start) is the conservative value: it admits only episodes of silence that
+-- begin after this deploy, which is the semantics the column was introduced with.
+UPDATE "agents" SET "follow_up_armed_at" = NOW() WHERE "follow_up_armed_at" IS NULL;
+
+RESET app.is_super_admin;

--- a/tests/modules/followup-armed-backfill.test.ts
+++ b/tests/modules/followup-armed-backfill.test.ts
@@ -90,6 +90,8 @@ describe.skipIf(!dbUp)("follow_up_armed_at backfill under RLS", () => {
     if (!dbUp) return;
     await suDb.agent.deleteMany({ where: { tenantId } });
     await suDb.tenant.delete({ where: { id: tenantId } });
+    await suDb.$disconnect();
+    await appDb.$disconnect();
   });
 
   test("arms the agents the original backfill left behind", async () => {

--- a/tests/modules/followup-armed-backfill.test.ts
+++ b/tests/modules/followup-armed-backfill.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+
+// The original `follow_up_armed_at` backfill (20260807032257) ends in a bare
+// `UPDATE "agents" SET "follow_up_armed_at" = NOW()`. `agents` carries FORCE ROW LEVEL SECURITY,
+// which subjects even the table OWNER to `tenant_isolation`; only a superuser (or BYPASSRLS) is
+// exempt. On managed Postgres the migration role is typically the owner WITHOUT rolsuper, so that
+// statement matched zero rows and reported success — leaving every pre-existing agent with a null
+// watermark, which the sweep reads as "never armed" and skips forever (issue #106).
+//
+// This suite runs the follow-up migration through the APP connection, which is a non-superuser
+// role with RLS in force — the same conditions the affected installs migrate under. Running it as
+// the suite's superuser would prove nothing: the bare UPDATE works there, which is exactly why the
+// defect shipped unnoticed.
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const MIGRATION_SQL =
+  "prisma/migrations/20260818120000_followup_armed_at_backfill_rls/migration.sql";
+
+// Statements in file order, comments stripped. They must run on ONE connection: the GUC the
+// backfill sets is session state, so splitting them across the pool would arm nothing.
+async function migrationStatements(): Promise<string[]> {
+  return (await Bun.file(MIGRATION_SQL).text())
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("--"))
+    .join("\n")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+describe.skipIf(!dbUp)("follow_up_armed_at backfill under RLS", () => {
+  let tenantId = 0n;
+  let strandedId = 0n;
+  let alreadyArmedId = 0n;
+  const armedLongAgo = new Date("2026-01-01T00:00:00.000Z");
+
+  beforeAll(async () => {
+    const tenant = await suDb.tenant.create({
+      data: { name: "ARM", slug: `arm-${process.pid}` },
+    });
+    tenantId = tenant.id;
+    // The agent an affected install is left with: created before the deploy, never armed.
+    const stranded = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "stranded",
+        systemPrompt: "p",
+        followUpArmedAt: null,
+      },
+    });
+    strandedId = stranded.id;
+    // An install where the original backfill DID work, or an agent armed later by the app. A
+    // re-run must not move its watermark: re-arming would re-open the historical backlog the
+    // column exists to fence off.
+    const armed = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "already armed",
+        systemPrompt: "p",
+        followUpArmedAt: armedLongAgo,
+      },
+    });
+    alreadyArmedId = armed.id;
+  });
+
+  afterAll(async () => {
+    if (!dbUp) return;
+    await suDb.agent.deleteMany({ where: { tenantId } });
+    await suDb.tenant.delete({ where: { id: tenantId } });
+  });
+
+  test("arms the agents the original backfill left behind", async () => {
+    const statements = await migrationStatements();
+    await appDb.$transaction(statements.map((s) => appDb.$executeRawUnsafe(s)));
+
+    const stranded = await suDb.agent.findUniqueOrThrow({
+      where: { id: strandedId },
+    });
+    expect(stranded.followUpArmedAt).not.toBeNull();
+  });
+
+  test("leaves an already-armed agent's watermark untouched", async () => {
+    const armed = await suDb.agent.findUniqueOrThrow({
+      where: { id: alreadyArmedId },
+    });
+    expect(armed.followUpArmedAt?.toISOString()).toBe(
+      armedLongAgo.toISOString(),
+    );
+  });
+});


### PR DESCRIPTION
## What was broken

The `follow_up_armed_at` backfill (`20260807032257`) ends in a bare statement:

```sql
UPDATE "agents" SET "follow_up_armed_at" = NOW();
```

`agents` carries `FORCE ROW LEVEL SECURITY`, which subjects even the table OWNER to the `tenant_isolation` policy; only a superuser (or a `BYPASSRLS` role) is exempt. `docs/deploy.md` documents `MIGRATION_DATABASE_URL` as "superuser **or** DB owner", and on managed Postgres (RDS, Neon, Supabase, several panel-managed setups) the administrative role is typically the owner **without** `rolsuper`.

On those installs the statement matches zero rows and reports success: no error, no warning, `migrate deploy` green.

That is not cosmetic. `conversations/service.ts` reads a null `followUpArmedAt` as "not armed", and the column gates sequence STARTS, so **no agent that existed before that deploy ever starts a follow-up sequence**, indefinitely. It fails safe and silently, which is why it would never arrive as a bug report: the operator sees follow-ups configured, enabled, and simply never firing, with nothing in the logs.

## Measured, not inferred

Reproduced against a live database, in a rolled-back transaction, with `agents` owned by a role created `NOSUPERUSER NOBYPASSRLS` — the shape of an affected install:

```
>>> owner, not superuser, the exact statement the migration runs:
UPDATE 0
>>> the same statement with the super-admin escape:
UPDATE 1
```

## The fix

A follow-up migration wrapped in the GUC the app's own `asSuperAdmin()` path uses, which `docs/deploy.md` (#105) already makes the rule for any DATA migration over a tenant-scoped table.

Two details that are load-bearing:

- **`WHERE "follow_up_armed_at" IS NULL`** — an install whose original backfill DID work keeps its watermark, and so does any agent armed since by the app's OFF→ON transition. Re-arming would move the watermark forward, and the watermark is what keeps the sweep off the historical backlog.
- **`SET`, not `SET LOCAL`** — outside a transaction `SET LOCAL` is a no-op with only a warning, which would reproduce the very failure being repaired.

Arming an agent whose follow-up is switched off is harmless: the sweep does not admit it, and the app re-stamps the watermark when the operator turns follow-up on.

## Validation scope

**Proved by test** (`tests/modules/followup-armed-backfill.test.ts`, DB-backed):

- an agent left with a null watermark is armed by the migration;
- an already-armed agent's watermark is untouched by a re-run.

The suite runs the migration through the **app connection** — a non-superuser role with RLS in force, the condition affected installs migrate under. Running it as the suite's superuser would prove nothing: the bare `UPDATE` works there, which is exactly why the defect shipped unnoticed.

**Mutation-checked**, one rule at a time:

| mutation | tests that fail |
|---|---|
| remove `SET app.is_super_admin = 'on'` | 1 (the agent is never armed) |
| remove `WHERE ... IS NULL` | 1 (the armed watermark moves) |

**Not validated:** how many installs are affected — unknowable from here. A self-hosted Postgres whose migration role is a real superuser was never affected, and this migration is a no-op there.

Fixes #106
