### PR TITLE
Cover the spelling that routes past the DCR registration limit

### DIFF
--- a/src/api/middlewares/rateLimit.ts
+++ b/src/api/middlewares/rateLimit.ts
@@ -115,6 +115,34 @@ export const staticRateLimitMiddleware = () =>
     skip: (request) => !isStaticRequest(request),
   });
 
+const REGISTER_PATH = "/api/v1/mcp/oauth/register";
+
+// NOTE: Elysia answers `/api/v1/mcp/oauth/register` and `.../register/` with the SAME handler, so
+// comparing the raw pathname is a one-character bypass of the limiter below: measured before this
+// normalization, 14 registrations through the slashed spelling under a ceiling of 10, every one a
+// 200 and none carrying a `RateLimit-*` header.
+//
+// Nothing else in the alias space reaches the route. Measured server-side with `curl --path-as-is`,
+// which is the only way to ask the question (a client normalizes the path before it leaves):
+// `//api/v1/...`, `/api//v1/...`, `.../register//`, a percent-encoded letter and a different case
+// all 404, and `.../oauth/./register` both routes AND is already counted, because the URL parser
+// collapses `.` segments before this predicate sees them. One trailing slash is the whole
+// normalization needed.
+//
+// NOTE: POST-only, because the path only EXISTS as POST. Now that a rejected request is charged, a
+// 404 spends this budget like anything else, so without the method check a crawler or a broken link
+// doing GET here would burn the registration budget for every client sharing that address. Those
+// still pay the global limit, which is where an unmatched route belongs.
+export const isRegisterRequest = (request: Request): boolean => {
+  if (request.method !== "POST") return false;
+  const { pathname } = new URL(request.url);
+  const canonical =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
+  return canonical === REGISTER_PATH;
+};
+
 // Tight per-IP limit dedicated to DCR self-registration (RFC 7591). When the DCR endpoint is open,
 // anyone can mint OAuth client rows, so cap it to a low rate to bound abuse / table flooding. Applies
 // ONLY to POST /api/v1/mcp/oauth/register (skips every other path, which keeps its own bucket).
@@ -122,6 +150,5 @@ export const registerRateLimitMiddleware = () =>
   rateLimit({
     ...sharedLimiterOptions,
     max: 10, // 10 registrations per minute per IP
-    skip: (request) =>
-      new URL(request.url).pathname !== "/api/v1/mcp/oauth/register",
+    skip: (request) => !isRegisterRequest(request),
   });

--- a/tests/api/middlewares/rateLimit.test.ts
+++ b/tests/api/middlewares/rateLimit.test.ts
@@ -1,6 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Elysia } from "elysia";
-import { clientKeyFor, rateLimitMiddleware } from "@/api/middlewares/rateLimit";
+import {
+  clientKeyFor,
+  isRegisterRequest,
+  rateLimitMiddleware,
+  registerRateLimitMiddleware,
+} from "@/api/middlewares/rateLimit";
 
 // NOTE: tests/setup.ts captures Bun's native Response before happy-dom replaces it globally, and
 // Bun.serve does not recognize the spec one. Restored for the duration of this file only, the same
@@ -103,5 +108,69 @@ describe("rate-limit keying (client address, not the socket peer)", () => {
       statuses.push(res.status);
     }
     expect(statuses).toEqual([200, 200, 429]);
+  });
+});
+
+// Which requests the DCR limiter covers. The budget is 10/min because an open DCR endpoint lets
+// anyone mint OAuth client rows, so a spelling that routes but escapes the limiter is the whole
+// limiter: measured before the fix, 14 registrations through `/register/` under that ceiling, every
+// one a 200 and none carrying a `RateLimit-*` header.
+describe("the DCR limiter covers every spelling that routes", () => {
+  const post = (path: string) =>
+    new Request(`http://localhost${path}`, { method: "POST" });
+
+  test("the trailing slash is the same request", () => {
+    expect(isRegisterRequest(post("/api/v1/mcp/oauth/register"))).toBe(true);
+    expect(isRegisterRequest(post("/api/v1/mcp/oauth/register/"))).toBe(true);
+  });
+
+  // The rest of the alias space, measured server-side with `curl --path-as-is`: every one of these
+  // 404s, so covering them would only spend the registration budget on requests that never register.
+  // `./` is absent on purpose: the URL parser collapses it before this sees it, so it arrives as the
+  // canonical spelling and is already covered by the case above.
+  test("spellings that do not route are left to the global limit", () => {
+    for (const alias of [
+      "//api/v1/mcp/oauth/register",
+      "/api//v1/mcp/oauth/register",
+      "/api/v1/mcp/oauth/register//",
+      "/api/v1/mcp/oauth/regist%65r",
+      "/API/v1/mcp/oauth/register",
+    ]) {
+      expect(isRegisterRequest(post(alias))).toBe(false);
+    }
+  });
+
+  // A 404 spends whatever budget covers it, so a crawler doing GET on this path would otherwise burn
+  // the registration budget for every client sharing that address. The path only exists as POST.
+  test("only POST is covered, since only POST registers", () => {
+    for (const method of ["GET", "PUT", "DELETE", "HEAD"]) {
+      const request = new Request(
+        "http://localhost/api/v1/mcp/oauth/register",
+        { method },
+      );
+      expect(isRegisterRequest(request)).toBe(false);
+    }
+  });
+
+  // End to end, through the real middleware: the two spellings share ONE bucket. Reading this as two
+  // buckets, or as one that the slashed spelling never touches, is the bug.
+  test("exhausting through the slashed spelling rejects the canonical one", async () => {
+    const app = new Elysia()
+      .use(registerRateLimitMiddleware())
+      .post("/api/v1/mcp/oauth/register", () => ({ ok: true }));
+    const listening = app.listen(0) as unknown as ListeningApp;
+    if (!listening.server?.port) throw new Error("Failed to start test server");
+    servers.push(listening.server);
+    const send = (path: string) =>
+      Bun.fetch(`http://localhost:${listening.server.port}${path}`, {
+        method: "POST",
+      });
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      statuses.push((await send("/api/v1/mcp/oauth/register/")).status);
+    }
+    expect(statuses.every((status) => status === 200)).toBe(true);
+    expect((await send("/api/v1/mcp/oauth/register")).status).toBe(429);
   });
 });


### PR DESCRIPTION
> **Stacked on #155.** The base is `fix/rate-limit-metering`, so this diff is only the DCR change. The POST-only half of it depends on #155 having landed, since it is about what a 404 costs. Retarget to `main` once #155 merges.

The DCR limiter decided whether a request was a registration by comparing `new URL(request.url).pathname` to the literal path. Elysia answers `/api/v1/mcp/oauth/register` and `.../register/` with the **same handler**, so the slashed spelling registered clients while skipping the limiter entirely.

## Measured

14 registrations through `/api/v1/mcp/oauth/register/` under a ceiling of 10 — every one a 200, none carrying a `RateLimit-*` header. The canonical spelling, alongside them, counted normally.

That budget is 10/min because an open DCR endpoint lets anyone mint OAuth client rows. A spelling that routes but escapes the limiter is not a smaller limit, it is no limit.

## The rest of the alias space is already fine

Measured server-side with `curl --path-as-is`, which is the only way to ask the question: a client normalizes the path before it leaves, so an in-process `fetch` cannot send most of these.

| path | routes? | counted? |
| --- | --- | --- |
| `/api/v1/mcp/oauth/register` | 200 | yes |
| `/api/v1/mcp/oauth/register/` | 200 | **no** ← the bypass |
| `/api/v1/mcp/oauth/./register` | 200 | yes (the URL parser collapses `.` first) |
| `//api/v1/mcp/oauth/register` | 404 | — |
| `/api//v1/mcp/oauth/register` | 404 | — |
| `/api/v1/mcp/oauth/register//` | 404 | — |
| `/api/v1/mcp/oauth/regist%65r` | 404 | — |
| `/API/v1/mcp/oauth/register` | 404 | — |

One trailing slash is the whole normalization needed.

## Also POST-only

The path only *exists* as POST, and since #155 a rejected request is charged, so a 404 spends this budget like anything else. Without the method check a crawler or a broken link doing `GET` here burns the registration budget for every client sharing that address — the bucket is keyed by IP, so the cost lands on the neighbours rather than on whoever sent the GETs. Those requests still pay the global limit, which is where an unmatched route belongs.

## Validation scope

**Proven by test.** The end-to-end case spends the whole budget through the slashed spelling and requires the canonical one to be **rejected**, so what it pins is that the two spellings share one bucket. With the old predicate it fails at `Expected: 429, Received: 200`, measured.

The alias table is pinned as unit cases over the exported predicate, because a client normalizes most of those paths and a `fetch`-based test cannot send them.

Full suite green on both trees: 2994 tests on the source tree, 2954 on the derived one, 0 failures.

**CI needed a manual dispatch.** The workflows are `pull_request: branches: [main]`, so a PR stacked on another branch gets no checks at all — `gh pr checks` reports "no checks reported", which reads like a pending state rather than a structural one. All three were dispatched against this branch explicitly, and their result is on the runs list for `fix/dcr-limiter-trailing-slash`. Retargeting to `main` after #155 merges will run them the normal way.

**Not validated live.** Every number here comes from the limiter served on a local port, plus `curl --path-as-is` against the same.

**Out of scope.** `strictRateLimitMiddleware` is still mounted nowhere, so the credential endpoints still have only the global budget. It also shares `(max: 10, duration: 60000, scoping: "scoped")` with this limiter, and `elysia-rate-limit` deduplicates plugin instances that match on those, so mounting it is not a one-liner.

---

**No `Fixes #N`**, same deviation as #155 and #156. Say the word and I will open an issue and amend.
