### PR TITLE
fix(integrations): authenticate the Asaas webhook by the header Asaas sends

### DIFF
--- a/src/modules/integrations/catalog.ts
+++ b/src/modules/integrations/catalog.ts
@@ -14,6 +14,10 @@ export const CATALOG: ReadonlyArray<CatalogEntry> = [
       "Brazilian payments. Outbound toolpack (payment links + PIX charges) plus the inbound payment webhook: when a charge is paid, the agent is woken on the conversation that generated it and decides whether to notify the customer.",
     supportsInbound: true,
     defaultInboundAuth: "STATIC_HEADER",
+    // Asaas sends the webhook's authentication token in `asaas-access-token` and the name is not
+    // configurable in their panel, so comparing against our generic default rejected every
+    // delivery (issue #107).
+    inboundAuthHeader: "asaas-access-token",
   },
   {
     catalogType: "GOOGLE_CALENDAR",

--- a/src/modules/integrations/types.ts
+++ b/src/modules/integrations/types.ts
@@ -56,4 +56,8 @@ export interface CatalogEntry {
   // NOTE: suggested default for the UI when an operator first enables the integration; the
   // instance can override. The actual gate is per-instance (inboundAuthStrategy column).
   defaultInboundAuth: InboundAuthStrategy;
+  // NOTE: the header THIS provider sends its static token in, when it fixes one. Absent ⇒ the
+  // generic default. This is not a preference: a provider that hardcodes its header name leaves the
+  // operator nothing to configure on their side, so the convention has to live here (issue #107).
+  inboundAuthHeader?: string;
 }

--- a/src/modules/webhooks/inbound/auth.ts
+++ b/src/modules/webhooks/inbound/auth.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { InboundAuthStrategy } from "@/../generated/prisma/client";
+import { getCatalogEntry } from "@/modules/integrations/catalog";
 
 // Per-instance inbound auth, verified AFTER the route token has resolved the tenant (so the
 // secret read is tenant-scoped and a bad signature for a real token still fails uniformly).
@@ -12,6 +13,29 @@ export const DEFAULT_SIGNATURE_HEADER = "x-webhook-signature";
 export interface InboundAuthConfig {
   authHeader?: string;
   signatureHeader?: string;
+}
+
+// Which header carries the credential for this instance. Precedence, most specific first: the
+// operator's per-instance override, then the provider's own convention from the catalog, then our
+// generic default. The middle layer is the one issue #107 was missing — a provider that fixes its
+// header name (Asaas: `asaas-access-token`) leaves the operator nothing to change on their side, so
+// the generic default rejected every delivery and the failure was visible only in the provider's
+// own queue.
+export function resolveInboundAuthConfig(
+  catalogType: string,
+  config: Record<string, unknown>,
+): Required<InboundAuthConfig> {
+  const entry = getCatalogEntry(catalogType);
+  const override = (v: unknown): string | undefined =>
+    typeof v === "string" && v.length > 0 ? v : undefined;
+  return {
+    authHeader:
+      override(config.authHeader) ??
+      entry?.inboundAuthHeader ??
+      DEFAULT_STATIC_HEADER,
+    signatureHeader:
+      override(config.signatureHeader) ?? DEFAULT_SIGNATURE_HEADER,
+  };
 }
 
 function timingEqual(a: string, b: string): boolean {

--- a/src/modules/webhooks/inbound/service.ts
+++ b/src/modules/webhooks/inbound/service.ts
@@ -16,7 +16,7 @@ import type {
   NormalizedInboundEvent,
 } from "@/modules/integrations/types";
 import { tryResolveVaultSecret } from "@/modules/vault/service";
-import { verifyInboundAuth } from "./auth";
+import { resolveInboundAuthConfig, verifyInboundAuth } from "./auth";
 
 // Generic inbound receptor. Resolve tenant by route token → verify the per-instance auth
 // strategy (tenant-scoped secret) → normalize via the integration's pure mapper → persist an
@@ -90,10 +90,7 @@ export async function receiveInbound(
     secret,
     rawBody: params.rawBody,
     getHeader: params.getHeader,
-    config: {
-      authHeader: asString(route.config.authHeader),
-      signatureHeader: asString(route.config.signatureHeader),
-    },
+    config: resolveInboundAuthConfig(route.catalogType, route.config),
   });
   if (!authOk) throw new UnauthorizedError();
 

--- a/tests/modules/inbound-receptor.test.ts
+++ b/tests/modules/inbound-receptor.test.ts
@@ -7,6 +7,7 @@ import { createIntegrationInstance } from "@/modules/integrations/service";
 import {
   DEFAULT_SIGNATURE_HEADER,
   DEFAULT_STATIC_HEADER,
+  resolveInboundAuthConfig,
   verifyInboundAuth,
 } from "@/modules/webhooks/inbound/auth";
 import {
@@ -27,6 +28,75 @@ describe("inbound route token", () => {
     expect(a.hash).toBe(hashRouteToken(a.token));
     expect(a.hash).toMatch(/^[0-9a-f]{64}$/);
   });
+});
+
+// The header Asaas fixes on its side; the operator cannot change it in the Asaas panel.
+const ASAAS_STATIC_HEADER = "asaas-access-token";
+
+// ── which header carries the token (unit, decision table) ──
+// Precedence, most specific first: the operator's per-instance override, then the provider's own
+// convention from the catalog, then our generic default. The catalog layer is what issue #107 was
+// missing: Asaas fixes `asaas-access-token` on its side and the operator cannot change it there, so
+// without it every Asaas delivery was compared against a header Asaas never sends.
+describe("inbound auth header resolution", () => {
+  const cases: Array<{
+    name: string;
+    catalogType: string;
+    config: Record<string, unknown>;
+    authHeader: string;
+    signatureHeader: string;
+  }> = [
+    {
+      name: "Asaas falls back to the header Asaas actually sends",
+      catalogType: "ASAAS",
+      config: {},
+      authHeader: "asaas-access-token",
+      signatureHeader: DEFAULT_SIGNATURE_HEADER,
+    },
+    {
+      name: "a per-instance override beats the catalog convention",
+      catalogType: "ASAAS",
+      config: { authHeader: "x-custom" },
+      authHeader: "x-custom",
+      signatureHeader: DEFAULT_SIGNATURE_HEADER,
+    },
+    {
+      name: "a catalog entry without a convention keeps the generic default",
+      catalogType: "GOOGLE_CALENDAR",
+      config: {},
+      authHeader: DEFAULT_STATIC_HEADER,
+      signatureHeader: DEFAULT_SIGNATURE_HEADER,
+    },
+    {
+      name: "an unknown catalogType keeps the generic default",
+      catalogType: "NOT_IN_THE_CATALOG",
+      config: {},
+      authHeader: DEFAULT_STATIC_HEADER,
+      signatureHeader: DEFAULT_SIGNATURE_HEADER,
+    },
+    {
+      name: "a non-string override is ignored rather than trusted",
+      catalogType: "ASAAS",
+      config: { authHeader: 42 },
+      authHeader: "asaas-access-token",
+      signatureHeader: DEFAULT_SIGNATURE_HEADER,
+    },
+    {
+      name: "the signature header is overridable per instance too",
+      catalogType: "ASAAS",
+      config: { signatureHeader: "x-sig" },
+      authHeader: "asaas-access-token",
+      signatureHeader: "x-sig",
+    },
+  ];
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(resolveInboundAuthConfig(c.catalogType, c.config)).toEqual({
+        authHeader: c.authHeader,
+        signatureHeader: c.signatureHeader,
+      });
+    });
+  }
 });
 
 // ── auth strategies (unit) ──
@@ -408,19 +478,32 @@ describe.skipIf(!dbUp)("inbound receptor", () => {
       payment: { id: "n1", status: "OVERDUE" },
     });
 
+    // The right header, the wrong value.
     await expect(
       receiveInbound({
         routeToken: routeToken as string,
         rawBody: body,
-        getHeader: headersFrom({ [DEFAULT_STATIC_HEADER]: "WRONG" }),
+        getHeader: headersFrom({ [ASAAS_STATIC_HEADER]: "WRONG" }),
         base: appDb,
       }),
     ).rejects.toMatchObject({ statusCode: 401 });
 
+    // The right value in the GENERIC header. Asaas never sends this one, so accepting it would
+    // mean the instance authenticates something Asaas cannot produce (issue #107).
+    await expect(
+      receiveInbound({
+        routeToken: routeToken as string,
+        rawBody: body,
+        getHeader: headersFrom({ [DEFAULT_STATIC_HEADER]: "T0KEN" }),
+        base: appDb,
+      }),
+    ).rejects.toMatchObject({ statusCode: 401 });
+
+    // What Asaas actually delivers: its token, in its own header.
     const ok = await receiveInbound({
       routeToken: routeToken as string,
       rawBody: body,
-      getHeader: headersFrom({ [DEFAULT_STATIC_HEADER]: "T0KEN" }),
+      getHeader: headersFrom({ [ASAAS_STATIC_HEADER]: "T0KEN" }),
       base: appDb,
     });
     expect(ok.outcome).toBe("queued");


### PR DESCRIPTION
## What was broken

The catalog ships Asaas with `defaultInboundAuth: "STATIC_HEADER"`, so an operator enabling the payment webhook from the console gets that strategy preselected. The receptor then compared the token against `x-webhook-token`, our generic default:

```ts
export const DEFAULT_STATIC_HEADER = "x-webhook-token";
// …
const headerName = config?.authHeader ?? DEFAULT_STATIC_HEADER;
```

Asaas sends the webhook's authentication token in **`asaas-access-token`**, and the name is fixed on their side — there is nothing for the operator to change in the Asaas panel. So every delivery was rejected with 401. Asaas has also made that token mandatory (webhooks can no longer be created without one), so `NONE` is not a clean way out: it drops the only per-instance factor and leaves the route token alone on the door.

The header name was only reachable through `instance.config.authHeader`, and nothing in the product put it there:

- the console exposes the strategy and the secret ref, not the header name;
- the MCP `integration_update` description documents the `config` shape for `GOOGLE_CALENDAR` and `GOOGLE_DRIVE`, and says nothing about `ASAAS`;
- no default existed per catalog entry, and no test covered a non-default header.

The comment above the constant already named Asaas as the reason the field is overridable at all, so what was missing was the value, not the mechanism.

**Why nobody reported it as a 401:** the receptor answers before persisting anything, deliberately, so an unknown token and a bad secret collapse into the same response. From our side an install in this state is indistinguishable from one receiving no traffic. The only trace is in the Asaas webhook queue, and the operator experiences it as "payments are only confirmed when the agent polls" — the latency the inbound path exists to remove.

## The fix

A catalog entry can now declare the header its provider fixes, and the resolution is a pure function stating the precedence once: **per-instance override → the provider's convention → the generic default**.

One existing test had to change, and the change is part of the point: `enforces STATIC_HEADER auth after resolving the tenant` authenticated an `ASAAS` instance using the generic header, which is a request Asaas cannot produce. It now asserts the opposite, next to the header Asaas really sends.

## Validation scope

**Proved by test:**

- a decision table over the resolution (6 rows): the Asaas fallback, the per-instance override winning, a catalog entry with no convention, an unknown `catalogType`, a non-string override that must not be trusted, and the signature header staying overridable;
- end to end through `receiveInbound` on a real `ASAAS` instance: right header with the wrong value → 401, **right value in the generic header → 401**, and the token in `asaas-access-token` → `queued`.

**Mutation-checked**, one rule at a time:

| mutation | tests that fail |
|---|---|
| drop the catalog layer from the resolution | 4 |
| let the catalog beat the per-instance override | 1 |
| trust a non-string override | 1 |

**Not validated:** a real delivery from Asaas. That needs a sandbox account plus a public URL for their webhook to reach, and neither is available here. What is verified is that the header name we compare against is the one Asaas documents sending; the end-to-end proof would be the natural first check on a live instance after this ships.

**Deliberately not in scope**, both listed as options in the issue: exposing the header in the console, and documenting the `ASAAS` config shape in the MCP tool description. Both lose their urgency once the default is right, since the field is no longer needed on the common path.

Fixes #107
