### PR TITLE
ci(test): run the suite against a real Postgres

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,36 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # NOTE: a REAL Postgres, not a mock. Roughly 1600 of this suite's assertions are database-backed
+    # and every one of them is gated on `describe.skipIf(!dbUp)`, so without a server here they do
+    # not fail: they SKIP, and the job reports green having never run the end-to-end layer the
+    # project's testing standard is built on. A stubbed database would be worse than none, because
+    # row-level security is enforced by the server and a stub cannot enforce it.
+    #
+    # pgvector, not plain postgres: `scripts/db-bootstrap.sql` runs CREATE EXTENSION vector. pg17 is
+    # what every docker-compose in this repo ships, so CI tests the server operators actually run.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    # Two URLs and nothing else: `tests/setup.ts` derives every connection the suite uses from them,
+    # and `scripts/db-bootstrap.ts` creates the app role from the first. Two ROLES because that is
+    # the point of running a real server: the app connection is NON-superuser and NON-BYPASSRLS, so
+    # row-level security is actually exercised, while the superuser one does DDL and the tests' own
+    # setup and teardown. The credentials are throwaway and reachable only from inside this job.
+    env:
+      TEST_APP_DATABASE_URL: postgres://fazerai_app:fazerai_app@localhost:5432/agents_ci_test
+      TEST_MIGRATION_DATABASE_URL: postgres://postgres:postgres@localhost:5432/agents_ci_test
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
@@ -37,6 +67,11 @@ jobs:
 
       - name: Generate Prisma Client
         run: bun run prisma:generate
+
+      # CREATE DATABASE, then db-bootstrap (vector extension, app role, grants, langgraph schema),
+      # then `prisma migrate deploy`. The same command a developer runs after cloning.
+      - name: Provision Test Database
+        run: bun run db:test:setup
 
       - name: Run Tests
         run: bun run test

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -33,6 +33,14 @@ if (testSuUrl) {
     const appUrl = new URL(process.env.TEST_APP_DATABASE_URL);
     appUrl.pathname = testDbPath;
     process.env.TEST_APP_DATABASE_URL = appUrl.toString();
+    // NOTE: the LangGraph checkpointer is the one connection the fence above used to miss.
+    // `config.langgraphDatabaseUrl` is `LANGGRAPH_DATABASE_URL || DATABASE_URL`, so the dead
+    // DATABASE_URL set at the top only catches it when LANGGRAPH_DATABASE_URL is UNSET, and a dev
+    // `.env` sets it to the DEV database. Measured before this line existed: every `bun test` run
+    // pointed the checkpointer at secretaria_v4_db (1685 live checkpoint rows) while everything else
+    // was on secretaria_v4_test, and the /reset test issued deleteThread against it. Forced onto the
+    // test DB with the app-role creds, same derivation as the line above.
+    process.env.LANGGRAPH_DATABASE_URL = appUrl.toString();
   }
 }
 process.env.JWT_SECRET = "test-secret-key-for-testing-only";


### PR DESCRIPTION
The test job had no database, so `dbUp` was false everywhere and every
database-backed `describe` skipped. Counted on the last green run before this
change:

| | assertions |
| --- | --- |
| ran | 2010 |
| **skipped** | **1627** |

The job reported success having never executed the end-to-end layer this
project's testing standard is built on. That is the worst kind of green, and it
is why both flakes fixed this week (#119, #121) were invisible here and only ever
showed on a developer's machine.

## A real server, not a stub

A stubbed database would be worse than none. Row-level security is enforced by
the server, and tenancy is the invariant most of these tests exist to prove, so
against a stub they would pass while proving nothing. `tests/lib/tenancy.integration.test.ts`
is the clearest case: it asserts RLS overrides an explicit cross-tenant `WHERE`,
which only a real Postgres can demonstrate.

`pgvector/pgvector:pg17` rather than plain `postgres`, for two reasons:
`scripts/db-bootstrap.sql` runs `CREATE EXTENSION vector`, and pg17 is what every
docker-compose in this repo ships, so CI now exercises the same server operators
actually run.

Two environment variables and nothing else. `bun run db:test:setup` is the same
command a developer runs after cloning: CREATE DATABASE, then db-bootstrap
(extension, app role, grants, langgraph schema), then `prisma migrate deploy`.
Two ROLES, because that is the point of running a real server: the app URL is a
NON-superuser NON-BYPASSRLS role so RLS is genuinely exercised, while the
superuser one does DDL and the tests' own setup and teardown.

## One connection was outside the test-database fence

Turning the suite on surfaced this, and it is the larger of the two findings here.

`tests/setup.ts` forces `MIGRATION_DATABASE_URL` and `TEST_APP_DATABASE_URL` onto
the dedicated test database precisely so the destructive suite (unscoped
`DELETE FROM scheduler_jobs`, tenant create and drop) can never reach the dev one.
The LangGraph checkpointer escaped it: `config.langgraphDatabaseUrl` is
`LANGGRAPH_DATABASE_URL || DATABASE_URL`, so the deliberately dead `DATABASE_URL`
that file sets only catches the checkpointer when `LANGGRAPH_DATABASE_URL` is
unset, and `.env.example` has developers set it.

Measured under the test preload, before this PR:

```
DATABASE_URL          : postgresql://test:***@localhost:5432/test      <- dead on purpose
TEST_APP_DATABASE_URL : postgres://...@localhost:5432/secretaria_v4_test
config.langgraphDatabaseUrl: postgres://...@localhost:5432/secretaria_v4_db   <- the DEV database
```

`secretaria_v4_db` held 1685 live checkpoint rows; the test database held 0. The
`/reset` test reaches that connection through production code and issues
`deleteThread` against it, so `bun test` has been deleting LangGraph threads in
the developer's dev database by whatever ids its fixtures happened to produce.
It is also the only reason that test passed: on a database that has never run the
app, the memory clear fails and the reset reports itself partial.

Forced onto the test database with the app-role credentials, the same derivation
the neighbouring line already used.

## Validation scope

Proven by running it, not by reading it. A throwaway `pgvector/pgvector:pg17`
container, provisioned from nothing by `bun run db:test:setup`, with exactly the
two variables this workflow sets and nothing else in the environment:

- three consecutive full-suite runs: **2746 passing, 0 failing, 0 skipped**;
- the same suite before the fence fix failed `/reset` on that virgin database,
  which is what led to the finding above;
- `bun check` green on a developer machine, where the fence now redirects the
  checkpointer to the test database even though `.env` still points
  `LANGGRAPH_DATABASE_URL` at the dev one.

Not validated: this PR's own CI run is the first execution of the workflow on
GitHub's runners, so the service container's startup and the provisioning step are
proven here rather than beforehand. Job duration will grow; the suite takes about
45s locally against a warm database and the provisioning step adds the migration
deploy on top.
