### PR TITLE
Charge the requests the app rejects, instead of refunding them

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "bun-plugin-tailwind": "^0.1.2",
         "elysia": "^1.4.29",
         "elysia-helmet": "^3.1.0",
-        "elysia-rate-limit": "^4.6.2",
+        "elysia-rate-limit": "^4.6.3",
         "i18next": "^26.3.6",
         "jose": "^6.2.7",
         "langfuse-langchain": "3.38.20",
@@ -876,7 +876,7 @@
 
     "elysia-helmet": ["elysia-helmet@3.1.0", "", { "peerDependencies": { "elysia": ">= 1.2.0" } }, "sha512-ejcNMv6BqLU70QOOAUB9pir0RViBxeuCr0zL50K0f1FAClyX01wcm6OOaZW+Aip8guRCVnnTBv6DoIj5pi3r/A=="],
 
-    "elysia-rate-limit": ["elysia-rate-limit@4.6.2", "", { "dependencies": { "@alloc/quick-lru": "5.2.0", "debug": "4.3.4" }, "peerDependencies": { "elysia": ">= 1.0.0" } }, "sha512-3axf0dl9PECqg+Duo+qfiI/RWyYnl63osuVgaI4DnXJjLs7PxNzJINfnKIV1Tyg0mqONO1jzdAjwDrJ3HEmuug=="],
+    "elysia-rate-limit": ["elysia-rate-limit@4.6.3", "", { "dependencies": { "@alloc/quick-lru": "5.2.0", "debug": "4.3.4" }, "peerDependencies": { "elysia": ">= 1.0.0" } }, "sha512-V77z0ZUpET9QDSbRYU3q5WE9Qj5S530u5iM5Wjy5t/7W1OdTkOXLxqbhOUlG8QsutC/C/cut9u8Ol7ikDO4oLw=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "bun-plugin-tailwind": "^0.1.2",
     "elysia": "^1.4.29",
     "elysia-helmet": "^3.1.0",
-    "elysia-rate-limit": "^4.6.2",
+    "elysia-rate-limit": "^4.6.3",
     "i18next": "^26.3.6",
     "jose": "^6.2.7",
     "langfuse-langchain": "3.38.20",

--- a/src/api/middlewares/rateLimit.ts
+++ b/src/api/middlewares/rateLimit.ts
@@ -50,6 +50,29 @@ export const clientKeyFor =
 
 const clientKey = clientKeyFor(config.trustProxy, config.trustedProxyHops);
 
+// Everything the five limiters must agree on, in one place. Spelling the options out per instance is
+// how a setting drifts: they already differ only in `max` and `skip`, and every difference beyond
+// those is a bug waiting to be introduced in one of the five.
+//
+// `countFailedRequest: true` is NOT the plugin default, and the default is not "counts less" but
+// "counts negative": the plugin calls `decrement` for any request that reaches `onError` outside the
+// codes it charges there, INCLUDING requests its own counting hook never saw. Measured on 4.6.2
+// against the real app: three requests took the budget from 599 to 597, five malformed-JSON POSTs
+// carried no `RateLimit-*` header at all, and the next legitimate request reported 601, above where
+// it started. Anyone willing to interleave garbage kept an unbounded budget. 4.6.3 charges PARSE and
+// request-side VALIDATION in that branch, which closes that specific refill; this flag closes the
+// rest, so a request that failed still costs what it cost the server to fail it.
+const sharedLimiterOptions = {
+  duration: 60000, // 1 minute
+  scoping: "scoped",
+  generator: clientKey,
+  countFailedRequest: true,
+  errorResponse: translate(
+    "errors.rateLimitExceeded",
+    "Rate limit exceeded. Please try again later.",
+  ),
+} as const;
+
 export const isMcpTransport = (request: Request): boolean => {
   const path = new URL(request.url).pathname;
   return path === "/api/v1/mcp" || path === "/api/v1/mcp/";
@@ -63,15 +86,10 @@ export const rateLimitMiddleware = (
   generator = clientKey,
 ) =>
   rateLimit({
-    duration: 60000, // 1 minute
+    ...sharedLimiterOptions,
     generator,
     max, // default 600 requests per minute per client
-    errorResponse: translate(
-      "errors.rateLimitExceeded",
-      "Rate limit exceeded. Please try again later.",
-    ),
     skip: (request) => isStaticRequest(request) || isMcpTransport(request),
-    scoping: "scoped",
   });
 
 // Dedicated per-IP bucket for the MCP JSON-RPC transport. Looser than the global limit because a
@@ -79,40 +97,22 @@ export const rateLimitMiddleware = (
 // throttle (see isMcpTransport). Skips every other path, which keeps its own bucket.
 export const mcpTransportRateLimitMiddleware = () =>
   rateLimit({
-    duration: 60000, // 1 minute
-    generator: clientKey,
+    ...sharedLimiterOptions,
     max: config.rateLimit.mcpPerMin, // default 1200 requests per minute per IP
-    errorResponse: translate(
-      "errors.rateLimitExceeded",
-      "Rate limit exceeded. Please try again later.",
-    ),
     skip: (request) => !isMcpTransport(request),
-    scoping: "scoped",
   });
 
 export const strictRateLimitMiddleware = () =>
   rateLimit({
-    duration: 60000, // 1 minute
-    generator: clientKey,
+    ...sharedLimiterOptions,
     max: 10, // 10 requests per minute
-    errorResponse: translate(
-      "errors.rateLimitExceeded",
-      "Rate limit exceeded. Please try again later.",
-    ),
-    scoping: "scoped",
   });
 
 export const staticRateLimitMiddleware = () =>
   rateLimit({
-    duration: 60000, // 1 minute
-    generator: clientKey,
+    ...sharedLimiterOptions,
     max: 1000, // 1000 requests per minute
-    errorResponse: translate(
-      "errors.rateLimitExceeded",
-      "Rate limit exceeded. Please try again later.",
-    ),
     skip: (request) => !isStaticRequest(request),
-    scoping: "scoped",
   });
 
 // Tight per-IP limit dedicated to DCR self-registration (RFC 7591). When the DCR endpoint is open,
@@ -120,14 +120,8 @@ export const staticRateLimitMiddleware = () =>
 // ONLY to POST /api/v1/mcp/oauth/register (skips every other path, which keeps its own bucket).
 export const registerRateLimitMiddleware = () =>
   rateLimit({
-    duration: 60000, // 1 minute
-    generator: clientKey,
+    ...sharedLimiterOptions,
     max: 10, // 10 registrations per minute per IP
-    errorResponse: translate(
-      "errors.rateLimitExceeded",
-      "Rate limit exceeded. Please try again later.",
-    ),
     skip: (request) =>
       new URL(request.url).pathname !== "/api/v1/mcp/oauth/register",
-    scoping: "scoped",
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -89,31 +89,54 @@ const app = new Elysia({
       set.headers["cache-control"] = "public, max-age=86400";
     }
   })
-  .onError(({ path, error, code, request, set }) => {
+  // NOTE: typed app errors (ForbiddenError 403, TenantTargetRequiredError 400, NotFoundError 404,
+  // ...) carry their HTTP status. Logged at warn, since they are expected control-flow and not server
+  // faults. When the error carries a translationKey, localize it from the request's Accept-Language
+  // (the request ALS may not be in scope here) so user-facing messages are not raw English.
+  //
+  // NOTE: registered BEFORE the limiters, while everything else below is registered AFTER them, and
+  // the split is load-bearing in BOTH directions. An AppError is thrown from a MATCHED route, or from
+  // a hook that runs after the limiters' counting hook, so the request has already been charged. The
+  // plugin cannot know that: its own `onError` reads `error.status ?? error.statusCode`, where our
+  // NotFoundError is indistinguishable from a route that never existed, so it charges a second time.
+  // That is not merely an overcharge. Measured with a max of 4 and one request of budget left, a
+  // request that should have been admitted and answered 404 came back 429: the second charge crossed
+  // the ceiling, and the limiter answers from its own hook without ever reaching the handler below.
+  // Answering AppError here keeps it away from the plugin entirely.
+  .onError(({ path, error, request, set }) => {
+    if (!(error instanceof AppError)) return;
+    logger.warn("%s %s", path, error.message);
+    const message = error.translationKey
+      ? translateWithLocale(
+          getLocaleFromHeader(request.headers.get("accept-language")),
+          error.translationKey,
+          error.message,
+          error.translationParams,
+        )
+      : error.message;
+    // NOTE: keep set.status in sync, because the access log in onAfterResponse reads it and a raw
+    // Response alone would make a 4xx show up there as a 500.
+    set.status = error.statusCode;
+    return Response.json({ error: message }, { status: error.statusCode });
+  })
+  .use(rateLimitMiddleware())
+  .use(mcpTransportRateLimitMiddleware())
+  .use(registerRateLimitMiddleware())
+  .use(staticRateLimitMiddleware())
+  // NOTE: everything the AppError handler above does not answer, registered AFTER the limiters ON
+  // PURPOSE. This is the mirror image of that split: a request rejected BEFORE the handler never
+  // reaches the plugin's counting hook, so the plugin charges those from its own `onError`, and
+  // Elysia stops at the first error handler that RETURNS A VALUE. With this registered first the
+  // NOT_FOUND branch below answered and the plugin never ran: measured on the real app, `POST
+  // /api/nope` and any request to a missing non-/api path came back 404 with no `RateLimit-*` header
+  // and no budget spent. An unknown GET under /api looked metered only because the `.get("/api/*")`
+  // guard below turns it into a MATCHED route, which the normal hook counts.
+  // PARSE and VALIDATION were never affected either way, because the `default:` branch below returns
+  // `undefined` for them and the chain continues to the plugin regardless of order.
+  .onError(({ path, error, code }) => {
     // NOTE: Handle BigInt parsing errors as 400 Bad Request
     if (error instanceof SyntaxError && error.message.includes("BigInt")) {
       return new Response("Invalid ID format", { status: 400 });
-    }
-
-    // NOTE: typed app errors (ForbiddenError 403, TenantTargetRequiredError 400,
-    // NotFoundError 404, ...) carry their HTTP status. Handle before the generic 500
-    // branch and log at warn (they are expected control-flow, not server faults). When
-    // the error carries a translationKey, localize it from the request's Accept-Language
-    // (the request ALS may not be in scope here) so user-facing messages aren't raw English.
-    if (error instanceof AppError) {
-      logger.warn("%s %s", path, error.message);
-      const message = error.translationKey
-        ? translateWithLocale(
-            getLocaleFromHeader(request.headers.get("accept-language")),
-            error.translationKey,
-            error.message,
-            error.translationParams,
-          )
-        : error.message;
-      // NOTE: keep set.status in sync — the access log in onAfterResponse reads it,
-      // so a raw Response alone would make a 4xx show up there as a 500.
-      set.status = error.statusCode;
-      return Response.json({ error: message }, { status: error.statusCode });
     }
 
     logger.error("%s\n%s", path, error);
@@ -136,10 +159,6 @@ const app = new Elysia({
       default:
     }
   })
-  .use(rateLimitMiddleware())
-  .use(mcpTransportRateLimitMiddleware())
-  .use(registerRateLimitMiddleware())
-  .use(staticRateLimitMiddleware())
   .use(
     await staticPlugin({
       assets: config.env === "production" ? "dist" : "public",

--- a/tests/api/middlewares/rateLimitMetering.test.ts
+++ b/tests/api/middlewares/rateLimitMetering.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { clientKeyFor, rateLimitMiddleware } from "@/api/middlewares/rateLimit";
+import app from "@/app";
+import { AppError, ForbiddenError, NotFoundError } from "@/lib/errors";
+
+// What a REJECTED request costs. Separate from rateLimit.test.ts, which is about who a bucket
+// belongs to: this file is about whether the bucket is charged at all.
+//
+// It goes through the REAL app rather than a rebuilt one, because the thing under test is the
+// REGISTRATION ORDER in src/app.ts. `elysia-rate-limit` counts in `onBeforeHandle`, which a request
+// rejected before the handler never reaches, so the plugin charges those from its own `onError`.
+// Elysia stops at the first error handler that RETURNS a value, so an app-level `onError` registered
+// before the limiters silences that branch. A test that built its own app would pin its own ordering
+// and pass either way.
+const nativeGlobals = globalThis as unknown as { BunResponse: typeof Response };
+const BunResponse = nativeGlobals.BunResponse;
+const happyResponse = globalThis.Response;
+
+interface ListeningApp {
+  server: { port: number; stop(force: boolean): void };
+}
+
+let base = "";
+let server: ListeningApp["server"] | undefined;
+
+beforeAll(() => {
+  (globalThis as { Response: typeof Response }).Response = BunResponse;
+  // NOTE: registered on the REAL app, so the hooks it exercises are the ones src/app.ts installed,
+  // in the order it installed them. There is no unauthenticated route in the app that throws a
+  // 404 to borrow for this, and rebuilding an equivalent app would pin the test's own ordering
+  // instead of the app's. It mutates the exported singleton, which is safe only because this is the
+  // one test file that imports it.
+  app.get("/__metering/thrown-404", () => {
+    throw new NotFoundError("gone");
+  });
+  const listening = app.listen(0) as unknown as ListeningApp;
+  if (!listening.server?.port) throw new Error("Failed to start the app");
+  server = listening.server;
+  base = `http://localhost:${listening.server.port}`;
+});
+
+afterAll(() => {
+  server?.stop(true);
+  (globalThis as { Response: typeof Response }).Response = happyResponse;
+});
+
+// The global limiter is one instance for the whole process and every request here resolves to the
+// same key, so absolute numbers drift as the file runs. Each case measures the DELTA it caused,
+// reading the budget from a request whose cost is known to be 1.
+const remaining = async (): Promise<number> => {
+  const res = await Bun.fetch(`${base}/api/health`);
+  const header = res.headers.get("ratelimit-remaining");
+  if (header === null)
+    throw new Error("the health check carried no budget header");
+  return Number(header);
+};
+
+// `cost` = what the request under test spent, with the two probe requests' own cost removed.
+const costOf = async (send: () => Promise<Response>): Promise<number> => {
+  const before = await remaining();
+  await send();
+  const after = await remaining();
+  return before - after - 1;
+};
+
+const send = (method: string, path: string, init: RequestInit = {}) =>
+  Bun.fetch(`${base}${path}`, { method, ...init });
+
+const json = (body: string): RequestInit => ({
+  headers: { "content-type": "application/json" },
+  body,
+});
+
+describe("rate-limit metering (what a rejected request costs)", () => {
+  // The regression this pins. Before the reorder these came back 404 with no `RateLimit-*` header
+  // and no budget spent, so anyone could hold a connection open against missing paths for free.
+  test("a route that does not exist is charged", async () => {
+    expect(await costOf(() => send("POST", "/api/nope"))).toBe(1);
+    expect(await costOf(() => send("POST", "/nope/at/all"))).toBe(1);
+  });
+
+  // This one was already metered before the change, and only by accident: the `.get("/api/*")` guard
+  // in src/app.ts turns an unknown GET into a MATCHED route, which the normal counting hook sees.
+  // Asserted so the gap cannot silently come back if that guard is ever removed.
+  test("an unknown GET under /api is charged too", async () => {
+    expect(await costOf(() => send("GET", "/api/nope"))).toBe(1);
+  });
+
+  // A body that is not JSON (PARSE) and a body that fails the route schema (VALIDATION) are both
+  // rejected before the handler. On 4.6.2 the plugin REFUNDED these: measured against this app,
+  // three requests took the budget from 599 to 597, five malformed POSTs carried no header, and the
+  // next legitimate request reported 601, above where it started. Sending garbage refilled the
+  // bucket, so the ceiling was not a ceiling for anyone willing to interleave it.
+  test("a malformed body is charged, and never refunds", async () => {
+    expect(
+      await costOf(() =>
+        send("POST", "/api/auth/login", json("{ not json at all")),
+      ),
+    ).toBe(1);
+    expect(
+      await costOf(() =>
+        send("POST", "/api/auth/login", json(JSON.stringify({ nope: 1 }))),
+      ),
+    ).toBe(1);
+  });
+
+  // The complement, and the reason `countFailedRequest: true` is not optional once `onError` moved
+  // behind the limiters: from that position the plugin sees every thrown error first, and its
+  // default is to REFUND anything outside the codes it charges. A rejected login would have cost
+  // nothing at all.
+  test("an unauthenticated request is charged", async () => {
+    expect(await costOf(() => send("GET", "/api/v1/agents"))).toBe(1);
+  });
+
+  // The regression test for the SPLIT in src/app.ts, run against src/app.ts. A matched route that
+  // throws a 404 is charged on the way in by the counting hook; if the AppError handler were
+  // registered behind the limiters instead of ahead of them, the plugin would see the error first,
+  // read `statusCode: 404`, take it for a route that never existed, and charge a second time. This
+  // reads 2 the moment that ordering is undone. What a second charge DOES at the ceiling is pinned
+  // separately below, on a probe small enough to reach the ceiling.
+  test("a matched route that throws a 404 is charged once, not twice", async () => {
+    expect(await costOf(() => send("GET", "/__metering/thrown-404"))).toBe(1);
+  });
+});
+
+// A matched route that THROWS a 404 is the case the split in src/app.ts exists for. The counting
+// hook charges it on the way in, and the plugin's `onError` cannot tell "never counted" from
+// "counted, then threw": it reads `error.status ?? error.statusCode`, so our NotFoundError looks
+// exactly like a route that never existed. Charging it twice is not just an overcharge: at the
+// ceiling the second charge is REJECTED, and the limiter answers 429 from its own hook without ever
+// reaching the app's error handler, so a request that was inside its budget gets a rate-limit error
+// where the API contract says 404. Both halves are pinned here, the cost and the status.
+describe("a thrown 404 on a matched route", () => {
+  // Mirrors src/app.ts: the AppError handler BEFORE the limiter, everything else after.
+  const serveWithAppOrdering = (max: number) => {
+    const probe = new Elysia()
+      .onError(({ error, set }) => {
+        if (!(error instanceof AppError)) return;
+        set.status = error.statusCode;
+        return Response.json(
+          { error: error.message },
+          { status: error.statusCode },
+        );
+      })
+      .use(rateLimitMiddleware(max, clientKeyFor(false, 1)))
+      .onError(({ code }) => {
+        if (code === "NOT_FOUND") return new Response("nope", { status: 404 });
+      })
+      .get("/ok", () => "ok")
+      .get("/missing", () => {
+        throw new NotFoundError("gone");
+      })
+      .get("/forbidden", () => {
+        throw new ForbiddenError("no");
+      });
+    const listening = probe.listen(0) as unknown as ListeningApp;
+    if (!listening.server?.port) throw new Error("Failed to start the probe");
+    return listening.server;
+  };
+
+  test("costs exactly one, like any other matched route", async () => {
+    const probe = serveWithAppOrdering(20);
+    const rem = async (path: string) => {
+      const res = await Bun.fetch(`http://localhost:${probe.port}${path}`);
+      return Number(res.headers.get("ratelimit-remaining"));
+    };
+    try {
+      const start = await rem("/ok");
+      const afterMissing = await rem("/missing");
+      const afterForbidden = await rem("/forbidden");
+      expect(start - afterMissing).toBe(1);
+      expect(afterMissing - afterForbidden).toBe(1);
+    } finally {
+      probe.stop(true);
+    }
+  });
+
+  // The half that made this worth fixing rather than documenting. With one request of budget left
+  // the double charge crossed the ceiling: measured at 429, carrying the rate-limit body, on a
+  // request the limiter had just admitted.
+  test("still answers 404 on the last request of the budget", async () => {
+    const probe = serveWithAppOrdering(4);
+    const get = (path: string) =>
+      Bun.fetch(`http://localhost:${probe.port}${path}`);
+    try {
+      for (let i = 0; i < 3; i++) expect((await get("/ok")).status).toBe(200);
+      const last = await get("/missing");
+      expect(last.status).toBe(404);
+      expect(await last.json()).toEqual({ error: "gone" });
+    } finally {
+      probe.stop(true);
+    }
+  });
+
+  // And the ceiling still bites on the request after it: charged once is charged, not waived.
+  test("the budget is still spent, so the next request is rejected", async () => {
+    const probe = serveWithAppOrdering(4);
+    const get = (path: string) =>
+      Bun.fetch(`http://localhost:${probe.port}${path}`);
+    try {
+      for (let i = 0; i < 3; i++) await get("/ok");
+      await get("/missing");
+      expect((await get("/ok")).status).toBe(429);
+    } finally {
+      probe.stop(true);
+    }
+  });
+});


### PR DESCRIPTION
The rate limiters count in `onBeforeHandle`. A request the app rejects **before** the handler never reaches that hook, so `elysia-rate-limit` charges those from its own `onError` instead. `src/app.ts` registered its `onError` ahead of the limiters, and Elysia stops at the first error handler that returns a value, so that branch never ran.

## What was measured, on the real app

| request | before | after |
| --- | --- | --- |
| `POST /api/nope` | 404, no `RateLimit-*` header, **0 spent** | 404, costs 1 |
| `POST /nope/at/all` | 404, no header, **0 spent** | 404, costs 1 |
| `GET /api/nope` | costs 1 | costs 1 |
| `POST /api/auth/login`, malformed JSON | see below | costs 1 |
| `GET /api/v1/agents`, no cookie | costs 1 | costs 1 |

The unknown **GET** was metered all along, and only by accident: the `.get("/api/*")` guard in `src/app.ts` turns it into a matched route, which the ordinary counting hook sees. A POST to a missing path, or any method a route does not serve, was free.

## The refund was worse than the gap

`countFailedRequest` defaults to `false`, and `false` does not mean "counts less". The plugin calls `decrement` for any request that reaches `onError` outside the codes it charges there, **including requests its counting hook never saw**. Measured on 4.6.2 against this app:

```
gasta 3x:          599 598 597
json quebrado 5x:  (no RateLimit-* header at all)
gasta de novo:     601      ← above where it started
```

Malformed JSON refilled the bucket. The ceiling was not a ceiling for anyone willing to interleave garbage with real requests.

## Three changes, and they only work together

- **4.6.3** (upstream [rayriffy/elysia-rate-limit#89](https://github.com/rayriffy/elysia-rate-limit/pull/89)) widens the plugin's charging branch from 404 to also cover PARSE and request-side VALIDATION. That is what closes the refill above.
- **Moving `onError` behind the limiters** is what lets that branch run at all for `NOT_FOUND`.
- **`countFailedRequest: true`** is required *because of* that move: from the new position the plugin sees every thrown error first, and its default would refund them. Without it, a rejected login would have started costing nothing.

Any one of the three alone leaves the limiters no better, or worse.

The options all five limiters must agree on move into one `sharedLimiterOptions`. They already differed only in `max` and `skip`; spelling out `duration`, `scoping`, `generator` and now `countFailedRequest` five times is how one of them drifts without a failing test.

## Why the error handling is now split around the limiters

Review round 1 caught this, and it is the reason the reorder could not be wholesale.

A matched route that **throws** a 404 was already charged by the counting hook on the way in. The plugin cannot know that: it reads `error.status ?? error.statusCode`, where our `NotFoundError` is indistinguishable from a route that never existed, so it charges again.

That is not just an overcharge. Measured with `max: 4` and one request of budget left:

```
/ok      -> 200 rem=3
/ok      -> 200 rem=2
/ok      -> 200 rem=1
/missing -> 429 "Rate limit exceeded. Please try again later."   ← should have been 404
```

The second charge crossed the ceiling, and the limiter answers from its own hook without ever reaching the app's error handler, so a request that was inside its budget got a rate-limit error where the API contract says a localized 404.

So the `AppError` branch is registered **before** the limiters, where the request is already counted and the plugin never sees it, and everything else stays after. Both directions are load-bearing, and both are commented at the registration site.

## Validation scope

**Proven by test.** `tests/api/middlewares/rateLimitMetering.test.ts` goes through the **real app**, because the thing under test is the registration order in `src/app.ts`: a test that built its own app would pin its own ordering and pass at either position. Each case measures the delta it caused against a request of known cost, since the limiter is one instance for the process and every request in it resolves to the same key.

The split has its own regression test on the real app, using a probe route registered on the app itself (there is no unauthenticated route in the app that throws a 404 to borrow). Undoing the split makes it fail with `Expected: 1, Received: 2`, measured. What a second charge *does* at the ceiling is pinned separately, on a probe small enough to reach it.

Full suite green on both trees: 2990 tests on the source tree, 2950 on the derived one, 0 failures.

**Not validated live.** No deployment was exercised; every number here comes from the app served on a local port.

**Out of scope, deliberately.** This changes what a request costs, not who the bucket belongs to (that was #145) and not which endpoints have their own budget. `strictRateLimitMiddleware` is still mounted nowhere, and the DCR limiter still matches its path exactly.

---

**No `Fixes #N`, and that is a deviation worth naming.** The repo norm is one issue per PR. There is no issue here because the issue's job is to settle the approach, and the approach was already settled upstream in the bunfire template, which shipped this exact fix. Say the word and I will open one and amend.
