### PR TITLE
Say how much one issue should hold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,16 @@
 Guia detalhado por subsistema vive em [`docs/`](docs/); as seções abaixo cobrem o que não cabe lá ou que você deve manter em memória de trabalho.
 
 
+## Uma PR fecha uma issue, e issue que nenhuma PR fecha está errada
+
+Toda PR sai com `Fixes #N`. O par é o teste de granularidade dos dois lados: se você não consegue apontar a issue que **esta** PR fecha, ou a PR está fazendo mais de uma coisa, ou a issue está pedindo mais de uma.
+
+Quando é a issue que não cabe, **reescrevê-la é parte do trabalho e vem antes do código**: uma issue com três entregáveis vira três issues, cada uma com o seu `Fixes`. Trocar por `Refs` e seguir em frente é o que produz a issue que ninguém consegue fechar, aberta pela metade e sem conseguir dizer o que falta.
+
+Isso é mais estrito do que o [`CONTRIBUTING.md`](CONTRIBUTING.md) pede de quem contribui de fora, e de propósito: lá a orientação é sobre como escrever uma issue, e uma PR sem issue continua bem-vinda; aqui vale para quem também escreve as issues.
+
+Quando de fato não couber, isso aparece pela necessidade concreta e se resolve ali. Não há lista de exceções, e não é esquecimento: a lista é o caminho pelo qual um default vira sugestão.
+
 ## Subsystem docs
 
 - [`docs/ui.md`](docs/ui.md): the operator console screen map (Dashboard KPIs, Conversations + detail, the progressive-disclosure Agent editor, Building blocks pools, Channels), the shared primitives (Select/Textarea/Switch/Tabs/FormField/ConfirmDialog/DataBoundary/EmptyState/Skeleton), the tool-selection grant model (replace-the-set; NATIVE/RAG semantics), and the i18n/extract gotchas (auto-added pt-BR keys need translating; conflicting defaults fail extract; `noJsxLiterals.allowedStrings`). Read before adding or changing any screen or client primitive.

--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -18,6 +18,7 @@ This changes little for contributors, but it explains two things:
 
 - Search existing issues (open and closed) before filing a new one.
 - For bugs, include: reproduction steps, expected behavior, observed behavior and relevant logs. Issues like [#2](https://github.com/fazer-ai/agents/issues/2) are a good model.
+- **One issue, one thing.** Scope an issue so that a single pull request can close it. Work that splits into several pull requests is several issues: an issue nobody can close is an issue nobody can finish, and it stops being able to say what is left. This is about how to write one, not a requirement that every pull request have an issue.
 - **Security vulnerabilities do not go in public issues:** write to [support@fazer.ai](mailto:support@fazer.ai).
 
 ## Pull requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Isso muda pouco para quem contribui, mas explica duas coisas:
 
 - Procure issues existentes (abertas e fechadas) antes de abrir uma nova.
 - Para bugs, inclua: passos de reprodução, comportamento esperado, comportamento observado e logs relevantes. Issues como a [#2](https://github.com/fazer-ai/agents/issues/2) são um bom modelo.
+- **Uma issue, uma coisa.** Dimensione a issue para que uma única pull request consiga fechá-la. Trabalho que se divide em várias pull requests são várias issues: issue que ninguém consegue fechar é issue que ninguém consegue terminar, e ela para de conseguir dizer o que falta. Isso é sobre como escrever uma, não uma exigência de que toda pull request tenha issue.
 - **Vulnerabilidades de segurança não vão em issue pública:** escreva para [support@fazer.ai](mailto:support@fazer.ai).
 
 ## Pull requests


### PR DESCRIPTION
## What was missing

`CONTRIBUTING.md` / `CONTRIBUTING-en.md` tell a contributor to search before filing, what a bug report should contain, and where security reports go. Neither says how much one issue should hold. `CLAUDE.md` said nothing about issues at all.

The gap has a specific failure attached to it: an issue holding several separable deliverables reads as normal, and then no pull request can close it. The PR that lands one part writes `Refs` instead of `Fixes`, the issue stays open at a fraction of itself, and it stops being able to say what is left. Whoever picks it up next has to re-read the whole body and diff it against the merged PRs to work out what remains.

#131 is the instance that prompted this: its first line says "three separable gaps", #135 delivered the second of the three and could only reference it, and the issue is now open with two thirds of its content live and nothing on it saying which is which.

## What changed

**CONTRIBUTING (both languages), in the Issues section.** Scope an issue so a single pull request can close it; work that splits into several PRs is several issues. Phrased as guidance for writing one, explicitly not as a requirement that every PR have an issue, because the section right below already says a contributor needs neither permission nor a prior issue to send one, and that stays true.

**CLAUDE.md**, as a working norm, and stricter on purpose: it applies to the people who also write the issues, so when the issue is the part that does not fit, rewriting it is part of the work and comes before the code.

Neither carries a list of exceptions, and that is deliberate rather than an omission: cases that genuinely do not fit show up through a concrete need and get handled there, while a catalogue is how a default turns into a suggestion. Both files say so.

## Validation scope

Documentation only, no code paths touched. `bun run derive:check` is clean and the additions sit outside every marker block in both files (`CLAUDE.md` has `@master-only` sections, `CONTRIBUTING.md` a `@free-only` CLA block), so they reach both editions.

Not validated: nothing here is executable, so nothing is covered by a test.

Fixes #138