### PR TITLE
fix(asaas): a config override can no longer clobber the correlation token

### DIFF
--- a/src/modules/integrations/toolpacks/asaas.ts
+++ b/src/modules/integrations/toolpacks/asaas.ts
@@ -194,11 +194,15 @@ function buildCreateLinkTool(
         name: input.name ?? input.description ?? "Pagamento",
         ...(input.description ? { description: input.description } : {}),
         value: input.value,
-        externalReference: correlationId,
         // Required by Asaas for DETACHED links (sandbox-confirmed 2026-06): business days the link
         // stays payable. Overridable via config.paymentLink.
         dueDateLimitDays: 3,
         ...overrides,
+        // Last: a config override must NOT clobber the correlation token. externalReference is the
+        // field Asaas offers for the merchant's own identifier, so an operator stamping an ERP id
+        // in config.paymentLink is the expected use of that map — and it used to win, leaving the
+        // paid webhook with nothing to tie back to the conversation (issue #108).
+        externalReference: correlationId,
       };
 
       let res: AsaasResponse;

--- a/tests/modules/toolpacks-asaas.test.ts
+++ b/tests/modules/toolpacks-asaas.test.ts
@@ -488,6 +488,57 @@ describe.skipIf(!dbUp)("asaas toolpack — correlation ref persistence", () => {
     expect(mapped.event.externalId).toBe(externalReference);
   });
 
+  test("an operator's config.paymentLink cannot clobber the correlation token", async () => {
+    const { impl, calls } = stubFetch(200, {
+      id: "plink_43",
+      url: "https://sandbox.asaas.com/i/def",
+    });
+    const threadId = `${tenantId}:1:778`;
+    const tool = asaasToolpack.build(
+      sel({
+        instanceId,
+        enabledTools: ["asaas_payment_link_create"],
+        config: {
+          environment: "sandbox",
+          // externalReference is the field Asaas offers for the merchant's OWN identifier, so an
+          // ERP/CRM id is the most plausible thing an operator puts in this map. It used to win
+          // over ours, and the payment then arrived uncorrelated to any conversation (issue #108).
+          paymentLink: {
+            externalReference: "ERP-1234",
+            billingType: "CREDIT_CARD",
+          },
+        },
+      }),
+      baseCtx({ tenantId, base: appDb, threadId, fetchImpl: impl }),
+    )[0];
+
+    await tool?.invoke({ value: 50, description: "Consulta" });
+
+    const body = JSON.parse(calls[0]?.init.body as string) as Record<
+      string,
+      unknown
+    >;
+    // The override still governs everything that is not load-bearing.
+    expect(body.billingType).toBe("CREDIT_CARD");
+    // The correlation token is not negotiable.
+    const externalReference = body.externalReference as string;
+    expect(externalReference).toMatch(/^[0-9a-f]{32}$/);
+    expect(externalReference).not.toBe("ERP-1234");
+
+    // What the token buys: the payment webhook still lands on THIS conversation.
+    const ref = await suDb.integrationExternalRef.findFirst({
+      where: { tenantId, externalId: externalReference },
+      select: { threadId: true },
+    });
+    expect(ref?.threadId).toBe(threadId);
+    const mapped = getMapper("ASAAS")?.map({
+      event: "PAYMENT_RECEIVED",
+      payment: { id: "pay_100", externalReference, status: "RECEIVED" },
+    });
+    if (!mapped?.ok) throw new Error("expected a mapped inbound event");
+    expect(mapped.event.externalId).toBe(externalReference);
+  });
+
   test("pix charge persists the correlation ref keyed by externalReference (metadata.paymentId)", async () => {
     const { impl, calls } = scriptedFetch([
       {


### PR DESCRIPTION
## What was broken

`asaas_payment_link_create` spread the operator's `config.paymentLink` map **after** the correlation token, so a config key named `externalReference` won over ours:

```ts
const body = {
  // …
  externalReference: correlationId,
  dueDateLimitDays: 3,
  ...overrides,          // ← wins
};
```

The sibling PIX tool in the same file already orders the body the other way, with the reason spelled out (`// Last: a config override must NOT clobber the correlation token.`). The protection was deliberate there and simply absent here.

`externalReference` is not an arbitrary key we happen to use: it is the opaque token that ties a payment back to a conversation. The toolpack sends it to Asaas and stores it as `IntegrationExternalRef.externalId`; the inbound mapper reads it back **preferentially over `payment.id`**, because a link-generated payment carries a different id than the link.

Overwrite it and the chain breaks at the last step: the link is created, the customer pays, Asaas delivers the webhook, the mapper normalizes it, and the correlation lookup finds nothing. The delivery is dropped with an info log (`inbound conversion uncorrelated (source=…); dropping`) and the agent is never woken on the conversation that generated the charge.

Every visible signal says success — a working payment link, a paid charge, a 200 on the webhook — and the only trace is one info line.

## Why fix rather than document

`externalReference` is the field Asaas offers for the merchant's own identifier, so stamping an ERP or CRM id there is the single most plausible thing an operator puts in that config map. The config is an arbitrary map on the REST/MCP surface with no reserved-key validation, so nothing warns them.

## Validation scope

**Proved by test** (`tests/modules/toolpacks-asaas.test.ts`, DB-backed): with `config.paymentLink` carrying both `externalReference: "ERP-1234"` and `billingType: "CREDIT_CARD"`, the assertion covers the whole loop rather than the request body alone:

- the override still governs `billingType` (the feature is intact);
- the token in the body is ours, and is not the operator's value;
- the persisted `IntegrationExternalRef` still points at this thread;
- the inbound mapper still resolves the same `externalId` from a `PAYMENT_RECEIVED` webhook.

Before the fix that test fails with `Received: "ERP-1234"`, which is the defect stated exactly.

**Mutation-checked:** moving `externalReference` back above the spread fails 1 test.

**Swept for the same shape elsewhere:** `...overrides` appears twice in the tree, both in this toolpack. The PIX charge was already ordered correctly. No other toolpack merges operator config into a request body.

**Not validated:** any install actually hitting this, which by construction would be invisible to us — the failure leaves an info log and no other trace.

A related hardening worth considering separately, not done here to keep the fix to its headline: rejecting or warning on reserved keys when the integration config is written, instead of letting a silent override through.

Fixes #108
