### PR TITLE
Report a guardrail that could not run, on the screen that enabled it

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5993,7 +5993,7 @@
           "Agents"
         ],
         "summary": "Get guardrail health",
-        "description": "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so a check counted here blocked nothing: whatever it would have caught went through.",
+        "description": "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so a check counted here caught nothing and held nothing back. It does not follow that the turn went out unscreened: the other direction may still have screened it, and a split output analysis can carry an error from one half and a violation from the other.",
         "parameters": [
           {
             "name": "id",

--- a/openapi.json
+++ b/openapi.json
@@ -5993,7 +5993,7 @@
           "Agents"
         ],
         "summary": "Get guardrail health",
-        "description": "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so every failure counted here is a turn that was delivered without being screened.",
+        "description": "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so a check counted here blocked nothing: whatever it would have caught went through.",
         "parameters": [
           {
             "name": "id",

--- a/openapi.json
+++ b/openapi.json
@@ -5987,6 +5987,116 @@
         "operationId": "deleteV1AgentsById"
       }
     },
+    "/v1/agents/{id}/guardrails/health": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Get guardrail health",
+        "description": "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so every failure counted here is a turn that was delivered without being screened.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Agent id, a BigInt encoded as a decimal string.",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getV1AgentsByIdGuardrailsHealth"
+      }
+    },
     "/v1/agents/{id}/clone": {
       "post": {
         "tags": [

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -24,6 +24,11 @@ import {
   updateAgent,
 } from "@/modules/agents/service";
 import { exportAgent, importAgent } from "@/modules/agents/transfer";
+import {
+  GUARDRAIL_HEALTH_WINDOW_HOURS,
+  guardrailHealthWindowStart,
+  readGuardrailHealth,
+} from "@/modules/guardrails/health";
 import { listProviderModels } from "@/modules/models/service";
 import { getPlaygroundMedia } from "@/modules/playground/media";
 import {
@@ -238,6 +243,33 @@ export const agentsController = new Elysia({
     }),
     {
       detail: doc("Get agent", "Returns a single agent by id."),
+      response: errors(400, 401, 403, 404),
+      requireRole: "TENANT_ADMIN",
+      params: t.Object({
+        id: t.String({
+          description: "Agent id, a BigInt encoded as a decimal string.",
+        }),
+      }),
+    },
+  )
+  // Whether this agent's guardrail screen is actually running, from what it recorded. The editor's
+  // configuration-warning panel needs it because configuration cannot answer the question: analysis
+  // is fail-open, so a screen that can never run reads as one that ran and approved everywhere else.
+  .get(
+    "/:id/guardrails/health",
+    async ({ tenantContext, params }) => ({
+      windowHours: GUARDRAIL_HEALTH_WINDOW_HOURS,
+      ...(await readGuardrailHealth(
+        ctxOrThrow(tenantContext),
+        BigInt(params.id),
+        guardrailHealthWindowStart(),
+      )),
+    }),
+    {
+      detail: doc(
+        "Get guardrail health",
+        "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so every failure counted here is a turn that was delivered without being screened.",
+      ),
       response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",
       params: t.Object({

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -258,6 +258,7 @@ export const agentsController = new Elysia({
   .get(
     "/:id/guardrails/health",
     async ({ tenantContext, params }) => ({
+      instance: instanceIdentity,
       windowHours: GUARDRAIL_HEALTH_WINDOW_HOURS,
       ...(await readGuardrailHealth(
         ctxOrThrow(tenantContext),

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -269,7 +269,7 @@ export const agentsController = new Elysia({
     {
       detail: doc(
         "Get guardrail health",
-        "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so a check counted here blocked nothing: whatever it would have caught went through.",
+        "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so a check counted here caught nothing and held nothing back. It does not follow that the turn went out unscreened: the other direction may still have screened it, and a split output analysis can carry an error from one half and a violation from the other.",
       ),
       response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -269,7 +269,7 @@ export const agentsController = new Elysia({
     {
       detail: doc(
         "Get guardrail health",
-        "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so every failure counted here is a turn that was delivered without being screened.",
+        "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so a check counted here blocked nothing: whatever it would have caught went through.",
       ),
       response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -18,6 +18,7 @@ export type ConfigIssueKey =
   | "ttsNormalize"
   | "vision"
   | "guardrails"
+  | "guardrailsFailing"
   | "knowledge"
   | "embedding"
   | "redirect"
@@ -50,6 +51,11 @@ export interface ConfigIssue {
   field?: string;
   length?: number;
   max?: number;
+  // For "guardrailsFailing": how many analyses could not run in the window, and when the last one
+  // was. The count is what makes the warning actionable (one is a blip, forty is a dead screen) and
+  // the timestamp is what lets an operator who just fixed it see the count stop.
+  failures?: number;
+  lastFailureAt?: string;
 }
 
 // Where a capped field is edited, by the path the walker reports. A path with no entry has no control
@@ -151,6 +157,14 @@ export interface ConfigHealthInput {
   // message is delivered as if it had been screened and approved.
   guardrailsEnabled?: boolean;
   guardrailsCredentialRef?: string;
+  // What the screen actually DID, read back from the execution log (modules/guardrails/health.ts):
+  // how many analyses could not run in the recent window, and when the last one was. Configuration
+  // alone cannot see this half. A model id the vendor retired, a parameter it rejects on every call
+  // and a chronic timeout are all valid configuration until the call is made, and the pass is
+  // fail-open, so each one delivers messages as if they had been reviewed. Absent or 0 raises
+  // nothing: the count has to have arrived from the server to mean anything.
+  guardrailsFailures?: number;
+  guardrailsLastFailureAt?: string | null;
   // Refs (`vault:<id>`) whose vault entry exists but is still pending (secret not filled in yet). A
   // feature wired to one of these is configured but cannot run until the operator fills it.
   pendingRefs?: Set<string>;
@@ -355,15 +369,36 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
     { key: "vision", tab: "behavior", sectionId: "vision" },
     credIssue(input.visionEnabled, input.visionCredentialRef, pending, known),
   );
+  const guardrailsCred = credIssue(
+    Boolean(input.guardrailsEnabled),
+    input.guardrailsCredentialRef ?? "",
+    pending,
+    known,
+  );
   push(
     { key: "guardrails", tab: "guardrails", sectionId: "gr-model" },
-    credIssue(
-      Boolean(input.guardrailsEnabled),
-      input.guardrailsCredentialRef ?? "",
-      pending,
-      known,
-    ),
+    guardrailsCred,
   );
+  // The credentialed guardrail that still could not run: same consequence (messages delivered
+  // unscreened), a cause no ref check can reach. Suppressed while the credential verdict above is
+  // live, and not for tidiness: with no credential the runtime never builds the model and writes no
+  // failure rows at all, so a count arriving next to a credential issue can only be a leftover from
+  // before that credential broke. Fixing the ref is the move either way.
+  if (
+    input.guardrailsEnabled &&
+    !guardrailsCred &&
+    (input.guardrailsFailures ?? 0) > 0
+  ) {
+    issues.push({
+      key: "guardrailsFailing",
+      tab: "guardrails",
+      sectionId: "gr-model",
+      failures: input.guardrailsFailures,
+      ...(input.guardrailsLastFailureAt
+        ? { lastFailureAt: input.guardrailsLastFailureAt }
+        : {}),
+    });
+  }
   // Knowledge bases with documents awaiting indexing. Indexing needs the tenant's embedding credential,
   // so if that prerequisite is missing we raise ONE "embedding" issue (the root cause) instead of N
   // per-base "index me" prompts that would just fail: no ref → point at embedding settings; a

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -679,8 +679,8 @@
       "ttsNormalize": "The speech rewrite is on but its model configuration cannot run, so replies will be spoken without it. Check its provider, model, key and endpoint.",
       "vision": "Image/document reading is on but has no API key set."
     },
-    "configIssueGuardrailsFailing": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.",
-    "configIssueGuardrailsFailingCause": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. The last one said: {{error}}",
+    "configIssueGuardrailsFailing": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. Check the model, the endpoint and the key.",
+    "configIssueGuardrailsFailingCause": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. The last one said: {{error}}",
     "configIssueKnowledge": "Knowledge base \"{{name}}\" has documents that need indexing.",
     "configIssuePending": {
       "embedding": "A knowledge base needs indexing, but the embedding credential is not filled in yet.",

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -679,8 +679,8 @@
       "ttsNormalize": "The speech rewrite is on but its model configuration cannot run, so replies will be spoken without it. Check its provider, model, key and endpoint.",
       "vision": "Image/document reading is on but has no API key set."
     },
-    "configIssueGuardrailsFailing": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. Check the model, the endpoint and the key.",
-    "configIssueGuardrailsFailingCause": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. The last one said: {{error}}",
+    "configIssueGuardrailsFailing": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. Check the model, the endpoint and the key.",
+    "configIssueGuardrailsFailingCause": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. The last one said: {{error}}",
     "configIssueKnowledge": "Knowledge base \"{{name}}\" has documents that need indexing.",
     "configIssuePending": {
       "embedding": "A knowledge base needs indexing, but the embedding credential is not filled in yet.",

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -680,6 +680,7 @@
       "vision": "Image/document reading is on but has no API key set."
     },
     "configIssueGuardrailsFailing": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.",
+    "configIssueGuardrailsFailingCause": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. The last one said: {{error}}",
     "configIssueKnowledge": "Knowledge base \"{{name}}\" has documents that need indexing.",
     "configIssuePending": {
       "embedding": "A knowledge base needs indexing, but the embedding credential is not filled in yet.",

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -679,6 +679,7 @@
       "ttsNormalize": "The speech rewrite is on but its model configuration cannot run, so replies will be spoken without it. Check its provider, model, key and endpoint.",
       "vision": "Image/document reading is on but has no API key set."
     },
+    "configIssueGuardrailsFailing": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.",
     "configIssueKnowledge": "Knowledge base \"{{name}}\" has documents that need indexing.",
     "configIssuePending": {
       "embedding": "A knowledge base needs indexing, but the embedding credential is not filled in yet.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -682,6 +682,7 @@
       "vision": "A leitura de imagens/documentos está ligada, mas sem chave de API definida."
     },
     "configIssueGuardrailsFailing": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}), então essas mensagens saíram sem passar pela revisão. Confira o modelo, o endpoint e a chave.",
+    "configIssueGuardrailsFailingCause": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}), então essas mensagens saíram sem passar pela revisão. A última respondeu: {{error}}",
     "configIssueKnowledge": "A base de conhecimento \"{{name}}\" tem documentos que precisam ser indexados.",
     "configIssuePending": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding ainda não foi preenchida.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -681,6 +681,7 @@
       "ttsNormalize": "A reescrita para fala está ligada mas a configuração de modelo dela não pode rodar, então o áudio sai sem ela. Confira provedor, modelo, chave e endpoint.",
       "vision": "A leitura de imagens/documentos está ligada, mas sem chave de API definida."
     },
+    "configIssueGuardrailsFailing": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}), então essas mensagens saíram sem passar pela revisão. Confira o modelo, o endpoint e a chave.",
     "configIssueKnowledge": "A base de conhecimento \"{{name}}\" tem documentos que precisam ser indexados.",
     "configIssuePending": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding ainda não foi preenchida.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -681,8 +681,8 @@
       "ttsNormalize": "A reescrita para fala está ligada mas a configuração de modelo dela não pode rodar, então o áudio sai sem ela. Confira provedor, modelo, chave e endpoint.",
       "vision": "A leitura de imagens/documentos está ligada, mas sem chave de API definida."
     },
-    "configIssueGuardrailsFailing": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). Verificação que não roda não bloqueia nada, então o que ela pegaria passou. Confira o modelo, o endpoint e a chave.",
-    "configIssueGuardrailsFailingCause": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). Verificação que não roda não bloqueia nada, então o que ela pegaria passou. A última respondeu: {{error}}",
+    "configIssueGuardrailsFailing": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). A análise é fail-open, então verificação que não rodou não pegou nada e não segurou nada. Confira o modelo, o endpoint e a chave.",
+    "configIssueGuardrailsFailingCause": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). A análise é fail-open, então verificação que não rodou não pegou nada e não segurou nada. A última respondeu: {{error}}",
     "configIssueKnowledge": "A base de conhecimento \"{{name}}\" tem documentos que precisam ser indexados.",
     "configIssuePending": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding ainda não foi preenchida.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -681,8 +681,8 @@
       "ttsNormalize": "A reescrita para fala está ligada mas a configuração de modelo dela não pode rodar, então o áudio sai sem ela. Confira provedor, modelo, chave e endpoint.",
       "vision": "A leitura de imagens/documentos está ligada, mas sem chave de API definida."
     },
-    "configIssueGuardrailsFailing": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}), então essas mensagens saíram sem passar pela revisão. Confira o modelo, o endpoint e a chave.",
-    "configIssueGuardrailsFailingCause": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}), então essas mensagens saíram sem passar pela revisão. A última respondeu: {{error}}",
+    "configIssueGuardrailsFailing": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). Verificação que não roda não bloqueia nada, então o que ela pegaria passou. Confira o modelo, o endpoint e a chave.",
+    "configIssueGuardrailsFailingCause": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). Verificação que não roda não bloqueia nada, então o que ela pegaria passou. A última respondeu: {{error}}",
     "configIssueKnowledge": "A base de conhecimento \"{{name}}\" tem documentos que precisam ser indexados.",
     "configIssuePending": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding ainda não foi preenchida.",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1281,8 +1281,8 @@ function AgentEditor() {
   // t('editor.configIssue.guardrails', 'Guardrails are on but have no API key set, so messages go out unscreened.')
   // t('editor.configIssuePending.guardrails', 'The guardrails credential is referenced but not filled in yet, so messages go out unscreened.')
   // t('editor.configIssueUnresolved.guardrails', 'The guardrails credential no longer exists, so messages go out unscreened.')
-  // t('editor.configIssueGuardrailsFailing', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.')
-  // t('editor.configIssueGuardrailsFailingCause', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. The last one said: {{error}}')
+  // t('editor.configIssueGuardrailsFailing', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. Check the model, the endpoint and the key.')
+  // t('editor.configIssueGuardrailsFailingCause', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. The last one said: {{error}}')
   // t('editor.configIssuePending.model', 'The model credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.stt', 'The transcription credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.tts', 'The audio-reply credential is referenced but not filled in yet.')
@@ -1437,15 +1437,20 @@ function AgentEditor() {
       // The vendor's own words when they survived the write, generic advice when they did not. They
       // are what separates "look at this" from "fix this": "400 temperature is not supported" names
       // the setting, while a list of three things to check makes the operator try all of them.
+      //
+      // What the line does NOT say is that these messages were delivered unscreened. A failed input
+      // check leaves the output check free to still screen the reply, and a split output analysis
+      // can report an error from one half while the other half trips and blocks the send. Fail-open
+      // is what every row does prove: the check that failed blocked nothing.
       return params.error
         ? t(
             "editor.configIssueGuardrailsFailingCause",
-            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. The last one said: {{error}}",
+            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. The last one said: {{error}}",
             params,
           )
         : t(
             "editor.configIssueGuardrailsFailing",
-            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.",
+            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. Check the model, the endpoint and the key.",
             params,
           );
     }

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1211,15 +1211,28 @@ function AgentEditor() {
   // What the guardrail screen actually DID lately, for the panel below. Configuration cannot answer
   // it: a retired model id, a parameter the vendor rejects and a chronic timeout are all valid
   // configuration until the call is made, and the pass is fail-open, so each one delivers messages
-  // as if they had been reviewed. Fetched once per agent (a count over a 24h window does not move
-  // while the editor is open) and only while guardrails are on, so an agent that never enabled the
-  // feature pays no request.
+  // as if they had been reviewed.
+  //
+  // A snapshot, not a subscription. It is taken when the agent loads, when guardrails are switched
+  // on, and after every successful save, which is the operator's loop here: change the model, save,
+  // see whether the screen is still failing. It does NOT follow live traffic, so an editor left
+  // open does not learn about failures that started meanwhile. Polling a config screen to close
+  // that gap costs a request a minute on every open editor to shorten a wait that ends the next
+  // time anybody looks.
+  //
+  // A request that FAILS leaves this null, which the panel reads as "nothing to say" rather than
+  // as a warning. That is the same call the panel already makes for an unloaded vault list, and for
+  // the same reason: this panel's currency is that every line on it is worth acting on, and a line
+  // saying the console could not reach its own API is one the operator cannot act on from here. The
+  // next save retries.
+  const [savedTick, setSavedTick] = useState(0);
   const [guardrailHealth, setGuardrailHealth] = useState<{
     windowHours: number;
     failures: number;
     lastAt: string | null;
   } | null>(null);
   const guardrailsOn = guardrails.enabled;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: savedTick is the refetch trigger, not a value this effect reads
   useEffect(() => {
     if (!id || !guardrailsOn) {
       setGuardrailHealth(null);
@@ -1235,7 +1248,7 @@ function AgentEditor() {
     return () => {
       alive = false;
     };
-  }, [id, guardrailsOn]);
+  }, [id, guardrailsOn, savedTick]);
 
   // Live config-health (item 1): features turned on but missing the credential they need to run, OR
   // referencing a credential whose secret is not filled in yet (pending). The import that strips
@@ -1825,6 +1838,10 @@ function AgentEditor() {
     if (updatedAt) loadedUpdatedAtRef.current = updatedAt;
     setStaleNotice(false);
     setConflictRetry(null);
+    // Every successful save funnels through here, which makes it the one place that can tell the
+    // server-read parts of this page to look again. The guardrail health snapshot is the first: a
+    // save is the operator's "I fixed it", and it is the only moment they are owed a fresh answer.
+    setSavedTick((n) => n + 1);
   }
 
   async function saveAgent(

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -103,6 +103,17 @@ type AgentResp = Awaited<
   ReturnType<ReturnType<typeof api.api.v1.agents>["get"]>
 >;
 type Agent = NonNullable<AgentResp["data"]>["agent"];
+// Derived, never hand-declared (docs/eden-treaty.md): a mirrored interface drifts the moment the
+// controller adds a field, and it did. Written by hand this type omitted `lastError`, which is the
+// one part of the reading that names the vendor's refusal, so the warning it feeds could only give
+// generic advice about a cause the server had already identified.
+type GuardrailHealthResp = NonNullable<
+  Awaited<
+    ReturnType<
+      ReturnType<typeof api.api.v1.agents>["guardrails"]["health"]["get"]
+    >
+  >["data"]
+>;
 type TabKey =
   | "general"
   | "channels"
@@ -1226,11 +1237,8 @@ function AgentEditor() {
   // saying the console could not reach its own API is one the operator cannot act on from here. The
   // next save retries.
   const [savedTick, setSavedTick] = useState(0);
-  const [guardrailHealth, setGuardrailHealth] = useState<{
-    windowHours: number;
-    failures: number;
-    lastAt: string | null;
-  } | null>(null);
+  const [guardrailHealth, setGuardrailHealth] =
+    useState<GuardrailHealthResp | null>(null);
   const guardrailsOn = guardrails.enabled;
   // biome-ignore lint/correctness/useExhaustiveDependencies: savedTick is the refetch trigger, not a value this effect reads
   useEffect(() => {
@@ -1264,6 +1272,7 @@ function AgentEditor() {
   // t('editor.configIssuePending.guardrails', 'The guardrails credential is referenced but not filled in yet, so messages go out unscreened.')
   // t('editor.configIssueUnresolved.guardrails', 'The guardrails credential no longer exists, so messages go out unscreened.')
   // t('editor.configIssueGuardrailsFailing', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.')
+  // t('editor.configIssueGuardrailsFailingCause', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. The last one said: {{error}}')
   // t('editor.configIssuePending.model', 'The model credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.stt', 'The transcription credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.tts', 'The audio-reply credential is referenced but not filled in yet.')
@@ -1407,17 +1416,28 @@ function AgentEditor() {
     // panel's other lines describe a state ("no key set"), this one describes what already happened,
     // and an operator has to be told that those turns went out unscreened rather than blocked.
     if (issue.key === "guardrailsFailing") {
-      return t(
-        "editor.configIssueGuardrailsFailing",
-        "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.",
-        {
-          failures: issue.failures ?? 0,
-          hours: guardrailHealth?.windowHours ?? 24,
-          when: issue.lastFailureAt
-            ? formatRelativeTime(issue.lastFailureAt, i18n.language)
-            : "-",
-        },
-      );
+      const params = {
+        failures: issue.failures ?? 0,
+        hours: guardrailHealth?.windowHours ?? 24,
+        when: issue.lastFailureAt
+          ? formatRelativeTime(issue.lastFailureAt, i18n.language)
+          : "-",
+        error: guardrailHealth?.lastError ?? "",
+      };
+      // The vendor's own words when they survived the write, generic advice when they did not. They
+      // are what separates "look at this" from "fix this": "400 temperature is not supported" names
+      // the setting, while a list of three things to check makes the operator try all of them.
+      return params.error
+        ? t(
+            "editor.configIssueGuardrailsFailingCause",
+            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. The last one said: {{error}}",
+            params,
+          )
+        : t(
+            "editor.configIssueGuardrailsFailing",
+            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.",
+            params,
+          );
     }
     if (issue.pending) {
       // biome-ignore lint/plugin/no-dynamic-i18n-key: pending keys registered via magic comments above computeConfigIssues

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -51,7 +51,7 @@ import { useTenantEvents } from "@/client/hooks/useTenantEvents";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { computeConfigIssues, issueHasAction } from "@/client/lib/configHealth";
-import { slugify } from "@/client/lib/utils";
+import { formatRelativeTime, slugify } from "@/client/lib/utils";
 import {
   invalidateVault,
   useVaultBaseUrls,
@@ -511,7 +511,7 @@ export function AgentEditorPage() {
 }
 
 function AgentEditor() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { showToast } = useToast();
   const navigate = useNavigate();
   const { id = "", tab: tabParam } = useParams();
@@ -1208,6 +1208,35 @@ function AgentEditor() {
     };
   }, []);
 
+  // What the guardrail screen actually DID lately, for the panel below. Configuration cannot answer
+  // it: a retired model id, a parameter the vendor rejects and a chronic timeout are all valid
+  // configuration until the call is made, and the pass is fail-open, so each one delivers messages
+  // as if they had been reviewed. Fetched once per agent (a count over a 24h window does not move
+  // while the editor is open) and only while guardrails are on, so an agent that never enabled the
+  // feature pays no request.
+  const [guardrailHealth, setGuardrailHealth] = useState<{
+    windowHours: number;
+    failures: number;
+    lastAt: string | null;
+  } | null>(null);
+  const guardrailsOn = guardrails.enabled;
+  useEffect(() => {
+    if (!id || !guardrailsOn) {
+      setGuardrailHealth(null);
+      return;
+    }
+    let alive = true;
+    api.api.v1
+      .agents({ id })
+      .guardrails.health.get()
+      .then(({ data }) => {
+        if (alive && data) setGuardrailHealth(data);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [id, guardrailsOn]);
+
   // Live config-health (item 1): features turned on but missing the credential they need to run, OR
   // referencing a credential whose secret is not filled in yet (pending). The import that strips
   // secrets is the common trigger; each issue deep-links to its tab + section, or to the vault fill
@@ -1221,6 +1250,7 @@ function AgentEditor() {
   // t('editor.configIssue.guardrails', 'Guardrails are on but have no API key set, so messages go out unscreened.')
   // t('editor.configIssuePending.guardrails', 'The guardrails credential is referenced but not filled in yet, so messages go out unscreened.')
   // t('editor.configIssueUnresolved.guardrails', 'The guardrails credential no longer exists, so messages go out unscreened.')
+  // t('editor.configIssueGuardrailsFailing', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.')
   // t('editor.configIssuePending.model', 'The model credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.stt', 'The transcription credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.tts', 'The audio-reply credential is referenced but not filled in yet.')
@@ -1273,6 +1303,8 @@ function AgentEditor() {
     visionCredentialRef: vision.credentialRef,
     guardrailsEnabled: guardrails.enabled,
     guardrailsCredentialRef: guardrails.credentialRef ?? "",
+    guardrailsFailures: guardrailHealth?.failures,
+    guardrailsLastFailureAt: guardrailHealth?.lastAt,
     pendingRefs,
     knownRefs,
     knowledgeBasesNeedingIndex,
@@ -1356,6 +1388,22 @@ function AgentEditor() {
         "editor.configIssueKnowledge",
         'Knowledge base "{{name}}" has documents that need indexing.',
         { name: issue.knowledgeBaseName ?? "" },
+      );
+    }
+    // A guardrail that HAS its credential and still could not run. The count is the whole point: the
+    // panel's other lines describe a state ("no key set"), this one describes what already happened,
+    // and an operator has to be told that those turns went out unscreened rather than blocked.
+    if (issue.key === "guardrailsFailing") {
+      return t(
+        "editor.configIssueGuardrailsFailing",
+        "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}), so those messages went out unscreened. Check the model, the endpoint and the key.",
+        {
+          failures: issue.failures ?? 0,
+          hours: guardrailHealth?.windowHours ?? 24,
+          when: issue.lastFailureAt
+            ? formatRelativeTime(issue.lastFailureAt, i18n.language)
+            : "-",
+        },
       );
     }
     if (issue.pending) {

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -880,6 +880,10 @@ function AgentEditor() {
       bumpSync(...SECTION_KEYS);
       setStaleNotice(false);
       setConflictRetry(null);
+      // The other half of the sync tick. A reload is an explicit "tell me the current state", and
+      // without it the server-read parts of the page would answer with whatever they read the first
+      // time, which is the state the operator just asked to replace.
+      setServerSyncTick((n) => n + 1);
       if (hoursRes.data) setHours([...hoursRes.data.businessHours]);
     } catch {
       setError(true);
@@ -1224,25 +1228,27 @@ function AgentEditor() {
   // configuration until the call is made, and the pass is fail-open, so each one delivers messages
   // as if they had been reviewed.
   //
-  // A snapshot, not a subscription. It is taken when the agent loads, when guardrails are switched
-  // on, and after every successful save, which is the operator's loop here: change the model, save,
-  // see whether the screen is still failing. It does NOT follow live traffic, so an editor left
-  // open does not learn about failures that started meanwhile. Polling a config screen to close
-  // that gap costs a request a minute on every open editor to shorten a wait that ends the next
-  // time anybody looks.
+  // A snapshot, not a subscription, and `serverSyncTick` is what decides when it is retaken: every
+  // successful load (including the Reload the stale-state banner offers) and every successful save.
+  // Those are the two moments the operator expects a fresh answer. Nothing is fetched before the
+  // first load completes (the tick starts at 0), so the page does not spend a request answering a
+  // question about an agent it has not read yet.
   //
-  // A request that FAILS leaves this null, which the panel reads as "nothing to say" rather than
-  // as a warning. That is the same call the panel already makes for an unloaded vault list, and for
-  // the same reason: this panel's currency is that every line on it is worth acting on, and a line
-  // saying the console could not reach its own API is one the operator cannot act on from here. The
-  // next save retries.
-  const [savedTick, setSavedTick] = useState(0);
+  // It does NOT follow live traffic. An editor left open does not learn about failures that started
+  // meanwhile, and closing that gap by polling costs a request a minute on every open editor to
+  // shorten a wait that ends the next time anybody loads or saves.
+  //
+  // A request that fails clears the snapshot instead of leaving the last one on screen, and a null
+  // snapshot is read by the panel as "nothing to say" rather than as a warning. Both halves are the
+  // same call the panel already makes for an unloaded vault list: under-reporting for a moment is
+  // the safe direction, because a stale count invites acting on a number nobody can vouch for, and
+  // a line saying the console could not reach its own API is not actionable from this screen.
+  const [serverSyncTick, setServerSyncTick] = useState(0);
   const [guardrailHealth, setGuardrailHealth] =
     useState<GuardrailHealthResp | null>(null);
   const guardrailsOn = guardrails.enabled;
-  // biome-ignore lint/correctness/useExhaustiveDependencies: savedTick is the refetch trigger, not a value this effect reads
   useEffect(() => {
-    if (!id || !guardrailsOn) {
+    if (!id || !guardrailsOn || serverSyncTick === 0) {
       setGuardrailHealth(null);
       return;
     }
@@ -1251,12 +1257,16 @@ function AgentEditor() {
       .agents({ id })
       .guardrails.health.get()
       .then(({ data }) => {
-        if (alive && data) setGuardrailHealth(data);
+        if (!alive) return;
+        setGuardrailHealth(data ?? null);
+      })
+      .catch(() => {
+        if (alive) setGuardrailHealth(null);
       });
     return () => {
       alive = false;
     };
-  }, [id, guardrailsOn, savedTick]);
+  }, [id, guardrailsOn, serverSyncTick]);
 
   // Live config-health (item 1): features turned on but missing the credential they need to run, OR
   // referencing a credential whose secret is not filled in yet (pending). The import that strips
@@ -1858,10 +1868,10 @@ function AgentEditor() {
     if (updatedAt) loadedUpdatedAtRef.current = updatedAt;
     setStaleNotice(false);
     setConflictRetry(null);
-    // Every successful save funnels through here, which makes it the one place that can tell the
-    // server-read parts of this page to look again. The guardrail health snapshot is the first: a
-    // save is the operator's "I fixed it", and it is the only moment they are owed a fresh answer.
-    setSavedTick((n) => n + 1);
+    // Every successful save funnels through here, which makes it one of the two places that can tell
+    // the server-read parts of this page to look again (the other is `load`). A save is the
+    // operator's "I fixed it", and the guardrail health snapshot is the first reader of the tick.
+    setServerSyncTick((n) => n + 1);
   }
 
   async function saveAgent(

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1281,8 +1281,8 @@ function AgentEditor() {
   // t('editor.configIssue.guardrails', 'Guardrails are on but have no API key set, so messages go out unscreened.')
   // t('editor.configIssuePending.guardrails', 'The guardrails credential is referenced but not filled in yet, so messages go out unscreened.')
   // t('editor.configIssueUnresolved.guardrails', 'The guardrails credential no longer exists, so messages go out unscreened.')
-  // t('editor.configIssueGuardrailsFailing', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. Check the model, the endpoint and the key.')
-  // t('editor.configIssueGuardrailsFailingCause', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. The last one said: {{error}}')
+  // t('editor.configIssueGuardrailsFailing', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. Check the model, the endpoint and the key.')
+  // t('editor.configIssueGuardrailsFailingCause', 'Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. The last one said: {{error}}')
   // t('editor.configIssuePending.model', 'The model credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.stt', 'The transcription credential is referenced but not filled in yet.')
   // t('editor.configIssuePending.tts', 'The audio-reply credential is referenced but not filled in yet.')
@@ -1438,19 +1438,21 @@ function AgentEditor() {
       // are what separates "look at this" from "fix this": "400 temperature is not supported" names
       // the setting, while a list of three things to check makes the operator try all of them.
       //
-      // What the line does NOT say is that these messages were delivered unscreened. A failed input
-      // check leaves the output check free to still screen the reply, and a split output analysis
-      // can report an error from one half while the other half trips and blocks the send. Fail-open
-      // is what every row does prove: the check that failed blocked nothing.
+      // The line stops at what a failure row proves, which is less than it looks. It does not say
+      // the message went out unscreened: a failed input check leaves the output check free to screen
+      // the reply, and a split output analysis merges both halves, so it can carry an error from one
+      // and a violation from the other and still replace or suppress the send. All that is certain
+      // is fail-open, and it applies to the failed check alone: that one caught nothing and held
+      // nothing back.
       return params.error
         ? t(
             "editor.configIssueGuardrailsFailingCause",
-            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. The last one said: {{error}}",
+            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. The last one said: {{error}}",
             params,
           )
         : t(
             "editor.configIssueGuardrailsFailing",
-            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). A check that cannot run blocks nothing, so whatever it would have caught went through. Check the model, the endpoint and the key.",
+            "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. Check the model, the endpoint and the key.",
             params,
           );
     }

--- a/src/modules/guardrails/health.ts
+++ b/src/modules/guardrails/health.ts
@@ -1,0 +1,74 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+import basePrisma from "@/api/lib/prisma";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+
+// Whether the guardrail screen is actually running, answered from what it did rather than from how
+// it was configured. Analysis is fail-open by design (a moderation call that times out must not
+// hold a customer's conversation), so a screen that can NEVER run behaves exactly like one that ran
+// and approved: the reply goes out either way. Configuration cannot tell the two apart, because
+// every cause is valid configuration right up to the moment the call is made:
+//
+//   - a model id the vendor has retired;
+//   - a parameter the vendor rejects on every call (agents#130 was a live instance: the guardrails
+//     pass pins temperature 0, and every current Claude model answers 400 to that);
+//   - a chronic timeout;
+//   - a credential that stopped resolving.
+//
+// The `guardrail` stage writes exactly two shapes (graph/runtime.ts): status "ok" when a check
+// TRIPPED, and status "error" when the analysis itself could not be performed. Nothing is written
+// when a screen runs and approves, so this counts failures and never a ratio: the honest reading of
+// "3 rows" is "3 turns were delivered unscreened", not "3 out of N".
+export const GUARDRAIL_HEALTH_WINDOW_HOURS = 24;
+
+// The window's start, as a function so the unit conversion is reachable by a test. Written inline in
+// the controller it is a silent bug class of its own: one missing factor of a thousand turns the
+// panel's "last 24 hours" into the last 24 seconds, and every test still passes because the count is
+// correct for the window it was actually given.
+export function guardrailHealthWindowStart(now: Date = new Date()): Date {
+  return new Date(
+    now.getTime() - GUARDRAIL_HEALTH_WINDOW_HOURS * 60 * 60 * 1000,
+  );
+}
+
+export interface GuardrailHealth {
+  // Analyses that could not run inside the window. Each one is a turn delivered unscreened.
+  failures: number;
+  // When the most recent one was, so a count that stopped growing reads differently from one that
+  // is still growing. Null exactly when `failures` is 0.
+  lastAt: string | null;
+  // The cause the most recent one carried, already scrubbed at write (sanitizeErrorMessage). It is
+  // what names the vendor's refusal, which is the whole difference between "fix this" and "look".
+  lastError: string | null;
+}
+
+export async function readGuardrailHealth(
+  ctx: TenantContext,
+  agentId: bigint,
+  since: Date,
+  base: PrismaClient = basePrisma,
+): Promise<GuardrailHealth> {
+  // Both sources on purpose. Alerting excludes the playground because a test turn must not page,
+  // but the playground is exactly where an operator re-tests after changing the model id, and a
+  // screen that cannot run there cannot run on real traffic either.
+  const where = {
+    agentId,
+    stage: "guardrail",
+    status: "error",
+    createdAt: { gte: since },
+  };
+  return runScopedOn(base, ctx, async (db) => {
+    const failures = await db.executionLog.count({ where });
+    const last = failures
+      ? await db.executionLog.findFirst({
+          where,
+          orderBy: { id: "desc" },
+          select: { createdAt: true, errorMessage: true },
+        })
+      : null;
+    return {
+      failures,
+      lastAt: last ? last.createdAt.toISOString() : null,
+      lastError: last?.errorMessage ?? null,
+    };
+  });
+}

--- a/src/modules/guardrails/health.ts
+++ b/src/modules/guardrails/health.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
+import { NotFoundError } from "@/lib/errors";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 
 // Whether the guardrail screen is actually running, answered from what it did rather than from how
@@ -47,9 +48,11 @@ export async function readGuardrailHealth(
   since: Date,
   base: PrismaClient = basePrisma,
 ): Promise<GuardrailHealth> {
-  // Both sources on purpose. Alerting excludes the playground because a test turn must not page,
-  // but the playground is exactly where an operator re-tests after changing the model id, and a
-  // screen that cannot run there cannot run on real traffic either.
+  // No source filter, which today means inbox: the guardrail stage is written from the turn path
+  // only, and the playground does not run the pass at all (modules/playground/service.ts never
+  // reaches analyzeGuardrail). Filtering to "inbox" anyway would encode that absence as a rule, so
+  // that the day the pass runs somewhere else its failures would be counted as zero by a filter
+  // nobody remembered. The question this answers is "could the screen run", not "on which surface".
   const where = {
     agentId,
     stage: "guardrail",
@@ -57,6 +60,16 @@ export async function readGuardrailHealth(
     createdAt: { gte: since },
   };
   return runScopedOn(base, ctx, async (db) => {
+    // The agent is resolved first so an id that never existed (or was deleted while its rows are
+    // still inside the retention window) answers 404 instead of a confident zero, or worse, the
+    // history of whoever held the id before. Same shape as getAgentToolSelections.
+    const agent = await db.agent.findUnique({
+      where: { id: agentId },
+      select: { id: true },
+    });
+    if (!agent) {
+      throw new NotFoundError("agent not found", "errors.agentNotFound");
+    }
     const failures = await db.executionLog.count({ where });
     const last = failures
       ? await db.executionLog.findFirst({

--- a/src/modules/guardrails/health.ts
+++ b/src/modules/guardrails/health.ts
@@ -74,7 +74,12 @@ export async function readGuardrailHealth(
     const last = failures
       ? await db.executionLog.findFirst({
           where,
-          orderBy: { id: "desc" },
+          // By createdAt, not by id. The rows are written fire-and-forget from independent
+          // transactions, and `now()` is the TRANSACTION's start time, so a turn that began
+          // earlier can be inserted later and take a higher id. Ordering by the sequence would
+          // then report an older failure as the most recent one, which is the single field an
+          // operator uses to decide whether the screen is still failing. id breaks ties.
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
           select: { createdAt: true, errorMessage: true },
         })
       : null;

--- a/src/modules/guardrails/health.ts
+++ b/src/modules/guardrails/health.ts
@@ -70,22 +70,35 @@ export async function readGuardrailHealth(
     if (!agent) {
       throw new NotFoundError("agent not found", "errors.agentNotFound");
     }
-    const failures = await db.executionLog.count({ where });
-    const last = failures
+    // The count and the newest timestamp come from ONE statement, because they have to agree. The
+    // rows are written fire-and-forget from other transactions and Postgres reads at READ COMMITTED,
+    // so two separate statements can straddle a commit and answer "2 failures, the most recent at
+    // <the third one's time>". The error is then read AT that timestamp rather than "the newest
+    // row", which keeps it part of the same answer instead of a third snapshot.
+    //
+    // Newest by createdAt, never by id: the writes are independent transactions and `now()` is the
+    // TRANSACTION's start time, so a turn that began earlier can be inserted later and take a higher
+    // id. The sequence would then name the wrong row as the most recent failure, which is the one
+    // field an operator reads to decide whether the screen is still failing.
+    const agg = await db.executionLog.aggregate({
+      where,
+      _count: { _all: true },
+      _max: { createdAt: true },
+    });
+    const lastAt = agg._max.createdAt;
+    const last = lastAt
       ? await db.executionLog.findFirst({
-          where,
-          // By createdAt, not by id. The rows are written fire-and-forget from independent
-          // transactions, and `now()` is the TRANSACTION's start time, so a turn that began
-          // earlier can be inserted later and take a higher id. Ordering by the sequence would
-          // then report an older failure as the most recent one, which is the single field an
-          // operator uses to decide whether the screen is still failing. id breaks ties.
-          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-          select: { createdAt: true, errorMessage: true },
+          // Exact timestamp, so this can only ever return a row the aggregate already counted. Two
+          // rows can share it (the resolution is microseconds, but a burst is a burst), and then the
+          // later insert wins; either one is "the most recent failure" and they agree on the time.
+          where: { ...where, createdAt: lastAt },
+          orderBy: { id: "desc" },
+          select: { errorMessage: true },
         })
       : null;
     return {
-      failures,
-      lastAt: last ? last.createdAt.toISOString() : null,
+      failures: agg._count._all,
+      lastAt: lastAt ? lastAt.toISOString() : null,
       lastError: last?.errorMessage ?? null,
     };
   });

--- a/src/modules/guardrails/health.ts
+++ b/src/modules/guardrails/health.ts
@@ -18,7 +18,11 @@ import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 // The `guardrail` stage writes exactly two shapes (graph/runtime.ts): status "ok" when a check
 // TRIPPED, and status "error" when the analysis itself could not be performed. Nothing is written
 // when a screen runs and approves, so this counts failures and never a ratio: the honest reading of
-// "3 rows" is "3 turns were delivered unscreened", not "3 out of N".
+// "3 rows" is "3 checks did not happen", not "3 out of N", and not "3 messages were delivered
+// unscreened" either. A failed INPUT check leaves the output check free to still screen the reply,
+// and a split output analysis can report an error from one half while the other half trips and
+// blocks the send. What every row does prove is the part that matters: fail-open means the check
+// that failed blocked nothing, so whatever it would have caught went through.
 export const GUARDRAIL_HEALTH_WINDOW_HOURS = 24;
 
 // The window's start, as a function so the unit conversion is reachable by a test. Written inline in
@@ -32,7 +36,8 @@ export function guardrailHealthWindowStart(now: Date = new Date()): Date {
 }
 
 export interface GuardrailHealth {
-  // Analyses that could not run inside the window. Each one is a turn delivered unscreened.
+  // Analyses that could not run inside the window. Each one is a check that did not happen, on a
+  // pass that is fail-open, so none of them blocked anything.
   failures: number;
   // When the most recent one was, so a count that stopped growing reads differently from one that
   // is still growing. Null exactly when `failures` is 0.
@@ -70,36 +75,31 @@ export async function readGuardrailHealth(
     if (!agent) {
       throw new NotFoundError("agent not found", "errors.agentNotFound");
     }
-    // The count and the newest timestamp come from ONE statement, because they have to agree. The
-    // rows are written fire-and-forget from other transactions and Postgres reads at READ COMMITTED,
-    // so two separate statements can straddle a commit and answer "2 failures, the most recent at
-    // <the third one's time>". The error is then read AT that timestamp rather than "the newest
-    // row", which keeps it part of the same answer instead of a third snapshot.
+    // Newest row FIRST, then a count bounded by that row's timestamp. The order is the whole point.
+    // These rows are written fire-and-forget from other transactions and Postgres reads at READ
+    // COMMITTED, so a row can commit between two statements; taken in this order the second
+    // statement can only ever be a superset of the first, so the row being quoted is always inside
+    // the count. Counting first and quoting second is what lets the pair disagree, reporting "2
+    // failures" beside an error from the third one. A row that commits after this makes the reading
+    // a moment stale, which is what a snapshot is, and leaves it internally consistent.
     //
     // Newest by createdAt, never by id: the writes are independent transactions and `now()` is the
     // TRANSACTION's start time, so a turn that began earlier can be inserted later and take a higher
     // id. The sequence would then name the wrong row as the most recent failure, which is the one
-    // field an operator reads to decide whether the screen is still failing.
-    const agg = await db.executionLog.aggregate({
+    // field an operator reads to decide whether the screen is still failing. id breaks ties.
+    const last = await db.executionLog.findFirst({
       where,
-      _count: { _all: true },
-      _max: { createdAt: true },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      select: { createdAt: true, errorMessage: true },
     });
-    const lastAt = agg._max.createdAt;
-    const last = lastAt
-      ? await db.executionLog.findFirst({
-          // Exact timestamp, so this can only ever return a row the aggregate already counted. Two
-          // rows can share it (the resolution is microseconds, but a burst is a burst), and then the
-          // later insert wins; either one is "the most recent failure" and they agree on the time.
-          where: { ...where, createdAt: lastAt },
-          orderBy: { id: "desc" },
-          select: { errorMessage: true },
-        })
-      : null;
+    if (!last) return { failures: 0, lastAt: null, lastError: null };
+    const failures = await db.executionLog.count({
+      where: { ...where, createdAt: { gte: since, lte: last.createdAt } },
+    });
     return {
-      failures: agg._count._all,
-      lastAt: lastAt ? lastAt.toISOString() : null,
-      lastError: last?.errorMessage ?? null,
+      failures,
+      lastAt: last.createdAt.toISOString(),
+      lastError: last.errorMessage,
     };
   });
 }

--- a/src/modules/guardrails/health.ts
+++ b/src/modules/guardrails/health.ts
@@ -20,9 +20,10 @@ import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 // when a screen runs and approves, so this counts failures and never a ratio: the honest reading of
 // "3 rows" is "3 checks did not happen", not "3 out of N", and not "3 messages were delivered
 // unscreened" either. A failed INPUT check leaves the output check free to still screen the reply,
-// and a split output analysis can report an error from one half while the other half trips and
-// blocks the send. What every row does prove is the part that matters: fail-open means the check
-// that failed blocked nothing, so whatever it would have caught went through.
+// and the output direction MERGES two analyses (splitAnalyses), so one half can report an error
+// while the other returns violated and the send is replaced or suppressed anyway. What every row
+// does prove is narrower and still worth saying: fail-open applies to the check that failed, so
+// that one caught nothing and held nothing back.
 export const GUARDRAIL_HEALTH_WINDOW_HOURS = 24;
 
 // The window's start, as a function so the unit conversion is reachable by a test. Written inline in

--- a/src/modules/guardrails/health.ts
+++ b/src/modules/guardrails/health.ts
@@ -90,11 +90,22 @@ export async function readGuardrailHealth(
     const last = await db.executionLog.findFirst({
       where,
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-      select: { createdAt: true, errorMessage: true },
+      select: { id: true, createdAt: true, errorMessage: true },
     });
     if (!last) return { failures: 0, lastAt: null, lastError: null };
+    // The cut is the keyset the ordering above defines, (createdAt, id), not the timestamp alone.
+    // createdAt is a TIMESTAMP(3), so a burst puts several failures in the same millisecond, and a
+    // bound of `createdAt <= last.createdAt` would readmit a row that this very ordering calls
+    // NEWER than the one being quoted: the count would then be reporting a failure the message is
+    // not describing.
     const failures = await db.executionLog.count({
-      where: { ...where, createdAt: { gte: since, lte: last.createdAt } },
+      where: {
+        ...where,
+        OR: [
+          { createdAt: { gte: since, lt: last.createdAt } },
+          { createdAt: last.createdAt, id: { lte: last.id } },
+        ],
+      },
     });
     return {
       failures,

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -714,6 +714,74 @@ describe("computeConfigIssues — the guardrails credential", () => {
   });
 });
 
+// The half of "unscreened" that configuration cannot see. A retired model id, a parameter the vendor
+// rejects on every call (#130 was a live instance) and a chronic timeout are all valid configuration
+// right up to the moment the call is made, and the analysis is fail-open, so every one of them
+// delivers messages as if they had been reviewed. What the screen actually DID is read back from the
+// execution log and handed to the panel as a count.
+describe("computeConfigIssues — a guardrail that could not run", () => {
+  const guarded = {
+    ...base,
+    guardrailsEnabled: true,
+    guardrailsCredentialRef: "vault:1",
+  };
+  const at = { tab: "guardrails", sectionId: "gr-model" } as const;
+
+  test("flags a credentialed guardrail whose analyses have been failing", () => {
+    expect(
+      computeConfigIssues({
+        ...guarded,
+        guardrailsFailures: 47,
+        guardrailsLastFailureAt: "2026-08-19T12:00:00.000Z",
+      }),
+    ).toEqual([
+      {
+        key: "guardrailsFailing",
+        ...at,
+        failures: 47,
+        lastFailureAt: "2026-08-19T12:00:00.000Z",
+      },
+    ]);
+  });
+
+  test("raises nothing when nothing failed in the window", () => {
+    expect(computeConfigIssues({ ...guarded, guardrailsFailures: 0 })).toEqual(
+      [],
+    );
+  });
+
+  test("raises nothing while guardrails are off, whatever the log holds", () => {
+    expect(
+      computeConfigIssues({
+        ...base,
+        guardrailsEnabled: false,
+        guardrailsCredentialRef: "vault:1",
+        guardrailsFailures: 47,
+      }),
+    ).toEqual([]);
+  });
+
+  // One root cause, not two. With no credential the runtime never builds the model, so it writes no
+  // failure rows at all: a count arriving alongside a credential issue can only be a leftover from
+  // before the credential broke, and repeating the symptom under the cause trains the operator to
+  // skim the panel.
+  test("stays quiet while the credential issue is live", () => {
+    expect(
+      computeConfigIssues({
+        ...guarded,
+        guardrailsCredentialRef: "",
+        guardrailsFailures: 47,
+      }),
+    ).toEqual([{ key: "guardrails", ...at }]);
+  });
+
+  test("survives a count with no timestamp", () => {
+    expect(computeConfigIssues({ ...guarded, guardrailsFailures: 3 })).toEqual([
+      { key: "guardrailsFailing", ...at, failures: 3 },
+    ]);
+  });
+});
+
 // Found by sweeping the panel's own inputs rather than by a review round: the rewrite's endpoint can
 // live on its CREDENTIAL, and the browser learns credential endpoints from the same vault list that
 // arrives a request after the first paint. Judged before that answer exists, an endpoint that is

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -7,11 +7,14 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { setPublisher, TOPICS } from "@/api/features/realtime/realtime.service";
 import { encryptJson } from "@/api/lib/crypto";
+import { computeConfigIssues } from "@/client/lib/configHealth";
 import { contactInboxThreadId } from "@/graph/checkpointer";
 import type { ResolvedModelConfig } from "@/graph/models";
 import { runAgentTurn } from "@/graph/runtime";
+import type { TenantContext } from "@/lib/tenancy";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
+import { readGuardrailHealth } from "@/modules/guardrails/health";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import {
   EmptyThenReplyModel,
@@ -1745,7 +1748,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     // But it also must not be indistinguishable from a guardrail that ran and approved, or an
     // operator whose credential expired reads "no violations" forever. Same argument that put
     // `retriedEmptyResponse` in the trail on #63.
-    test("a guardrail that cannot run leaves a line in the turn trail", async () => {
+    test("a guardrail that cannot run is reported on the screen that enabled it", async () => {
       await setGuardrails({
         enabled: true,
         provider: "openai",
@@ -1791,21 +1794,49 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       // The customer still gets answered: moderation failing is not the customer's problem.
       expect(sent).toEqual([[952, REPLY]]);
 
+      // ...and the console says so where the feature was turned on. The chain under test is the
+      // whole one: the vendor refuses the call, the turn records a guardrail failure, the health
+      // read counts it, and the editor's configuration-warning panel raises a line for it. Ending
+      // at the log row instead would assert a proxy: that row already existed and the operator
+      // still had no way to learn the screen was dead from the screen that switched it on.
       // emitFlowEvent is fire-and-forget, so poll briefly.
-      let failureLogged = false;
-      for (let i = 0; i < 30 && !failureLogged; i++) {
-        const rows = await suDb.executionLog.findMany({
-          where: { tenantId: gTenantId, stage: "guardrail", level: "warn" },
-          select: { detail: true },
-        });
-        failureLogged = rows.some(
-          (r) =>
-            (r.detail as Record<string, unknown> | null)?.outcome ===
-            "analysis_failed",
-        );
-        if (!failureLogged) await new Promise((r) => setTimeout(r, 100));
+      const ctx: TenantContext = {
+        tenantId: gTenantId,
+        userId: null,
+        role: "TENANT_ADMIN",
+      };
+      const since = new Date(Date.now() - 3_600_000);
+      let health = { failures: 0, lastAt: null as string | null };
+      for (let i = 0; i < 30 && health.failures === 0; i++) {
+        health = await readGuardrailHealth(ctx, gAgentId, since, appDb);
+        if (health.failures === 0) await new Promise((r) => setTimeout(r, 100));
       }
-      expect(failureLogged).toBe(true);
+      expect(health.failures).toBeGreaterThan(0);
+      expect(
+        computeConfigIssues({
+          modelProvider: "openai",
+          modelCredentialRef: "vault:1",
+          savedModelProvider: "openai",
+          sttEnabled: false,
+          sttCredentialRef: "",
+          ttsMode: "never",
+          ttsCredentialRef: "",
+          visionEnabled: false,
+          visionCredentialRef: "",
+          guardrailsEnabled: true,
+          guardrailsCredentialRef: "vault:1",
+          guardrailsFailures: health.failures,
+          guardrailsLastFailureAt: health.lastAt,
+        }),
+      ).toEqual([
+        {
+          key: "guardrailsFailing",
+          tab: "guardrails",
+          sectionId: "gr-model",
+          failures: health.failures,
+          lastFailureAt: health.lastAt as string,
+        },
+      ]);
     });
     // answer_relevance is the only check that needs the customer's own message: without it the
     // reviewer can judge tone, scope and persona, but not whether the reply answered the question.

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -1,0 +1,247 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import type { TenantContext } from "@/lib/tenancy";
+import {
+  GUARDRAIL_HEALTH_WINDOW_HOURS,
+  guardrailHealthWindowStart,
+  readGuardrailHealth,
+} from "@/modules/guardrails/health";
+
+// What the guardrail screen actually did, read back from the flow log. The reason this read exists
+// at all: analysis is fail-open, so a screen that can never run is indistinguishable from one that
+// ran and approved, and the `guardrail`/`error` row is the only place the difference survives.
+//
+// Every row below carries an EXPLICIT createdAt from this process's clock, and the window is
+// computed from that same clock. Letting Postgres stamp `now()` while the window comes from the
+// host puts the two on different clocks, and a Docker VM that drifted behind after a sleep is
+// exactly how a past worker test started reading rows "from the future" (see the alert-worker
+// incident): the count would go empty for reasons that have nothing to do with this code.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+// Seeding runs as the migration role (it writes rows for two tenants); every READ goes through the
+// application role, which is the one RLS actually constrains.
+const suDb = su as PrismaClient;
+const appDb = app as PrismaClient;
+
+const NOW = new Date();
+const ago = (minutes: number) => new Date(NOW.getTime() - minutes * 60_000);
+const SINCE = ago(24 * 60);
+
+let tenantA = 0n;
+let tenantB = 0n;
+const AGENT = 4_242n;
+const OTHER_AGENT = 4_243n;
+function ctx(t: bigint): TenantContext {
+  return { tenantId: t, userId: null, role: "TENANT_ADMIN" };
+}
+
+// The window the controller hands the read. Pinned to an exact instant because the failure mode is
+// an arithmetic one that no other test can see: the count is always right for the window it gets.
+describe("guardrailHealthWindowStart", () => {
+  test("goes back exactly the advertised number of hours", () => {
+    expect(
+      guardrailHealthWindowStart(new Date("2026-08-19T12:00:00.000Z")),
+    ).toEqual(new Date("2026-08-18T12:00:00.000Z"));
+    expect(GUARDRAIL_HEALTH_WINDOW_HOURS).toBe(24);
+  });
+
+  test("crosses a month boundary without drifting", () => {
+    expect(
+      guardrailHealthWindowStart(new Date("2026-03-01T03:00:00.000Z")),
+    ).toEqual(new Date("2026-02-28T03:00:00.000Z"));
+  });
+});
+
+describe.skipIf(!dbUp)("readGuardrailHealth", () => {
+  beforeAll(async () => {
+    tenantA = (
+      await suDb.tenant.create({
+        data: { name: "GhA", slug: `gh-a-${process.pid}` },
+      })
+    ).id;
+    tenantB = (
+      await suDb.tenant.create({
+        data: { name: "GhB", slug: `gh-b-${process.pid}` },
+      })
+    ).id;
+    await suDb.executionLog.createMany({
+      data: [
+        // Two analyses that could not run, the newer one carrying the cause.
+        {
+          tenantId: tenantA,
+          turnId: "g1",
+          agentId: AGENT,
+          stage: "guardrail",
+          level: "warn",
+          status: "error",
+          source: "inbox",
+          errorMessage: "401 incorrect api key provided",
+          createdAt: ago(90),
+        },
+        {
+          tenantId: tenantA,
+          turnId: "g2",
+          agentId: AGENT,
+          stage: "guardrail",
+          level: "warn",
+          status: "error",
+          source: "inbox",
+          errorMessage: "400 temperature is not supported",
+          createdAt: ago(5),
+        },
+        // A screen that RAN and tripped a check. It is the healthy shape of this stage and must
+        // never be counted as a failure: the same stage, the same warn level, a different status.
+        {
+          tenantId: tenantA,
+          turnId: "g3",
+          agentId: AGENT,
+          stage: "guardrail",
+          level: "warn",
+          status: "ok",
+          source: "inbox",
+          createdAt: ago(10),
+        },
+        // Another stage failing on the same agent says nothing about moderation.
+        {
+          tenantId: tenantA,
+          turnId: "g4",
+          agentId: AGENT,
+          stage: "tts",
+          level: "error",
+          status: "error",
+          source: "inbox",
+          errorMessage: "boom",
+          createdAt: ago(10),
+        },
+        // Outside the window: real, but not what the panel is reporting on.
+        {
+          tenantId: tenantA,
+          turnId: "g5",
+          agentId: AGENT,
+          stage: "guardrail",
+          level: "warn",
+          status: "error",
+          source: "inbox",
+          errorMessage: "ancient",
+          createdAt: ago(48 * 60),
+        },
+        // A different agent on the same tenant has its own answer.
+        {
+          tenantId: tenantA,
+          turnId: "g6",
+          agentId: OTHER_AGENT,
+          stage: "guardrail",
+          level: "warn",
+          status: "error",
+          source: "inbox",
+          errorMessage: "not this agent",
+          createdAt: ago(3),
+        },
+        // Another tenant's failure, for the RLS assertion.
+        {
+          tenantId: tenantB,
+          turnId: "g7",
+          agentId: AGENT,
+          stage: "guardrail",
+          level: "warn",
+          status: "error",
+          source: "inbox",
+          errorMessage: "other tenant",
+          createdAt: ago(3),
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    for (const tid of [tenantA, tenantB]) {
+      if (!tid) continue;
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM execution_logs WHERE tenant_id = ${tid}`,
+      );
+      await suDb.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tid}`);
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  test("counts the analyses that could not run, and only those", async () => {
+    const health = await readGuardrailHealth(ctx(tenantA), AGENT, SINCE, appDb);
+    expect(health.failures).toBe(2);
+  });
+
+  test("reports the most recent failure and the cause it carried", async () => {
+    const health = await readGuardrailHealth(ctx(tenantA), AGENT, SINCE, appDb);
+    expect(health.lastError).toBe("400 temperature is not supported");
+    expect(health.lastAt).toBe(ago(5).toISOString());
+  });
+
+  test("a different agent gets its own count", async () => {
+    const health = await readGuardrailHealth(
+      ctx(tenantA),
+      OTHER_AGENT,
+      SINCE,
+      appDb,
+    );
+    expect(health.failures).toBe(1);
+    expect(health.lastError).toBe("not this agent");
+  });
+
+  test("an agent with nothing logged reads as zero, not as unknown", async () => {
+    const health = await readGuardrailHealth(
+      ctx(tenantA),
+      9_999n,
+      SINCE,
+      appDb,
+    );
+    expect(health).toEqual({ failures: 0, lastAt: null, lastError: null });
+  });
+
+  // The playground is where an operator re-tests after changing the model id, and a screen that
+  // cannot run there cannot run on real traffic either. Alerting excludes playground (a test turn
+  // must not page); a configuration warning is not a page.
+  test("a playground failure counts too", async () => {
+    await suDb.executionLog.create({
+      data: {
+        tenantId: tenantA,
+        turnId: "g8",
+        agentId: AGENT,
+        stage: "guardrail",
+        level: "warn",
+        status: "error",
+        source: "playground",
+        errorMessage: "400 temperature is not supported",
+        createdAt: ago(1),
+      },
+    });
+    const health = await readGuardrailHealth(ctx(tenantA), AGENT, SINCE, appDb);
+    expect(health.failures).toBe(3);
+    expect(health.lastAt).toBe(ago(1).toISOString());
+  });
+
+  test("RLS: another tenant's failures are never counted", async () => {
+    const health = await readGuardrailHealth(ctx(tenantB), AGENT, SINCE, appDb);
+    expect(health.failures).toBe(1);
+    expect(health.lastError).toBe("other tenant");
+  });
+});

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -353,6 +353,72 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
     expect(health.lastError).toBe("second of the burst");
   });
 
+  // The rule that only concurrency can see. The two reads are ordered newest-row-first so the count
+  // can never exclude the row being quoted, and the count is capped at that row's timestamp to keep
+  // it that way. Both statements run at READ COMMITTED, so a row committing between them is real:
+  // this test forces exactly that interleaving by inserting a NEWER failure, from another
+  // connection, in the moment between the row read and the count.
+  test("a failure that commits mid-read cannot land in the count alone", async () => {
+    const late = (
+      await suDb.agent.create({
+        data: {
+          tenantId: tenantA,
+          name: "Late",
+          systemPrompt: "x",
+          modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        },
+        select: { id: true },
+      })
+    ).id;
+    await suDb.executionLog.create({
+      data: {
+        tenantId: tenantA,
+        turnId: "g11",
+        agentId: late,
+        stage: "guardrail",
+        level: "warn",
+        status: "error",
+        source: "inbox",
+        errorMessage: "the one that was read",
+        createdAt: ago(20),
+      },
+    });
+    let injected = false;
+    const racing = appDb.$extends({
+      query: {
+        executionLog: {
+          count: async ({ args, query }) => {
+            if (!injected) {
+              injected = true;
+              await suDb.executionLog.create({
+                data: {
+                  tenantId: tenantA,
+                  turnId: "g12",
+                  agentId: late,
+                  stage: "guardrail",
+                  level: "warn",
+                  status: "error",
+                  source: "inbox",
+                  errorMessage: "committed mid-read",
+                  createdAt: ago(1),
+                },
+              });
+            }
+            return query(args);
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    const health = await readGuardrailHealth(ctx(tenantA), late, SINCE, racing);
+    expect(injected).toBe(true);
+    // One or the other, never a mix: the count must not include a failure newer than the one it is
+    // reporting, or the panel reads "2 failures, the most recent 20 minutes ago" while the newest is
+    // a minute old and said something else.
+    expect(health.failures).toBe(1);
+    expect(health.lastError).toBe("the one that was read");
+    expect(health.lastAt).toBe(ago(20).toISOString());
+  });
+
   test("RLS: a tenant only ever reads its own agent's failures", async () => {
     const health = await readGuardrailHealth(
       ctx(tenantB),

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -315,6 +315,44 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
     expect(health.lastAt).toBe(ago(3).toISOString());
   });
 
+  // Two rows can carry the same createdAt, and the error has to come from one of them rather than
+  // from a third read of "the newest row". The later insert wins; both answers agree on the time.
+  test("a tie on the timestamp resolves to the later insert", async () => {
+    // Its own agent: the rows above are shared by every test in this block, and a burst asserted
+    // against a shared agent would be answered by whatever an earlier test happened to add.
+    const burst = (
+      await suDb.agent.create({
+        data: {
+          tenantId: tenantA,
+          name: "Burst",
+          systemPrompt: "x",
+          modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        },
+        select: { id: true },
+      })
+    ).id;
+    const at = ago(4);
+    for (const msg of ["first of the burst", "second of the burst"]) {
+      await suDb.executionLog.create({
+        data: {
+          tenantId: tenantA,
+          turnId: "g10",
+          agentId: burst,
+          stage: "guardrail",
+          level: "warn",
+          status: "error",
+          source: "inbox",
+          errorMessage: msg,
+          createdAt: at,
+        },
+      });
+    }
+    const health = await readGuardrailHealth(ctx(tenantA), burst, SINCE, appDb);
+    expect(health.failures).toBe(2);
+    expect(health.lastAt).toBe(at.toISOString());
+    expect(health.lastError).toBe("second of the burst");
+  });
+
   test("RLS: a tenant only ever reads its own agent's failures", async () => {
     const health = await readGuardrailHealth(
       ctx(tenantB),

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -240,6 +240,41 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
     expect(health).toEqual({ failures: 0, lastAt: null, lastError: null });
   });
 
+  // An agent whose only failure predates the window. The count is bounded twice over (the window on
+  // the filter, the keyset on the count), but the row being QUOTED is chosen by the filter alone, so
+  // without the window there the reading comes back as zero failures next to a timestamp and an
+  // error from days ago: a response that contradicts itself, and a "last error" the operator would
+  // read as current.
+  test("a failure older than the window leaves nothing behind, not even a timestamp", async () => {
+    const healed = (
+      await suDb.agent.create({
+        data: {
+          tenantId: tenantA,
+          name: "Healed",
+          systemPrompt: "x",
+          modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        },
+        select: { id: true },
+      })
+    ).id;
+    await suDb.executionLog.create({
+      data: {
+        tenantId: tenantA,
+        turnId: "g14",
+        agentId: healed,
+        stage: "guardrail",
+        level: "warn",
+        status: "error",
+        source: "inbox",
+        errorMessage: "fixed three days ago",
+        createdAt: ago(72 * 60),
+      },
+    });
+    expect(
+      await readGuardrailHealth(ctx(tenantA), healed, SINCE, appDb),
+    ).toEqual({ failures: 0, lastAt: null, lastError: null });
+  });
+
   // Zero and "there is no such agent" are different answers, and the endpoint advertises 404. Rows
   // outlive the agent inside the retention window, so without this an id that was deleted (or one
   // that never existed) answers with a confident zero, and a recycled id answers with somebody

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -280,6 +280,41 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
     expect(health.lastAt).toBe(ago(1).toISOString());
   });
 
+  // The rows are written fire-and-forget from independent transactions, and `now()` is the
+  // TRANSACTION's start time, so the sequence can hand a higher id to a turn that started earlier.
+  // Reading "the most recent" off the id would then report a failure that is not the most recent,
+  // and that single field is what an operator uses to decide whether the screen is still failing.
+  test("the most recent failure is the newest one, not the highest id", async () => {
+    const older = await suDb.executionLog.create({
+      data: {
+        tenantId: tenantA,
+        turnId: "g9",
+        agentId: OTHER_AGENT,
+        stage: "guardrail",
+        level: "warn",
+        status: "error",
+        source: "inbox",
+        errorMessage: "started earlier, written later",
+        createdAt: ago(30),
+      },
+      select: { id: true },
+    });
+    const newer = await suDb.executionLog.findFirst({
+      where: { tenantId: tenantA, turnId: "g6" },
+      select: { id: true },
+    });
+    // The row that must win is the one with the EARLIER id, which is the whole point.
+    expect(older.id > (newer?.id ?? 0n)).toBe(true);
+    const health = await readGuardrailHealth(
+      ctx(tenantA),
+      OTHER_AGENT,
+      SINCE,
+      appDb,
+    );
+    expect(health.lastError).toBe("not this agent");
+    expect(health.lastAt).toBe(ago(3).toISOString());
+  });
+
   test("RLS: a tenant only ever reads its own agent's failures", async () => {
     const health = await readGuardrailHealth(
       ctx(tenantB),

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -411,12 +411,64 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
     }) as unknown as PrismaClient;
     const health = await readGuardrailHealth(ctx(tenantA), late, SINCE, racing);
     expect(injected).toBe(true);
+    expect(health.failures).toBe(1);
     // One or the other, never a mix: the count must not include a failure newer than the one it is
     // reporting, or the panel reads "2 failures, the most recent 20 minutes ago" while the newest is
     // a minute old and said something else.
     expect(health.failures).toBe(1);
     expect(health.lastError).toBe("the one that was read");
     expect(health.lastAt).toBe(ago(20).toISOString());
+  });
+
+  // Same interleaving, same millisecond. createdAt is a TIMESTAMP(3), so a burst lands several
+  // failures inside one, and the row that commits mid-read is then NEWER by the ordering this module
+  // uses (createdAt, then id) while carrying the same timestamp. A count cut on the timestamp alone
+  // readmits it and reports a failure the message is not describing.
+  test("a mid-read failure in the same millisecond is not counted either", async () => {
+    const tied = (
+      await suDb.agent.create({
+        data: {
+          tenantId: tenantA,
+          name: "Tied",
+          systemPrompt: "x",
+          modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        },
+        select: { id: true },
+      })
+    ).id;
+    const at = ago(20);
+    const row = (msg: string) => ({
+      tenantId: tenantA,
+      turnId: "g13",
+      agentId: tied,
+      stage: "guardrail",
+      level: "warn",
+      status: "error",
+      source: "inbox",
+      errorMessage: msg,
+      createdAt: at,
+    });
+    await suDb.executionLog.create({ data: row("the one that was read") });
+    let injected = false;
+    const racing = appDb.$extends({
+      query: {
+        executionLog: {
+          count: async ({ args, query }) => {
+            if (!injected) {
+              injected = true;
+              await suDb.executionLog.create({
+                data: row("same millisecond, higher id"),
+              });
+            }
+            return query(args);
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    const health = await readGuardrailHealth(ctx(tenantA), tied, SINCE, racing);
+    expect(injected).toBe(true);
+    expect(health.failures).toBe(1);
+    expect(health.lastError).toBe("the one that was read");
   });
 
   test("RLS: a tenant only ever reads its own agent's failures", async () => {

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -49,8 +49,9 @@ const SINCE = ago(24 * 60);
 
 let tenantA = 0n;
 let tenantB = 0n;
-const AGENT = 4_242n;
-const OTHER_AGENT = 4_243n;
+let AGENT = 0n;
+let OTHER_AGENT = 0n;
+let AGENT_B = 0n;
 function ctx(t: bigint): TenantContext {
   return { tenantId: t, userId: null, role: "TENANT_ADMIN" };
 }
@@ -84,6 +85,22 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
         data: { name: "GhB", slug: `gh-b-${process.pid}` },
       })
     ).id;
+    const agentRow = (tenantId: bigint, name: string) =>
+      suDb.agent.create({
+        data: {
+          tenantId,
+          name,
+          systemPrompt: "x",
+          modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        },
+        select: { id: true },
+      });
+    AGENT = (await agentRow(tenantA, "Guarded")).id;
+    OTHER_AGENT = (await agentRow(tenantA, "Sibling")).id;
+    // Tenant B's own agent. The RLS assertion below asks for a reading while scoped to B, and with
+    // the agent resolved first that has to be an agent B can actually see, or the read would 404 for
+    // the wrong reason and the leak it guards against would go untested.
+    AGENT_B = (await agentRow(tenantB, "Other tenant")).id;
     await suDb.executionLog.createMany({
       data: [
         // Two analyses that could not run, the newer one carrying the cause.
@@ -161,7 +178,7 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
         {
           tenantId: tenantB,
           turnId: "g7",
-          agentId: AGENT,
+          agentId: AGENT_B,
           stage: "guardrail",
           level: "warn",
           status: "error",
@@ -208,19 +225,43 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
   });
 
   test("an agent with nothing logged reads as zero, not as unknown", async () => {
-    const health = await readGuardrailHealth(
-      ctx(tenantA),
-      9_999n,
-      SINCE,
-      appDb,
-    );
+    const quiet = (
+      await suDb.agent.create({
+        data: {
+          tenantId: tenantA,
+          name: "Quiet",
+          systemPrompt: "x",
+          modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        },
+        select: { id: true },
+      })
+    ).id;
+    const health = await readGuardrailHealth(ctx(tenantA), quiet, SINCE, appDb);
     expect(health).toEqual({ failures: 0, lastAt: null, lastError: null });
   });
 
-  // The playground is where an operator re-tests after changing the model id, and a screen that
-  // cannot run there cannot run on real traffic either. Alerting excludes playground (a test turn
-  // must not page); a configuration warning is not a page.
-  test("a playground failure counts too", async () => {
+  // Zero and "there is no such agent" are different answers, and the endpoint advertises 404. Rows
+  // outlive the agent inside the retention window, so without this an id that was deleted (or one
+  // that never existed) answers with a confident zero, and a recycled id answers with somebody
+  // else's history.
+  test("an agent that does not exist is a 404, never a zero", async () => {
+    await expect(
+      readGuardrailHealth(ctx(tenantA), 9_999_999n, SINCE, appDb),
+    ).rejects.toThrow("agent not found");
+  });
+
+  test("another tenant's agent is a 404, not a reading", async () => {
+    await expect(
+      readGuardrailHealth(ctx(tenantA), AGENT_B, SINCE, appDb),
+    ).rejects.toThrow("agent not found");
+  });
+
+  // The read does not filter by source. Today that is a distinction without a difference: the
+  // guardrail stage is only ever written from the turn path, and the playground does not run the
+  // pass at all, so this row is seeded by hand and the product cannot currently produce it. Pinned
+  // anyway, because a filter added "for correctness" would report zero the day the pass runs
+  // somewhere else, which is the exact failure this module exists to remove.
+  test("a failure from any source counts, not just inbox", async () => {
     await suDb.executionLog.create({
       data: {
         tenantId: tenantA,
@@ -239,8 +280,13 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
     expect(health.lastAt).toBe(ago(1).toISOString());
   });
 
-  test("RLS: another tenant's failures are never counted", async () => {
-    const health = await readGuardrailHealth(ctx(tenantB), AGENT, SINCE, appDb);
+  test("RLS: a tenant only ever reads its own agent's failures", async () => {
+    const health = await readGuardrailHealth(
+      ctx(tenantB),
+      AGENT_B,
+      SINCE,
+      appDb,
+    );
     expect(health.failures).toBe(1);
     expect(health.lastError).toBe("other tenant");
   });


### PR DESCRIPTION
## What was broken

Guardrail analysis is fail-open, and that is deliberate: a moderation call that times out must not hold a customer's conversation. The cost of that policy is that a screen which can **never** run is indistinguishable, from the operator's side, from one that ran and approved.

Configuration cannot close the gap, because every cause is valid configuration right up to the moment the call is made:

- a model id the vendor has retired;
- a parameter the vendor rejects on every call (#130 was a live instance: the guardrails pass pins `temperature: 0`, and every current Claude model answers 400 to that);
- a chronic timeout;
- a credential that stopped resolving.

The trip already reaches `ExecutionLog` as a `guardrail` row with `status: "error"`, so it shows on the Logs page. It never reached the Guardrails tab, which is where somebody turned the feature on and where they would go to check on it.

Measured, not assumed: with the guardrails model answering `401` on every call, the turn is delivered, the row is written, and `computeConfigIssues` returned an empty list. That is the assertion the new e2e makes fail on the pre-fix code.

## What changed

`src/modules/guardrails/health.ts` (new). `readGuardrailHealth` counts, per agent and over a 24-hour window, the analyses that could not run, and reports the most recent one with the error it carried. No new storage and no new event: the rows already exist.

The count is a count, never a ratio. The stage writes nothing when a screen runs and approves, so "3 rows" means "3 checks did not happen".

`GET /v1/agents/:id/guardrails/health` exposes it, TENANT_ADMIN like the rest of the agent surface, and 404s for an agent that does not exist rather than answering a confident zero (rows outlive the agent inside the retention window, and a recycled id would otherwise answer with somebody else's history).

`src/client/lib/configHealth.ts` raises a `guardrailsFailing` issue from that count, into the panel that already flags a guardrail with no credential. It is suppressed while the credential verdict is live, and not for tidiness: with no credential the runtime never builds the model and writes no failure rows at all, so a count arriving next to a credential issue can only be a leftover from before that credential broke.

### What the warning does and does not claim

It says the checks did not run, and that fail-open means the ones that failed caught nothing and held nothing back. It does **not** say the messages went out unscreened, because a failure row does not prove that: a failed input check leaves the output check free to still screen the reply, and the output direction merges two analyses (`splitAnalyses`), so one half can report an error while the other returns `violated` and the send is replaced or suppressed anyway.

### Reading it consistently

The two reads are ordered newest-row-first, then a count cut on the same `(createdAt, id)` keyset the ordering uses. Both statements run at READ COMMITTED against a table written fire-and-forget from other transactions, so a row committing between them is real; taken in this order the counted set is exactly the rows at or before the one being quoted, so the triple cannot contradict itself. A row that commits after makes the reading a moment stale, which is what a snapshot is.

Newest by `createdAt`, never by `id`: the writes are independent transactions and `now()` is the transaction's start time, so a turn that began earlier can be inserted later and take a higher id.

On the client, one `serverSyncTick` decides when the snapshot is retaken: every successful load (the stale-state Reload included) and every successful save. Nothing is fetched before the first load completes, and a request that fails clears the snapshot rather than leaving a count nobody can vouch for on screen.

## What was considered and left out

**A positive "screened and clean" event.** It would turn the count into a streak ("N failures and nothing has succeeded since"), which self-clears the moment a fix works. It also costs one flow-log row per direction per turn on a high-write table, and the argument for it is a UX hypothesis about operator confusion, not a measurement.

**A save-time probe** that makes one real call when the guardrails config is saved. It would catch three of the four causes before any traffic. It is a second mechanism with its own failure modes (a paid call on every save, flakiness) and it does not catch drift, so it is worth its own issue rather than a rider on this one.

**Polling for live traffic.** An editor left open does not learn about failures that started meanwhile. Closing that costs a request a minute on every open editor to shorten a wait that ends the next time anybody loads or saves.

**A composite index for the health query**, suggested in review and measured instead of argued: one tenant, 8 guarded agents all failing, 60k guardrail failures inside the window plus their siblings (180k rows). The aggregate answers in 8.2 ms on the planner's own choice and 8.1 ms forced onto the index path production would use; the proposed index takes it to 2.7 ms. Five milliseconds on a query that runs once per editor load, paid for with write amplification on every insert into the log this codebase writes fire-and-forget precisely to keep latency out of the hot path, is not a trade worth making.

## Validation scope

**Proven by test**

- `tests/modules/guardrail-health.test.ts`, 15 tests, DB-backed. The read counts `guardrail`/`error` and never the `guardrail`/`ok` row a tripped check writes; respects the agent, the window and RLS; 404s for an unknown agent and for another tenant's agent; reports the most recent failure and its error; reads zero rather than unknown for an agent with nothing logged; and leaves nothing behind, not even a timestamp, for an agent whose only failure predates the window. Every row carries an explicit `createdAt` from the test process's clock and the window comes from that same clock, so a drifted container clock cannot empty the count.
- Two of them force the concurrent interleaving the ordering exists for, committing a newer failure from another connection in the gap between the two reads: once with a later timestamp, once inside the same millisecond with a higher id.
- `guardrailHealthWindowStart` is pinned to exact instants. The unit conversion is invisible to every other test (the count is always correct for the window it was given), so a missing factor of a thousand would ship a 24-second window in silence.
- `tests/client/config-health.test.ts`, 5 new: raised for a credentialed guardrail with failures, quiet at zero, quiet while guardrails are off, quiet while the credential issue is live, and correct with a count but no timestamp.
- `tests/graph/runtime.test.ts`: the e2e goes the whole way. The vendor answers `401`, the customer is still answered, the turn records the failure, the health read counts it, and the editor's warning panel carries the line. Red before this change, at the panel assertion and not at the log row.
- Mutation, one clause at a time, re-run against the final code rather than trusting the earlier rounds: 11 on the module and 5 on the client issue. All 16 break at least one test. The re-run is what caught the last commit here: once the count grew its own keyset bound, deleting the window from the filter stopped breaking anything, while the row being quoted is still chosen by the filter alone.

**Not validated**

- No HTTP-level test of the new route. Its path is proven by the client's Eden types (a wrong path fails `bun build-check`) and the `/api/v1/*` carve-out smoke covers the group, but the role guard on this route specifically is declarative and untested, like its neighbours.
- No DOM test of the rendered panel, and none of the client wiring (the sync tick, the failed-request clear) is covered by a test. The chain is asserted up to `computeConfigIssues`, which is the value the panel renders.
- Not exercised against a live vendor. The 400-on-every-call cause was measured live in #130; this PR only reads back what that failure records.

`bun check` green (2929 tests). No derivation markers in any file touched, so the diff is 1:1 in both editions.

Refs #131 (item 2 of three).
