### PR TITLE
Assert on the request the form sent, not on the last one anything sent

### DIFF
--- a/tests/client/components/BusinessHoursForm.test.tsx
+++ b/tests/client/components/BusinessHoursForm.test.tsx
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { BusinessHoursForm } from "@/client/components/BusinessHoursForm";
 import { ToastProvider } from "@/client/components/Toast";
 
@@ -26,13 +26,35 @@ const EXCEPTIONS = [
 describe("BusinessHoursForm", () => {
   // Stubbing globalThis.fetch rather than mocking the api module on purpose: `mock.module` is global
   // to the process and leaks into whatever else shares the worker.
+  //
+  // NOTE: but `globalThis.fetch` is process-global too, just in a different way, so this records
+  // whatever ANYTHING in the worker sends while the stub is installed. Keeping a single `sent` and
+  // asserting on it made this test read the last request in the process rather than the one the form
+  // made: in CI it saw `POST` where a `mode="update"` form with an id can only have sent `PATCH`, on
+  // a branch that touched nothing near it, and passed on a rerun unchanged. The stray request was
+  // never identified, which is the point — so every call is recorded WITH ITS URL and the assertions
+  // look up the one the form is responsible for. A future stray lands in `calls` where it can be
+  // named, instead of overwriting the answer.
   const realFetch = globalThis.fetch;
-  let sent: { method: string; body: unknown } | null = null;
-  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
-    sent = {
+  const calls: { method: string; url: string; body: unknown }[] = [];
+  // NOTE: matches the whole endpoint, collection route included, rather than only the item route the
+  // update is supposed to hit. That is deliberate: `POST /api/v1/business-hours` is what this same
+  // form sends in CREATE mode, and catching a wrongly-taken create branch is half of what this test
+  // is for. Narrowing to `/business-hours/7` would turn that failure into a timeout with nothing to
+  // read. So the assertions require exactly ONE business-hours call and then say which one it is: a
+  // create reports the wrong method and URL, and an unrelated business-hours request from elsewhere
+  // reports a count of 2 with every URL in hand.
+  const businessHoursCalls = () =>
+    calls.filter((call) => call.url.includes("/business-hours"));
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
       method: String(init?.method ?? "GET"),
+      url:
+        typeof input === "string"
+          ? input
+          : String((input as Request).url ?? input),
       body: init?.body ? JSON.parse(String(init.body)) : null,
-    };
+    });
     return new Response(
       JSON.stringify({ businessHours: { id: "7", name: "Atendimento" } }),
       { headers: { "content-type": "application/json" } },
@@ -41,7 +63,7 @@ describe("BusinessHoursForm", () => {
 
   afterEach(() => {
     cleanup();
-    sent = null;
+    calls.length = 0;
   });
   afterAll(() => {
     globalThis.fetch = realFetch;
@@ -66,11 +88,16 @@ describe("BusinessHoursForm", () => {
     );
     const save = screen.getByRole("button", { name: /^(Salvar|Save)$/ });
     save.click();
-    await Promise.resolve();
-    await new Promise((r) => setTimeout(r, 0));
+    // NOTE: waits for the EFFECT, the way the rest of the client suite already does, rather than for
+    // a fixed number of ticks. Measured on an idle runner the call lands on the first macrotask,
+    // which is exactly what the previous `await Promise.resolve()` + `setTimeout(0)` allowed, so the
+    // margin was zero even though that was not what broke here.
+    await waitFor(() => expect(businessHoursCalls().length).toBe(1));
 
+    const [sent] = businessHoursCalls();
     const body = sent?.body as { exceptions?: unknown } | null;
     expect(sent?.method).toBe("PATCH");
+    expect(sent?.url.endsWith("/api/v1/business-hours/7")).toBe(true);
     expect(JSON.stringify(body?.exceptions)).toBe(JSON.stringify(EXCEPTIONS));
   });
 


### PR DESCRIPTION
`tests/client/components/BusinessHoursForm.test.tsx` stubs `globalThis.fetch` and keeps a single `sent` variable, so its assertions read the last request **any** code in the worker made while the stub was installed, not the one the form made.

## What CI saw

```
expect(sent?.method).toBe("PATCH")

Expected: "PATCH"
Received: "POST"
```

`sent` was not empty, which rules out the obvious reading of a timing problem. It held a **POST**, and a form rendered with `mode="update"` and an id can only take the PATCH branch. Something else in the process sent that POST into this file's mailbox. The rerun passed with no change, on the same commit.

The stray request was never identified. That is the argument *for* this fix rather than against it: the file's own comment already says `mock.module` is global to the process and leaks into whatever shares the worker, and `globalThis.fetch` is global in exactly the same way. A test that asserts on a shared mailbox is asking every other file in the worker not to send anything, which is not a property any of them promise.

## What changed

Calls are recorded in a list **with their URL**, and the assertions require exactly **one** business-hours call and then say which one it is:

```ts
const businessHoursCalls = () => calls.filter((call) => call.url.includes("/business-hours"));
```

The filter keeps the whole endpoint rather than narrowing to the item route, and review round 2 is why that is spelled out: `POST /api/v1/business-hours` is what this same form sends in **create** mode (measured: update is `PATCH …/business-hours/7`, create is `POST …/business-hours`), and catching a wrongly-taken create branch is half of what this test is for. Narrowing to `/business-hours/7` would turn that failure into a `waitFor` timeout with nothing to read.

So the shape is count-then-name. A create reports the wrong method **and** the wrong URL. An unrelated business-hours request reports a count of 2, with every URL in hand.

The wait becomes `waitFor`, matching the rest of the client suite (`CredentialPicker`, `KnowledgeApprovals`, `KnowledgeDocsBlock` already do this). **Not what broke here**: measured on an idle runner the call lands on the first macrotask, which is exactly what `await Promise.resolve()` + `setTimeout(0)` allowed. The margin was zero, which is worth removing on its own but is a separate weakness.

## Validation scope

**Reproduced, both directions.** A probe rendered the form, let it save, then sent an unrelated POST through the same stub inside its window. The old shape reads `POST` (the CI failure, reproduced) and the new one reads `PATCH`.

Full suite green: 2982 tests on the source tree, 0 failures.

**Not a sweep.** I checked whether the pattern is a family: this is the only client test that clicks and then waits a fixed number of ticks, and the other `globalThis.fetch` stubs in `tests/client` already assert on a filtered list rather than a single last-write. The `useWebSocket` and `vaultCache` timers are about the scheduling they test, not about waiting for an effect.

**Culprit not found.** The files that ran immediately before this one in that CI job (`ToolEditModal`, `useWebSocket`, `Modal`, `Toast`, `ModelPicker`, `Header`) do not touch `fetch`, so the POST came from somewhere further back or from an in-flight request. Naming it would be better; the recorded URLs are what makes that possible next time.

---

**No `Fixes #N`.** Same deviation as #155, flagged for the same reason: the approach here has nothing to settle. Say the word and I will open an issue and amend.
