### PR TITLE
fix(editor): flag a credential whose vault entry is gone

### DIFF
--- a/src/client/components/CredentialPicker.tsx
+++ b/src/client/components/CredentialPicker.tsx
@@ -20,7 +20,7 @@ import {
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { Modal, useModalController } from "@/client/components/Modal";
 import { api } from "@/client/lib/api";
-import { formatVaultRef } from "@/client/lib/credentialRef";
+import { canonicalVaultRef, formatVaultRef } from "@/client/lib/credentialRef";
 import {
   isTestableSecretType,
   secretTypeService,
@@ -124,7 +124,8 @@ export function CredentialPicker({
   useEffect(() => {
     if (!loaded) return;
     const selected =
-      entries.find((e) => formatVaultRef(e.id) === value) ?? null;
+      entries.find((e) => formatVaultRef(e.id) === canonicalVaultRef(value)) ??
+      null;
     const notifyKey = value + (selected?.id ?? "__none__");
     if (prevNotifiedRef.current === notifyKey) return;
     prevNotifiedRef.current = notifyKey;
@@ -165,7 +166,9 @@ export function CredentialPicker({
 
   // Stored refs are always `vault:<id>`; a value with no matching entry (after load) points at a
   // removed credential → flagged "unavailable" in the trigger (never the raw id).
-  const selected = entries.find((e) => formatVaultRef(e.id) === value) ?? null;
+  const selected =
+    entries.find((e) => formatVaultRef(e.id) === canonicalVaultRef(value)) ??
+    null;
   const unresolved = !selected && !!value;
   const canTest = !!selected && isTestableSecretType(selected.kind);
   // Same compatibility rule as the list ranking: flags a selection left behind after the
@@ -255,7 +258,7 @@ export function CredentialPicker({
             {t(`vault.secretType.${e.kind}`, e.kind)}
           </span>
         )}
-        {value === formatVaultRef(e.id) && (
+        {canonicalVaultRef(value) === formatVaultRef(e.id) && (
           <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
         )}
       </DropdownMenuPrimitive.Item>
@@ -495,7 +498,9 @@ export function CredentialPicker({
           onSaved={(ref) => {
             createModal.close();
             onChange(ref);
-            void refreshVault();
+            // A failed refresh leaves the previous list in place rather than throwing into the
+            // void: the entry was already saved, and the vault-changed listeners re-read anyway.
+            refreshVault().catch(() => undefined);
           }}
           onCancel={() => createModal.close()}
         />
@@ -514,7 +519,9 @@ export function CredentialPicker({
             // Clear the notify guard so onEntryChange re-fires with the updated entry once the
             // refreshed list arrives (via the vault-changed listener above).
             prevNotifiedRef.current = null;
-            void refreshVault();
+            // A failed refresh leaves the previous list in place rather than throwing into the
+            // void: the entry was already saved, and the vault-changed listeners re-read anyway.
+            refreshVault().catch(() => undefined);
           }}
           onCancel={() => editModal.close()}
         />

--- a/src/client/components/CredentialPicker.tsx
+++ b/src/client/components/CredentialPicker.tsx
@@ -203,9 +203,12 @@ export function CredentialPicker({
   ]);
 
   async function testExisting() {
-    if (!value) return;
-    // value is `vault:<id>`; extract the id to call POST /:id/test.
-    const id = value.slice("vault:".length);
+    // The ENTRY's id, never the ref's own spelling: the route takes `^\d+$`, and a ref reaches this
+    // field unvalidated (`PATCH /v1/agents/:id` stores what it is handed), so `vault: 7 ` — which
+    // resolves everywhere else, including the selection above — would be refused here and the
+    // credential reported as unreachable.
+    if (!selected) return;
+    const id = selected.id;
     setTesting(true);
     setTestResult(null);
     try {

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -29,6 +29,11 @@ export interface ConfigIssue {
   pending?: boolean;
   // The pending vault entry id (parsed from the `vault:<id>` ref). Only set when `pending` is true.
   vaultId?: string;
+  // When true, the credential is referenced but the vault does not hold it: it was deleted, or the
+  // ref was written by something that does not check (REST stores it verbatim, and MCP speaks
+  // NAMES, which no resolver matches). There is nothing to fill in, so this deep-links to the field
+  // like a missing credential does.
+  unresolved?: boolean;
   // For "knowledge" issues: the base that has imported-but-unindexed documents (and its name), so the
   // editor can open that base's documents modal.
   knowledgeBaseId?: string;
@@ -65,6 +70,13 @@ export interface ConfigHealthInput {
   // Refs (`vault:<id>`) whose vault entry exists but is still pending (secret not filled in yet). A
   // feature wired to one of these is configured but cannot run until the operator fills it.
   pendingRefs?: Set<string>;
+  // Every ref the vault currently holds, so a ref that resolves to nothing can be told apart from
+  // one that resolves. `null`/absent means the list has NOT loaded, and that has to be its own value
+  // rather than an empty set: the vault arrives a request after the first paint, and an empty set
+  // would read as "nothing resolves" and flag every credential on the page for that one paint.
+  // Under-reporting for a moment is the safe direction here; over-reporting trains the operator to
+  // ignore the panel.
+  knownRefs?: Set<string> | null;
   // Knowledge bases this agent uses that still have documents awaiting indexing (status UNINDEXED),
   // e.g. right after an import that bundled the source text. Each becomes a "knowledge" issue — unless
   // the embedding prerequisite below is missing, in which case a single "embedding" issue is raised.
@@ -81,38 +93,57 @@ export interface ConfigHealthInput {
 
 const VAULT_REF_PREFIX = "vault:";
 
+// The three ways one credentialed feature can be unrunnable. Every credential ref on the agent goes
+// through this one function, all six of them: a rule that reaches half its fields is worse than no
+// rule, because the half it misses now reads as checked.
+type CredVerdict =
+  | { kind: "missing" }
+  | { kind: "pending"; vaultId: string }
+  | { kind: "unresolved" };
+
 // For one credentialed feature, decides which issue (if any) to raise:
 //   - not enabled → none;
 //   - enabled with NO ref → "missing" (the classic enabled-but-uncredentialed case);
-//   - enabled with a ref that points to a PENDING vault entry → "pending" (referenced, not filled).
+//   - enabled with a ref that points to a PENDING vault entry → "pending" (referenced, not filled);
+//   - enabled with a ref the vault does not hold → "unresolved" (deleted, or never resolvable).
+// "pending" and "unresolved" are mutually exclusive for any list-derived input, since a pending
+// entry EXISTS and is therefore also a known ref — the order below is for the reader, nothing
+// depends on it: swapping the two branches changes no test, which is why this note replaced a claim
+// that it did. What matters is that they stay separate verdicts, because the fixes differ — fill
+// the secret in place, or pick a different key.
 function credIssue(
   enabled: boolean,
   ref: string,
   pendingRefs: Set<string> | undefined,
-): { pending: boolean; vaultId?: string } | null {
+  knownRefs: Set<string> | null | undefined,
+): CredVerdict | null {
   if (!enabled) return null;
-  if (!ref) return { pending: false };
+  if (!ref) return { kind: "missing" };
   if (pendingRefs?.has(ref)) {
-    return { pending: true, vaultId: ref.slice(VAULT_REF_PREFIX.length) };
+    return { kind: "pending", vaultId: ref.slice(VAULT_REF_PREFIX.length) };
   }
+  if (knownRefs && !knownRefs.has(ref)) return { kind: "unresolved" };
   return null;
 }
 
-// Returns the list of features that are enabled but cannot run: either no credential is set
-// ("missing"), or the referenced credential is a pending vault entry whose secret is not filled yet
-// ("pending"). An OpenAI-compatible model can authenticate via its base URL alone, so it is not
-// flagged (mirrors the editor's `required={provider !== "openai-compatible"}`).
+// Returns the list of features that are enabled but cannot run: no credential is set ("missing"),
+// the referenced credential is a pending vault entry whose secret is not filled yet ("pending"), or
+// the referenced credential is not in the vault at all ("unresolved"). An OpenAI-compatible model
+// can authenticate via its base URL alone, so it is not flagged (mirrors the editor's
+// `required={provider !== "openai-compatible"}`).
 export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   const issues: ConfigIssue[] = [];
   const pending = input.pendingRefs;
-  const push = (
-    base: ConfigIssue,
-    res: { pending: boolean; vaultId?: string } | null,
-  ): void => {
+  const known = input.knownRefs;
+  const push = (base: ConfigIssue, res: CredVerdict | null): void => {
     if (!res) return;
-    issues.push(
-      res.pending ? { ...base, pending: true, vaultId: res.vaultId } : base,
-    );
+    if (res.kind === "pending") {
+      issues.push({ ...base, pending: true, vaultId: res.vaultId });
+    } else if (res.kind === "unresolved") {
+      issues.push({ ...base, unresolved: true });
+    } else {
+      issues.push(base);
+    }
   };
   push(
     { key: "model", tab: "general", sectionId: "general-model" },
@@ -122,15 +153,21 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
       ),
       input.modelCredentialRef,
       pending,
+      known,
     ),
   );
   push(
     { key: "stt", tab: "behavior", sectionId: "stt" },
-    credIssue(input.sttEnabled, input.sttCredentialRef, pending),
+    credIssue(input.sttEnabled, input.sttCredentialRef, pending, known),
   );
   push(
     { key: "tts", tab: "behavior", sectionId: "tts" },
-    credIssue(input.ttsMode !== "never", input.ttsCredentialRef, pending),
+    credIssue(
+      input.ttsMode !== "never",
+      input.ttsCredentialRef,
+      pending,
+      known,
+    ),
   );
   // The speech rewrite. Both ways it fails are SILENT at runtime (best-effort: the audio still goes
   // out, unrewritten), so the editor is the only place they surface.
@@ -169,21 +206,30 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   // is the only place they are ever seen. The issue is raised whether or not a ref is present,
   // because a present-but-unusable ref is the whole problem. A resolvable configuration can still be
   // waiting on a vault entry nobody filled in, which is the ordinary pending case.
-  const refused = normalizeResolution !== null && !normalizeResolution.runnable;
-  push(
-    { key: "ttsNormalize", tab: "behavior", sectionId: "tts" },
-    refused
-      ? { pending: false }
-      : credIssue(
-          normalizeResolution !== null &&
-            Boolean(input.ttsNormalizeCredentialRef),
-          input.ttsNormalizeCredentialRef ?? "",
-          pending,
-        ),
-  );
+  const normalizeIssue: ConfigIssue = {
+    key: "ttsNormalize",
+    tab: "behavior",
+    sectionId: "tts",
+  };
+  if (normalizeResolution !== null && !normalizeResolution.runnable) {
+    // The refusal is a verdict on the BAG, so it holds whatever the vault says and it is what the
+    // operator has to act on first. One issue, not two.
+    issues.push(normalizeIssue);
+  } else {
+    push(
+      normalizeIssue,
+      credIssue(
+        normalizeResolution !== null &&
+          Boolean(input.ttsNormalizeCredentialRef),
+        input.ttsNormalizeCredentialRef ?? "",
+        pending,
+        known,
+      ),
+    );
+  }
   push(
     { key: "vision", tab: "behavior", sectionId: "vision" },
-    credIssue(input.visionEnabled, input.visionCredentialRef, pending),
+    credIssue(input.visionEnabled, input.visionCredentialRef, pending, known),
   );
   // Knowledge bases with documents awaiting indexing. Indexing needs the tenant's embedding credential,
   // so if that prerequisite is missing we raise ONE "embedding" issue (the root cause) instead of N
@@ -192,15 +238,17 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   // the per-base "knowledge" issues (the operator just needs to click index).
   const kbsNeedingIndex = input.knowledgeBasesNeedingIndex ?? [];
   if (kbsNeedingIndex.length > 0) {
-    const embRef = input.embeddingCredentialRef ?? "";
-    if (!embRef) {
-      issues.push({ key: "embedding" });
-    } else if (input.pendingRefs?.has(embRef)) {
-      issues.push({
-        key: "embedding",
-        pending: true,
-        vaultId: embRef.slice(VAULT_REF_PREFIX.length),
-      });
+    // The tenant's embedding key is the sixth ref that can dangle, and it fails exactly like the
+    // other five — hence the same verdict function rather than a second reading of the same three
+    // states. Only when it IS usable do the per-base "index me" prompts make sense.
+    const embedding = credIssue(
+      true,
+      input.embeddingCredentialRef ?? "",
+      pending,
+      known,
+    );
+    if (embedding) {
+      push({ key: "embedding" }, embedding);
     } else {
       for (const kb of kbsNeedingIndex) {
         issues.push({

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -16,6 +16,7 @@ export type ConfigIssueKey =
   | "tts"
   | "ttsNormalize"
   | "vision"
+  | "guardrails"
   | "knowledge"
   | "embedding"
   | "redirect";
@@ -24,7 +25,7 @@ export interface ConfigIssue {
   key: ConfigIssueKey;
   // Deep-link target for credential issues (tab + section anchor). Absent for "knowledge" issues,
   // which open the knowledge-base documents modal instead of scrolling to a section.
-  tab?: "general" | "behavior" | "channelRedirect";
+  tab?: "general" | "behavior" | "guardrails" | "channelRedirect";
   // The DOM anchor id of the section to scroll to (matches the section's `id`).
   sectionId?: string;
   // When true, the credential IS referenced but its secret has not been filled yet (a "pending"
@@ -71,6 +72,11 @@ export interface ConfigHealthInput {
   ttsNormalizeBaseURL?: string;
   visionEnabled: boolean;
   visionCredentialRef: string;
+  // Guardrails run on a model of their own, and theirs is the one credential whose failure is not
+  // just a feature going quiet: `loadAgentConfig` fails open, so the analysis is skipped and every
+  // message is delivered as if it had been screened and approved.
+  guardrailsEnabled?: boolean;
+  guardrailsCredentialRef?: string;
   // Refs (`vault:<id>`) whose vault entry exists but is still pending (secret not filled in yet). A
   // feature wired to one of these is configured but cannot run until the operator fills it.
   pendingRefs?: Set<string>;
@@ -156,12 +162,17 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
       issues.push(base);
     }
   };
+  // An OpenAI-compatible model authenticates through its base URL, so it needs no credential at all
+  // (mirrors the editor's `required={provider !== "openai-compatible"}`). That exempts the ABSENT
+  // credential and nothing else: a ref that IS set is resolved by `loadAgentConfig` before the
+  // provider is ever consulted, and a ref that does not resolve returns null for the whole agent,
+  // which is silence on every message rather than one feature going quiet.
   push(
     { key: "model", tab: "general", sectionId: "general-model" },
     credIssue(
-      Boolean(
-        input.modelProvider && input.modelProvider !== "openai-compatible",
-      ),
+      Boolean(input.modelProvider) &&
+        (input.modelProvider !== "openai-compatible" ||
+          Boolean(input.modelCredentialRef)),
       input.modelCredentialRef,
       pending,
       known,
@@ -241,6 +252,15 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   push(
     { key: "vision", tab: "behavior", sectionId: "vision" },
     credIssue(input.visionEnabled, input.visionCredentialRef, pending, known),
+  );
+  push(
+    { key: "guardrails", tab: "guardrails", sectionId: "gr-model" },
+    credIssue(
+      Boolean(input.guardrailsEnabled),
+      input.guardrailsCredentialRef ?? "",
+      pending,
+      known,
+    ),
   );
   // Knowledge bases with documents awaiting indexing. Indexing needs the tenant's embedding credential,
   // so if that prerequisite is missing we raise ONE "embedding" issue (the root cause) instead of N

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -56,6 +56,9 @@ export interface ConfigHealthInput {
   // none of General's pending edits.
   savedModelProvider: string;
   savedModelBaseURL?: string;
+  // The saved model's credential, needed for one question only: whether an endpoint the rewrite
+  // INHERITS could still arrive from that credential once the vault answers.
+  savedModelCredentialRef?: string;
   sttEnabled: boolean;
   sttCredentialRef: string;
   // TTS has no boolean toggle — any mode other than "never" means audio replies are on.
@@ -233,17 +236,34 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
     tab: "behavior",
     sectionId: "tts",
   };
-  // One of the resolver's refusals is not a verdict on the bag alone: an endpoint can live on the
-  // rewrite's CREDENTIAL, and credential endpoints are read from the same vault list that arrives a
-  // request after the first paint. Until it does, an endpoint that is merely unread looks absent,
-  // and announcing that a runnable rewrite cannot run is the false alarm the null-until-loaded rule
-  // exists to prevent. Every other refusal is decided by the bag itself, so waiting on a list that
-  // cannot change the answer would only delay it.
+  // One of the resolver's refusals is not a verdict on the bag alone: an endpoint the bag does not
+  // state can arrive on a CREDENTIAL, and credential endpoints are read from the same vault list
+  // that lands a request after the first paint. Until it does, an endpoint that is merely unread
+  // looks absent, and announcing that a runnable rewrite cannot run is the false alarm the
+  // null-until-loaded rule exists to prevent.
+  //
+  // So it waits, and only where waiting can change the answer. A missing vault list is not a
+  // momentary state: a failed load leaves it missing until a mutation or a reload, so deferring a
+  // verdict no credential could rescue would not delay that warning, it would delete it. Three
+  // things have to be true at once, and each rules out a permanent problem:
+  //
+  //   * the vault has not answered — otherwise every endpoint is already known;
+  //   * some credential is in play that could carry one: the rewrite's own, or the agent's, whose
+  //     endpoint the rewrite inherits with the rest of its model.
+  //
+  // A stated endpoint does NOT settle it, which is worth writing down because the opposite reads as
+  // obvious: a credential's own base URL WINS over the typed field, here and in the runtime alike
+  // (`credentialBaseUrl ?? mc.baseURL`), so a credential still unread can replace an undialable
+  // string with a working host. What settles it is having no credential to hear from, which is the
+  // case in the reviewer's example — a keyless openai-compatible rewrite pointed at `llama:8080`.
   const endpointsKnown = known !== null;
+  const endpointStillOwed =
+    !endpointsKnown &&
+    Boolean(input.ttsNormalizeCredentialRef || input.savedModelCredentialRef);
   const refusalHolds =
     normalizeResolution !== null &&
     !normalizeResolution.runnable &&
-    (endpointsKnown || normalizeResolution.reason !== "endpoint_unusable");
+    !(endpointStillOwed && normalizeResolution.reason === "endpoint_unusable");
   if (refusalHolds) {
     // The refusal is a verdict on the BAG, so it holds whatever the vault says about the credential
     // itself, and it is what the operator has to act on first. One issue, not two.

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -1,3 +1,7 @@
+import {
+  canonicalVaultRef,
+  VAULT_REF_PREFIX,
+} from "@/client/lib/credentialRef";
 import { isValidHttpUrl } from "@/client/lib/validation";
 import { resolveNormalizeModel } from "@/modules/tts/normalize-model";
 
@@ -91,8 +95,6 @@ export interface ConfigHealthInput {
   redirectWidgetInboxId?: number | null;
 }
 
-const VAULT_REF_PREFIX = "vault:";
-
 // The three ways one credentialed feature can be unrunnable. Every credential ref on the agent goes
 // through this one function, all six of them: a rule that reaches half its fields is worse than no
 // rule, because the half it misses now reads as checked.
@@ -119,10 +121,19 @@ function credIssue(
 ): CredVerdict | null {
   if (!enabled) return null;
   if (!ref) return { kind: "missing" };
-  if (pendingRefs?.has(ref)) {
-    return { kind: "pending", vaultId: ref.slice(VAULT_REF_PREFIX.length) };
+  const canonical = canonicalVaultRef(ref);
+  if (canonical !== null && pendingRefs?.has(canonical)) {
+    return {
+      kind: "pending",
+      vaultId: canonical.slice(VAULT_REF_PREFIX.length),
+    };
   }
-  if (knownRefs && !knownRefs.has(ref)) return { kind: "unresolved" };
+  // A ref no id can be read out of is unresolvable on its own terms, but it is still only REPORTED
+  // once the vault has answered: one panel that stays quiet until it knows is easier to trust than
+  // one that is right about a rare case and wrong about every field for a paint.
+  if (knownRefs && (canonical === null || !knownRefs.has(canonical))) {
+    return { kind: "unresolved" };
+  }
   return null;
 }
 

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -233,9 +233,20 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
     tab: "behavior",
     sectionId: "tts",
   };
-  if (normalizeResolution !== null && !normalizeResolution.runnable) {
-    // The refusal is a verdict on the BAG, so it holds whatever the vault says and it is what the
-    // operator has to act on first. One issue, not two.
+  // One of the resolver's refusals is not a verdict on the bag alone: an endpoint can live on the
+  // rewrite's CREDENTIAL, and credential endpoints are read from the same vault list that arrives a
+  // request after the first paint. Until it does, an endpoint that is merely unread looks absent,
+  // and announcing that a runnable rewrite cannot run is the false alarm the null-until-loaded rule
+  // exists to prevent. Every other refusal is decided by the bag itself, so waiting on a list that
+  // cannot change the answer would only delay it.
+  const endpointsKnown = known !== null;
+  const refusalHolds =
+    normalizeResolution !== null &&
+    !normalizeResolution.runnable &&
+    (endpointsKnown || normalizeResolution.reason !== "endpoint_unusable");
+  if (refusalHolds) {
+    // The refusal is a verdict on the BAG, so it holds whatever the vault says about the credential
+    // itself, and it is what the operator has to act on first. One issue, not two.
     issues.push(normalizeIssue);
   } else {
     push(

--- a/src/client/lib/credentialRef.ts
+++ b/src/client/lib/credentialRef.ts
@@ -6,3 +6,20 @@ export const VAULT_REF_PREFIX = "vault:";
 export function formatVaultRef(id: string): string {
   return `${VAULT_REF_PREFIX}${id}`;
 }
+
+// The one spelling of a ref that can be compared against anything built from the vault list, or
+// null when no entry id can be read out of it at all — a bare NAME (which MCP speaks and REST
+// stores verbatim) or a malformed id, neither of which any resolver ever matches.
+//
+// `vault:0007`, `vault: 7` and `vault:7` are the same entry to every resolver in this system: they
+// parse the id with BigInt, which tolerates padding and surrounding space. A ref reaches the field
+// unvalidated through `PATCH /v1/agents/:id`, so comparing raw strings against a canonical list
+// reports a working credential as unavailable, in the picker as much as in the health panel.
+export function canonicalVaultRef(ref: string): string | null {
+  if (!ref.startsWith(VAULT_REF_PREFIX)) return null;
+  try {
+    return formatVaultRef(String(BigInt(ref.slice(VAULT_REF_PREFIX.length))));
+  } catch {
+    return null;
+  }
+}

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -155,7 +155,14 @@ export function useVaultRefs(): {
     void load();
   }, [load]);
   useEffect(() => {
-    const onChanged = () => void load();
+    // The announcement means the vault CHANGED, so the list in hand is now known to predate it —
+    // and whoever changed it has usually just created the credential a field points at. Dropping to
+    // not-loaded for the length of the re-read is what keeps that credential from reading as
+    // deleted; every mutation in the app comes through here, so this one line covers all of them.
+    const onChanged = () => {
+      setEntries(null);
+      void load();
+    };
     window.addEventListener(VAULT_CHANGED_EVENT, onChanged);
     return () => window.removeEventListener(VAULT_CHANGED_EVENT, onChanged);
   }, [load]);

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -15,6 +15,13 @@ export type VaultEntry = NonNullable<
 // served across tenants (a tenant SWITCH does a full page reload anyway, which clears this).
 const TTL_MS = 30_000;
 
+// Bumped by every announced vault change. Clearing the in-flight map does not cancel the request it
+// was tracking, so a read that started before the change is still on the wire and still carries the
+// vault as it WAS. Landing last, it would overwrite the cache and every listener with pre-mutation
+// data — the created credential reading as deleted, for a whole TTL. The generation is what lets
+// such an answer be recognised and dropped.
+let generation = 0;
+
 type CacheEntry = { entries: VaultEntry[]; at: number };
 const cache = new Map<string, CacheEntry>();
 const inflight = new Map<string, Promise<VaultEntry[]>>();
@@ -33,20 +40,20 @@ function notifyChanged(): void {
   }
 }
 
-async function fetchVault(k: string): Promise<VaultEntry[]> {
-  try {
-    // The treaty reports a non-2xx by resolving with `data: null`, not by rejecting, so a 500 and an
-    // empty vault arrive in the same shape. Callers already treat a rejection as "unknown" (both
-    // catch it), and one of them turns an empty list into "no credential resolves", so a failed
-    // load must not pass for a successful one.
-    const { data, error } = await api.api.v1.vault.get();
-    if (error || !data) throw new Error("vault load failed");
-    const entries = [...data.entries];
-    cache.set(k, { entries, at: Date.now() });
-    return entries;
-  } finally {
-    inflight.delete(k);
-  }
+async function fetchVault(k: string, startedAt: number): Promise<VaultEntry[]> {
+  // The treaty reports a non-2xx by resolving with `data: null`, not by rejecting, so a 500 and an
+  // empty vault arrive in the same shape. Callers already treat a rejection as "unknown" (both
+  // catch it), and one of them turns an empty list into "no credential resolves", so a failed
+  // load must not pass for a successful one.
+  const { data, error } = await api.api.v1.vault.get();
+  if (error || !data) throw new Error("vault load failed");
+  const entries = [...data.entries];
+  // Overtaken: the vault changed after this read left. Neither cached nor returned, because the
+  // caller asked what the vault holds NOW and this answer is about a vault that no longer exists.
+  // They get the current one instead, from the cache or from the read that replaced this.
+  if (startedAt !== generation) return loadVault();
+  cache.set(k, { entries, at: Date.now() });
+  return entries;
 }
 
 // Returns the vault list, served from the per-tenant cache when fresh and de-duplicated across
@@ -57,7 +64,12 @@ export function loadVault(): Promise<VaultEntry[]> {
   if (hit && Date.now() - hit.at < TTL_MS) return Promise.resolve(hit.entries);
   const pending = inflight.get(k);
   if (pending) return pending;
-  const p = fetchVault(k);
+  // The in-flight entry is cleared by whoever set it, and only while it is still theirs: an
+  // invalidation empties the map, and a request that finished after that must not delete the entry
+  // belonging to the read that replaced it.
+  const p = fetchVault(k, generation).finally(() => {
+    if (inflight.get(k) === p) inflight.delete(k);
+  });
   inflight.set(k, p);
   return p;
 }
@@ -71,6 +83,7 @@ export function loadVault(): Promise<VaultEntry[]> {
 // fresh list or fails again and leaves them at "not loaded", and both of those are honest.
 export async function refreshVault(): Promise<VaultEntry[]> {
   const k = tenantKey();
+  generation += 1;
   cache.delete(k);
   inflight.delete(k);
   try {
@@ -86,6 +99,7 @@ export async function refreshVault(): Promise<VaultEntry[]> {
 // Drop cached vault data (after a mutation, e.g. a VaultPanel delete) and notify listeners; the next
 // loadVault re-fetches.
 export function invalidateVault(): void {
+  generation += 1;
   cache.clear();
   inflight.clear();
   notifyChanged();

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { getActiveTenantId } from "@/client/lib/activeTenant";
 import { api } from "@/client/lib/api";
-import { formatVaultRef } from "@/client/lib/credentialRef";
+import { canonicalVaultRef, formatVaultRef } from "@/client/lib/credentialRef";
 
 // Derived from the treaty response, never hand-mirrored (see docs/eden-treaty.md).
 export type VaultEntry = NonNullable<
@@ -35,8 +35,13 @@ function notifyChanged(): void {
 
 async function fetchVault(k: string): Promise<VaultEntry[]> {
   try {
-    const { data } = await api.api.v1.vault.get();
-    const entries = data ? [...data.entries] : [];
+    // The treaty reports a non-2xx by resolving with `data: null`, not by rejecting, so a 500 and an
+    // empty vault arrive in the same shape. Callers already treat a rejection as "unknown" (both
+    // catch it), and one of them turns an empty list into "no credential resolves", so a failed
+    // load must not pass for a successful one.
+    const { data, error } = await api.api.v1.vault.get();
+    if (error || !data) throw new Error("vault load failed");
+    const entries = [...data.entries];
     cache.set(k, { entries, at: Date.now() });
     return entries;
   } finally {
@@ -58,6 +63,8 @@ export function loadVault(): Promise<VaultEntry[]> {
 }
 
 // Force a refetch (after a create/update) and notify listeners once the fresh list is in the cache.
+// Rejects when the refetch fails, since `loadVault` now does; the fire-and-forget callers below
+// catch it, and the listeners are deliberately NOT notified, because there is no fresh list to read.
 export async function refreshVault(): Promise<VaultEntry[]> {
   const k = tenantKey();
   cache.delete(k);
@@ -105,7 +112,8 @@ export function useVaultBaseUrls(): (ref: string) => string | null {
   return useCallback(
     (ref: string) =>
       (ref
-        ? entries.find((e) => formatVaultRef(e.id) === ref)?.baseUrl
+        ? entries.find((e) => formatVaultRef(e.id) === canonicalVaultRef(ref))
+            ?.baseUrl
         : null) ?? null,
     [entries],
   );

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -63,15 +63,24 @@ export function loadVault(): Promise<VaultEntry[]> {
 }
 
 // Force a refetch (after a create/update) and notify listeners once the fresh list is in the cache.
-// Rejects when the refetch fails, since `loadVault` now does; the fire-and-forget callers below
-// catch it, and the listeners are deliberately NOT notified, because there is no fresh list to read.
+//
+// Listeners are told either way, and the failure path is the one that needs saying: the caller has
+// just CHANGED the vault and usually pointed a field at the result, so a listener left holding the
+// pre-change list would answer from a vault that no longer exists — a credential created a moment
+// ago reading as deleted. The notification sends them back to `loadVault`, which either gets the
+// fresh list or fails again and leaves them at "not loaded", and both of those are honest.
 export async function refreshVault(): Promise<VaultEntry[]> {
   const k = tenantKey();
   cache.delete(k);
   inflight.delete(k);
-  const entries = await loadVault();
-  notifyChanged();
-  return entries;
+  try {
+    const entries = await loadVault();
+    notifyChanged();
+    return entries;
+  } catch (err) {
+    notifyChanged();
+    throw err;
+  }
 }
 
 // Drop cached vault data (after a mutation, e.g. a VaultPanel delete) and notify listeners; the next

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -46,12 +46,15 @@ async function fetchVault(k: string, startedAt: number): Promise<VaultEntry[]> {
   // catch it), and one of them turns an empty list into "no credential resolves", so a failed
   // load must not pass for a successful one.
   const { data, error } = await api.api.v1.vault.get();
+  // Overtaken: the vault changed after this read left, so this answer is about a vault that no
+  // longer exists and the caller asked what it holds NOW. Checked BEFORE the response is judged,
+  // because a superseded FAILURE is just as irrelevant as a superseded list — reported as the
+  // caller's own failure it would drive them to "unknown" on top of the fresh list that already
+  // arrived, with nothing coming to put it back. Either way they get the current answer instead,
+  // from the cache or from the read that replaced this one.
+  if (startedAt !== generation) return loadVault();
   if (error || !data) throw new Error("vault load failed");
   const entries = [...data.entries];
-  // Overtaken: the vault changed after this read left. Neither cached nor returned, because the
-  // caller asked what the vault holds NOW and this answer is about a vault that no longer exists.
-  // They get the current one instead, from the cache or from the read that replaced this.
-  if (startedAt !== generation) return loadVault();
   cache.set(k, { entries, at: Date.now() });
   return entries;
 }
@@ -82,10 +85,12 @@ export function loadVault(): Promise<VaultEntry[]> {
 // ago reading as deleted. The notification sends them back to `loadVault`, which either gets the
 // fresh list or fails again and leaves them at "not loaded", and both of those are honest.
 export async function refreshVault(): Promise<VaultEntry[]> {
-  const k = tenantKey();
-  generation += 1;
-  cache.delete(k);
-  inflight.delete(k);
+  // Announce the drop NOW, through the same call every other mutation uses. The caller has just
+  // changed the vault and usually pointed a field at the result, so the seconds between dropping
+  // the old list and receiving the new one are exactly when a listener still holding the old one
+  // reports the created credential as deleted. Waiting for the GET to announce anything is what
+  // left that window open.
+  invalidateVault();
   try {
     const entries = await loadVault();
     notifyChanged();

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { getActiveTenantId } from "@/client/lib/activeTenant";
 import { api } from "@/client/lib/api";
 import { formatVaultRef } from "@/client/lib/credentialRef";
@@ -109,4 +109,53 @@ export function useVaultBaseUrls(): (ref: string) => string | null {
         : null) ?? null,
     [entries],
   );
+}
+
+// Which refs the vault holds right now, and which of those are still waiting for their secret. Both
+// answers come off the same list the pickers already load, and a page needs them whether or not the
+// field that displays them is mounted (the agent editor renders one tab at a time but judges the
+// whole configuration on every one of them).
+//
+// `known` is null until the first list lands, and that distinction is the point: an empty set means
+// "the vault holds nothing", which would declare every credential on the page unresolvable for the
+// one paint between mount and response. `pending` has no such state because the safe direction is
+// the opposite — an unfilled credential simply goes unreported until the list arrives.
+export function useVaultRefs(): {
+  known: Set<string> | null;
+  pending: Set<string>;
+  pendingEntries: VaultEntry[];
+} {
+  const [entries, setEntries] = useState<VaultEntry[] | null>(null);
+  const load = useCallback(async () => {
+    try {
+      setEntries(await loadVault());
+    } catch {
+      // A failed load stays "not loaded": the vault is unknown, not empty.
+      setEntries(null);
+    }
+  }, []);
+  useEffect(() => {
+    void load();
+  }, [load]);
+  useEffect(() => {
+    const onChanged = () => void load();
+    window.addEventListener(VAULT_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(VAULT_CHANGED_EVENT, onChanged);
+  }, [load]);
+  const pendingEntries = useMemo(
+    () => (entries ?? []).filter((e) => e.status === "pending"),
+    [entries],
+  );
+  return {
+    known: useMemo(
+      () =>
+        entries ? new Set(entries.map((e) => formatVaultRef(e.id))) : null,
+      [entries],
+    ),
+    pending: useMemo(
+      () => new Set(pendingEntries.map((e) => formatVaultRef(e.id))),
+      [pendingEntries],
+    ),
+    pendingEntries,
+  };
 }

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -669,6 +669,7 @@
     "cloneUnsavedNote": "Cloning uses the last saved version; your unsaved changes won't be included.",
     "configIssue": {
       "embedding": "A knowledge base needs indexing, but the tenant embedding is not configured.",
+      "guardrails": "Guardrails are on but have no API key set, so messages go out unscreened.",
       "model": "The model has no API key set, so the agent cannot reply.",
       "redirect": "Redirect is on but a WhatsApp or website-chat inbox is not set, so it will not run.",
       "stt": "Voice transcription is on but has no API key set.",
@@ -679,6 +680,7 @@
     "configIssueKnowledge": "Knowledge base \"{{name}}\" has documents that need indexing.",
     "configIssuePending": {
       "embedding": "A knowledge base needs indexing, but the embedding credential is not filled in yet.",
+      "guardrails": "The guardrails credential is referenced but not filled in yet, so messages go out unscreened.",
       "model": "The model credential is referenced but not filled in yet.",
       "stt": "The transcription credential is referenced but not filled in yet.",
       "tts": "The audio-reply credential is referenced but not filled in yet.",
@@ -688,6 +690,7 @@
     "configIssuesTitle": "Configuration warnings",
     "configIssueUnresolved": {
       "embedding": "A knowledge base needs indexing, but the embedding credential no longer exists.",
+      "guardrails": "The guardrails credential no longer exists, so messages go out unscreened.",
       "model": "The model credential no longer exists, so the agent cannot reply. Pick another one.",
       "stt": "The transcription credential no longer exists, so voice messages are not transcribed.",
       "tts": "The audio-reply credential no longer exists, so replies are sent as text.",

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -686,6 +686,14 @@
       "vision": "The image-reading credential is referenced but not filled in yet."
     },
     "configIssuesTitle": "Configuration warnings",
+    "configIssueUnresolved": {
+      "embedding": "A knowledge base needs indexing, but the embedding credential no longer exists.",
+      "model": "The model credential no longer exists, so the agent cannot reply. Pick another one.",
+      "stt": "The transcription credential no longer exists, so voice messages are not transcribed.",
+      "tts": "The audio-reply credential no longer exists, so replies are sent as text.",
+      "ttsNormalize": "The speech-rewrite credential no longer exists, so replies are spoken without the rewrite.",
+      "vision": "The image-reading credential no longer exists, so images and documents are not read."
+    },
     "conflictToast": "This agent was changed elsewhere. Reload, or save again to overwrite.",
     "credential": "API key",
     "dangerZone": "Danger zone",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -671,6 +671,7 @@
     "cloneUnsavedNote": "A clonagem usa a última versão salva; suas alterações não salvas não serão incluídas.",
     "configIssue": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas o embedding do tenant não está configurado.",
+      "guardrails": "Os guardrails estão ligados, mas sem chave de API definida, então as mensagens saem sem triagem.",
       "model": "O modelo não tem chave de API definida, então o agente não consegue responder.",
       "redirect": "O redirecionamento está ativado mas uma caixa de WhatsApp ou de chat do site não foi definida, então ele não vai rodar.",
       "stt": "A transcrição de voz está ligada, mas sem chave de API definida.",
@@ -681,6 +682,7 @@
     "configIssueKnowledge": "A base de conhecimento \"{{name}}\" tem documentos que precisam ser indexados.",
     "configIssuePending": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding ainda não foi preenchida.",
+      "guardrails": "A credencial dos guardrails está referenciada, mas ainda não foi preenchida, então as mensagens saem sem triagem.",
       "model": "A credencial do modelo está referenciada, mas ainda não foi preenchida.",
       "stt": "A credencial de transcrição está referenciada, mas ainda não foi preenchida.",
       "tts": "A credencial de resposta em áudio está referenciada, mas ainda não foi preenchida.",
@@ -690,6 +692,7 @@
     "configIssuesTitle": "Avisos de configuração",
     "configIssueUnresolved": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding não existe mais.",
+      "guardrails": "A credencial dos guardrails não existe mais, então as mensagens saem sem triagem.",
       "model": "A credencial do modelo não existe mais, então o agente não consegue responder. Escolha outra.",
       "stt": "A credencial de transcrição não existe mais, então as mensagens de voz não são transcritas.",
       "tts": "A credencial de resposta em áudio não existe mais, então as respostas saem como texto.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -688,6 +688,14 @@
       "vision": "A credencial de leitura de imagens está referenciada, mas ainda não foi preenchida."
     },
     "configIssuesTitle": "Avisos de configuração",
+    "configIssueUnresolved": {
+      "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding não existe mais.",
+      "model": "A credencial do modelo não existe mais, então o agente não consegue responder. Escolha outra.",
+      "stt": "A credencial de transcrição não existe mais, então as mensagens de voz não são transcritas.",
+      "tts": "A credencial de resposta em áudio não existe mais, então as respostas saem como texto.",
+      "ttsNormalize": "A credencial da reescrita para fala não existe mais, então o áudio sai sem a reescrita.",
+      "vision": "A credencial de leitura de imagens não existe mais, então imagens e documentos não são lidos."
+    },
     "conflictToast": "Este agente foi alterado em outro lugar. Recarregue, ou salve de novo para sobrescrever.",
     "credential": "Chave de API",
     "dangerZone": "Zona de perigo",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1250,6 +1250,7 @@ function AgentEditor() {
     ttsCredentialRef: tts.credentialRef,
     savedModelProvider: savedModel.provider,
     savedModelBaseURL: savedModelBaseUrl,
+    savedModelCredentialRef: savedModel.credentialRef,
     ttsNormalize: tts.normalize,
     ttsNormalizeProvider: tts.normalizeProvider,
     ttsNormalizeModel: tts.normalizeModel,

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1206,6 +1206,9 @@ function AgentEditor() {
   // t('editor.configIssue.ttsNormalize', 'The speech rewrite is on but its model configuration cannot run, so replies will be spoken without it. Check its provider, model, key and endpoint.')
   // t('editor.configIssuePending.ttsNormalize', 'The speech-rewrite credential is referenced but not filled in yet.')
   // t('editor.configIssue.vision', 'Image/document reading is on but has no API key set.')
+  // t('editor.configIssue.guardrails', 'Guardrails are on but have no API key set, so messages go out unscreened.')
+  // t('editor.configIssuePending.guardrails', 'The guardrails credential is referenced but not filled in yet, so messages go out unscreened.')
+  // t('editor.configIssueUnresolved.guardrails', 'The guardrails credential no longer exists, so messages go out unscreened.')
   // t('editor.configIssuePending.model', 'The model credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.stt', 'The transcription credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.tts', 'The audio-reply credential is referenced but not filled in yet.')
@@ -1254,6 +1257,8 @@ function AgentEditor() {
     ttsNormalizeBaseURL: ttsNormalizeCredBaseUrl ?? tts.normalizeBaseURL,
     visionEnabled: vision.enabled,
     visionCredentialRef: vision.credentialRef,
+    guardrailsEnabled: guardrails.enabled,
+    guardrailsCredentialRef: guardrails.credentialRef ?? "",
     pendingRefs,
     knownRefs,
     knowledgeBasesNeedingIndex,

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -54,9 +54,8 @@ import type { ApiErrorPayload } from "@/client/lib/types";
 import { slugify } from "@/client/lib/utils";
 import {
   invalidateVault,
-  loadVault,
   useVaultBaseUrls,
-  VAULT_CHANGED_EVENT,
+  useVaultRefs,
 } from "@/client/lib/vaultCache";
 import { IntegrationEditModal } from "@/client/pages/resources/IntegrationEditModal";
 import { McpEditModal } from "@/client/pages/resources/McpEditModal";
@@ -1171,26 +1170,16 @@ function AgentEditor() {
     dirty.tools ||
     dirty.knowledge;
 
-  // Pending credentials (referenced but not filled yet — e.g. created via the MCP credential_create
-  // tool). A feature wired to one of these is configured but cannot run. Loaded from the shared vault
-  // cache and refreshed on any vault change (e.g. the operator fills the secret), so the warning
-  // clears without a manual reload.
-  const [pendingEntries, setPendingEntries] = useState<VaultEntry[]>([]);
-  useEffect(() => {
-    let alive = true;
-    const refresh = () =>
-      loadVault().then((entries) => {
-        if (!alive) return;
-        setPendingEntries(entries.filter((e) => e.status === "pending"));
-      });
-    refresh();
-    window.addEventListener(VAULT_CHANGED_EVENT, refresh);
-    return () => {
-      alive = false;
-      window.removeEventListener(VAULT_CHANGED_EVENT, refresh);
-    };
-  }, []);
-  const pendingRefs = new Set(pendingEntries.map((e) => `vault:${e.id}`));
+  // What the vault holds, for the two credential states the panel below can only see from the list:
+  // referenced but not filled yet (created via the MCP credential_create tool, say), and referenced
+  // but not there at all (deleted, or a name written over REST/MCP that no resolver matches). Both
+  // refresh on any vault change (e.g. the operator fills the secret), so a warning clears without a
+  // manual reload.
+  const {
+    known: knownRefs,
+    pending: pendingRefs,
+    pendingEntries,
+  } = useVaultRefs();
 
   // The tenant's embedding credential ref — a prerequisite for indexing knowledge bases. Loaded once so
   // config health can, when a base needs indexing, point at the real blocker (embedding unconfigured, or
@@ -1224,6 +1213,12 @@ function AgentEditor() {
   // t('editor.configIssue.embedding', 'A knowledge base needs indexing, but the tenant embedding is not configured.')
   // t('editor.configIssuePending.embedding', 'A knowledge base needs indexing, but the embedding credential is not filled in yet.')
   // t('editor.configIssue.redirect', 'Redirect is on but a WhatsApp or website-chat inbox is not set, so it will not run.')
+  // t('editor.configIssueUnresolved.model', 'The model credential no longer exists, so the agent cannot reply. Pick another one.')
+  // t('editor.configIssueUnresolved.stt', 'The transcription credential no longer exists, so voice messages are not transcribed.')
+  // t('editor.configIssueUnresolved.tts', 'The audio-reply credential no longer exists, so replies are sent as text.')
+  // t('editor.configIssueUnresolved.ttsNormalize', 'The speech-rewrite credential no longer exists, so replies are spoken without the rewrite.')
+  // t('editor.configIssueUnresolved.vision', 'The image-reading credential no longer exists, so images and documents are not read.')
+  // t('editor.configIssueUnresolved.embedding', 'A knowledge base needs indexing, but the embedding credential no longer exists.')
   // Knowledge bases this agent uses (its RAG grant) that still have documents awaiting indexing —
   // surfaced as a config warning so a freshly-imported agent flags "index me" right in the editor.
   const ragGrant = grants.find((g) => g.source === "RAG");
@@ -1260,6 +1255,7 @@ function AgentEditor() {
     visionEnabled: vision.enabled,
     visionCredentialRef: vision.credentialRef,
     pendingRefs,
+    knownRefs,
     knowledgeBasesNeedingIndex,
     embeddingCredentialRef,
     redirectEnabled: channelRedirect.enabled,
@@ -1309,8 +1305,10 @@ function AgentEditor() {
     );
   }
 
-  // The human-facing line for a config issue: a "pending credential" variant vs the classic
-  // "missing credential" one. Kept out of the JSX so the dynamic-key biome-ignore sits on the t() call.
+  // The human-facing line for a config issue: "referenced but not filled in" and "referenced but
+  // gone" each read differently from the classic "no credential set", because the operator's next
+  // move differs (fill it, pick another, set one). Kept out of the JSX so the dynamic-key lint
+  // suppression sits on the t() call.
   function issueMessage(issue: (typeof configIssues)[number]): string {
     if (issue.key === "knowledge") {
       return t(
@@ -1323,6 +1321,12 @@ function AgentEditor() {
       // biome-ignore lint/plugin/no-dynamic-i18n-key: pending keys registered via magic comments above computeConfigIssues
       return t(`editor.configIssuePending.${issue.key}` as const, {
         defaultValue: "This credential is referenced but not filled in yet.",
+      });
+    }
+    if (issue.unresolved) {
+      // biome-ignore lint/plugin/no-dynamic-i18n-key: unresolved keys registered via magic comments above computeConfigIssues
+      return t(`editor.configIssueUnresolved.${issue.key}` as const, {
+        defaultValue: "This credential no longer exists. Pick another one.",
       });
     }
     // biome-ignore lint/plugin/no-dynamic-i18n-key: issue keys registered via magic comments above computeConfigIssues

--- a/tests/client/components/CredentialPicker.test.tsx
+++ b/tests/client/components/CredentialPicker.test.tsx
@@ -1,0 +1,83 @@
+/// <reference lib="dom" />
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { CredentialPicker } from "@/client/components/CredentialPicker";
+import { invalidateVault } from "@/client/lib/vaultCache";
+
+// The picker resolves a ref to an entry the same way every resolver does, by the id BigInt reads out
+// of it, so a ref stored as `vault: 7 ` or `vault:0x7` selects entry 7 instead of reading as an
+// unavailable credential. Anything downstream of that selection has to use the ENTRY's id: the test
+// route takes `^\d+$`, so passing the raw ref through would turn a working credential into
+// "unreachable" — the picker recognizing the ref is what makes that reachable at all.
+//
+// NOTE: every assertion reduces to a boolean or a string BEFORE expect. A failing expectation that
+// holds a DOM node serializes a cyclic happy-dom tree and stalls the runner.
+
+const realFetch = globalThis.fetch;
+let testUrls: string[] = [];
+
+beforeEach(() => {
+  invalidateVault();
+  testUrls = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (url.includes("/test")) {
+      testUrls.push(new URL(url, "http://localhost").pathname);
+      return new Response(JSON.stringify({ testable: true, ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("/api/v1/vault")) {
+      return new Response(
+        JSON.stringify({
+          entries: [
+            {
+              id: "7",
+              name: "openai-main",
+              kind: "openai",
+              baseUrl: null,
+              paramName: null,
+              status: "active",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return realFetch(input as RequestInfo | URL, init);
+  }) as typeof fetch;
+});
+
+afterEach(() => cleanup());
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("CredentialPicker with a noncanonical ref", () => {
+  test("selects the entry and tests it by its own id", async () => {
+    render(
+      <CredentialPicker
+        value="vault: 7 "
+        onChange={() => {}}
+        ariaLabel="key"
+      />,
+    );
+    // Selected: the trigger names the entry rather than reporting it unavailable.
+    await waitFor(() =>
+      expect(screen.queryAllByText("openai-main").length > 0).toBe(true),
+    );
+    const testButton = screen.getByLabelText("Test connection");
+    testButton.click();
+    await waitFor(() => expect(testUrls.length).toBe(1));
+    expect(testUrls[0]).toBe("/api/v1/vault/7/test");
+  });
+});

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -713,3 +713,48 @@ describe("computeConfigIssues — the guardrails credential", () => {
     ).toEqual([{ key: "guardrails", ...at, unresolved: true }]);
   });
 });
+
+// Found by sweeping the panel's own inputs rather than by a review round: the rewrite's endpoint can
+// live on its CREDENTIAL, and the browser learns credential endpoints from the same vault list that
+// arrives a request after the first paint. Judged before that answer exists, an endpoint that is
+// merely unread reads as absent, and the panel announces that a runnable rewrite cannot run — the
+// same false alarm the null-until-loaded rule exists to prevent, arriving through the endpoint
+// instead of through the ref.
+describe("computeConfigIssues — the rewrite endpoint while the vault is unknown", () => {
+  const compatRewrite = {
+    ...base,
+    ttsMode: "mirror",
+    ttsCredentialRef: "vault:2",
+    ttsNormalize: true,
+    ttsNormalizeProvider: "openai-compatible",
+    ttsNormalizeCredentialRef: "vault:3",
+    ttsNormalizeBaseURL: "",
+  };
+
+  test("holds the endpoint refusal while the vault has not answered", () => {
+    expect(computeConfigIssues({ ...compatRewrite, knownRefs: null })).toEqual(
+      [],
+    );
+  });
+
+  test("raises it once the vault has answered and the endpoint is still nowhere", () => {
+    expect(
+      computeConfigIssues({
+        ...compatRewrite,
+        knownRefs: new Set(["vault:1", "vault:2", "vault:3"]),
+      }),
+    ).toEqual([{ key: "ttsNormalize", tab: "behavior", sectionId: "tts" }]);
+  });
+
+  // Only the endpoint answer comes from the vault. A bag naming a provider that does not exist is
+  // wrong on its face, and waiting on a list that cannot change that verdict would just delay it.
+  test("still refuses a bag the vault could not rescue", () => {
+    expect(
+      computeConfigIssues({
+        ...compatRewrite,
+        ttsNormalizeProvider: "not-a-provider",
+        knownRefs: null,
+      }),
+    ).toEqual([{ key: "ttsNormalize", tab: "behavior", sectionId: "tts" }]);
+  });
+});

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -617,3 +617,99 @@ describe("computeConfigIssues — noncanonical ref spellings", () => {
     ]);
   });
 });
+
+// An OpenAI-compatible model authenticates through its base URL, so it needs no credential — which
+// is a statement about a credential being ABSENT, and it was being read as "this field is never
+// checked". A ref that IS set has to resolve whatever the provider is: `loadAgentConfig` resolves
+// it before it looks at the provider, and returns null for the whole agent when it cannot, so the
+// agent goes silent on every message.
+describe("computeConfigIssues — an openai-compatible model with a ref of its own", () => {
+  const compat = { ...base, modelProvider: "openai-compatible" };
+
+  test("still raises nothing when no credential is set", () => {
+    expect(
+      computeConfigIssues({
+        ...compat,
+        modelCredentialRef: "",
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([]);
+  });
+
+  test("flags a credential it does set whose entry is gone", () => {
+    expect(
+      computeConfigIssues({ ...compat, knownRefs: new Set(["vault:9"]) }),
+    ).toEqual([
+      {
+        key: "model",
+        tab: "general",
+        sectionId: "general-model",
+        unresolved: true,
+      },
+    ]);
+  });
+
+  test("flags a credential it does set that is still pending", () => {
+    expect(
+      computeConfigIssues({
+        ...compat,
+        pendingRefs: new Set(["vault:1"]),
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([
+      {
+        key: "model",
+        tab: "general",
+        sectionId: "general-model",
+        pending: true,
+        vaultId: "1",
+      },
+    ]);
+  });
+});
+
+// The seventh credential the agent can hold, and the only one whose failure lets messages through
+// UNSCREENED: `loadAgentConfig` fails open when the guardrails credential does not resolve, so the
+// analysis is skipped and every message is delivered as if it had been reviewed and approved.
+describe("computeConfigIssues — the guardrails credential", () => {
+  const guarded = { ...base, guardrailsEnabled: true };
+  const at = { tab: "guardrails", sectionId: "gr-model" } as const;
+
+  test("raises nothing while guardrails are off, whatever the ref says", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        guardrailsEnabled: false,
+        guardrailsCredentialRef: "vault:404",
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([]);
+  });
+
+  test("flags guardrails enabled with no credential", () => {
+    expect(
+      computeConfigIssues({ ...guarded, guardrailsCredentialRef: "" }),
+    ).toEqual([{ key: "guardrails", ...at }]);
+  });
+
+  test("flags a pending guardrails credential", () => {
+    expect(
+      computeConfigIssues({
+        ...guarded,
+        guardrailsCredentialRef: "vault:5",
+        pendingRefs: new Set(["vault:5"]),
+        knownRefs: new Set(["vault:1", "vault:5"]),
+      }),
+    ).toEqual([{ key: "guardrails", ...at, pending: true, vaultId: "5" }]);
+  });
+
+  test("flags a guardrails credential whose entry is gone", () => {
+    expect(
+      computeConfigIssues({
+        ...guarded,
+        guardrailsCredentialRef: "vault:5",
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([{ key: "guardrails", ...at, unresolved: true }]);
+  });
+});

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -564,3 +564,56 @@ describe("computeConfigIssues — a credential whose vault entry is gone", () =>
     ).toEqual([{ key: "embedding", unresolved: true }]);
   });
 });
+
+// `vault:007` and `vault:7` are the same entry: the runtime parses the id with BigInt, so a
+// noncanonical spelling resolves fine. It reaches the field the way every unvalidated ref does,
+// through `PATCH /v1/agents/:id`, which stores what it is handed. Comparing raw strings against a
+// list that only ever holds the canonical spelling would call a working credential deleted, which
+// is a worse failure than the silence this whole change replaced.
+describe("computeConfigIssues — noncanonical ref spellings", () => {
+  test("a padded id resolves against the canonical list", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        modelCredentialRef: "vault:0001",
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([]);
+  });
+
+  test("a padded id still reports pending, with the canonical vaultId", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        modelCredentialRef: "vault:0001",
+        knownRefs: new Set(["vault:1"]),
+        pendingRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([
+      {
+        key: "model",
+        tab: "general",
+        sectionId: "general-model",
+        pending: true,
+        vaultId: "1",
+      },
+    ]);
+  });
+
+  test("a ref whose id is not a number is unresolvable, like a name", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        modelCredentialRef: "vault:abc",
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([
+      {
+        key: "model",
+        tab: "general",
+        sectionId: "general-model",
+        unresolved: true,
+      },
+    ]);
+  });
+});

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -442,3 +442,125 @@ describe("computeConfigIssues — redirect enabled but incomplete", () => {
     });
   });
 });
+
+// A stored ref can point at a vault entry that no longer exists. Deleting an entry is not blocked by
+// its references (the vault's delete is a plain deleteMany; the reference list it shows is
+// informational), and `PATCH /v1/agents/:id` stores whatever ref it is handed, name or id. The
+// runtime is where it lands: the agent's own model logs "cannot reply until it is fixed", and
+// STT/vision/TTS/the speech rewrite skip with a warn line nobody is watching for. Which makes this
+// panel the one place it can be caught before the next customer message, and it stayed green.
+describe("computeConfigIssues — a credential whose vault entry is gone", () => {
+  const linked = {
+    key: "model",
+    tab: "general",
+    sectionId: "general-model",
+  } as const;
+
+  test("flags the model credential when the vault no longer holds it", () => {
+    expect(
+      computeConfigIssues({ ...base, knownRefs: new Set(["vault:7"]) }),
+    ).toEqual([{ ...linked, unresolved: true }]);
+  });
+
+  // The vault list arrives one request after the first paint. An empty set would mean "no credential
+  // resolves" and light up every field on screen for a moment, so "not loaded" has to be its own
+  // value and it has to mean silence.
+  test("raises nothing while the vault has not loaded (undefined or null)", () => {
+    expect(computeConfigIssues(base)).toEqual([]);
+    expect(computeConfigIssues({ ...base, knownRefs: null })).toEqual([]);
+  });
+
+  // Refs are resolved by id and only by id (`vaultRefWhere` matches `vault:<id>`; anything else falls
+  // through to a never-matching row). A name reaches the field over MCP and REST, reads as configured
+  // in the editor, and resolves to nothing at runtime — the same failure by another spelling.
+  test("flags a ref stored as a name, which no resolver will ever match", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        modelCredentialRef: "openai-key",
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([{ ...linked, unresolved: true }]);
+  });
+
+  // A pending entry EXISTS, so it is in the known set; the two states cannot both be true. Asserted
+  // anyway because the fixes differ: pending opens the fill modal, unresolved sends the operator
+  // back to the field to pick another key.
+  test("a pending entry is reported as pending, never as unresolved", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        pendingRefs: new Set(["vault:1"]),
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([{ ...linked, pending: true, vaultId: "1" }]);
+  });
+
+  test("flags stt, tts and vision the same way, each to its own section", () => {
+    const issues = computeConfigIssues({
+      ...base,
+      sttEnabled: true,
+      sttCredentialRef: "vault:9",
+      ttsMode: "mirror",
+      ttsCredentialRef: "vault:8",
+      visionEnabled: true,
+      visionCredentialRef: "vault:6",
+      knownRefs: new Set(["vault:1"]),
+    });
+    expect(
+      issues.map((i) => `${i.key}:${i.unresolved}:${i.sectionId}`),
+    ).toEqual(["stt:true:stt", "tts:true:tts", "vision:true:vision"]);
+  });
+
+  test("flags the speech rewrite's own credential", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        ttsMode: "mirror",
+        ttsCredentialRef: "vault:2",
+        ttsNormalize: true,
+        ttsNormalizeProvider: "anthropic",
+        ttsNormalizeCredentialRef: "vault:3",
+        knownRefs: new Set(["vault:1", "vault:2"]),
+      }),
+    ).toEqual([
+      {
+        key: "ttsNormalize",
+        tab: "behavior",
+        sectionId: "tts",
+        unresolved: true,
+      },
+    ]);
+  });
+
+  // The rewrite has a second, earlier way to be unusable: the resolver refusing the bag outright.
+  // That verdict does not depend on the vault, and it is the one the operator has to act on first,
+  // so it stays the single issue raised.
+  test("a bag the resolver refuses stays one issue, not two", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        ttsMode: "mirror",
+        ttsCredentialRef: "vault:2",
+        ttsNormalize: true,
+        ttsNormalizeProvider: "not-a-provider",
+        ttsNormalizeCredentialRef: "vault:3",
+        knownRefs: new Set(["vault:1", "vault:2"]),
+      }),
+    ).toEqual([{ key: "ttsNormalize", tab: "behavior", sectionId: "tts" }]);
+  });
+
+  // The tenant's embedding key is the sixth ref that can dangle, and it fails the same way: the
+  // per-base "index me" prompts would all fail on a key that is not there, so the root cause is the
+  // one issue raised.
+  test("flags the tenant embedding credential instead of the per-base index prompts", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        knowledgeBasesNeedingIndex: [{ id: "5", name: "FAQ" }],
+        embeddingCredentialRef: "vault:7",
+        knownRefs: new Set(["vault:1"]),
+      }),
+    ).toEqual([{ key: "embedding", unresolved: true }]);
+  });
+});

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -758,3 +758,96 @@ describe("computeConfigIssues — the rewrite endpoint while the vault is unknow
     ).toEqual([{ key: "ttsNormalize", tab: "behavior", sectionId: "tts" }]);
   });
 });
+
+// The endpoint refusal waits for the vault, but only where the vault could still change it. A
+// failed vault load leaves that answer missing INDEFINITELY (nothing retries until a mutation or a
+// reload), so deferring a verdict the vault cannot rescue would not delay a warning, it would
+// delete one.
+describe("computeConfigIssues — which endpoint refusals wait for the vault", () => {
+  const audio = { ...base, ttsMode: "mirror", ttsCredentialRef: "vault:2" };
+
+  test("an undialable endpoint with no credential to correct it is decided now", () => {
+    expect(
+      computeConfigIssues({
+        ...audio,
+        ttsNormalize: true,
+        ttsNormalizeProvider: "openai-compatible",
+        ttsNormalizeBaseURL: "llama:8080",
+        knownRefs: null,
+      }),
+    ).toEqual([{ key: "ttsNormalize", tab: "behavior", sectionId: "tts" }]);
+  });
+
+  // A stated endpoint does not settle the question, because a credential's own base URL WINS over
+  // the typed one, here and in the runtime alike — so an unread credential can still replace an
+  // undialable string with a working host, and calling the rewrite dead before reading it would be
+  // wrong in the same way it was wrong with no endpoint at all.
+  test("waits on an undialable endpoint that a credential could still replace", () => {
+    expect(
+      computeConfigIssues({
+        ...audio,
+        ttsNormalize: true,
+        ttsNormalizeProvider: "openai-compatible",
+        ttsNormalizeCredentialRef: "vault:3",
+        ttsNormalizeBaseURL: "llama:8080",
+        knownRefs: null,
+      }),
+    ).toEqual([]);
+  });
+
+  test("no endpoint and no credential anywhere is decided without the vault", () => {
+    expect(
+      computeConfigIssues({
+        ...audio,
+        savedModelProvider: "openai",
+        ttsNormalize: true,
+        ttsNormalizeProvider: "openai-compatible",
+        ttsNormalizeBaseURL: "",
+        knownRefs: null,
+      }),
+    ).toEqual([{ key: "ttsNormalize", tab: "behavior", sectionId: "tts" }]);
+  });
+
+  test("waits when the rewrite's own credential could carry the endpoint", () => {
+    expect(
+      computeConfigIssues({
+        ...audio,
+        ttsNormalize: true,
+        ttsNormalizeProvider: "openai-compatible",
+        ttsNormalizeCredentialRef: "vault:3",
+        ttsNormalizeBaseURL: "",
+        knownRefs: null,
+      }),
+    ).toEqual([]);
+  });
+
+  // Inheriting the agent's model means inheriting its endpoint, and the agent's endpoint can live on
+  // the agent's credential — read from the same list.
+  test("waits when the inherited agent credential could carry it", () => {
+    expect(
+      computeConfigIssues({
+        ...audio,
+        savedModelProvider: "openai-compatible",
+        savedModelCredentialRef: "vault:1",
+        savedModelBaseURL: "",
+        ttsNormalize: true,
+        ttsNormalizeProvider: "",
+        ttsNormalizeBaseURL: "",
+        knownRefs: null,
+      }),
+    ).toEqual([]);
+  });
+
+  test("stops waiting once the vault has answered and nothing supplied one", () => {
+    expect(
+      computeConfigIssues({
+        ...audio,
+        ttsNormalize: true,
+        ttsNormalizeProvider: "openai-compatible",
+        ttsNormalizeCredentialRef: "vault:3",
+        ttsNormalizeBaseURL: "",
+        knownRefs: new Set(["vault:1", "vault:2", "vault:3"]),
+      }),
+    ).toEqual([{ key: "ttsNormalize", tab: "behavior", sectionId: "tts" }]);
+  });
+});

--- a/tests/client/lib/credentialRef.test.ts
+++ b/tests/client/lib/credentialRef.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { canonicalVaultRef, formatVaultRef } from "@/client/lib/credentialRef";
+
+// One spelling to compare against, because a ref reaches the agent unvalidated (`PATCH
+// /v1/agents/:id` stores what it is handed) while every list the browser builds is canonical.
+describe("canonicalVaultRef", () => {
+  test("keeps a canonical ref as it is", () => {
+    expect(canonicalVaultRef("vault:7")).toBe("vault:7");
+  });
+
+  // The forms BigInt accepts, which is what every resolver in this system parses the id with.
+  test("normalizes the spellings the resolvers already accept", () => {
+    expect(canonicalVaultRef("vault:0007")).toBe(formatVaultRef("7"));
+    expect(canonicalVaultRef("vault: 7 ")).toBe(formatVaultRef("7"));
+  });
+
+  test("has no answer for a name or a malformed id", () => {
+    expect(canonicalVaultRef("openai-key")).toBeNull();
+    expect(canonicalVaultRef("vault:abc")).toBeNull();
+    expect(canonicalVaultRef("")).toBeNull();
+  });
+
+  // `BigInt("")` is 0n, so an empty id canonicalizes to entry 0 instead of to "not a ref". That
+  // MIRRORS the server resolver, which builds the same `{ id: 0n }` and matches nothing (ids are a
+  // positive bigserial). Both routes end at the same verdict, and the canonicalizer's job is to
+  // agree with the resolver rather than to be independently tidy.
+  test("follows the resolver on an empty id, which matches no entry", () => {
+    expect(canonicalVaultRef("vault:")).toBe(formatVaultRef("0"));
+  });
+});

--- a/tests/client/lib/vaultCache.test.ts
+++ b/tests/client/lib/vaultCache.test.ts
@@ -6,6 +6,7 @@ import {
   loadVault,
   refreshVault,
   useVaultBaseUrls,
+  useVaultRefs,
   VAULT_CHANGED_EVENT,
 } from "@/client/lib/vaultCache";
 
@@ -19,6 +20,7 @@ let entriesToReturn: Array<{
   name: string;
   kind: string | null;
   baseUrl?: string;
+  status?: string;
 }> = [];
 
 beforeEach(() => {
@@ -149,6 +151,56 @@ describe("useVaultBaseUrls", () => {
     });
     await waitFor(() =>
       expect(result.current("vault:7")).toBe("http://llama:8080/v1"),
+    );
+    cleanup();
+  });
+});
+
+// Which refs the vault currently holds, and which of those are still unfilled. Both answers come off
+// the same list, and the page needs them whether or not the field that displays them is mounted —
+// the editor renders one tab at a time.
+describe("useVaultRefs", () => {
+  test("holds `known` at null until the first list arrives", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    const { result } = renderHook(() => useVaultRefs());
+    // The state that matters: before the response, "nothing is known" must not read as "nothing
+    // resolves". An empty set here would light up every credential on the page for one paint.
+    expect(result.current.known).toBeNull();
+    expect(result.current.pending.size).toBe(0);
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:3")).toBe(true),
+    );
+    cleanup();
+  });
+
+  test("separates filled entries from the ones still awaiting a secret", async () => {
+    entriesToReturn = [
+      { id: "3", name: "openai", kind: "openai" },
+      { id: "4", name: "eleven", kind: "elevenlabs", status: "pending" },
+    ];
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() => expect(result.current.known?.size).toBe(2));
+    // A pending entry EXISTS: it is known AND pending, and the two answers are used for different
+    // fixes (fill it in place vs pick another key).
+    expect(result.current.known?.has("vault:4")).toBe(true);
+    expect([...result.current.pending]).toEqual(["vault:4"]);
+    expect(result.current.pendingEntries.map((e) => e.id)).toEqual(["4"]);
+    cleanup();
+  });
+
+  test("follows a deletion made elsewhere on the page", async () => {
+    entriesToReturn = [
+      { id: "3", name: "openai", kind: "openai" },
+      { id: "9", name: "gone", kind: "openai" },
+    ];
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() => expect(result.current.known?.size).toBe(2));
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    await act(async () => {
+      await refreshVault();
+    });
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:9")).toBe(false),
     );
     cleanup();
   });

--- a/tests/client/lib/vaultCache.test.ts
+++ b/tests/client/lib/vaultCache.test.ts
@@ -19,6 +19,22 @@ let getCalls = 0;
 // load" — the treaty reports both with an empty `data`.
 let failNext = false;
 let failAll = false;
+// Holds responses open so an EARLIER request can finish after a later one. Each hold is claimed by
+// the next request to start, in order, and released by its index; the body is snapshot at claim
+// time, which is the point — a held request answers with the vault as it was when it left.
+type Hold = { promise: Promise<unknown>; release: () => void; fail?: boolean };
+let queuedHolds: Hold[] = [];
+let claimedHolds: Hold[] = [];
+function holdNextResponse(opts?: { fail?: boolean }): void {
+  let release = (): void => undefined;
+  const promise = new Promise<unknown>((resolve) => {
+    release = () => resolve(undefined);
+  });
+  queuedHolds.push({ promise, release, fail: opts?.fail });
+}
+function releaseHeld(index: number): void {
+  claimedHolds[index]?.release();
+}
 let entriesToReturn: Array<{
   id: string;
   name: string;
@@ -33,11 +49,26 @@ beforeEach(() => {
   getCalls = 0;
   failNext = false;
   failAll = false;
+  queuedHolds = [];
+  claimedHolds = [];
   entriesToReturn = [{ id: "1", name: "openai", kind: "openai" }];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
     if (url.includes("/api/v1/vault")) {
       getCalls++;
+      const snapshot = entriesToReturn;
+      const hold = queuedHolds.shift();
+      if (hold) {
+        claimedHolds.push(hold);
+        await hold.promise;
+        return new Response(
+          JSON.stringify(hold.fail ? { error: "boom" } : { entries: snapshot }),
+          {
+            status: hold.fail ? 500 : 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
       await new Promise((r) => setTimeout(r, 5));
       if (failNext || failAll) {
         failNext = false;
@@ -335,6 +366,75 @@ describe("useVaultRefs across a vault change", () => {
     await waitFor(() =>
       expect(result.current.known?.has("vault:9")).toBe(true),
     );
+    cleanup();
+  });
+});
+
+// Clearing the in-flight map does not cancel the request it was tracking. A load that started
+// BEFORE the vault changed is still on the wire, and if it lands last it describes the vault as it
+// was: it would overwrite both the shared cache and the listener with pre-mutation data, and the
+// credential just created would read as deleted until something else moved.
+describe("a load overtaken by a vault change", () => {
+  test("discards the answer that describes the vault as it was", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    holdNextResponse();
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() => expect(getCalls).toBe(1));
+    // The vault changes while that first read is still on the wire.
+    entriesToReturn = [
+      { id: "3", name: "openai", kind: "openai" },
+      { id: "9", name: "just-created", kind: "openai" },
+    ];
+    await act(async () => {
+      invalidateVault();
+    });
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:9")).toBe(true),
+    );
+    // Now the overtaken read lands, carrying the list from before the change.
+    await act(async () => {
+      releaseHeld(0);
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(result.current.known?.has("vault:9")).toBe(true);
+    // And it did not poison the shared cache for everyone else either.
+    const cached = await loadVault();
+    expect(cached.map((e) => e.id).sort()).toEqual(["3", "9"]);
+    cleanup();
+  });
+});
+
+// The in-flight entry belongs to the read that set it, and a read that FAILS is the case where that
+// matters: an overtaken read that succeeds settles only once its replacement lands (it hands the
+// caller that newer answer), while a rejection is immediate and lands mid-flight. Clearing the map
+// there would evict the entry of the read still on the wire, and the next caller to arrive would
+// fire a third request for a list already coming — the whole reason this cache exists.
+describe("the in-flight entry while a superseded load fails", () => {
+  test("survives the failure of the read it replaced", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    holdNextResponse({ fail: true });
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() => expect(getCalls).toBe(1));
+    holdNextResponse();
+    await act(async () => {
+      invalidateVault();
+    });
+    await waitFor(() => expect(getCalls).toBe(2));
+    // The overtaken read fails now, while the current one is still on the wire.
+    await act(async () => {
+      releaseHeld(0);
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    // A newcomer joins that read instead of starting another. The tick matters: the request would
+    // only reach the stub on the next turn, so asserting immediately would pass either way.
+    const joined = loadVault();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(getCalls).toBe(2);
+    await act(async () => {
+      releaseHeld(1);
+      await joined;
+    });
+    expect(result.current.known?.has("vault:3")).toBe(true);
     cleanup();
   });
 });

--- a/tests/client/lib/vaultCache.test.ts
+++ b/tests/client/lib/vaultCache.test.ts
@@ -15,6 +15,9 @@ import {
 // active tenant with the real setActiveTenantId (localStorage, provided by happy-dom).
 const realFetch = globalThis.fetch;
 let getCalls = 0;
+// Flips one response to a server error, to separate "the vault is empty" from "the vault did not
+// load" — the treaty reports both with an empty `data`.
+let failNext = false;
 let entriesToReturn: Array<{
   id: string;
   name: string;
@@ -27,12 +30,20 @@ beforeEach(() => {
   invalidateVault();
   setActiveTenantId(null);
   getCalls = 0;
+  failNext = false;
   entriesToReturn = [{ id: "1", name: "openai", kind: "openai" }];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
     if (url.includes("/api/v1/vault")) {
       getCalls++;
       await new Promise((r) => setTimeout(r, 5));
+      if (failNext) {
+        failNext = false;
+        return new Response(JSON.stringify({ error: "boom" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        });
+      }
       return new Response(JSON.stringify({ entries: entriesToReturn }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -202,6 +213,49 @@ describe("useVaultRefs", () => {
     await waitFor(() =>
       expect(result.current.known?.has("vault:9")).toBe(false),
     );
+    cleanup();
+  });
+});
+
+// A vault that failed to load is UNKNOWN, not empty. The treaty resolves a non-2xx with `data:
+// null` instead of rejecting, so without an explicit check the failure would arrive as an empty
+// list — and an empty list means "no credential resolves", which would flag every field on the page
+// as deleted on a transient 500.
+describe("a failed vault load", () => {
+  test("rejects instead of resolving to an empty list", async () => {
+    failNext = true;
+    expect(loadVault()).rejects.toThrow();
+  });
+
+  test("leaves useVaultRefs at not-loaded", async () => {
+    failNext = true;
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() => expect(getCalls).toBe(1));
+    expect(result.current.known).toBeNull();
+    cleanup();
+  });
+});
+
+// The same ref can be written more than one way and mean the same entry, and the endpoint lookup is
+// judged by the speech rewrite: a padded id reading as "no endpoint" would declare a runnable
+// rewrite dead.
+describe("useVaultBaseUrls with a noncanonical ref", () => {
+  test("resolves a padded id to the same entry", async () => {
+    entriesToReturn = [
+      {
+        id: "7",
+        name: "llama",
+        kind: "openai",
+        baseUrl: "http://llama:8080/v1",
+      },
+    ];
+    const { result } = renderHook(() => useVaultBaseUrls());
+    await waitFor(() =>
+      expect(result.current("vault:7")).toBe("http://llama:8080/v1"),
+    );
+    expect(result.current("vault:0007")).toBe("http://llama:8080/v1");
+    // A name is not a ref: no id can be read out of it, and no resolver matches it.
+    expect(result.current("llama")).toBeNull();
     cleanup();
   });
 });

--- a/tests/client/lib/vaultCache.test.ts
+++ b/tests/client/lib/vaultCache.test.ts
@@ -306,3 +306,35 @@ describe("a failed refreshVault", () => {
     cleanup();
   });
 });
+
+// Every vault mutation in the app funnels through `invalidateVault` or `refreshVault`, and both
+// announce it. From the announcement until the replacement list lands, the list in hand is known to
+// predate the change — and the caller has usually just created the credential a field now points
+// at. Answering "the vault does not hold this ref" from that list is how a credential created a
+// second ago reads as deleted, so the answer is withheld for the length of the request.
+describe("useVaultRefs across a vault change", () => {
+  test("stops answering from the pre-change list until the new one lands", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:3")).toBe(true),
+    );
+    // What a create does: the entry exists in the vault, the field already points at it, and the
+    // list in hand is the one from before.
+    entriesToReturn = [
+      { id: "3", name: "openai", kind: "openai" },
+      { id: "9", name: "just-created", kind: "openai" },
+    ];
+    // The real path every mutation takes: the cache is dropped and the listeners are told, in that
+    // order (VaultPanel's delete and the editor's credential-fill modal both call exactly this).
+    act(() => {
+      invalidateVault();
+    });
+    // Mid-flight: no claim either way about vault:9.
+    expect(result.current.known).toBeNull();
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:9")).toBe(true),
+    );
+    cleanup();
+  });
+});

--- a/tests/client/lib/vaultCache.test.ts
+++ b/tests/client/lib/vaultCache.test.ts
@@ -109,7 +109,11 @@ describe("vaultCache", () => {
     expect(getCalls).toBe(1);
   });
 
-  test("refreshVault forces a refetch and emits the change event", async () => {
+  // Two announcements, one refetch. The first says the list in hand is stale — it goes out before
+  // the request, because that gap is when a listener would otherwise answer from a vault that has
+  // already changed — and the second says the replacement has arrived. Listeners re-read on both,
+  // and the second re-read is served from the cache, which is why this still costs one GET.
+  test("refreshVault forces a refetch and brackets it with change events", async () => {
     await loadVault();
     let fired = 0;
     const h = () => {
@@ -119,7 +123,7 @@ describe("vaultCache", () => {
     await refreshVault();
     window.removeEventListener(VAULT_CHANGED_EVENT, h);
     expect(getCalls).toBe(2);
-    expect(fired).toBe(1);
+    expect(fired).toBe(2);
   });
 
   test("invalidateVault drops the cache (next load refetches) and emits", async () => {
@@ -435,6 +439,76 @@ describe("the in-flight entry while a superseded load fails", () => {
       await joined;
     });
     expect(result.current.known?.has("vault:3")).toBe(true);
+    cleanup();
+  });
+});
+
+// The two orderings a refresh can take, and both used to end with the panel answering from
+// something that is not the current vault.
+describe("refreshVault while listeners are watching", () => {
+  test("tells them the moment it drops the list, not when the new one lands", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:3")).toBe(true),
+    );
+    // The picker's create: the entry exists, the field already points at it, and this refresh is
+    // what will deliver it. Until it does, the list in hand is the one from before.
+    entriesToReturn = [
+      { id: "3", name: "openai", kind: "openai" },
+      { id: "9", name: "just-created", kind: "openai" },
+    ];
+    holdNextResponse();
+    let pending: Promise<unknown> = Promise.resolve();
+    await act(async () => {
+      pending = refreshVault().catch(() => undefined);
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    expect(result.current.known).toBeNull();
+    await act(async () => {
+      releaseHeld(0);
+      await pending;
+    });
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:9")).toBe(true),
+    );
+    cleanup();
+  });
+});
+
+// A superseded read is irrelevant whether it succeeded or FAILED: its 500 says nothing about the
+// vault the caller is asking about. Reported as the caller's own failure, it drove the listener to
+// not-loaded on top of the fresh list that had already arrived, and nothing would come along to put
+// it back — the panel silent about pending and dangling credentials until the next reload.
+describe("a superseded read that fails after the fresh one landed", () => {
+  test("does not erase the answer that replaced it", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    holdNextResponse({ fail: true });
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() => expect(getCalls).toBe(1));
+    entriesToReturn = [
+      { id: "3", name: "openai", kind: "openai" },
+      { id: "9", name: "just-created", kind: "openai" },
+    ];
+    holdNextResponse();
+    await act(async () => {
+      invalidateVault();
+    });
+    await waitFor(() => expect(getCalls).toBe(2));
+    // The replacement lands first...
+    await act(async () => {
+      releaseHeld(1);
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:9")).toBe(true),
+    );
+    // ...and then the read it replaced fails.
+    await act(async () => {
+      releaseHeld(0);
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(result.current.known?.has("vault:9")).toBe(true);
     cleanup();
   });
 });

--- a/tests/client/lib/vaultCache.test.ts
+++ b/tests/client/lib/vaultCache.test.ts
@@ -18,6 +18,7 @@ let getCalls = 0;
 // Flips one response to a server error, to separate "the vault is empty" from "the vault did not
 // load" — the treaty reports both with an empty `data`.
 let failNext = false;
+let failAll = false;
 let entriesToReturn: Array<{
   id: string;
   name: string;
@@ -31,13 +32,14 @@ beforeEach(() => {
   setActiveTenantId(null);
   getCalls = 0;
   failNext = false;
+  failAll = false;
   entriesToReturn = [{ id: "1", name: "openai", kind: "openai" }];
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
     if (url.includes("/api/v1/vault")) {
       getCalls++;
       await new Promise((r) => setTimeout(r, 5));
-      if (failNext) {
+      if (failNext || failAll) {
         failNext = false;
         return new Response(JSON.stringify({ error: "boom" }), {
           status: 500,
@@ -256,6 +258,51 @@ describe("useVaultBaseUrls with a noncanonical ref", () => {
     expect(result.current("vault:0007")).toBe("http://llama:8080/v1");
     // A name is not a ref: no id can be read out of it, and no resolver matches it.
     expect(result.current("llama")).toBeNull();
+    cleanup();
+  });
+});
+
+// A refresh that fails leaves the listeners holding a list the cache no longer has, and the caller
+// has usually just CHANGED the vault (created or filled a credential) and pointed a field at the
+// result. Staying quiet there means the editor keeps answering from a list that predates the change
+// — a credential created a moment ago reading as deleted.
+describe("a failed refreshVault", () => {
+  test("sends listeners back to the vault, which heals a transient failure", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:3")).toBe(true),
+    );
+    // What the caller just did: created entry 9 and pointed a field at it. The refresh that would
+    // have delivered it fails; the re-read that the notification triggers succeeds.
+    entriesToReturn = [
+      { id: "3", name: "openai", kind: "openai" },
+      { id: "9", name: "fresh", kind: "openai" },
+    ];
+    failNext = true;
+    await act(async () => {
+      await refreshVault().catch(() => undefined);
+    });
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:9")).toBe(true),
+    );
+    cleanup();
+  });
+
+  test("leaves them at not-loaded when the vault stays down", async () => {
+    entriesToReturn = [{ id: "3", name: "openai", kind: "openai" }];
+    const { result } = renderHook(() => useVaultRefs());
+    await waitFor(() =>
+      expect(result.current.known?.has("vault:3")).toBe(true),
+    );
+    failAll = true;
+    await act(async () => {
+      await refreshVault().catch(() => undefined);
+    });
+    // Not the stale list, which is what silence would have left behind: a credential the operator
+    // just created reading as deleted.
+    await waitFor(() => expect(result.current.known).toBeNull());
+    failAll = false;
     cleanup();
   });
 });

--- a/tests/modules/vault/dangling-ref.test.ts
+++ b/tests/modules/vault/dangling-ref.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { computeConfigIssues } from "@/client/lib/configHealth";
+import { formatVaultRef } from "@/client/lib/credentialRef";
+import type { TenantContext } from "@/lib/tenancy";
+import {
+  deleteVaultEntry,
+  listVaultEntryInfos,
+  vaultReferences,
+} from "@/modules/vault/service";
+
+// An agent holding a ref to a vault entry that no longer exists, produced the way the product
+// produces it: the operator deletes the key. Nothing blocks that delete and nothing rewrites the
+// agents that named the key, so the ref survives its target. This walks the whole chain in one test,
+// because each half on its own proves the wrong thing — that the state is reachable says nothing
+// about what the editor does with it, and a hand-written "gone" ref in a unit test proves the
+// product can produce one only by assertion.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let agentId = 0n;
+let keyId = 0n;
+let keptId = 0n;
+// The client helper, fed the serialized id exactly as the API hands it to the browser.
+const ref = (id: bigint): string => formatVaultRef(String(id));
+const ctx = (): TenantContext => ({
+  tenantId,
+  userId: null,
+  role: "TENANT_ADMIN",
+});
+
+describe.skipIf(!dbUp)("a vault entry deleted out from under an agent", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "DANGLE", slug: `dangle-${process.pid}` },
+    });
+    tenantId = t.id;
+    const key = await suDb.vaultEntry.create({
+      data: { tenantId, name: "openai-main", secret: encryptJson("sk-x") },
+      select: { id: true },
+    });
+    keyId = key.id;
+    const kept = await suDb.vaultEntry.create({
+      data: { tenantId, name: "eleven", secret: encryptJson("sk-y") },
+      select: { id: true },
+    });
+    keptId = kept.id;
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "dangling",
+        systemPrompt: "p",
+        modelConfig: { provider: "openai", credentialRef: ref(keyId) },
+        settings: {
+          tts: { mode: "mirror", credentialRef: ref(keptId) },
+        },
+      },
+      select: { id: true },
+    });
+    agentId = agent.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const table of ["agents", "vault_entries"]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  test("the delete goes through even though an agent names the key", async () => {
+    const before = await vaultReferences(ctx(), keyId, appDb);
+    expect(before.agents.map((a) => a.name)).toEqual(["dangling"]);
+    // The reference list is what the vault UI shows before deleting; it informs, it does not refuse.
+    await deleteVaultEntry(ctx(), keyId, appDb);
+    const rows = await listVaultEntryInfos(ctx(), appDb);
+    expect(rows.map((r) => r.id)).toEqual([String(keptId)]);
+  });
+
+  test("the agent still carries the ref, now pointing at nothing", async () => {
+    const row = await suDb.agent.findFirst({
+      where: { id: agentId },
+      select: { modelConfig: true },
+    });
+    const mc = row?.modelConfig as { credentialRef?: string };
+    expect(mc.credentialRef).toBe(ref(keyId));
+  });
+
+  // The effect this issue is about: the panel that exists to say "this agent has something that will
+  // not run" reads the vault list above, and that list is the only thing that can tell it the key is
+  // gone. Same refs, same list the editor loads.
+  test("the editor's health panel flags it from the vault list alone", async () => {
+    const rows = await listVaultEntryInfos(ctx(), appDb);
+    const issues = computeConfigIssues({
+      modelProvider: "openai",
+      modelCredentialRef: ref(keyId),
+      savedModelProvider: "openai",
+      sttEnabled: false,
+      sttCredentialRef: "",
+      ttsMode: "mirror",
+      ttsCredentialRef: ref(keptId),
+      visionEnabled: false,
+      visionCredentialRef: "",
+      knownRefs: new Set(rows.map((r) => formatVaultRef(r.id))),
+      pendingRefs: new Set(
+        rows
+          .filter((r) => r.status === "pending")
+          .map((r) => formatVaultRef(r.id)),
+      ),
+    });
+    expect(issues).toEqual([
+      {
+        key: "model",
+        tab: "general",
+        sectionId: "general-model",
+        unresolved: true,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
The agent editor's configuration-health panel knew two states for a credential reference: unset, and pointing at a **pending** vault entry (referenced, secret never filled). A reference pointing at an entry that **no longer exists** read as configured, so the one panel meant to summarise "this agent has something that will not run" stayed green while the runtime skipped.

## What was measured

The state is reachable through the product, not only over the API. `deleteVaultEntry` is a plain `deleteMany`; the reference list the delete dialog shows is informational and does not refuse. Nothing rewrites the agents that named the key.

Reproduced end to end in the browser, on a real install:

1. point an agent's model credential at a key, save → panel green, correctly;
2. delete that key from the vault screen (the dialog lists the agent, then deletes anyway);
3. reopen the editor → **before this change**, the panel stayed green while the credential field itself already said "credential unavailable"; the agent could not reply.

At runtime the same state produces: the agent's own model logging `did not resolve — the agent cannot reply until it is fixed`, and STT / vision / TTS / the speech rewrite / the guardrails analysis skipping with a `warn` line on the flow log. All silent from the operator's side.

## The change

The third state goes through the **same** verdict function as the other two, and every reference that can hold a credential now runs through it: `modelConfig.credentialRef`, `stt`, `tts`, `tts.normalizeCredentialRef`, `vision`, `guardrails`, and the tenant's `embedding` key.

Guardrails were missing from the panel entirely before this (found in review): `SETTINGS_CREDENTIAL_PATHS` lists five settings references and the panel checked four. Theirs is the one worth having most, because `loadAgentConfig` fails **open** on it — the analysis is skipped and every message goes out as if it had been screened and approved. Adding the field brought its missing and pending states with it, since all three come from one function.

Two more states the same rule catches, beyond the deletion it was written for:

- **a reference stored as a NAME**, or in any spelling no resolver matches. References resolve by id only. MCP speaks names and `PATCH /v1/agents/:id` stores whatever it is handed, so a name reads as configured in the editor and resolves to nothing at runtime.
- **`vault:0007` and `vault:7` are one entry.** Every resolver parses the id with `BigInt`. Comparing raw strings would report a working credential as deleted, so the comparison is canonical — in `credentialRef.ts`, because the panel was not the only place asking "which entry is this reference": the endpoint lookup and the picker's own selected-entry lookups had the identical comparison, and the connection test downstream had to move to the entry's id for the same reason.

**An OpenAI-compatible model's exemption covers an absent credential, not a broken one.** That provider authenticates through its base URL, and the check read that as "this field is never examined". `loadAgentConfig` resolves a reference that IS set before it looks at the provider, and returns null for the whole agent when it cannot — silence on every message, not one feature going quiet.

## Not answering from a vault you do not have

Most of this branch's review rounds were one family: something that is not the *current* vault list being compared against the vault list. The panel's job is to be trusted, so it is quiet whenever it does not know:

- `knownRefs` is `null` until the first list lands, because an empty set means "nothing resolves" and would flag every field on the page for one paint;
- a failed `GET /vault` **rejects** instead of arriving as an empty list (the treaty resolves a non-2xx with `data: null`);
- every mutation announces itself before its refetch, not after, so the seconds between dropping the old list and receiving the new one are not spent claiming a just-created credential was deleted;
- vault knowledge carries a **generation**: a read that started before a change is neither cached nor returned when it lands late, whether it succeeded or failed, because its answer is about a vault that no longer exists.

One deferral is deliberately narrow. The rewrite's endpoint can arrive on a credential, so `endpoint_unusable` waits for the vault — but only while some credential is in play that could carry one. A missing vault list is not a momentary state (a failed load leaves it missing until a mutation or a reload), so deferring a verdict no credential could rescue would delete that warning rather than delay it.

Out of scope, deliberately: making `deleteVaultEntry` refuse (409) when the entry is referenced. That is a workflow change rather than a fix to this symptom, and the delete dialog already lists what will break.

## Validation scope

**Proved red first**, then green, in every round. The first round's five failing cases were the defect itself; each review round since added its own failing case before its fix.

- `tests/client/config-health.test.ts` — the three states across all seven references, the deep-link target of each, the openai-compatible exemption, and which endpoint refusals wait for the vault.
- `tests/client/lib/vaultCache.test.ts` — not-loaded vs empty, a rejecting load, both endings of a failed refresh, the announcement ordering, and two out-of-order-response races driven by a stub that holds responses open and snapshots each body when its request leaves.
- `tests/client/lib/credentialRef.test.ts` (new) — the canonical form, including that it follows the server resolver rather than being independently tidy.
- `tests/client/components/CredentialPicker.test.tsx` (new) — a noncanonical reference selects its entry and tests `/api/v1/vault/7/test`, the id the route accepts.
- `tests/modules/vault/dangling-ref.test.ts` (DB-backed, new) — the whole chain in one test, because each half proves the wrong thing alone: the delete goes through while an agent names the key, the agent still carries the reference afterwards, and the panel flags it from the vault list alone.

**Mutation-tested**, one rule at a time, every round. Three mutations survived and each one changed the code rather than being explained away: an ordering nothing depends on (documented as such), and two conditions in the endpoint deferral that turned out to be wrong and dead respectively — a stated endpoint does not settle the question, because a credential's base URL wins over the typed field in the editor and the runtime alike.

**Validated live** in the browser against a local install, twice: on the original change, and again on the merge candidate, where the guardrails field was driven end to end (enable → warning, credential → clear, delete the credential → "no longer exists", and the deep link landing on the field).

`bun check` green with the test Postgres up: 2708 pass, 0 fail.

Fixes #114
