### PR TITLE
test(semaphore): stop asserting the concurrency peak with a stopwatch

### DIFF
--- a/tests/lib/semaphore.test.ts
+++ b/tests/lib/semaphore.test.ts
@@ -45,6 +45,59 @@ describe("Semaphore", () => {
     expect(results).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
+  // A released permit is handed straight to the next waiter. Bumping `available` on that path as
+  // well would MINT a permit on every handoff, leaving the semaphore permanently wider than it was
+  // built: measured on the mutation, a 3-permit semaphore came out of one 10-task burst with 10
+  // permits. It is invisible INSIDE a burst, because the minted permits appear as the queue drains
+  // and every caller has already acquired by then, so a second wave is the only place the invariant
+  // is observable. Left untested, the leak surfaced only as a neighbouring suite failing, since the
+  // agent model semaphore is a process-wide singleton.
+  test("a burst that queued waiters does not widen the semaphore", async () => {
+    const sem = new Semaphore(3);
+    const burst = async () => {
+      let active = 0;
+      let maxActive = 0;
+      await Promise.all(
+        Array.from({ length: 10 }, () =>
+          sem.run(async () => {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            await tick();
+            active -= 1;
+          }),
+        ),
+      );
+      return maxActive;
+    };
+    expect(await burst()).toBe(3);
+    expect(await burst()).toBe(3);
+  });
+
+  // FIFO is a fairness claim, not an implementation detail: this bounds how long the conversation
+  // that has been waiting longest can be overtaken. Under LIFO a sustained burst starves the oldest
+  // waiter indefinitely, and the customer on the other end of that turn is the one already waiting.
+  test("a freed permit goes to the waiter that queued first", async () => {
+    const sem = new Semaphore(1);
+    const order: string[] = [];
+    let releaseHolder: () => void = () => {};
+    const held = new Promise<void>((resolve) => {
+      releaseHolder = resolve;
+    });
+    // `run` calls acquire synchronously, so the map below queues the waiters in exactly this order.
+    const holder = sem.run(async () => {
+      order.push("holder");
+      await held;
+    });
+    const queued = ["a", "b", "c"].map((name) =>
+      sem.run(async () => {
+        order.push(name);
+      }),
+    );
+    releaseHolder();
+    await Promise.all([holder, ...queued]);
+    expect(order).toEqual(["holder", "a", "b", "c"]);
+  });
+
   test("clamps non-positive permits to at least 1 (no deadlock)", async () => {
     const sem = new Semaphore(0);
     const ok = await sem.run(() => Promise.resolve("ran"));

--- a/tests/modules/debounce-parallelism.test.ts
+++ b/tests/modules/debounce-parallelism.test.ts
@@ -69,16 +69,37 @@ function threadOf(convId: number) {
 // per call, which keeps a real failure fast and readable instead of a test-timeout.
 const QUORUM_GRACE_MS = 1_000;
 
+// NOTE: reaching quorum only settles the LOWER half of `toBe(cap)`. Releasing there would let the
+// parked calls drain within `delayMs` while an over-admitted call was still doing its own DB work,
+// and the peak would read exactly `cap` on a semaphore that admits more than one. So quorum does not
+// release: everyone stays parked through this window, where an extra arrival still counts. Sized
+// from the measured tail (the 5 surplus turns arrive within ~25ms of the 20th) at 3x the fake
+// latency, so it is not a stopwatch on the same scale as the thing it observes.
+//
+// It is a window, not a proof: no finite wait can rule out an admission that comes later still. The
+// deterministic upper bound lives in tests/lib/semaphore.test.ts and tests/graph/model-limit.test.ts,
+// where every caller acquires synchronously in one tick and no timing is involved. What this buys is
+// that the INTEGRATION path can see over-admission at all, which it could not before.
+const OVERFLOW_PROBE_MS = 300;
+
 function quorumGate(quorum: number, meter: { active: number }) {
   let reached: () => void = () => {};
   const atQuorum = new Promise<void>((resolve) => {
     reached = resolve;
   });
+  let quorumMet = false;
   let grace: Promise<unknown> | undefined;
   return async () => {
-    if (meter.active >= quorum) reached();
+    if (meter.active >= quorum) {
+      quorumMet = true;
+      reached();
+    }
     grace ??= sleep(QUORUM_GRACE_MS);
     await Promise.race([atQuorum, grace]);
+    // Skipped when the gate opened on the grace clock instead: a semaphore that admits FEWER than
+    // the cap never reaches quorum, and charging it the probe per serialized call would end the
+    // test on the clock rather than on the assertion that names the defect.
+    if (quorumMet) await sleep(OVERFLOW_PROBE_MS);
   };
 }
 
@@ -276,8 +297,12 @@ describe.skipIf(!dbUp)("debounce parallelism", () => {
     // semaphore holds the line at config.agent.modelConcurrency. Deterministic thanks to the
     // rendezvous above, which is why this is `toBe` and not a range.
     expect(meter.max).toBe(cap);
-    // Anti-serial guard, generous to avoid timing flakiness: serial would be ~M*delayMs (the real
-    // number is in the log). meter.max === cap above is the strong, deterministic proof of parallelism.
-    expect(elapsed).toBeLessThan(M * delayMs);
+    // NOTE: the wall-clock anti-serial guard that used to sit here is gone. It bounded `elapsed`
+    // below M*delayMs, but the rendezvous adds fixed harness time (grace clock, probe window) that
+    // has nothing to do with the code under test, so the bound had drifted into measuring this
+    // file's own overhead: 1428ms observed against a 2500ms threshold. It also bought nothing.
+    // Serializing the worker's own `Promise.allSettled` over the jobs is caught above with a peak of
+    // 1, before the timing assertion is ever reached. `elapsed` stays in the log, where a human
+    // reading a failure wants it, and asserts nothing.
   });
 });

--- a/tests/modules/debounce-parallelism.test.ts
+++ b/tests/modules/debounce-parallelism.test.ts
@@ -52,9 +52,44 @@ function threadOf(convId: number) {
   return `${tenantId}:${instanceId}:${convId}`;
 }
 
-// Fake chat model: sleeps `delayMs` (LLM latency) and tracks concurrent in-flight calls via a shared
-// meter. bindTools returns self so it works whether or not the runtime binds native tools.
-function sleepyModel(delayMs: number, meter: { active: number; max: number }) {
+// NOTE: turns reach the model at their own pace, because each one does real DB work first. Measured
+// on this suite: 20 turns spread their arrivals over 91-147ms while the fake latency was 100ms, so
+// the first turn regularly released its permit before the last one arrived and the observed peak
+// landed at 15-19 instead of 20. The test failed ~13% of local runs, isolated, with nothing wrong in
+// the code under test.
+//
+// The gate turns that race into a rendezvous: every call parks until `quorum` are in flight at once,
+// so the peak becomes a property of the SEMAPHORE rather than of how loaded the machine is. What it
+// deliberately does not do is weaken the assertion — a semaphore that admits more than the cap still
+// pushes the peak above it, and one that admits fewer never reaches quorum, waits out the grace
+// window and fails on the same `toBe(cap)`. Both directions are covered by mutation.
+//
+// The grace window is ONE shared clock started by the first arrival, not a per-call timeout: a
+// broken semaphore that serializes the calls then costs the test one window in total instead of one
+// per call, which keeps a real failure fast and readable instead of a test-timeout.
+const QUORUM_GRACE_MS = 1_000;
+
+function quorumGate(quorum: number, meter: { active: number }) {
+  let reached: () => void = () => {};
+  const atQuorum = new Promise<void>((resolve) => {
+    reached = resolve;
+  });
+  let grace: Promise<unknown> | undefined;
+  return async () => {
+    if (meter.active >= quorum) reached();
+    grace ??= sleep(QUORUM_GRACE_MS);
+    await Promise.race([atQuorum, grace]);
+  };
+}
+
+// Fake chat model: waits for the rendezvous, then sleeps `delayMs` (LLM latency), tracking concurrent
+// in-flight calls via a shared meter. bindTools returns self so it works whether or not the runtime
+// binds native tools.
+function sleepyModel(
+  delayMs: number,
+  meter: { active: number; max: number },
+  gate: () => Promise<void>,
+) {
   const model = {
     bindTools() {
       return model;
@@ -63,6 +98,7 @@ function sleepyModel(delayMs: number, meter: { active: number; max: number }) {
       meter.active += 1;
       meter.max = Math.max(meter.max, meter.active);
       try {
+        await gate();
         await sleep(delayMs);
         return new AIMessage(REPLY);
       } finally {
@@ -209,6 +245,7 @@ describe.skipIf(!dbUp)("debounce parallelism", () => {
     for (const id of convIds) await seedConversation(id);
 
     const meter = { active: 0, max: 0 };
+    const gate = quorumGate(cap, meter);
     const sent: Array<[number, string]> = [];
     const jobs = convIds.map((id) => jobFor(id));
 
@@ -220,7 +257,7 @@ describe.skipIf(!dbUp)("debounce parallelism", () => {
           job,
           base: appDb,
           deps: {
-            makeModel: () => sleepyModel(delayMs, meter),
+            makeModel: () => sleepyModel(delayMs, meter, gate),
             makeClient: parallelStub(sent),
             checkpointer: new MemorySaver(),
           },
@@ -235,8 +272,9 @@ describe.skipIf(!dbUp)("debounce parallelism", () => {
     expect(out.claimed).toBe(M);
     // Every conversation answered exactly once (no turn stuck/dropped under concurrency).
     expect(sent.length).toBe(M);
-    // Concurrency reached the model cap — proves parallel (serial would peak at 1) AND that the
-    // semaphore holds the line at config.agent.modelConcurrency.
+    // Concurrency reached the model cap: proves parallel (serial would peak at 1) AND that the
+    // semaphore holds the line at config.agent.modelConcurrency. Deterministic thanks to the
+    // rendezvous above, which is why this is `toBe` and not a range.
     expect(meter.max).toBe(cap);
     // Anti-serial guard, generous to avoid timing flakiness: serial would be ~M*delayMs (the real
     // number is in the log). meter.max === cap above is the strong, deterministic proof of parallelism.


### PR DESCRIPTION
The model semaphore's guarantees were asserted by comment, and the one test that
did assert them was a race.

## The flake

`debounce parallelism > N conversations drain in parallel` failed ~13% of local
runs, isolated, with nothing wrong in the code under test. It is invisible in CI,
where the whole `describe` is skipped for lack of a database.

The test drives 25 turns through the real tick and asserts the observed peak
concurrency `toBe(config.agent.modelConcurrency)` (20). Reaching 20 required the
20th turn to enter the model before the 1st left it, and the fake latency was
100ms. Instrumenting the arrivals showed how thin that is:

| observed spread of the first 20 arrivals | result |
| --- | --- |
| 91ms | pass |
| 107ms, 114ms, 127ms, 135ms, 139ms, 142ms, 147ms | fail, peak 15-19 |

Each turn does real work before the model (its own Prisma reads, graph assembly),
which costs ~5ms and does not overlap. Twenty of them is ~100ms, so the test sat
exactly on its own threshold and any load decided the outcome. Nothing about it
was specific to a slow machine: the arithmetic never had room.

The peak never once exceeded the cap across 13 measured runs, so the semaphore
itself was never implicated.

## The fix

The fake model now parks every call until `cap` are in flight, so the peak is
decided by the semaphore rather than by how fast turns can reach it. The grace
window is one shared clock started by the first arrival, not a per-call timeout,
so a semaphore that serialises the calls costs the test one window in total
instead of one per call, and fails on the assertion rather than on a test timeout.

The assertion is not weakened. A semaphore admitting more than the cap still
pushes the peak above it; one admitting fewer never reaches quorum and fails on
the same `toBe(cap)`.

## Two guards nobody was testing

Mutation found them, and each is a claim the code makes in a comment:

**A released permit is handed to the next waiter without bumping `available`.**
Bumping it as well MINTS a permit per handoff: measured on the mutation, a
3-permit semaphore came out of one 10-task burst holding 10 permits. It is
invisible inside a burst, because the minted permits appear as the queue drains
and every caller has already acquired by then. With the agent's semaphore being a
process-wide singleton, the only symptom was a NEIGHBOURING suite failing later in
the same run. A second burst is where the invariant is observable, so that is the
test.

**FIFO.** The class header claims it and nothing checked it. It is a fairness
claim, not an implementation detail: under LIFO a sustained burst starves the
waiter that has been queued longest, and that is the customer already waiting.

## Validation scope

Proven by test:

- 25 consecutive isolated runs of the parallelism test, peak exactly 20 every
  time, 0 failures. Before: 2 failures in 15 runs of the same file.
- 7 mutations of `Semaphore` and `runModelCall`, all killed: no cap at all; cap
  one lower; cap of 1; double release; `runModelCall` bypassing the semaphore;
  FIFO turned into LIFO; the non-positive-permit clamp removed. The last three
  were survivors before this change.
- Full suite green.

Not validated: nothing here runs in CI, because `test.yml` has no Postgres
service and every database-backed test is skipped there. That gap is real and
larger than this change; it is not addressed by this PR.
