### PR TITLE
Key the rate limiters on the client, not on the reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,11 +135,41 @@ ALERT_COALESCE_WINDOW_MS=30000
 # daily per-tenant FLOWLOG_SWEEP job deletes older rows. Default 30.
 FLOWLOG_RETENTION_DAYS=30
 
-# NOTE: Per-IP rate-limit ceilings (requests/minute). Runaway guards, not tight throttles: the
+# NOTE: Per-client rate-limit ceilings (requests/minute). Runaway guards, not tight throttles: the
 # console fires dozens of parallel reads per navigation, and one MCP client funnels every tool call
-# through a single IP. Raise if a shared-NAT deployment trips them. Defaults: user 600, MCP 1200.
+# through a single address. Raise if a shared-NAT deployment trips them. Defaults: user 600, MCP 1200.
 RATE_LIMIT_USER_PER_MIN=600
 RATE_LIMIT_MCP_PER_MIN=1200
+
+# NOTE: Who the limits above apply to. The app sees the reverse proxy as the client of every request,
+# so until TRUST_PROXY is on, the whole deployment shares one bucket.
+# Turn it on only when BOTH hold, because either one alone is a bypass:
+#   1. The app port is unreachable except through your proxy. docker-compose.prod.yml publishes it on
+#      every interface by default, and anyone who can reach it directly could otherwise send an
+#      X-Forwarded-For of their choosing and give themselves a private bucket. Narrow the binding
+#      (APP_PORT=127.0.0.1:3000) or firewall it first. This is not derived from the source address
+#      because Docker's userland proxy rewrites a direct caller to the same bridge address a real
+#      sidecar proxy connects from, so the two cannot be told apart.
+#      With TRUSTED_PROXY_HOPS above 1 this applies to EVERY proxy you counted, not just to this app:
+#      a reachable origin behind a CDN is the same bypass one layer out. Reaching the origin directly
+#      with an X-Forwarded-For of your own produces a chain the same length as the CDN path, so the
+#      entry this reads is the forged one and nothing in the request distinguishes the two. Restrict
+#      the origin to the CDN's ranges before counting the CDN as a hop.
+#   2. Your proxy OVERWRITES or APPENDS to X-Forwarded-For rather than passing the client's value
+#      through. Caddy and Traefik overwrite by default; nginx does only with
+#      `$proxy_add_x_forwarded_for` — the `$http_x_forwarded_for` spelling forwards whatever the
+#      client sent, which puts the last entry back under the client's control.
+# TRUSTED_PROXY_HOPS is how many proxies sit in front, counted from the END of the chain, because a
+# proxy appends what it saw and a client can prepend but never append. Raising it only helps if the
+# proxy NEAREST to this app preserves the chain it received: measured, Caddy with no `trusted_proxies`
+# discards the incoming chain entirely and emits just its own peer, so behind a CDN the app would key
+# on the CDN unless Caddy is told to trust it — and a hop count larger than the chain falls back to
+# the peer, putting everyone in one bucket again. Leave it at 1 unless you have configured the
+# nearest proxy to forward the upstream chain.
+# This is a limit on one source either way, not brute-force protection: everyone behind one NAT
+# still shares a bucket.
+TRUST_PROXY=false
+TRUSTED_PROXY_HOPS=1
 
 # NOTE: Allow stdio MCP servers (spawns a local process = RCE risk in multi-tenant hosting).
 # OFF by default; enable only on a single-tenant/self-hosted box you control. When off, a stdio

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -19,6 +19,14 @@ services:
       # NOTE: default to the public URL, NOT `*` — the WS realtime origin check does an exact
       # match, so `*` matches no real Origin and 403s every WebSocket upgrade.
       - CORS_ORIGIN=${CORS_ORIGIN:-${SERVICE_URL_AGENTS}}
+      # Rate-limit keying. Safe to trust here: this service publishes no port, so every request
+      # arrives through Coolify's proxy and X-Forwarded-For is written by it. Without this the whole
+      # deployment shares one bucket. Leave the hops at 1: a proxy that does not trust its upstream
+      # emits only its own peer, so behind a CDN a higher count finds a chain shorter than itself and
+      # falls back to the proxy socket, collapsing everyone into one bucket. Configure the platform
+      # proxy to trust the CDN before raising it.
+      - TRUST_PROXY=true
+      - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
       # First-run: disable the /setup token in this trusted, TLS-fronted onboarding window (the
       # advisory lock still caps /setup at one admin). Set to `true` to require it.
       - SETUP_TOKEN_REQUIRED=${SETUP_TOKEN_REQUIRED:-false}

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -81,6 +81,15 @@ services:
       # NOTE: default to the public URL, NOT `*` — the WS realtime origin check does an exact
       # match, so `*` matches no real Origin and 403s every WebSocket upgrade.
       - CORS_ORIGIN=${CORS_ORIGIN:-${PUBLIC_URL}}
+      # Rate-limit keying. Safe to trust here: this service publishes no port and is reachable only
+      # through the caddy service above, which writes X-Forwarded-For itself. Without this the whole
+      # deployment shares one bucket. Hops stays 1 even behind a CDN: measured, a Caddy with no
+      # `trusted_proxies` DISCARDS the incoming chain and emits only its own peer, so raising it would
+      # find a chain shorter than the count and fall back to the Caddy socket — one bucket again. To
+      # key on the real client behind a CDN, give the caddy service `trusted_proxies` for the CDN's
+      # ranges first, then raise this to 2.
+      - TRUST_PROXY=true
+      - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
       # First-run: disable the /setup token in this trusted, TLS-fronted onboarding window (the
       # advisory lock still caps /setup at one admin). Set to `true` to require it.
       - SETUP_TOKEN_REQUIRED=${SETUP_TOKEN_REQUIRED:-false}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,16 @@ services:
       # NOTE: default to the public URL, NOT `*` — the WS realtime origin check does an exact
       # match, so `*` matches no real Origin and 403s every WebSocket upgrade.
       - CORS_ORIGIN=${CORS_ORIGIN:-${PUBLIC_URL}}
+      # Rate-limit keying. OFF here, unlike the bundled-proxy files, because the app port above is
+      # published on every interface by default: anyone who can reach it directly could otherwise
+      # send an X-Forwarded-For of their choosing and give themselves a private bucket. Before setting
+      # this to `true`, narrow the binding (APP_PORT=127.0.0.1:3000) or firewall the port, AND check
+      # that your proxy overwrites or appends to X-Forwarded-For instead of passing the client's value
+      # through (nginx `$proxy_add_x_forwarded_for`, not `$http_x_forwarded_for`) — otherwise the last
+      # entry is still the client's. Leave the hops at 1 unless the proxy nearest to this app is
+      # configured to forward the chain it received; see .env.example.
+      - TRUST_PROXY=${TRUST_PROXY:-false}
+      - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
       # First-run: disable the /setup token in this trusted, TLS-fronted onboarding window (the
       # advisory lock still caps /setup at one admin). Set to `true` to require it.
       - SETUP_TOKEN_REQUIRED=${SETUP_TOKEN_REQUIRED:-false}

--- a/src/api/lib/clientIp.ts
+++ b/src/api/lib/clientIp.ts
@@ -1,8 +1,71 @@
-export function extractClientIp(request: Request): string {
-  return (
-    request.headers.get("cf-connecting-ip") ??
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    request.headers.get("x-real-ip") ??
-    "unknown"
-  );
+// Resolving the address a request "came from" is a trust decision, not a lookup: every candidate
+// header is attacker-controlled unless a proxy we trust overwrote it. Getting it wrong in either
+// direction breaks the rate limiters that key on the result — trust a header nobody sanitizes and a
+// client picks its own bucket (unlimited attempts, or poisoning someone else's); ignore one a real
+// proxy set and EVERY client collapses into a single bucket, which is what this deployment does
+// today, since the plugin's default generator reads the TCP peer and every compose file here puts a
+// reverse proxy in front. Being wrong toward the shared bucket is a worse limit; being wrong toward
+// the header is no limit at all, so the trust is declared rather than guessed.
+
+// NOTE: Only ONE thing in a request is reliably written by our own proxy: the entry a proxy APPENDS
+// to X-Forwarded-For. Everything else is a guess at a name — `cf-connecting-ip`, `x-real-ip` and
+// friends are set by SOME proxies, and a proxy that does not manage a header forwards it verbatim,
+// so on a generic Traefik/Caddy/nginx deployment a client can send `CF-Connecting-IP: <anything>`
+// and, if we prefer it, name its own rate-limit bucket.
+//
+// So this counts hops instead of trusting names. `hops` is how many proxies sit between the client
+// and us: with the usual single proxy the LAST entry is the one it wrote (a client that sends
+// `X-Forwarded-For: 1.2.3.4` only turns the list into `1.2.3.4, <real client>`, and can prepend but
+// never append). With Cloudflare in front of that proxy the last entry is Cloudflare, so hops is 2.
+// A chain shorter than `hops` means the configuration and the topology disagree; that returns
+// nothing and the caller falls back to the peer, which over-groups rather than handing a client the
+// key.
+//
+// NOTE: each hop counted moves the read one entry LEFT, and the leftmost entry is the one a client
+// can write. At hops 1 that never matters — the entry read is the one our own proxy appended. Above
+// 1 it does: a caller who can reach the SECOND proxy directly, skipping the first, sends an
+// X-Forwarded-For of their choosing and the proxy that answers appends their peer, producing a chain
+// exactly as long as the legitimate path. Nothing in the request tells the two apart, so raising
+// `hops` is only safe when every proxy counted is itself unreachable except through the one in front
+// of it — the precondition .env.example states for the app port, applied to the whole chain.
+export function extractForwardedIp(
+  request: Request,
+  hops: number,
+): string | undefined {
+  const chain = request.headers
+    .get("x-forwarded-for")
+    ?.split(",")
+    .map((hop) => hop.trim())
+    .filter(Boolean);
+  if (!chain?.length) return undefined;
+  const index = chain.length - hops;
+  return index >= 0 ? chain[index] : undefined;
+}
+
+// `trustProxy` mirrors config.trustProxy, which is explicit on purpose. Deriving it from the peer
+// ("is it a private address?") reads as the convenient default and does not hold here:
+// docker-compose.prod.yml publishes the app port on every interface unless the operator narrows it,
+// so a caller on the same network reaches this process directly — and under Docker's userland proxy
+// their connection is SNATed to the bridge gateway, which is indistinguishable from the address a
+// real sidecar proxy connects from. In that topology no heuristic can tell the two apart, and
+// guessing wrong hands every limiter's key to the caller. So trust is declared by whoever knows the
+// deployment, and the compose files that guarantee a proxy declare it themselves.
+export function resolveClientIp({
+  request,
+  peer,
+  trustProxy,
+  hops,
+}: {
+  request: Request;
+  peer: string | undefined;
+  trustProxy: boolean;
+  hops: number;
+}): string {
+  if (trustProxy) {
+    const forwarded = extractForwardedIp(request, hops);
+    if (forwarded) return forwarded;
+  }
+  // NOTE: Falls back to the peer rather than to a constant, so a trusted proxy that forgets to
+  // forward anything degrades to one bucket per proxy instead of one bucket named "unknown".
+  return peer ?? "unknown";
 }

--- a/src/api/middlewares/rateLimit.ts
+++ b/src/api/middlewares/rateLimit.ts
@@ -1,4 +1,5 @@
 import { rateLimit } from "elysia-rate-limit";
+import { resolveClientIp } from "@/api/lib/clientIp";
 import { translate } from "@/api/lib/i18n";
 import config from "@/config";
 
@@ -26,15 +27,45 @@ const isStaticRequest = (request: Request): boolean => {
 // was considered but would be single-replica (in-memory) for the MVP, so we key by IP like the rest.
 // The OAuth subpaths (/oauth/*) are NOT covered here, they keep the global limit so /token
 // brute-force stays bounded.
+// NOTE: The plugin's default generator keys on `server.requestIP()`, which is the SOCKET PEER.
+// Behind a reverse proxy — what every compose file in this repo puts in front, and what the
+// Portainer one ships itself — that is the proxy for every request, so the whole deployment shares
+// one bucket and the ceilings below stop being per-client at all. Every limiter takes this one, so
+// the keying cannot drift between them; the trust decision behind it lives in api/lib/clientIp.ts.
+// NOTE: exported as a factory only so a test can build the key a DECLARED-proxy deployment would
+// use; the suite runs with the shipped default, where nothing is declared and the peer is the key.
+export const clientKeyFor =
+  (trustProxy: boolean, hops: number) =>
+  (request: Request, server: { requestIP?: unknown } | null) =>
+    resolveClientIp({
+      request,
+      peer: (
+        server as {
+          requestIP?: (r: Request) => { address?: string } | null;
+        } | null
+      )?.requestIP?.(request)?.address,
+      trustProxy,
+      hops,
+    });
+
+const clientKey = clientKeyFor(config.trustProxy, config.trustedProxyHops);
+
 export const isMcpTransport = (request: Request): boolean => {
   const path = new URL(request.url).pathname;
   return path === "/api/v1/mcp" || path === "/api/v1/mcp/";
 };
 
-export const rateLimitMiddleware = () =>
+// NOTE: `max` is a parameter only so a test can drive the REAL middleware at a reachable budget;
+// production always takes the default. Exercising the shipped limiter is the point — a test that
+// rebuilt an equivalent one would pass while this one was mounted without a generator.
+export const rateLimitMiddleware = (
+  max = config.rateLimit.userPerMin,
+  generator = clientKey,
+) =>
   rateLimit({
     duration: 60000, // 1 minute
-    max: config.rateLimit.userPerMin, // default 600 requests per minute per IP
+    generator,
+    max, // default 600 requests per minute per client
     errorResponse: translate(
       "errors.rateLimitExceeded",
       "Rate limit exceeded. Please try again later.",
@@ -49,6 +80,7 @@ export const rateLimitMiddleware = () =>
 export const mcpTransportRateLimitMiddleware = () =>
   rateLimit({
     duration: 60000, // 1 minute
+    generator: clientKey,
     max: config.rateLimit.mcpPerMin, // default 1200 requests per minute per IP
     errorResponse: translate(
       "errors.rateLimitExceeded",
@@ -61,6 +93,7 @@ export const mcpTransportRateLimitMiddleware = () =>
 export const strictRateLimitMiddleware = () =>
   rateLimit({
     duration: 60000, // 1 minute
+    generator: clientKey,
     max: 10, // 10 requests per minute
     errorResponse: translate(
       "errors.rateLimitExceeded",
@@ -72,6 +105,7 @@ export const strictRateLimitMiddleware = () =>
 export const staticRateLimitMiddleware = () =>
   rateLimit({
     duration: 60000, // 1 minute
+    generator: clientKey,
     max: 1000, // 1000 requests per minute
     errorResponse: translate(
       "errors.rateLimitExceeded",
@@ -87,6 +121,7 @@ export const staticRateLimitMiddleware = () =>
 export const registerRateLimitMiddleware = () =>
   rateLimit({
     duration: 60000, // 1 minute
+    generator: clientKey,
     max: 10, // 10 registrations per minute per IP
     errorResponse: translate(
       "errors.rateLimitExceeded",

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,8 @@ const {
   SSRF_ALLOW_PRIVATE_TARGETS,
   RATE_LIMIT_USER_PER_MIN,
   RATE_LIMIT_MCP_PER_MIN,
+  TRUST_PROXY,
+  TRUSTED_PROXY_HOPS,
   BUN_PUBLIC_EDITION,
   FAZER_AI_HUB_URL,
   AGENTS_UPDATE_CHECK_URL,
@@ -67,6 +69,34 @@ const parseDomainList = (
   }
 
   return values;
+};
+
+// TRUST_PROXY decides whether the forwarded chain is believed when keying the rate limiters.
+// Unset means false: without a declaration the safe reading is that the app may be reached directly,
+// where believing the header would let a caller pick its own bucket. A value that is neither
+// spelling fails by name rather than falling back, because the fallback is the strict side and an
+// operator who typed `yes` would get the opposite of what they meant, silently and permanently.
+const parseTrustProxy = (raw: string | undefined, envName: string): boolean => {
+  const value = (raw ?? "").trim().toLowerCase();
+  if (value === "") return false;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(
+    `${envName} must be "true" or "false" (got "${raw}"). It decides whether X-Forwarded-For is believed when keying the rate limiters.`,
+  );
+};
+
+// A hop count selects WHICH X-Forwarded-For entry is believed to be the client, so a silently
+// defaulted bad value would change who shares a bucket. Fail by name at boot instead.
+const parseHops = (raw: string | undefined, envName: string): number => {
+  if (raw === undefined || raw.trim() === "") return 1;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(
+      `${envName} must be a whole number >= 1 (got "${raw}"). It selects which X-Forwarded-For entry is read as the client.`,
+    );
+  }
+  return value;
 };
 
 const googleClientId = (GOOGLE_CLIENT_ID ?? "").trim();
@@ -235,10 +265,21 @@ const config = {
           ? false
           : (NODE_ENV || "development") === "development",
   },
-  // NOTE: Per-IP rate-limit ceilings (requests/minute). These are runaway guards, NOT tight
+  // NOTE: Whether to believe the X-Forwarded-For chain when keying the rate limiters. OFF unless
+  // declared: the compose files that guarantee the app is only reachable through a proxy set it, and
+  // the one that publishes the app port leaves the operator to. See src/api/lib/clientIp.ts for why
+  // this is not derived from the peer address.
+  trustProxy: parseTrustProxy(TRUST_PROXY, "TRUST_PROXY"),
+  // NOTE: How many proxies sit between the client and this app. The client address is read that many
+  // hops from the END of X-Forwarded-For, since a proxy appends the peer it saw and a client can
+  // prepend but never append. One proxy (every compose file here) is the last entry; a CDN in front
+  // of that proxy makes it two.
+  trustedProxyHops: parseHops(TRUSTED_PROXY_HOPS, "TRUSTED_PROXY_HOPS"),
+  // NOTE: Per-client rate-limit ceilings (requests/minute). These are runaway guards, NOT tight
   // throttles: navigating the console fires dozens of parallel reads, and one MCP client funnels
-  // every tool call through a single IP, so the buckets must be generous. CAVEAT: shared-NAT users
-  // count against the same bucket. The strict auth (10/min) and static (1000/min) limits are fixed.
+  // every tool call through a single address, so the buckets must be generous. CAVEAT: everyone
+  // behind one NAT counts against the same bucket. The static (1000/min) and DCR (10/min) limits are
+  // fixed in the middleware.
   rateLimit: {
     userPerMin:
       RATE_LIMIT_USER_PER_MIN && Number(RATE_LIMIT_USER_PER_MIN) > 0

--- a/tests/api/lib/clientIp.test.ts
+++ b/tests/api/lib/clientIp.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { extractForwardedIp, resolveClientIp } from "@/api/lib/clientIp";
+
+const requestWith = (headers: Record<string, string>) =>
+  new Request("http://localhost/api/v1/agents", { headers });
+
+describe("extractForwardedIp", () => {
+  // A proxy APPENDS the peer it saw, so with one trusted hop the last entry is the only one it
+  // wrote. Reading the left would let a client prepend whatever it likes and pick its own bucket.
+  test("counts hops from the right, ignoring what the client prepended", () => {
+    expect(
+      extractForwardedIp(
+        requestWith({ "x-forwarded-for": "1.2.3.4, 203.0.113.10" }),
+        1,
+      ),
+    ).toBe("203.0.113.10");
+  });
+
+  test("two trusted hops read one entry further in", () => {
+    expect(
+      extractForwardedIp(
+        requestWith({ "x-forwarded-for": "203.0.113.10, 198.51.100.1" }),
+        2,
+      ),
+    ).toBe("203.0.113.10");
+  });
+
+  // The cost of every hop counted: the read moves one entry LEFT, and the leftmost entry is the slot
+  // a client writes. The two chains below are indistinguishable — same length, same index — but the
+  // first was built by a CDN and an origin, and the second by a caller who reached the origin
+  // DIRECTLY and sent the first entry themselves. Pinned rather than defended because no property of
+  // the request separates them: raising hops is safe only when every proxy counted is unreachable
+  // except through the one in front of it, which is the precondition .env.example states.
+  test("above one hop, the entry read is the slot a client can write", () => {
+    const viaCdn = "203.0.113.10, 198.51.100.1";
+    const forgedAtTheOrigin = "9.9.9.9, 203.0.113.99";
+    expect(
+      extractForwardedIp(requestWith({ "x-forwarded-for": viaCdn }), 2),
+    ).toBe("203.0.113.10");
+    expect(
+      extractForwardedIp(
+        requestWith({ "x-forwarded-for": forgedAtTheOrigin }),
+        2,
+      ),
+    ).toBe("9.9.9.9");
+    // At the shipped hop count the same forgery buys nothing: the entry read is the one our own
+    // proxy appended, and the forged prefix is ignored.
+    expect(
+      extractForwardedIp(
+        requestWith({ "x-forwarded-for": forgedAtTheOrigin }),
+        1,
+      ),
+    ).toBe("203.0.113.99");
+  });
+
+  // A chain shorter than the configured hops means the config and the topology disagree. Returning
+  // nothing makes the caller fall back to the peer, which over-groups; returning the leftmost entry
+  // would hand a client the key instead.
+  test("a chain shorter than the configured hops yields nothing", () => {
+    expect(
+      extractForwardedIp(requestWith({ "x-forwarded-for": "203.0.113.10" }), 2),
+    ).toBeUndefined();
+    expect(extractForwardedIp(requestWith({}), 1)).toBeUndefined();
+  });
+});
+
+describe("resolveClientIp", () => {
+  const client = "203.0.113.10";
+  const forwarded = { "x-forwarded-for": `1.2.3.4, ${client}` };
+
+  test("reads the chain only where the deployment declared a proxy", () => {
+    expect(
+      resolveClientIp({
+        request: requestWith(forwarded),
+        peer: "172.17.0.1",
+        trustProxy: true,
+        hops: 1,
+      }),
+    ).toBe(client);
+  });
+
+  // The case that made trust explicit instead of derived from the peer. docker-compose.prod.yml
+  // publishes the app port on every interface, and Docker's userland proxy rewrites a direct caller
+  // to the same bridge address a sidecar proxy connects from — so a heuristic that trusted a private
+  // peer would let anyone who can reach that port name their own bucket, one per request.
+  test("an undeclared deployment ignores the chain, whatever the peer looks like", () => {
+    for (const peer of [
+      "172.17.0.1",
+      "192.168.1.50",
+      "127.0.0.1",
+      "198.51.100.7",
+    ]) {
+      expect(
+        resolveClientIp({
+          request: requestWith(forwarded),
+          peer,
+          trustProxy: false,
+          hops: 1,
+        }),
+      ).toBe(peer);
+    }
+  });
+
+  // The headers a client can forge on a proxy that does not manage them. Naming any of these is the
+  // bypass this module exists to refuse: a caller rotating one would mint a fresh bucket per request.
+  test("never reads an address from a header a proxy does not own", () => {
+    const forged = requestWith({
+      "cf-connecting-ip": "9.9.9.9",
+      "x-real-ip": "9.9.9.8",
+      "true-client-ip": "9.9.9.7",
+    });
+    expect(
+      resolveClientIp({
+        request: forged,
+        peer: "172.17.0.1",
+        trustProxy: true,
+        hops: 1,
+      }),
+    ).toBe("172.17.0.1");
+  });
+
+  // Degrades to one bucket per proxy rather than to a shared constant everyone lands on.
+  test("a trusted proxy that forwards nothing falls back to the peer", () => {
+    expect(
+      resolveClientIp({
+        request: requestWith({}),
+        peer: "172.17.0.1",
+        trustProxy: true,
+        hops: 1,
+      }),
+    ).toBe("172.17.0.1");
+    expect(
+      resolveClientIp({
+        request: requestWith({}),
+        peer: undefined,
+        trustProxy: true,
+        hops: 1,
+      }),
+    ).toBe("unknown");
+  });
+});

--- a/tests/api/middlewares/rateLimit.test.ts
+++ b/tests/api/middlewares/rateLimit.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { clientKeyFor, rateLimitMiddleware } from "@/api/middlewares/rateLimit";
+
+// NOTE: tests/setup.ts captures Bun's native Response before happy-dom replaces it globally, and
+// Bun.serve does not recognize the spec one. Restored for the duration of this file only, the same
+// way tests/api/features/realtime does it. Requests go through `Bun.fetch` for the mirror-image
+// reason: the global `fetch` is happy-dom's, which enforces the Same Origin Policy against the
+// window's origin and refuses a request to a localhost port before it reaches the server.
+const nativeGlobals = globalThis as unknown as { BunResponse: typeof Response };
+const BunResponse = nativeGlobals.BunResponse;
+const happyResponse = globalThis.Response;
+
+// The bug this pins is only observable against a LISTENING server: `app.handle()` gives the plugin
+// no `server`, so its generator sees no peer and every request in the process collapses into one key
+// regardless of which generator is installed. A test built on `handle()` would pass either way.
+// Each case therefore serves the REAL middleware on a real port and reads the status the client got.
+interface ListeningApp {
+  server: { port: number; stop(force: boolean): void };
+}
+
+const servers: ListeningApp["server"][] = [];
+
+// `trusted` is what a deployment that declared a proxy (the bundled-Caddy and Coolify compose files)
+// keys on; `false` is the shipped default, where nothing is declared and the peer wins.
+// NOTE: both branches pass the key explicitly rather than letting the untrusted one fall through to
+// the module default. That default reads `config.trustProxy`, so a developer with TRUST_PROXY=true
+// in their own .env would have flipped the untrusted case into the trusted one and read green.
+const serve = (max: number, trusted = false) => {
+  const app = new Elysia()
+    .use(rateLimitMiddleware(max, clientKeyFor(trusted, 1)))
+    .get("/api/x", () => "x");
+  const listening = app.listen(0) as unknown as ListeningApp;
+  if (!listening.server?.port) throw new Error("Failed to start test server");
+  servers.push(listening.server);
+  return { url: `http://localhost:${listening.server.port}/api/x` };
+};
+
+beforeAll(() => {
+  (globalThis as { Response: typeof Response }).Response = BunResponse;
+});
+
+afterAll(() => {
+  for (const server of servers) server.stop(true);
+  (globalThis as { Response: typeof Response }).Response = happyResponse;
+});
+
+describe("rate-limit keying (client address, not the socket peer)", () => {
+  // The regression. Before the generator was installed the key was `server.requestIP()`, which for
+  // every request behind a proxy is the proxy: three distinct clients would exhaust a max=2 bucket
+  // between them and the third — never seen before — would be rejected.
+  test("distinct forwarded clients do not share a bucket", async () => {
+    const { url } = serve(2, true);
+    const statuses: number[] = [];
+    for (const client of ["203.0.113.10", "203.0.113.11", "203.0.113.12"]) {
+      const res = await Bun.fetch(url, {
+        headers: { "x-forwarded-for": `1.2.3.4, ${client}` },
+      });
+      statuses.push(res.status);
+    }
+    expect(statuses).toEqual([200, 200, 200]);
+  });
+
+  // The other half: the limit still has to BITE. Same client, same bucket, budget spent.
+  test("one forwarded client still exhausts its own budget", async () => {
+    const { url } = serve(2, true);
+    const statuses: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await Bun.fetch(url, {
+        headers: { "x-forwarded-for": "1.2.3.4, 203.0.113.20" },
+      });
+      statuses.push(res.status);
+    }
+    expect(statuses).toEqual([200, 200, 429]);
+  });
+
+  // A client can prepend to X-Forwarded-For but never append, so rotating the leftmost entry must
+  // not mint a new bucket. Reading the left — which the previous, unused helper in api/lib/clientIp
+  // did — would have made every limiter opt-out by header.
+  test("rotating what the client prepended does not mint a new bucket", async () => {
+    const { url } = serve(2, true);
+    const statuses: number[] = [];
+    for (const spoofed of ["9.9.9.1", "9.9.9.2", "9.9.9.3"]) {
+      const res = await Bun.fetch(url, {
+        headers: { "x-forwarded-for": `${spoofed}, 203.0.113.30` },
+      });
+      statuses.push(res.status);
+    }
+    expect(statuses).toEqual([200, 200, 429]);
+  });
+
+  // The shipped default. Nothing declared a proxy, so the forwarded chain is ignored entirely and
+  // three distinct clients share the peer's bucket — a worse limit, and the deliberate trade: being
+  // wrong this way over-groups, while believing an undeclared header would remove the limit for
+  // whoever is trying to get around it.
+  test("with no proxy declared, the chain is ignored and the peer is the key", async () => {
+    const { url } = serve(2);
+    const statuses: number[] = [];
+    for (const client of ["203.0.113.40", "203.0.113.41", "203.0.113.42"]) {
+      const res = await Bun.fetch(url, {
+        headers: { "x-forwarded-for": `1.2.3.4, ${client}` },
+      });
+      statuses.push(res.status);
+    }
+    expect(statuses).toEqual([200, 200, 429]);
+  });
+});


### PR DESCRIPTION
The five rate limiters are written as per-client ceilings and every comment calls them that. Behind the reverse proxy every deployment path in this repo puts in front, they are not: the whole install shares a single bucket.

## What was measured

`elysia-rate-limit`'s default generator keys on `server.requestIP()`, the TCP peer. Against a listening server, three requests carrying distinct forwarded clients hit a `max=2` limiter and the third was rejected having never been seen before.

The peer is the proxy in the topologies this repo ships: `docker-compose.portainer.yml` bundles a Caddy whose generated Caddyfile is `reverse_proxy agents:3000`, and `docker-compose.prod.yml` states TLS and the proxy are external. So the budgets, chosen generously precisely because they were believed to be per-client, became deployment-wide.

`POST /api/v1/chatwoot`, the inbound webhook customer messages arrive through, draws from that same bucket. Once the shared ceiling is reached the next inbound message is answered with 429, and a webhook the app rejects is a message the agent never sees.

## Why the existing helper was not the fix

`src/api/lib/clientIp.ts` was written for this and imported by nothing. Wiring it as it stood would have replaced one shared bucket with a bucket the caller picks:

- It preferred `cf-connecting-ip`, then `x-real-ip`, **by name**. A proxy that does not manage a header forwards it exactly as the client sent it, so on a generic Traefik/Caddy/nginx deployment those are client-controlled and a caller could rotate one per request.
- It read the **leftmost** `x-forwarded-for` entry. A proxy *appends* the peer it saw, so the last entry is the one our proxy wrote and the first is whatever the client sent: `X-Forwarded-For: 1.2.3.4` simply becomes `1.2.3.4, <the real client>`.

## What it does now

Only the entry a proxy appends is guaranteed to come from our own proxy, so the module reads `x-forwarded-for` alone and counts hops from the right. `TRUSTED_PROXY_HOPS` (default 1) says how many proxies sit in front: one proxy is the last entry, a CDN in front of that proxy is the second from the last. A chain shorter than the configured depth means the configuration and the topology disagree; that falls back to the peer, which over-groups rather than handing a client the key.

`TRUST_PROXY` decides whether the chain is believed at all, and is **off unless declared**. It is not derived from the peer address, which was this change's first shape: `docker-compose.prod.yml` publishes the app port on every interface unless the operator narrows it, and Docker's userland proxy rewrites a direct caller to the same bridge address a real sidecar proxy connects from, so in that topology no heuristic tells a proxy from a caller. Being wrong toward the shared bucket is a worse limit; being wrong toward the header is no limit at all, so the trust is declared by whoever knows the deployment.

The compose files pass both variables through. They list their environment explicitly, so without that the settings would have been unreachable in every shipped deployment. The two that guarantee the app is reachable only through a proxy (Coolify's platform proxy, Portainer's bundled Caddy, neither of which publishes the app port) declare the trust themselves; the prod file, which does publish it, passes the operator's value and defaults to off.

## What counting a hop costs

Each hop counted moves the trusted entry one place **left**, and the leftmost entry is the slot a client writes.

At the shipped `TRUSTED_PROXY_HOPS=1` that never bites: the entry read is the one our own proxy appended, and a forged prefix is ignored. Above 1 it does. A caller who reaches the **second** proxy directly, skipping the first, sends an `X-Forwarded-For` of their own and the proxy that answers appends their peer:

| path | chain the app sees | index at `hops=2` |
| --- | --- | --- |
| client → CDN → origin | `<client>, <CDN>` | `<client>` ✅ |
| attacker → origin, forging | `FAKE, <attacker>` | `FAKE` ❌ |

Same length, same index, and nothing in the request separates them. Length cannot discriminate, and requiring `chain.length === hops` holds in both. The only discriminator is the identity of the proxy at the remaining index, which means shipping and maintaining CDN address ranges: a second trust store, wrong for a self-hosted product where the CDN is the operator's choice.

So this is a stated precondition rather than a defence. The requirement that the app port be unreachable except through the proxy now applies to **every proxy counted**, in `.env.example` and in the module, and a test walks both chains so the trade is executable rather than prose.

The separate reason to leave the count at 1 is measured: a Caddy with no `trusted_proxies`, which is what the Portainer file generates, **discards** the incoming chain and emits only its own peer. A CDN in front does not lengthen it, and a hop count larger than the chain falls back to the peer and collapses everyone into one bucket again.

## Also corrected

The `NOTE` in `src/config.ts` described a per-IP guarantee the code did not provide. Its caveat said shared-NAT users land in the same bucket, which understated things: nobody had their own.

An unrecognized `TRUST_PROXY` value fails at boot, by name, rather than falling back. The fallback here is the strict side, so `yes` would have silently meant the opposite of what the operator wrote.

## Validation scope

**Proven by test.** `tests/api/middlewares/rateLimit.test.ts` serves the real middleware on a real port and reads the status the client got. That matters: `app.handle()` gives the plugin no `server`, so its generator sees no peer and every request in the process collapses into one key regardless of which generator is installed. A test built on `handle()` passes either way.

- Removing `generator` from the limiters fails the distinct-clients case, with the third client rejected exactly as measured before the fix.
- Reading the chain from the left instead of the right fails six tests across both files, including the end-to-end one proving a caller could mint a fresh bucket per request.
- Both branches of the middleware test pass the key explicitly instead of letting the untrusted one fall through to the module default, which reads `config.trustProxy`. With `TRUST_PROXY=true` in a developer's own `.env` the untrusted case silently became the trusted one and read green (measured: 3 pass, 1 fail on the previous shape under that environment).
- The complementary invariants are pinned too: one client still exhausts its own budget, a forged `cf-connecting-ip` / `x-real-ip` / `true-client-ip` is never read, and the undeclared default ignores the chain so three distinct clients share the peer's bucket.

Full suite green on both trees: 2982 tests on the source tree, 2942 on the derived one, 0 failures.

**Not validated live.** No deployment was reconfigured. The Caddy behaviour above was measured against `caddy:2` with the exact Caddyfile the Portainer compose generates; the hop-count hazard was reasoned and pinned by test, not staged against a real CDN.

**Out of scope, deliberately.** This changes who a bucket belongs to, not which requests are counted or which endpoints have their own. Requests rejected before the handler are still counted by nothing, and the credential endpoints still have no dedicated budget.

Fixes #145
