### PR TITLE
feat(playground): public no-login share links to chat with an agent

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9411,6 +9411,399 @@
         "operationId": "deleteV1AgentsByIdPlaygroundSessionsByThreadId"
       }
     },
+    "/v1/agents/{id}/playground/share": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Mint playground share link",
+        "description": "Creates a public, no-login link that lets a customer chat with this agent for a bounded time and message count.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Agent id, a BigInt encoded as a decimal string.",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ttlHours": {
+                    "minimum": 1,
+                    "maximum": 48,
+                    "type": "number"
+                  },
+                  "maxMessages": {
+                    "minimum": 1,
+                    "maximum": 500,
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ttlHours": {
+                    "minimum": 1,
+                    "maximum": 48,
+                    "type": "number"
+                  },
+                  "maxMessages": {
+                    "minimum": 1,
+                    "maximum": 500,
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ttlHours": {
+                    "minimum": 1,
+                    "maximum": 48,
+                    "type": "number"
+                  },
+                  "maxMessages": {
+                    "minimum": 1,
+                    "maximum": 500,
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postV1AgentsByIdPlaygroundShare"
+      },
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "List playground share links",
+        "description": "Lists the agent's share links (no tokens returned — the plaintext is only shown once, at mint time).",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Agent id, a BigInt encoded as a decimal string.",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getV1AgentsByIdPlaygroundShare"
+      }
+    },
+    "/v1/agents/{id}/playground/share/{linkId}": {
+      "delete": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Revoke playground share link",
+        "description": "Immediately invalidates a share link.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Agent id, a BigInt encoded as a decimal string.",
+              "type": "string"
+            }
+          },
+          {
+            "name": "linkId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Share link id, a BigInt encoded as a decimal string.",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "deleteV1AgentsByIdPlaygroundShareByLinkId"
+      }
+    },
     "/v1/agents/models/list": {
       "post": {
         "tags": [
@@ -28289,6 +28682,206 @@
           }
         },
         "operationId": "postV1ChatwootInboxesByIdReconnect"
+      }
+    },
+    "/v1/playground/share/{token}": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Resolve playground share link",
+        "description": "Public lookup for a share link: returns the agent's display name if the link is valid, or 404/429 if invalid, expired, or exhausted.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests — rate limited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Too many requests — rate limited.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getV1PlaygroundShareByToken"
+      }
+    },
+    "/v1/playground/share/{token}/message": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Send playground share link message",
+        "description": "Public chat turn against the agent bound to this share link. Consumes one message from the link's quota.",
+        "security": [],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "minLength": 1,
+                    "maxLength": 10000,
+                    "type": "string"
+                  },
+                  "threadId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "minLength": 1,
+                    "maxLength": 10000,
+                    "type": "string"
+                  },
+                  "threadId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "minLength": 1,
+                    "maxLength": 10000,
+                    "type": "string"
+                  },
+                  "threadId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests — rate limited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Too many requests — rate limited.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postV1PlaygroundShareByTokenMessage"
       }
     }
   }

--- a/prisma/migrations/20260819220000_playground_share_links/migration.sql
+++ b/prisma/migrations/20260819220000_playground_share_links/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable: PlaygroundShareLink — operator-minted, no-login public link to chat with an agent
+-- in an isolated playground thread. Only the SHA-256 hash of the token is stored.
+CREATE TABLE "playground_share_links" (
+    "id"            BIGSERIAL    NOT NULL,
+    "tenant_id"     BIGINT       NOT NULL,
+    "agent_id"      BIGINT       NOT NULL,
+    "token_hash"    TEXT         NOT NULL,
+    "message_count" INTEGER      NOT NULL DEFAULT 0,
+    "max_messages"  INTEGER      NOT NULL DEFAULT 60,
+    "expires_at"    TIMESTAMP(3) NOT NULL,
+    "revoked_at"    TIMESTAMP(3),
+    "created_at"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "playground_share_links_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes
+CREATE UNIQUE INDEX "playground_share_links_token_hash_key" ON "playground_share_links"("token_hash");
+CREATE INDEX "playground_share_links_tenant_id_idx" ON "playground_share_links"("tenant_id");
+CREATE INDEX "playground_share_links_agent_id_idx" ON "playground_share_links"("agent_id");
+
+-- FKs
+ALTER TABLE "playground_share_links"
+  ADD CONSTRAINT "playground_share_links_tenant_id_fkey"
+  FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "playground_share_links"
+  ADD CONSTRAINT "playground_share_links_agent_id_fkey"
+  FOREIGN KEY ("agent_id") REFERENCES "agents"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RLS: same tenant-isolation pattern as all other tenant-scoped tables. Uses 'on' (not 'true')
+-- for is_super_admin, matching asSuperAdminOn's set_config call. The public (no-login) route that
+-- consumes a token does its lookup via asSuperAdminOn (it has no tenant context yet — the token
+-- itself resolves the tenant), same shape as Chatwoot's resolveBotByRouteToken.
+ALTER TABLE "playground_share_links" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "playground_share_links" FORCE ROW LEVEL SECURITY;
+CREATE POLICY "tenant_isolation" ON "playground_share_links"
+  USING (
+    tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::BIGINT
+    OR current_setting('app.is_super_admin', true) = 'on'
+  );
+
+-- No GRANT statements here: scripts/db-bootstrap.ts's ALTER DEFAULT PRIVILEGES already covers
+-- every table created after it runs — see .claude/rules/prisma.md.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model Tenant {
   knowledgeDocuments            KnowledgeDocument[]
   playgroundSessions            PlaygroundSession[]
   playgroundMedia               PlaygroundMedia[]
+  playgroundShareLinks          PlaygroundShareLink[]
   approvalQueueItems            ApprovalQueueItem[]
   vaultEntries                  VaultEntry[]
   toolDefinitions               ToolDefinition[]
@@ -561,9 +562,10 @@ model Agent {
   createdAt           DateTime @default(now()) @map("created_at")
   updatedAt           DateTime @updatedAt @map("updated_at")
 
-  tenant         Tenant               @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  toolSelections AgentToolSelection[]
-  chatwootBots   ChatwootAgentBot[]
+  tenant               Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  toolSelections       AgentToolSelection[]
+  chatwootBots         ChatwootAgentBot[]
+  playgroundShareLinks PlaygroundShareLink[]
 
   @@index([tenantId])
   @@map("agents")
@@ -669,6 +671,27 @@ model PlaygroundSession {
   @@unique([tenantId, threadId])
   @@index([tenantId, agentId, updatedAt])
   @@map("playground_sessions")
+}
+
+// Operator-minted, no-login public link to chat with an agent in an isolated playground thread. Only
+// the SHA-256 hash of the token is stored (see src/modules/webhooks/inbound/route-token.ts).
+model PlaygroundShareLink {
+  id           BigInt    @id @default(autoincrement())
+  tenantId     BigInt    @map("tenant_id")
+  agentId      BigInt    @map("agent_id")
+  tokenHash    String    @unique @map("token_hash")
+  messageCount Int       @default(0) @map("message_count")
+  maxMessages  Int       @default(60) @map("max_messages")
+  expiresAt    DateTime  @map("expires_at")
+  revokedAt    DateTime? @map("revoked_at")
+  createdAt    DateTime  @default(now()) @map("created_at")
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  agent  Agent  @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@index([agentId])
+  @@map("playground_share_links")
 }
 
 // Binary media (recorded voice notes, generated TTS replies, uploaded files) for playground replay.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -33,6 +33,7 @@ import {
   oauthMcpCallbackController,
   oauthMcpVaultController,
 } from "@/api/v1/oauth-mcp.controller";
+import { playgroundShareController } from "@/api/v1/playground-share.controller";
 import { quotesController } from "@/api/v1/quotes.controller";
 import { tenantSettingsController } from "@/api/v1/tenant-settings.controller";
 import { toolsController } from "@/api/v1/tools.controller";
@@ -249,6 +250,7 @@ const api = new Elysia()
   .use(mcpMeController)
   .use(mcpAdminController)
   .use(chatwootController)
-  .use(chatwootAdminController);
+  .use(chatwootAdminController)
+  .use(playgroundShareController);
 
 export default api;

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -40,6 +40,15 @@ import {
   getPlaygroundSessionTurns,
   listPlaygroundSessions,
 } from "@/modules/playground/sessions";
+import {
+  listPlaygroundShareLinks,
+  MAX_MAX_MESSAGES,
+  MAX_TTL_HOURS,
+  MIN_MAX_MESSAGES,
+  MIN_TTL_HOURS,
+  mintPlaygroundShareLink,
+  revokePlaygroundShareLink,
+} from "@/modules/playground/share";
 import { listTtsOptions } from "@/modules/tts/listing";
 
 // translate('errors.agentConfirmMismatch', 'The agent name does not match')
@@ -1080,6 +1089,113 @@ export const agentsController = new Elysia({
         threadId: t.String({
           description:
             "Playground thread id, shaped tenantId:playground:agentId:uuid.",
+        }),
+      }),
+    },
+  )
+  // Public no-login share links: an operator mints a link (bounded TTL + message quota) that a
+  // customer can open to chat with the agent, no Chatwoot/login involved. The public side (resolve +
+  // send message) lives in playground-share.controller.ts, unauthenticated by design (opaque token).
+  .post(
+    "/:id/playground/share",
+    async ({ tenantContext, params, body }) => {
+      const ctx = ctxOrThrow(tenantContext);
+      const minted = await mintPlaygroundShareLink({
+        tenantId: ctx.tenantId as bigint,
+        agentId: BigInt(params.id),
+        ttlHours: body?.ttlHours,
+        maxMessages: body?.maxMessages,
+      });
+      return {
+        instance: instanceIdentity,
+        id: String(minted.id),
+        token: minted.token,
+        url: `${config.publicUrl.replace(/\/+$/, "")}/playground-share/${minted.token}`,
+        expiresAt: minted.expiresAt,
+        maxMessages: minted.maxMessages,
+      };
+    },
+    {
+      detail: doc(
+        "Mint playground share link",
+        "Creates a public, no-login link that lets a customer chat with this agent for a bounded time and message count.",
+      ),
+      response: errors(400, 401, 403, 404),
+      requireRole: "TENANT_ADMIN",
+      params: t.Object({
+        id: t.String({
+          description: "Agent id, a BigInt encoded as a decimal string.",
+        }),
+      }),
+      body: t.Optional(
+        t.Object({
+          ttlHours: t.Optional(
+            t.Number({ minimum: MIN_TTL_HOURS, maximum: MAX_TTL_HOURS }),
+          ),
+          maxMessages: t.Optional(
+            t.Number({ minimum: MIN_MAX_MESSAGES, maximum: MAX_MAX_MESSAGES }),
+          ),
+        }),
+      ),
+    },
+  )
+  .get(
+    "/:id/playground/share",
+    async ({ tenantContext, params }) => {
+      const ctx = ctxOrThrow(tenantContext);
+      const links = await listPlaygroundShareLinks(
+        ctx.tenantId as bigint,
+        BigInt(params.id),
+      );
+      return {
+        instance: instanceIdentity,
+        links: links.map((l) => ({
+          id: String(l.id),
+          messageCount: l.messageCount,
+          maxMessages: l.maxMessages,
+          expiresAt: l.expiresAt,
+          revokedAt: l.revokedAt,
+          createdAt: l.createdAt,
+        })),
+      };
+    },
+    {
+      detail: doc(
+        "List playground share links",
+        "Lists the agent's share links (no tokens returned — the plaintext is only shown once, at mint time).",
+      ),
+      response: errors(400, 401, 403, 404),
+      requireRole: "TENANT_ADMIN",
+      params: t.Object({
+        id: t.String({
+          description: "Agent id, a BigInt encoded as a decimal string.",
+        }),
+      }),
+    },
+  )
+  .delete(
+    "/:id/playground/share/:linkId",
+    async ({ tenantContext, params }) => {
+      const ctx = ctxOrThrow(tenantContext);
+      await revokePlaygroundShareLink(
+        ctx.tenantId as bigint,
+        BigInt(params.linkId),
+      );
+      return { instance: instanceIdentity, ok: true };
+    },
+    {
+      detail: doc(
+        "Revoke playground share link",
+        "Immediately invalidates a share link.",
+      ),
+      response: errors(400, 401, 403, 404),
+      requireRole: "TENANT_ADMIN",
+      params: t.Object({
+        id: t.String({
+          description: "Agent id, a BigInt encoded as a decimal string.",
+        }),
+        linkId: t.String({
+          description: "Share link id, a BigInt encoded as a decimal string.",
         }),
       }),
     },

--- a/src/api/v1/playground-share.controller.ts
+++ b/src/api/v1/playground-share.controller.ts
@@ -1,0 +1,110 @@
+import { Elysia, t } from "elysia";
+import { doc, errors } from "@/api/lib/openapi";
+import { AppError } from "@/lib/errors";
+import { runPlaygroundTurn } from "@/modules/playground/service";
+import {
+  claimPlaygroundShareLinkMessage,
+  resolvePlaygroundShareLink,
+} from "@/modules/playground/share";
+import {
+  isValidPlaygroundThread,
+  newPlaygroundThreadId,
+} from "@/modules/playground/thread";
+
+interface ResolvedLink {
+  id: bigint;
+  tenantId: bigint;
+  agentId: bigint;
+  agentName: string;
+}
+
+// Public, no-login playground share link: an operator-minted link a customer can open to chat
+// with an agent (isolated thread, no Chatwoot side effects). Not behind tenancyPlugin — the
+// opaque token resolves the tenant. "not_found" and "expired" collapse into one generic message
+// (no token-enumeration signal, same principle as the inbound receptor's UnauthorizedError);
+// "exhausted" is surfaced distinctly since it's a legitimate state for a valid link.
+async function resolveOrThrow(token: string): Promise<ResolvedLink> {
+  const resolved = await resolvePlaygroundShareLink(token);
+  if (resolved.status === "exhausted")
+    throw new AppError(
+      "This chat link has reached its message limit",
+      429,
+      "errors.playgroundShareLinkExhausted",
+    );
+  if (resolved.status !== "ok" || !resolved.link)
+    throw new AppError(
+      "This chat link is invalid or has expired",
+      404,
+      "errors.playgroundShareLinkInvalid",
+    );
+  return resolved.link;
+}
+
+export const playgroundShareController = new Elysia({
+  prefix: "/v1/playground/share",
+  tags: ["Agents"],
+})
+  .get(
+    "/:token",
+    async ({ params }) => {
+      const link = await resolveOrThrow(params.token);
+      return { agentName: link.agentName };
+    },
+    {
+      detail: {
+        ...doc(
+          "Resolve playground share link",
+          "Public lookup for a share link: returns the agent's display name if the link is valid, or 404/429 if invalid, expired, or exhausted.",
+        ),
+        security: [],
+      },
+      response: errors(404, 429),
+      params: t.Object({ token: t.String() }),
+    },
+  )
+  .post(
+    "/:token/message",
+    async ({ params, body }) => {
+      const link = await resolveOrThrow(params.token);
+      const claimed = await claimPlaygroundShareLinkMessage(
+        link.tenantId,
+        link.id,
+      );
+      if (!claimed)
+        throw new AppError(
+          "This chat link has reached its message limit",
+          429,
+          "errors.playgroundShareLinkExhausted",
+        );
+
+      const threadId =
+        body.threadId &&
+        isValidPlaygroundThread(body.threadId, link.tenantId, link.agentId)
+          ? body.threadId
+          : newPlaygroundThreadId(link.tenantId, link.agentId);
+
+      const result = await runPlaygroundTurn({
+        tenantId: link.tenantId,
+        agentId: link.agentId,
+        message: body.message,
+        threadId,
+      });
+      // Public clients never see internal trace/tool-call details, only the reply.
+      return { reply: result.reply, threadId: result.threadId };
+    },
+    {
+      detail: {
+        ...doc(
+          "Send playground share link message",
+          "Public chat turn against the agent bound to this share link. Consumes one message from the link's quota.",
+        ),
+        security: [],
+      },
+      response: errors(400, 404, 429),
+      params: t.Object({ token: t.String() }),
+      body: t.Object({
+        message: t.String({ minLength: 1, maxLength: 10_000 }),
+        threadId: t.Optional(t.String()),
+      }),
+    },
+  );

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -33,6 +33,7 @@ import { LoginPage } from "@/client/pages/LoginPage";
 import { LogsPage } from "@/client/pages/LogsPage";
 import { McpPage } from "@/client/pages/McpPage";
 import { OAuthConsentPage } from "@/client/pages/OAuthConsentPage";
+import { PlaygroundSharePage } from "@/client/pages/PlaygroundSharePage";
 import { AdvancedPanel } from "@/client/pages/resources/AdvancedPanel";
 import { BusinessHoursPanel } from "@/client/pages/resources/BusinessHoursPanel";
 import { IntegrationsPanel } from "@/client/pages/resources/IntegrationsPanel";
@@ -193,6 +194,10 @@ export function App() {
                                 element={<AcceptInvitePage />}
                               />
                               <Route path="/login" element={<LoginPage />} />
+                              <Route
+                                path="/playground-share/:token"
+                                element={<PlaygroundSharePage />}
+                              />
                               <Route path="/signup" element={<SignupPage />} />
                               <Route
                                 path="/oauth/consent"

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1688,6 +1688,27 @@
     "resize": "Drag to resize",
     "send": "Send",
     "sessions": "Sessions",
+    "share": {
+      "button": "Share",
+      "create": "Create link",
+      "createFailed": "Could not create the link",
+      "empty": "No share links yet.",
+      "existing": "Existing links",
+      "hint": "Create a public link so a customer can chat with this agent, no login required. It expires and stops accepting messages after its quota.",
+      "maxMessages": "Message limit",
+      "messageCount": "{{used}}/{{max}} messages",
+      "revoke": "Revoke",
+      "revokeAria": "Revoke share link",
+      "revokeFailed": "Could not revoke the link",
+      "revokeMessage": "The link will stop working immediately. This cannot be undone.",
+      "revokeTitle": "Revoke share link",
+      "statusActive": "Active until {{date}}",
+      "statusExpired": "Expired",
+      "statusRevoked": "Revoked",
+      "title": "Share this agent",
+      "ttl": "Expires in (hours)",
+      "urlWarning": "Copy this link now. It is shown only once here."
+    },
     "thinking": "Thinking…",
     "toolsDirtyNote": "Prompt and model changes are tested live. Tool changes need saving first.",
     "toolsim": {
@@ -1717,6 +1738,14 @@
       "visionImage": "Image reading"
     },
     "untitledSession": "Untitled session"
+  },
+  "playgroundShare": {
+    "chattingWith": "Chatting with {{name}}",
+    "empty": "Send a message to start.",
+    "exhausted": "This chat link has reached its message limit.",
+    "inputPlaceholder": "Type a message…",
+    "invalid": "This chat link is invalid or has expired.",
+    "sendError": "Something went wrong. Please try again."
   },
   "resources": {
     "deleteRefsWarning_one": "{{count}} agent uses this and will stop working if you delete it.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1693,6 +1693,27 @@
     "resize": "Arrastar para redimensionar",
     "send": "Enviar",
     "sessions": "Sessões",
+    "share": {
+      "button": "Compartilhar",
+      "create": "Criar link",
+      "createFailed": "Não foi possível criar o link",
+      "empty": "Nenhum link de compartilhamento ainda.",
+      "existing": "Links existentes",
+      "hint": "Crie um link público para o cliente conversar com este agente, sem precisar de login. O link expira e para de aceitar mensagens após atingir a cota.",
+      "maxMessages": "Limite de mensagens",
+      "messageCount": "{{used}}/{{max}} mensagens",
+      "revoke": "Revogar",
+      "revokeAria": "Revogar link de compartilhamento",
+      "revokeFailed": "Não foi possível revogar o link",
+      "revokeMessage": "O link deixará de funcionar imediatamente. Isso não pode ser desfeito.",
+      "revokeTitle": "Revogar link de compartilhamento",
+      "statusActive": "Ativo até {{date}}",
+      "statusExpired": "Expirado",
+      "statusRevoked": "Revogado",
+      "title": "Compartilhar este agente",
+      "ttl": "Expira em (horas)",
+      "urlWarning": "Copie este link agora. Ele é exibido apenas uma vez aqui."
+    },
     "thinking": "Pensando…",
     "toolsDirtyNote": "Mudanças de prompt e modelo são testadas ao vivo. Mudanças de ferramentas precisam ser salvas antes.",
     "toolsim": {
@@ -1722,6 +1743,14 @@
       "visionImage": "Leitura de imagem"
     },
     "untitledSession": "Sessão sem título"
+  },
+  "playgroundShare": {
+    "chattingWith": "Conversando com {{name}}",
+    "empty": "Envie uma mensagem para começar.",
+    "exhausted": "Este link de chat atingiu o limite de mensagens.",
+    "inputPlaceholder": "Digite uma mensagem…",
+    "invalid": "Este link de chat é inválido ou expirou.",
+    "sendError": "Algo deu errado. Tente novamente."
   },
   "resources": {
     "deleteRefsWarning_one": "{{count}} agente usa isto e vai parar de funcionar se você excluir.",

--- a/src/client/pages/PlaygroundSharePage.tsx
+++ b/src/client/pages/PlaygroundSharePage.tsx
@@ -1,0 +1,209 @@
+import { AlertTriangle, Loader2, Send } from "lucide-react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router";
+import { Button, Logo, Markdown, Textarea } from "@/client/components";
+import { api } from "@/client/lib/api";
+import { cn } from "@/client/lib/utils";
+
+interface ChatTurn {
+  role: "user" | "assistant" | "error";
+  text: string;
+}
+
+type PageState = "loading" | "invalid" | "exhausted" | "ready";
+
+function threadStorageKey(token: string) {
+  return `@app:playground-share-thread:${token}`;
+}
+
+// Public, no-login page for an operator-minted playground share link: a customer opens this URL to
+// chat with an agent, with no Chatwoot side effects. No auth, no trace/tool details — just the reply.
+// biome-ignore lint/plugin/require-page-container: public page renders its own centered layout outside <Layout>, so <PageContainer> does not apply
+export function PlaygroundSharePage() {
+  const { t } = useTranslation();
+  const { token } = useParams<{ token: string }>();
+  const [state, setState] = useState<PageState>("loading");
+  const [agentName, setAgentName] = useState("");
+  const [turns, setTurns] = useState<ChatTurn[]>([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const threadId = useRef<string | undefined>(undefined);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!token) {
+      setState("invalid");
+      return;
+    }
+    threadId.current =
+      sessionStorage.getItem(threadStorageKey(token)) ?? undefined;
+    let active = true;
+    api.api.v1.playground
+      .share({ token })
+      .get()
+      .then(({ data, error }) => {
+        if (!active) return;
+        if (error || !data) {
+          setState(error?.status === 429 ? "exhausted" : "invalid");
+          return;
+        }
+        setAgentName(data.agentName);
+        setState("ready");
+      });
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on every turn added
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [turns]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!token) return;
+    const text = input.trim();
+    if (!text || sending) return;
+    setInput("");
+    setSending(true);
+    setTurns((prev) => [...prev, { role: "user", text }]);
+    const { data, error } = await api.api.v1.playground
+      .share({ token })
+      .message.post({ message: text, threadId: threadId.current });
+    setSending(false);
+    if (error || !data) {
+      if (error?.status === 429) setState("exhausted");
+      setTurns((prev) => [
+        ...prev,
+        {
+          role: "error",
+          text: t(
+            "playgroundShare.sendError",
+            "Something went wrong. Please try again.",
+          ),
+        },
+      ]);
+      return;
+    }
+    threadId.current = data.threadId;
+    sessionStorage.setItem(threadStorageKey(token), data.threadId);
+    setTurns((prev) => [...prev, { role: "assistant", text: data.reply }]);
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center bg-bg-primary px-4 py-8">
+      <div className="flex w-full max-w-2xl flex-1 flex-col">
+        <div className="mb-6 flex items-center justify-center">
+          <Logo className="h-8" />
+        </div>
+
+        {state === "loading" && (
+          <div className="flex flex-1 items-center justify-center py-24">
+            <Loader2
+              className="h-6 w-6 animate-spin text-text-muted"
+              aria-hidden="true"
+            />
+          </div>
+        )}
+
+        {(state === "invalid" || state === "exhausted") && (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 rounded-lg border border-border bg-bg-secondary px-6 py-16 text-center">
+            <AlertTriangle
+              className="h-6 w-6 text-text-muted"
+              aria-hidden="true"
+            />
+            <p className="text-sm text-text-primary">
+              {state === "exhausted"
+                ? t(
+                    "playgroundShare.exhausted",
+                    "This chat link has reached its message limit.",
+                  )
+                : t(
+                    "playgroundShare.invalid",
+                    "This chat link is invalid or has expired.",
+                  )}
+            </p>
+          </div>
+        )}
+
+        {state === "ready" && (
+          <>
+            <p className="mb-4 text-center text-sm text-text-muted">
+              {t("playgroundShare.chattingWith", "Chatting with {{name}}", {
+                name: agentName,
+              })}
+            </p>
+            <div
+              ref={scrollRef}
+              className="flex flex-1 flex-col gap-3 overflow-y-auto rounded-lg border border-border bg-bg-secondary p-4"
+              style={{ minHeight: "50vh" }}
+            >
+              {turns.length === 0 && (
+                <p className="self-center px-2 py-8 text-center text-sm text-text-muted">
+                  {t("playgroundShare.empty", "Send a message to start.")}
+                </p>
+              )}
+              {turns.map((turn, i) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: append-only local transcript, never reordered
+                  key={i}
+                  className={cn(
+                    "flex max-w-[85%] flex-col gap-1",
+                    turn.role === "user" ? "items-end self-end" : "self-start",
+                  )}
+                >
+                  <div
+                    className={cn("rounded-lg px-3 py-2 text-sm", {
+                      "bg-accent text-accent-foreground": turn.role === "user",
+                      "bg-bg-tertiary text-text-primary":
+                        turn.role === "assistant",
+                      "border border-error/40 bg-error/10 text-error":
+                        turn.role === "error",
+                    })}
+                  >
+                    {turn.role === "assistant" ? (
+                      <Markdown>{turn.text}</Markdown>
+                    ) : (
+                      <span className="whitespace-pre-wrap">{turn.text}</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {sending && (
+                <div className="self-start rounded-lg bg-bg-tertiary px-3 py-2">
+                  <Loader2
+                    className="h-4 w-4 animate-spin text-text-muted"
+                    aria-hidden="true"
+                  />
+                </div>
+              )}
+            </div>
+            <form onSubmit={handleSubmit} className="mt-3 flex items-end gap-2">
+              <Textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSubmit(e);
+                  }
+                }}
+                placeholder={t(
+                  "playgroundShare.inputPlaceholder",
+                  "Type a message…",
+                )}
+                rows={1}
+                className="flex-1 resize-none"
+              />
+              <Button type="submit" disabled={sending || !input.trim()}>
+                <Send className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/client/pages/agents/PlaygroundChat.tsx
+++ b/src/client/pages/agents/PlaygroundChat.tsx
@@ -19,6 +19,7 @@ import {
   RefreshCw,
   Send,
   Settings2,
+  Share2,
   Trash2,
   Wrench,
   X,
@@ -45,6 +46,7 @@ import { useModalController } from "@/client/components/Modal";
 import { useMediaObjectUrl } from "@/client/components/useMediaObjectUrl";
 import { cn } from "@/client/lib/utils";
 import { useKnowledgeManager } from "@/client/pages/resources/useKnowledgeManager";
+import { PlaygroundShareModal } from "./PlaygroundShareModal";
 import type {
   PlaygroundSessionMeta,
   PlaygroundTurn,
@@ -132,6 +134,7 @@ export function PlaygroundChat({
   // or its base without leaving the playground (onChanged is a no-op — we only preview here).
   const km = useKnowledgeManager({ onChanged: () => {} });
   const confirm = useModalController<ConfirmPayload>();
+  const shareModal = useModalController();
 
   // Keep the latest turn in view as the conversation grows / the agent answers.
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on every turn/typing change
@@ -220,6 +223,14 @@ export function PlaygroundChat({
                   </Button>
                 </span>
               </Tooltip>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => shareModal.open()}
+              >
+                <Share2 className="h-4 w-4" aria-hidden="true" />
+                {t("playground.share.button", "Share")}
+              </Button>
             </div>
           </div>
 
@@ -311,6 +322,7 @@ export function PlaygroundChat({
       </div>
       {km.modals}
       <ConfirmDialog modal={confirm} />
+      <PlaygroundShareModal modal={shareModal} agentId={agentId} />
     </>
   );
 }

--- a/src/client/pages/agents/PlaygroundShareModal.tsx
+++ b/src/client/pages/agents/PlaygroundShareModal.tsx
@@ -1,0 +1,270 @@
+import { Check, Copy, Link2, Plus, Trash2 } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  ConfirmDialog,
+  type ConfirmPayload,
+  FormField,
+  Input,
+  Modal,
+  type ModalController,
+  useModalController,
+  useOnModalOpen,
+  useToast,
+} from "@/client/components";
+import { api } from "@/client/lib/api";
+import { formatDate } from "@/client/lib/utils";
+
+// Derived from the treaty response; never hand-mirrored (see docs/eden-treaty.md).
+type ShareLinksData = Awaited<
+  ReturnType<ReturnType<typeof api.api.v1.agents>["playground"]["share"]["get"]>
+>["data"];
+type ShareLink = NonNullable<ShareLinksData>["links"][number];
+
+const DEFAULT_TTL_HOURS = 48;
+const DEFAULT_MAX_MESSAGES = 60;
+
+// Operator-facing manager for public, no-login playground share links: lists existing links,
+// mints a new one (reveals the URL once — only the token hash is stored server-side), and revokes.
+export function PlaygroundShareModal({
+  modal,
+  agentId,
+}: {
+  modal: ModalController;
+  agentId: string;
+}) {
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+  const confirm = useModalController<ConfirmPayload>();
+  const [links, setLinks] = useState<ShareLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [ttlHours, setTtlHours] = useState(String(DEFAULT_TTL_HOURS));
+  const [maxMessages, setMaxMessages] = useState(String(DEFAULT_MAX_MESSAGES));
+  const [minting, setMinting] = useState(false);
+  const [mintedUrl, setMintedUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const fetchLinks = useCallback(async () => {
+    setLoading(true);
+    const { data } = await api.api.v1
+      .agents({ id: agentId })
+      .playground.share.get();
+    setLinks(data?.links ?? []);
+    setLoading(false);
+  }, [agentId]);
+
+  useOnModalOpen(modal, () => {
+    setMintedUrl(null);
+    setCopied(false);
+    setTtlHours(String(DEFAULT_TTL_HOURS));
+    setMaxMessages(String(DEFAULT_MAX_MESSAGES));
+    void fetchLinks();
+  });
+
+  const mint = async () => {
+    setMinting(true);
+    setCopied(false);
+    try {
+      const { data, error } = await api.api.v1
+        .agents({ id: agentId })
+        .playground.share.post({
+          ttlHours: Number(ttlHours) || undefined,
+          maxMessages: Number(maxMessages) || undefined,
+        });
+      if (error || !data) {
+        showToast(
+          t("playground.share.createFailed", "Could not create the link"),
+          "error",
+        );
+        return;
+      }
+      setMintedUrl(data.url);
+      void fetchLinks();
+    } finally {
+      setMinting(false);
+    }
+  };
+
+  const copyUrl = async () => {
+    if (!mintedUrl) return;
+    try {
+      await navigator.clipboard.writeText(mintedUrl);
+      setCopied(true);
+    } catch {
+      // Clipboard may be unavailable (insecure context); the URL stays selectable.
+    }
+  };
+
+  const requestRevoke = (link: ShareLink) => {
+    confirm.open({
+      title: t("playground.share.revokeTitle", "Revoke share link"),
+      message: t(
+        "playground.share.revokeMessage",
+        "The link will stop working immediately. This cannot be undone.",
+      ),
+      confirmLabel: t("playground.share.revoke", "Revoke"),
+      danger: true,
+      onConfirm: async () => {
+        const { error } = await api.api.v1
+          .agents({ id: agentId })
+          .playground.share({ linkId: link.id })
+          .delete();
+        if (error) {
+          showToast(
+            t("playground.share.revokeFailed", "Could not revoke the link"),
+            "error",
+          );
+          throw new Error("revoke failed");
+        }
+        void fetchLinks();
+      },
+    });
+  };
+
+  const isActive = (link: ShareLink) =>
+    !link.revokedAt && new Date(link.expiresAt).getTime() > Date.now();
+
+  return (
+    <Modal
+      modal={modal}
+      title={t("playground.share.title", "Share this agent")}
+      size="md"
+    >
+      <div className="space-y-5">
+        <p className="text-text-secondary text-xs">
+          {t(
+            "playground.share.hint",
+            "Create a public link so a customer can chat with this agent, no login required. It expires and stops accepting messages after its quota.",
+          )}
+        </p>
+
+        {mintedUrl ? (
+          <div className="space-y-3 rounded-lg border border-warning bg-warning-soft px-3 py-2">
+            <p className="text-text-primary text-xs">
+              {t(
+                "playground.share.urlWarning",
+                "Copy this link now. It is shown only once here.",
+              )}
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded-lg border border-border bg-bg-tertiary px-3 py-2 font-mono text-text-primary text-xs">
+                {mintedUrl}
+              </code>
+              <Button size="sm" variant="secondary" onClick={copyUrl}>
+                {copied ? (
+                  <Check className="h-4 w-4" aria-hidden="true" />
+                ) : (
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                )}
+                {copied
+                  ? t("common.copied", "Copied")
+                  : t("common.copy", "Copy")}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-end gap-3">
+            <FormField label={t("playground.share.ttl", "Expires in (hours)")}>
+              <Input
+                type="number"
+                min={1}
+                max={48}
+                value={ttlHours}
+                onChange={(e) => setTtlHours(e.target.value)}
+                className="w-28"
+              />
+            </FormField>
+            <FormField
+              label={t("playground.share.maxMessages", "Message limit")}
+            >
+              <Input
+                type="number"
+                min={1}
+                max={500}
+                value={maxMessages}
+                onChange={(e) => setMaxMessages(e.target.value)}
+                className="w-28"
+              />
+            </FormField>
+            <Button onClick={() => void mint()} loading={minting}>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              {t("playground.share.create", "Create link")}
+            </Button>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <h3 className="font-medium text-text-secondary text-xs uppercase tracking-wide">
+            {t("playground.share.existing", "Existing links")}
+          </h3>
+          {loading ? (
+            <p className="text-text-muted text-xs">
+              {t("common.loading", "Loading…")}
+            </p>
+          ) : links.length === 0 ? (
+            <p className="text-text-muted text-xs">
+              {t("playground.share.empty", "No share links yet.")}
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {links.map((link) => {
+                const active = isActive(link);
+                return (
+                  <li
+                    key={link.id}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2 text-xs"
+                  >
+                    <div className="flex min-w-0 flex-col gap-0.5">
+                      <span className="flex items-center gap-1.5 text-text-primary">
+                        <Link2
+                          className="h-3.5 w-3.5 shrink-0"
+                          aria-hidden="true"
+                        />
+                        {active
+                          ? t(
+                              "playground.share.statusActive",
+                              "Active until {{date}}",
+                              { date: formatDate(link.expiresAt) },
+                            )
+                          : link.revokedAt
+                            ? t("playground.share.statusRevoked", "Revoked")
+                            : t("playground.share.statusExpired", "Expired")}
+                      </span>
+                      <span className="text-text-muted">
+                        {t(
+                          "playground.share.messageCount",
+                          "{{used}}/{{max}} messages",
+                          { used: link.messageCount, max: link.maxMessages },
+                        )}
+                      </span>
+                    </div>
+                    {active && (
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        onClick={() => requestRevoke(link)}
+                        aria-label={t(
+                          "playground.share.revokeAria",
+                          "Revoke share link",
+                        )}
+                      >
+                        <Trash2 className="h-4 w-4" aria-hidden="true" />
+                      </Button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex justify-end">
+          <Button onClick={modal.close}>{t("common.done", "Done")}</Button>
+        </div>
+      </div>
+
+      <ConfirmDialog modal={confirm} />
+    </Modal>
+  );
+}

--- a/src/modules/playground/share.ts
+++ b/src/modules/playground/share.ts
@@ -1,0 +1,177 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+import basePrisma from "@/api/lib/prisma";
+import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
+import {
+  generateRouteToken,
+  hashRouteToken,
+} from "@/modules/webhooks/inbound/route-token";
+
+// Operator-minted, no-login public link that lets a customer chat with an agent in an isolated
+// playground thread (no Chatwoot, no real conversation). Mirrors the Chatwoot webhook route-token
+// pattern: only the SHA-256 hash is stored, the plaintext is shown once at mint time.
+
+function sysCtx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}
+
+export const MIN_TTL_HOURS = 1;
+export const MAX_TTL_HOURS = 48;
+export const DEFAULT_TTL_HOURS = 48;
+export const MIN_MAX_MESSAGES = 1;
+export const MAX_MAX_MESSAGES = 500;
+export const DEFAULT_MAX_MESSAGES = 60;
+
+export interface PlaygroundShareLinkRow {
+  id: bigint;
+  agentId: bigint;
+  messageCount: number;
+  maxMessages: number;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  createdAt: Date;
+}
+
+export interface MintShareLinkParams {
+  tenantId: bigint;
+  agentId: bigint;
+  ttlHours?: number;
+  maxMessages?: number;
+  base?: PrismaClient;
+}
+
+export interface MintedShareLink {
+  id: bigint;
+  token: string;
+  expiresAt: Date;
+  maxMessages: number;
+}
+
+export async function mintPlaygroundShareLink(
+  params: MintShareLinkParams,
+): Promise<MintedShareLink> {
+  const base = params.base ?? basePrisma;
+  const ttlHours = Math.min(
+    Math.max(params.ttlHours ?? DEFAULT_TTL_HOURS, MIN_TTL_HOURS),
+    MAX_TTL_HOURS,
+  );
+  const maxMessages = Math.min(
+    Math.max(params.maxMessages ?? DEFAULT_MAX_MESSAGES, MIN_MAX_MESSAGES),
+    MAX_MAX_MESSAGES,
+  );
+  const { token, hash } = generateRouteToken();
+  const expiresAt = new Date(Date.now() + ttlHours * 60 * 60 * 1000);
+  const row = await runScopedOn(base, sysCtx(params.tenantId), (db) =>
+    db.playgroundShareLink.create({
+      data: {
+        tenantId: params.tenantId,
+        agentId: params.agentId,
+        tokenHash: hash,
+        maxMessages,
+        expiresAt,
+      },
+      select: { id: true },
+    }),
+  );
+  return { id: row.id, token, expiresAt, maxMessages };
+}
+
+export async function listPlaygroundShareLinks(
+  tenantId: bigint,
+  agentId: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<PlaygroundShareLinkRow[]> {
+  return runScopedOn(base, sysCtx(tenantId), (db) =>
+    db.playgroundShareLink.findMany({
+      where: { agentId },
+      orderBy: { createdAt: "desc" },
+    }),
+  );
+}
+
+export async function revokePlaygroundShareLink(
+  tenantId: bigint,
+  id: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<void> {
+  await runScopedOn(base, sysCtx(tenantId), (db) =>
+    db.playgroundShareLink.updateMany({
+      where: { id, revokedAt: null },
+      data: { revokedAt: new Date() },
+    }),
+  );
+}
+
+export type ResolvedShareLinkStatus =
+  | "ok"
+  | "not_found"
+  | "expired"
+  | "exhausted";
+
+export interface ResolvedShareLink {
+  status: ResolvedShareLinkStatus;
+  link?: { id: bigint; tenantId: bigint; agentId: bigint; agentName: string };
+}
+
+// Resolves a share link by its opaque token. No tenant context exists yet (the token itself
+// resolves the tenant), so this runs as super-admin, mirroring resolveBotByRouteToken (Chatwoot).
+export async function resolvePlaygroundShareLink(
+  token: string,
+  base: PrismaClient = basePrisma,
+): Promise<ResolvedShareLink> {
+  const tokenHash = hashRouteToken(token);
+  const row = await asSuperAdminOn(base, (db) =>
+    db.playgroundShareLink.findUnique({
+      where: { tokenHash },
+      select: {
+        id: true,
+        tenantId: true,
+        agentId: true,
+        messageCount: true,
+        maxMessages: true,
+        expiresAt: true,
+        revokedAt: true,
+        agent: { select: { name: true } },
+      },
+    }),
+  );
+  if (!row) return { status: "not_found" };
+  if (row.revokedAt !== null || row.expiresAt.getTime() <= Date.now())
+    return { status: "expired" };
+  if (row.messageCount >= row.maxMessages) return { status: "exhausted" };
+  return {
+    status: "ok",
+    link: {
+      id: row.id,
+      tenantId: row.tenantId,
+      agentId: row.agentId,
+      agentName: row.agent.name,
+    },
+  };
+}
+
+// Atomically claims one message slot. Returns false if another concurrent request already
+// exhausted the link between resolve and here (CAS on messageCount < maxMessages, re-read fresh so
+// the check is against the current count, not the one seen at resolve time).
+export async function claimPlaygroundShareLinkMessage(
+  tenantId: bigint,
+  id: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<boolean> {
+  return runScopedOn(base, sysCtx(tenantId), async (db) => {
+    const row = await db.playgroundShareLink.findUnique({
+      where: { id },
+      select: { maxMessages: true },
+    });
+    if (!row) return false;
+    const result = await db.playgroundShareLink.updateMany({
+      where: {
+        id,
+        revokedAt: null,
+        expiresAt: { gt: new Date() },
+        messageCount: { lt: row.maxMessages },
+      },
+      data: { messageCount: { increment: 1 } },
+    });
+    return result.count > 0;
+  });
+}


### PR DESCRIPTION
## Summary
- An operator can mint a **public, no-login share link** for an agent (from the console's Playground tab), with a bounded TTL (1–48h) and a message quota (default 60).
- The customer opens the link and chats with the agent directly — no Chatwoot, no account, isolated playground thread, no trace/tool details exposed.
- The link's opaque token is stored only as a SHA-256 hash (same pattern already used for the Chatwoot webhook route token); the message quota is claimed atomically before each turn so concurrent requests can't overrun it.

## What's included
- `src/modules/playground/share.ts`: mint / list / revoke / resolve / claim
- New public routes (unauthenticated, opaque-token-gated): `GET /v1/playground/share/:token`, `POST /v1/playground/share/:token/message`
- New authenticated routes on the existing agent controller: `POST|GET /v1/agents/:id/playground/share`, `DELETE /v1/agents/:id/playground/share/:linkId`
- Console: a **Share** button + modal on the Playground tab (create/list/revoke links, reveal-once URL)
- Public page: `/playground-share/:token` — minimal chat UI, no login
- New `PlaygroundShareLink` model + migration (tenant-isolated via RLS, same pattern as every other tenant-scoped table)

## Test plan
- [x] `bun check` (lint, types, i18n, openapi, tests) green
- [x] Verified live on a production instance: minted a link from the console, chatted through the public page end to end, confirmed expiry/quota enforcement and revoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)