### PR TITLE
Give the credential endpoints a bucket of their own, and refuse a config that deletes one

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,19 @@ FLOWLOG_RETENTION_DAYS=30
 # through a single address. Raise if a shared-NAT deployment trips them. Defaults: user 600, MCP 1200.
 RATE_LIMIT_USER_PER_MIN=600
 RATE_LIMIT_MCP_PER_MIN=1200
+# NOTE: The credential endpoints (login, signup, the one-time /setup token, accept-invite) get a
+# SECOND, tighter bucket on top of the global one. The window is minutes rather than one minute on
+# purpose: a per-minute ceiling resets 60 times an hour, so 10/min would still allow 600 password
+# guesses an hour against one account. 20 per 5 minutes is 240 an hour and still absorbs a burst,
+# which is what a whole office signing in at once looks like through a single NAT. Raise the max if
+# yours trips it. Boot refuses a value that collides with another limiter's budget+window (they are
+# deduplicated by the plugin, and the loser silently stops limiting) or that is not tighter than
+# RATE_LIMIT_USER_PER_MIN. All four of these must be positive WHOLE numbers, and boot refuses
+# anything else by name rather than falling back: a window the limiter cannot turn into a date (an
+# `Infinity`, which is also what `1e309` parses to) makes it advertise `RateLimit-Reset: NaN` and
+# never reset, so the endpoints it guards answer 429 for good once the budget is spent.
+RATE_LIMIT_CREDENTIAL_MAX=20
+RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES=5
 
 # NOTE: Who the limits above apply to. The app sees the reverse proxy as the client of every request,
 # so until TRUST_PROXY is on, the whole deployment shares one bucket.

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -27,6 +27,17 @@ services:
       # proxy to trust the CDN before raising it.
       - TRUST_PROXY=true
       - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
+      # NOTE: rate-limit ceilings, per client address. The first two are runaway guards, generous on
+      # purpose. The credential pair is the tight one: it covers login, signup, the one-time /setup
+      # token and accept-invite, and its window is minutes rather than one minute because a
+      # per-minute ceiling resets 60 times an hour. Raise RATE_LIMIT_CREDENTIAL_MAX if a shared
+      # office address trips it; the bucket is keyed by IP, so everyone behind one NAT shares it.
+      # Boot refuses a credential budget that collides with another limiter's budget+window, or that
+      # is not tighter than RATE_LIMIT_USER_PER_MIN. See .env.example.
+      - RATE_LIMIT_USER_PER_MIN=${RATE_LIMIT_USER_PER_MIN:-600}
+      - RATE_LIMIT_MCP_PER_MIN=${RATE_LIMIT_MCP_PER_MIN:-1200}
+      - RATE_LIMIT_CREDENTIAL_MAX=${RATE_LIMIT_CREDENTIAL_MAX:-20}
+      - RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES=${RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES:-5}
       # First-run: disable the /setup token in this trusted, TLS-fronted onboarding window (the
       # advisory lock still caps /setup at one admin). Set to `true` to require it.
       - SETUP_TOKEN_REQUIRED=${SETUP_TOKEN_REQUIRED:-false}

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -90,6 +90,17 @@ services:
       # ranges first, then raise this to 2.
       - TRUST_PROXY=true
       - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
+      # NOTE: rate-limit ceilings, per client address. The first two are runaway guards, generous on
+      # purpose. The credential pair is the tight one: it covers login, signup, the one-time /setup
+      # token and accept-invite, and its window is minutes rather than one minute because a
+      # per-minute ceiling resets 60 times an hour. Raise RATE_LIMIT_CREDENTIAL_MAX if a shared
+      # office address trips it; the bucket is keyed by IP, so everyone behind one NAT shares it.
+      # Boot refuses a credential budget that collides with another limiter's budget+window, or that
+      # is not tighter than RATE_LIMIT_USER_PER_MIN. See .env.example.
+      - RATE_LIMIT_USER_PER_MIN=${RATE_LIMIT_USER_PER_MIN:-600}
+      - RATE_LIMIT_MCP_PER_MIN=${RATE_LIMIT_MCP_PER_MIN:-1200}
+      - RATE_LIMIT_CREDENTIAL_MAX=${RATE_LIMIT_CREDENTIAL_MAX:-20}
+      - RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES=${RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES:-5}
       # First-run: disable the /setup token in this trusted, TLS-fronted onboarding window (the
       # advisory lock still caps /setup at one admin). Set to `true` to require it.
       - SETUP_TOKEN_REQUIRED=${SETUP_TOKEN_REQUIRED:-false}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -43,6 +43,17 @@ services:
       # configured to forward the chain it received; see .env.example.
       - TRUST_PROXY=${TRUST_PROXY:-false}
       - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
+      # NOTE: rate-limit ceilings, per client address. The first two are runaway guards, generous on
+      # purpose. The credential pair is the tight one: it covers login, signup, the one-time /setup
+      # token and accept-invite, and its window is minutes rather than one minute because a
+      # per-minute ceiling resets 60 times an hour. Raise RATE_LIMIT_CREDENTIAL_MAX if a shared
+      # office address trips it; the bucket is keyed by IP, so everyone behind one NAT shares it.
+      # Boot refuses a credential budget that collides with another limiter's budget+window, or that
+      # is not tighter than RATE_LIMIT_USER_PER_MIN. See .env.example.
+      - RATE_LIMIT_USER_PER_MIN=${RATE_LIMIT_USER_PER_MIN:-600}
+      - RATE_LIMIT_MCP_PER_MIN=${RATE_LIMIT_MCP_PER_MIN:-1200}
+      - RATE_LIMIT_CREDENTIAL_MAX=${RATE_LIMIT_CREDENTIAL_MAX:-20}
+      - RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES=${RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES:-5}
       # First-run: disable the /setup token in this trusted, TLS-fronted onboarding window (the
       # advisory lock still caps /setup at one admin). Set to `true` to require it.
       - SETUP_TOKEN_REQUIRED=${SETUP_TOKEN_REQUIRED:-false}

--- a/src/api/middlewares/rateLimit.ts
+++ b/src/api/middlewares/rateLimit.ts
@@ -102,10 +102,60 @@ export const mcpTransportRateLimitMiddleware = () =>
     skip: (request) => !isMcpTransport(request),
   });
 
-export const strictRateLimitMiddleware = () =>
+// The routes where guessing IS the attack: a password, a signup, the one-time /setup token, and the
+// invite token, which travels unauthenticated on BOTH the endpoint that consumes it and the one that
+// merely validates it.
+//
+// NOTE: matched as METHOD + path rather than a path set gated on POST, because the credential does
+// not always travel in a body. `GET /auth/invite?token=` is declared `security: []`, looks the token
+// up, and answers 200 with the invited email and role when it exists and 404 when it does not: a
+// pure oracle, and cheaper to probe than the POST that consumes the token. Pairing the method with
+// the path is what lets that one in while still keeping every OTHER GET out, which matters because a
+// 404 spends whatever budget covers it, so covering `GET /auth/login` would let a crawler or a
+// broken link burn the login budget for every client sharing that address. The bucket is keyed by
+// IP, so that cost lands on the neighbours rather than on whoever sent the GETs.
+//
+// Everything else under /auth is out on purpose. `/auth/me` is polled by the frontend on every page
+// load, so it would lock the app out of itself. `/auth/password` sits behind a session, where
+// including it would let whoever stole that session lock the owner out of changing their password.
+// `/auth/google` needs a token Google signed, which is not a thing to guess.
+//
+// NOTE: matched at the mount point, which is the root app, so the paths carry the /api prefix.
+const CREDENTIAL_ROUTES = new Set([
+  "POST /api/auth/login",
+  "POST /api/auth/signup",
+  "POST /api/auth/setup",
+  "POST /api/auth/accept-invite",
+  "GET /api/auth/invite",
+]);
+
+// NOTE: HEAD is folded into GET rather than listed, because Elysia dispatches HEAD to the GET
+// handler: measured, `HEAD /auth/invite?token=` runs the same lookup and returns the same 200/404,
+// which is the whole oracle, since HEAD leaks the status and the status is the answer. Folding it
+// here means any GET route added to the set above covers its HEAD alias automatically, instead of
+// leaving the same omission to be rediscovered. It does not widen anything else: `HEAD /auth/login`
+// resolves to `GET /auth/login`, which is not in the set, so a crawler still cannot burn the login
+// budget with it.
+export const isCredentialRequest = (request: Request): boolean => {
+  const method = request.method === "HEAD" ? "GET" : request.method;
+  return CREDENTIAL_ROUTES.has(`${method} ${canonicalPath(request)}`);
+};
+
+// A SECOND, tighter bucket on the credential endpoints, layered ON TOP of the global one rather than
+// replacing it. Deliberate: a complementary pair (the global limiter skipping what this one covers)
+// would leave these endpoints with NO limit at all the moment the two budgets collided, while
+// layering means the worst case is the global budget, which is what they have today.
+//
+// NOTE: the window is minutes, not one minute, and that is the point. A per-minute ceiling resets 60
+// times an hour, so a 10/min credential limit still allows 600 password guesses an hour against one
+// account. config.ts rejects a budget that collides with another limiter's (max, duration) or that
+// is not tighter than the global one.
+export const credentialRateLimitMiddleware = () =>
   rateLimit({
     ...sharedLimiterOptions,
-    max: 10, // 10 requests per minute
+    duration: config.rateLimit.credentialWindowMinutes * 60_000,
+    max: config.rateLimit.credentialMax,
+    skip: (request) => !isCredentialRequest(request),
   });
 
 export const staticRateLimitMiddleware = () =>
@@ -114,6 +164,19 @@ export const staticRateLimitMiddleware = () =>
     max: 1000, // 1000 requests per minute
     skip: (request) => !isStaticRequest(request),
   });
+
+// NOTE: Elysia answers a path and that path with ONE trailing slash using the same handler, so any
+// limiter that decides by comparing the raw pathname is one character away from being bypassed.
+// Shared by the two limiters that gate specific paths. Nothing else in the alias space reaches a
+// route: measured server-side with `curl --path-as-is`, a doubled slash anywhere, a trailing `//`, a
+// percent-encoded letter and a different case all 404, and `./` is collapsed by the URL parser
+// before this sees it.
+const canonicalPath = (request: Request): string => {
+  const { pathname } = new URL(request.url);
+  return pathname.length > 1 && pathname.endsWith("/")
+    ? pathname.slice(0, -1)
+    : pathname;
+};
 
 const REGISTER_PATH = "/api/v1/mcp/oauth/register";
 
@@ -133,15 +196,8 @@ const REGISTER_PATH = "/api/v1/mcp/oauth/register";
 // 404 spends this budget like anything else, so without the method check a crawler or a broken link
 // doing GET here would burn the registration budget for every client sharing that address. Those
 // still pay the global limit, which is where an unmatched route belongs.
-export const isRegisterRequest = (request: Request): boolean => {
-  if (request.method !== "POST") return false;
-  const { pathname } = new URL(request.url);
-  const canonical =
-    pathname.length > 1 && pathname.endsWith("/")
-      ? pathname.slice(0, -1)
-      : pathname;
-  return canonical === REGISTER_PATH;
-};
+export const isRegisterRequest = (request: Request): boolean =>
+  request.method === "POST" && canonicalPath(request) === REGISTER_PATH;
 
 // Tight per-IP limit dedicated to DCR self-registration (RFC 7591). When the DCR endpoint is open,
 // anyone can mint OAuth client rows, so cap it to a low rate to bound abuse / table flooding. Applies

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import logger from "@/api/lib/logger";
 import { parseOrigins } from "@/api/lib/origin";
 import { localeMiddleware } from "@/api/middlewares/locale";
 import {
+  credentialRateLimitMiddleware,
   mcpTransportRateLimitMiddleware,
   rateLimitMiddleware,
   registerRateLimitMiddleware,
@@ -122,6 +123,7 @@ const app = new Elysia({
   .use(rateLimitMiddleware())
   .use(mcpTransportRateLimitMiddleware())
   .use(registerRateLimitMiddleware())
+  .use(credentialRateLimitMiddleware())
   .use(staticRateLimitMiddleware())
   // NOTE: everything the AppError handler above does not answer, registered AFTER the limiters ON
   // PURPOSE. This is the mirror image of that split: a request rejected BEFORE the handler never

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,8 @@ const {
   SSRF_ALLOW_PRIVATE_TARGETS,
   RATE_LIMIT_USER_PER_MIN,
   RATE_LIMIT_MCP_PER_MIN,
+  RATE_LIMIT_CREDENTIAL_MAX,
+  RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES,
   TRUST_PROXY,
   TRUSTED_PROXY_HOPS,
   BUN_PUBLIC_EDITION,
@@ -90,6 +92,47 @@ const parseTrustProxy = (raw: string | undefined, envName: string): boolean => {
 
 // A hop count selects WHICH X-Forwarded-For entry is believed to be the client, so a silently
 // defaulted bad value would change who shares a bucket. Fail by name at boot instead.
+// NOTE: the upper bound is not tidiness, it is the second half of the same defect. A window that
+// `Number.isInteger` accepts can still be one the limiter cannot honour: at 1e12 minutes the
+// millisecond duration passes Date's ±8.64e15 range, and the reset lands on an invalid date exactly
+// like Infinity does. Bounding the window at a day is well past any real throttle and puts every
+// unrepresentable value on the other side of the check. The budgets are bounded for the mirror-image
+// reason: an absurd ceiling is a bucket that never trips while reading as a configured one.
+//
+// NOTE: `Number.isInteger` is what makes the rest of this safe, not `> 0`. The pattern these budgets used to
+// share (`RAW && Number(RAW) > 0 ? Number(RAW) : fallback`) accepts `Infinity`, and `1e309` parses to
+// exactly that. Measured with an infinite window: the limiter advertises `RateLimit-Reset: NaN` and
+// the bucket NEVER resets, so the endpoints it guards answer 429 permanently once the budget is
+// spent. On a max instead of a window it is the mirror image, an unlimited bucket that reads as a
+// configured one. `isInteger` refuses Infinity, NaN and fractions in one go.
+//
+// NOTE: it also throws on garbage instead of falling back. Falling back is how a typo becomes a
+// budget nobody chose, silently: same reasoning as TRUST_PROXY above, where the quiet default is the
+// strict side and guessing would mean the opposite of what the operator wrote.
+// A day. Any real throttle is orders of magnitude under this, and every window whose millisecond
+// duration Date cannot represent is orders of magnitude over it.
+const MAX_WINDOW_MINUTES = 1440;
+// Generous enough that "effectively unlimited" is still expressible, small enough that a slipped
+// exponent is caught rather than silently disabling a limiter.
+const MAX_BUDGET = 1_000_000;
+
+export const parseBudget = (
+  raw: string | undefined,
+  envName: string,
+  fallback: number,
+  consequence: string,
+  upperBound: number,
+): number => {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0 || value > upperBound) {
+    throw new Error(
+      `${envName} must be a whole number between 1 and ${upperBound} (got "${raw}"). ${consequence}`,
+    );
+  }
+  return value;
+};
+
 const parseHops = (raw: string | undefined, envName: string): number => {
   if (raw === undefined || raw.trim() === "") return 1;
   const value = Number(raw);
@@ -294,15 +337,41 @@ const config = {
   // every tool call through a single address, so the buckets must be generous. CAVEAT: everyone
   // behind one NAT counts against the same bucket. The static (1000/min) and DCR (10/min) limits are
   // fixed in the middleware.
+  //
+  // NOTE: the credential budget is the exception, and it is deliberately NOT per-minute. A
+  // per-minute ceiling resets 60 times an hour, so 10/min is 600 password guesses an hour against
+  // one account; the window is what bounds brute force, not the number. 20 per 5 minutes is 240 an
+  // hour and still absorbs a burst, which is what an office arriving at once looks like through a
+  // single NAT.
   rateLimit: {
-    userPerMin:
-      RATE_LIMIT_USER_PER_MIN && Number(RATE_LIMIT_USER_PER_MIN) > 0
-        ? Number(RATE_LIMIT_USER_PER_MIN)
-        : 600,
-    mcpPerMin:
-      RATE_LIMIT_MCP_PER_MIN && Number(RATE_LIMIT_MCP_PER_MIN) > 0
-        ? Number(RATE_LIMIT_MCP_PER_MIN)
-        : 1200,
+    userPerMin: parseBudget(
+      RATE_LIMIT_USER_PER_MIN,
+      "RATE_LIMIT_USER_PER_MIN",
+      600,
+      "It is the ceiling every request that is not static or MCP transport counts against.",
+      MAX_BUDGET,
+    ),
+    mcpPerMin: parseBudget(
+      RATE_LIMIT_MCP_PER_MIN,
+      "RATE_LIMIT_MCP_PER_MIN",
+      1200,
+      "It is the ceiling the MCP JSON-RPC transport counts against.",
+      MAX_BUDGET,
+    ),
+    credentialMax: parseBudget(
+      RATE_LIMIT_CREDENTIAL_MAX,
+      "RATE_LIMIT_CREDENTIAL_MAX",
+      20,
+      "It is how many credential attempts one address gets per window.",
+      MAX_BUDGET,
+    ),
+    credentialWindowMinutes: parseBudget(
+      RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES,
+      "RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES",
+      5,
+      "It is the window the credential budget resets on, so a value the limiter cannot turn into a date leaves those endpoints answering 429 for good.",
+      MAX_WINDOW_MINUTES,
+    ),
   },
   // NOTE: Central fazer.ai hub (app.fazer.ai) that serves operator announcements (the top banner)
   // and the "new version available" check. Empty string DISABLES all hub communication (air-gapped,
@@ -343,6 +412,74 @@ if (
     }
   }
 }
+
+// NOTE: `elysia-rate-limit` registers itself as an Elysia plugin named "elysia-rate-limit" seeded
+// with `max:duration:scoping`, so ANY TWO of the five limiters mounted in src/app.ts that share all
+// three are DEDUPLICATED by Elysia and the later one silently never mounts. Measured on 4.6.3: two
+// limiters at max=3 guarding different paths, and the path guarded by the SECOND served 4 of 4
+// requests with no `RateLimit-*` header at all and nothing logged.
+//
+// The failure is not symmetric, which is why this throws instead of warning. Whichever limiter loses
+// is the ONLY one counting its traffic, so a collision never tightens anything, it deletes a bucket.
+// It is also exactly the trap the credential budget was walking into: the DCR limiter is
+// (10, 60000, scoped) and the limiter written for the credential endpoints shipped as
+// (10, 60000, scoped) and mounted nowhere, so mounting it as written would have left those endpoints
+// with the global budget they already had, while every test and every reader said otherwise.
+export function assertLimiterBudgetsAreDistinct(
+  seeds: readonly (readonly [name: string, max: number, durationMs: number])[],
+): void {
+  for (const [nameA, maxA, durationA] of seeds) {
+    for (const [nameB, maxB, durationB] of seeds) {
+      if (nameA < nameB && maxA === maxB && durationA === durationB) {
+        throw new Error(
+          `${nameA} and ${nameB} are both ${maxA} per ${durationA / 1000}s. elysia-rate-limit seeds its plugin with max:duration:scoping, and all of these are scoped, so two limiters sharing a budget AND a window are deduplicated by Elysia: one of them silently never mounts and its traffic goes unlimited. Give them different values.`,
+        );
+      }
+    }
+  }
+}
+
+// Beyond the collision above, a credential budget that is not tighter than the global one is
+// meaningless: the same requests are counted by BOTH limiters, so the looser one never trips first.
+// Compared as rates, because the two windows differ.
+export function assertCredentialBudgetIsTighter(
+  credentialMax: number,
+  windowMinutes: number,
+  userPerMin: number,
+): void {
+  const perMinute = credentialMax / windowMinutes;
+  if (perMinute >= userPerMin) {
+    throw new Error(
+      `RATE_LIMIT_CREDENTIAL_MAX (${credentialMax} per ${windowMinutes} min = ${perMinute}/min) must be below RATE_LIMIT_USER_PER_MIN (${userPerMin}/min): the credential endpoints are counted by both limiters, so a credential budget at or above the global one never applies.`,
+    );
+  }
+}
+
+assertLimiterBudgetsAreDistinct([
+  [
+    "the global budget (RATE_LIMIT_USER_PER_MIN)",
+    config.rateLimit.userPerMin,
+    60_000,
+  ],
+  [
+    "the MCP transport budget (RATE_LIMIT_MCP_PER_MIN)",
+    config.rateLimit.mcpPerMin,
+    60_000,
+  ],
+  ["the static asset budget", 1000, 60_000],
+  ["the DCR registration budget", 10, 60_000],
+  [
+    "the credential budget (RATE_LIMIT_CREDENTIAL_MAX / _WINDOW_MINUTES)",
+    config.rateLimit.credentialMax,
+    config.rateLimit.credentialWindowMinutes * 60_000,
+  ],
+]);
+
+assertCredentialBudgetIsTighter(
+  config.rateLimit.credentialMax,
+  config.rateLimit.credentialWindowMinutes,
+  config.rateLimit.userPerMin,
+);
 
 if (config.env === "production") {
   if (config.jwtSecret === "change-me-in-production") {

--- a/tests/api/middlewares/credentialRateLimit.test.ts
+++ b/tests/api/middlewares/credentialRateLimit.test.ts
@@ -1,0 +1,269 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { isCredentialRequest } from "@/api/middlewares/rateLimit";
+import app from "@/app";
+import {
+  assertCredentialBudgetIsTighter,
+  assertLimiterBudgetsAreDistinct,
+  parseBudget,
+} from "@/config";
+
+// The credential endpoints had no bucket of their own: `strictRateLimitMiddleware` was written for
+// them and mounted nowhere, so a password guess was bounded only by the global 600/min, and there is
+// no lockout, no failed-attempt counter and no backoff anywhere else in the auth path.
+//
+// Mounting it was never the hard part. The plugin seeds itself with `max:duration:scoping` and
+// Elysia deduplicates matching plugins, and the limiter as written was (10, 60000, scoped), which is
+// exactly the DCR limiter. Mounting it unchanged would have left these endpoints with the budget
+// they already had while looking fixed, so the tests below check that BOTH buckets exist, not just
+// that one of them answers.
+const nativeGlobals = globalThis as unknown as { BunResponse: typeof Response };
+const BunResponse = nativeGlobals.BunResponse;
+const happyResponse = globalThis.Response;
+
+interface ListeningApp {
+  server: { port: number; stop(force: boolean): void };
+}
+
+let base = "";
+let server: ListeningApp["server"] | undefined;
+
+beforeAll(() => {
+  (globalThis as { Response: typeof Response }).Response = BunResponse;
+  const listening = app.listen(0) as unknown as ListeningApp;
+  if (!listening.server?.port) throw new Error("Failed to start the app");
+  server = listening.server;
+  base = `http://localhost:${listening.server.port}`;
+});
+
+afterAll(() => {
+  server?.stop(true);
+  (globalThis as { Response: typeof Response }).Response = happyResponse;
+});
+
+const post = (path: string) =>
+  Bun.fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "nobody@example.com", password: "12345678" }),
+  });
+
+// Which bucket answered, read off the ceiling it advertises, so the number names the limiter.
+//
+// NOTE: the numbers below are the shipped defaults, and tests/setup.ts PINS the `RATE_LIMIT_*`
+// variables to them at preload for this file's sake. They are configurable, and a developer with
+// `RATE_LIMIT_CREDENTIAL_MAX` in their `.env` would otherwise watch a correct app fail here with
+// `Expected: "20", Received: "600"`, which is the exact signature of the collision regression these
+// tests exist to make legible. Reading the expectations from `config` instead would keep the suite
+// green but not the signal: the boot check keeps the (budget, window) PAIRS distinct, not the
+// budgets, so `RATE_LIMIT_CREDENTIAL_MAX=600` is a supported setting that boots fine and leaves the
+// two buckets advertising the same ceiling, with nothing here able to tell them apart.
+const ceilingOf = async (response: Response) =>
+  response.headers.get("ratelimit-limit");
+
+describe("which requests the credential bucket covers", () => {
+  test("the routes where guessing is the attack", () => {
+    for (const [method, path] of [
+      ["POST", "/api/auth/login"],
+      ["POST", "/api/auth/signup"],
+      ["POST", "/api/auth/setup"],
+      ["POST", "/api/auth/accept-invite"],
+      // Declared `security: []`, looks the token up, and answers 200 with the invited email and
+      // role when it exists. A pure oracle, and cheaper to probe than the POST that consumes it.
+      ["GET", "/api/auth/invite"],
+      // Elysia dispatches HEAD to the GET handler, so this is the SAME oracle: the lookup runs and
+      // the 200/404 is the answer, which HEAD returns in full. Listing GET alone left it on the
+      // global 600 budget, measured.
+      ["HEAD", "/api/auth/invite"],
+    ] as const) {
+      const request = new Request(`http://localhost${path}`, { method });
+      expect(isCredentialRequest(request)).toBe(true);
+    }
+  });
+
+  // The same one-character bypass the DCR limiter had: Elysia routes both spellings to one handler.
+  test("a trailing slash is the same request", () => {
+    const slashed = new Request("http://localhost/api/auth/login/", {
+      method: "POST",
+    });
+    expect(isCredentialRequest(slashed)).toBe(true);
+  });
+
+  // `/auth/me` is polled by the frontend on every page load, so it would lock the app out of itself.
+  // `/auth/password` sits behind a session, where including it would let whoever stole that session
+  // lock the owner out of changing their password. `/auth/google` needs a token Google signed.
+  test("the rest of /auth stays on the global budget", () => {
+    for (const [method, path] of [
+      ["GET", "/api/auth/me"],
+      ["PATCH", "/api/auth/password"],
+      ["POST", "/api/auth/google"],
+      ["POST", "/api/auth/logout"],
+    ] as const) {
+      const request = new Request(`http://localhost${path}`, { method });
+      expect(isCredentialRequest(request)).toBe(false);
+    }
+  });
+
+  // Matched as METHOD + path, so a method a route does not serve is NOT covered. A 404 spends
+  // whatever budget covers it, and covering `GET /auth/login` would let a crawler or a broken link
+  // burn the login budget for every client sharing that address.
+  test("a method the route does not serve is left to the global budget", () => {
+    for (const method of ["GET", "PUT", "DELETE", "HEAD"]) {
+      const request = new Request("http://localhost/api/auth/login", {
+        method,
+      });
+      expect(isCredentialRequest(request)).toBe(false);
+    }
+    // And the mirror image on the one GET route that IS covered.
+    for (const method of ["POST", "PUT", "DELETE"]) {
+      const request = new Request("http://localhost/api/auth/invite", {
+        method,
+      });
+      expect(isCredentialRequest(request)).toBe(false);
+    }
+    // Folding HEAD into GET must not widen the POST routes: `HEAD /auth/login` resolves to
+    // `GET /auth/login`, which is not covered, so a crawler still cannot burn the login budget.
+    const headLogin = new Request("http://localhost/api/auth/login", {
+      method: "HEAD",
+    });
+    expect(isCredentialRequest(headLogin)).toBe(false);
+  });
+});
+
+describe("both buckets exist on the real app", () => {
+  // The regression the whole change is about. If the credential limiter had kept the DCR limiter's
+  // budget, Elysia would have dropped it and this would read the global 600 instead.
+  test("a credential request answers from the credential bucket", async () => {
+    expect(await ceilingOf(await post("/api/auth/login"))).toBe("20");
+  });
+
+  test("the slashed spelling lands in the same bucket", async () => {
+    expect(await ceilingOf(await post("/api/auth/login/"))).toBe("20");
+  });
+
+  test("the four paths share one bucket", async () => {
+    const before = Number(await ceilingOf(await post("/api/auth/login")));
+    expect(before).toBe(20);
+    for (const path of [
+      "/api/auth/signup",
+      "/api/auth/setup",
+      "/api/auth/accept-invite",
+    ]) {
+      expect(await ceilingOf(await post(path))).toBe("20");
+    }
+  });
+
+  // The DCR limiter is the one that would have been deduplicated away, or would have taken the
+  // credential one with it. Both still answer, each from its own ceiling.
+  test("the DCR limiter still has its own bucket", async () => {
+    expect(await ceilingOf(await post("/api/v1/mcp/oauth/register"))).toBe(
+      "10",
+    );
+  });
+
+  test("everything else stays on the global bucket", async () => {
+    const response = await Bun.fetch(`${base}/api/auth/me`);
+    expect(response.headers.get("ratelimit-limit")).toBe("600");
+  });
+});
+
+describe("boot refuses a configuration that would delete a bucket", () => {
+  // What the check is FOR. Two limiters with the same budget and window are one limiter, and the one
+  // that loses is the only thing counting its traffic, so a collision never tightens anything.
+  test("two limiters with the same budget and window are refused", () => {
+    expect(() =>
+      assertLimiterBudgetsAreDistinct([
+        ["the DCR registration budget", 10, 60_000],
+        ["the credential budget", 10, 60_000],
+      ]),
+    ).toThrow(/deduplicated by Elysia/);
+  });
+
+  test("the same budget over a different window is fine", () => {
+    expect(() =>
+      assertLimiterBudgetsAreDistinct([
+        ["the DCR registration budget", 10, 60_000],
+        ["the credential budget", 10, 300_000],
+      ]),
+    ).not.toThrow();
+  });
+
+  test("the shipped set passes", () => {
+    expect(() =>
+      assertLimiterBudgetsAreDistinct([
+        ["the global budget", 600, 60_000],
+        ["the MCP transport budget", 1200, 60_000],
+        ["the static asset budget", 1000, 60_000],
+        ["the DCR registration budget", 10, 60_000],
+        ["the credential budget", 20, 300_000],
+      ]),
+    ).not.toThrow();
+  });
+
+  // Compared as rates, because the windows differ: 20 per 5 minutes is 4/min against the global
+  // 600/min, so the credential bucket is the one that trips.
+  test("a credential budget looser than the global one is refused", () => {
+    // The shipped values: 20 per 5 minutes is 4/min against 600/min.
+    expect(() => assertCredentialBudgetIsTighter(20, 5, 600)).not.toThrow();
+    // 6000 per 5 minutes is 1200/min, twice the global budget.
+    expect(() => assertCredentialBudgetIsTighter(6000, 5, 600)).toThrow(
+      /must be below RATE_LIMIT_USER_PER_MIN/,
+    );
+    // Equal rates are refused too, not just looser ones: 3000 per 5 minutes is exactly 600/min, and
+    // the global limiter fronts the same requests, so a credential budget that only matches it never
+    // trips first and the endpoints are no better off than before.
+    expect(() => assertCredentialBudgetIsTighter(3000, 5, 600)).toThrow(
+      /must be below RATE_LIMIT_USER_PER_MIN/,
+    );
+  });
+});
+
+describe("boot refuses a budget the limiter cannot honour", () => {
+  const parse = (raw: string | undefined) =>
+    parseBudget(
+      raw,
+      "RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES",
+      5,
+      "because.",
+      1440,
+    );
+
+  test("unset or blank takes the default", () => {
+    expect(parse(undefined)).toBe(5);
+    expect(parse("   ")).toBe(5);
+  });
+
+  test("a positive whole number is taken as written", () => {
+    expect(parse("15")).toBe(15);
+  });
+
+  // The finding this family came from. `Number("Infinity") > 0` is true and `1e309` parses to
+  // exactly Infinity, so the old `RAW && Number(RAW) > 0` shape accepted both. Measured with an
+  // infinite window: the limiter advertises `RateLimit-Reset: NaN` and the bucket never resets, so
+  // the credential endpoints answer 429 permanently once the budget is spent. A config typo would
+  // have locked login for good, with no way back short of an edit and a restart.
+  test("an infinite window is refused, however it is spelled", () => {
+    expect(() => parse("Infinity")).toThrow(/between 1 and/);
+    expect(() => parse("1e309")).toThrow(/between 1 and/);
+  });
+
+  // The other half of the same defect, and the reason the bound exists rather than a finiteness
+  // check. `Number.isInteger(1e12)` is true, but 1e12 minutes in milliseconds is past Date's
+  // ±8.64e15 range, so the reset lands on an invalid date exactly like Infinity does. A day is well
+  // past any real throttle, and every unrepresentable value is far on the other side of it.
+  test("a window too large for a reset date is refused", () => {
+    expect(() => parse("1000000000000")).toThrow(/between 1 and 1440/);
+    expect(parse("1440")).toBe(1440);
+    expect(() => parse("1441")).toThrow(/between 1 and 1440/);
+  });
+
+  // Falling back would be worse than throwing: a typo becomes a budget nobody chose, silently.
+  test("garbage throws instead of quietly becoming the default", () => {
+    for (const raw of ["abc", "0", "-5", "2.5", "NaN", "5 minutes"]) {
+      expect(() => parse(raw)).toThrow(/between 1 and/);
+    }
+  });
+
+  test("the error names the variable, so the operator knows which one", () => {
+    expect(() => parse("nope")).toThrow(/RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES/);
+  });
+});

--- a/tests/api/middlewares/rateLimitMetering.test.ts
+++ b/tests/api/middlewares/rateLimitMetering.test.ts
@@ -120,6 +120,16 @@ describe("rate-limit metering (what a rejected request costs)", () => {
   // reads 2 the moment that ordering is undone. What a second charge DOES at the ceiling is pinned
   // separately below, on a probe small enough to reach the ceiling.
   test("a matched route that throws a 404 is charged once, not twice", async () => {
+    // NOTE: the status is asserted before the cost, because the cost alone cannot tell this case
+    // from the case where the probe route is not there at all. It is registered on the shared app
+    // singleton in beforeAll, and credentialRateLimit.test.ts runs earlier in the SAME process and
+    // has already called `listen()` on it, so the route is added to a compiled app. Elysia routes it
+    // anyway, measured alone and under the full suite, but if that ever changed the request would
+    // fall through to the SPA catch-all, spend exactly the same 1, and leave this test green while
+    // it stopped testing a matched route entirely.
+    const answered = await send("GET", "/__metering/thrown-404");
+    expect(answered.status).toBe(404);
+    expect(await answered.json()).toEqual({ error: "gone" });
     expect(await costOf(() => send("GET", "/__metering/thrown-404"))).toBe(1);
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -48,3 +48,18 @@ process.env.JWT_SECRET = "test-secret-key-for-testing-only";
 // `/auth/google` regardless of the developer's local `.env` and so tests can
 // exercise the enabled-mode code path.
 process.env.GOOGLE_CLIENT_ID = "test-google-client.apps.googleusercontent.com";
+// NOTE: Force the shipped rate-limit budgets, for the same reason as the line
+// above and with one consequence worth spelling out. Two test files read a real
+// response from the real app: one identifies WHICH limiter answered by the
+// ceiling it advertises (`RateLimit-Limit: 20` is the credential bucket, 600 the
+// global one), the other measures what a rejected request costs by watching the
+// remaining budget move. All four of these are environment variables, so a
+// developer who tunes one in their `.env` would watch a correct app fail, and
+// fail with `Expected: "20", Received: "600"`, which is exactly the signature of
+// the limiter-collision regression those tests exist to catch. Pinning here, at
+// preload and before any module reads config, is what keeps that signal
+// unambiguous.
+process.env.RATE_LIMIT_USER_PER_MIN = "600";
+process.env.RATE_LIMIT_MCP_PER_MIN = "1200";
+process.env.RATE_LIMIT_CREDENTIAL_MAX = "20";
+process.env.RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES = "5";


### PR DESCRIPTION
`/api/auth/login`, `/signup`, `/setup` and `/accept-invite` were bounded only by the global 600/min. There is no lockout, no failed-attempt counter and no backoff anywhere else in the auth path, so that number **was** the brute-force protection: 600 password guesses a minute against one account. `/accept-invite` consumes a token from an unauthenticated request body, so it is a guessing target too.

`strictRateLimitMiddleware` was written for exactly this, and mounted nowhere.

## Mounting it as written would have been worse than leaving it out

The plugin seeds itself with `max:duration:scoping` and Elysia deduplicates matching plugins. It shipped as `(10, 60000, scoped)`, which is the DCR limiter **exactly**. Measured on the real app with that collision in place:

```
POST /api/auth/login              -> RateLimit-Limit: 600   ← the GLOBAL bucket
POST /api/v1/mcp/oauth/register   -> RateLimit-Limit: 10
```

The credential limiter never mounted. Nothing was logged. The endpoints were no better off than before, while every reader of `src/app.ts` would have said they were protected.

That is also what the tests here pin: reintroducing the collision fails them with `Expected: "20", Received: "600"`.

## Why the window is minutes

A per-minute ceiling resets 60 times an hour, so a 10/min credential limit still allows 600 guesses an hour. The window is what bounds brute force, not the number.

**20 per 5 minutes** is 240 an hour and still absorbs a burst, which is what a whole office signing in at once looks like through a single NAT. Having a different `duration` also puts the collision out of reach *by construction*, rather than by a `max` that happens not to clash.

## Boot refuses the configuration that deletes a bucket

`config.ts` throws, naming both limiters, when any two of the five share a budget **and** a window. It also refuses a credential budget that is not tighter than the global one, compared as rates since the windows differ.

Both checks are exported as plain functions so a test can drive them. Without them the trap above is reachable again the next time anyone adds a limiter, with a green suite. The failure is not symmetric, which is why it throws rather than warns: whichever limiter loses is the only thing counting its traffic, so a collision never tightens anything, it deletes a bucket.

## What is in the bucket, and what is not

| route | in | why |
| --- | --- | --- |
| `POST /api/auth/login` | yes | password guessing |
| `POST /api/auth/signup` | yes | account creation |
| `POST /api/auth/setup` | yes | the one-time setup token |
| `POST /api/auth/accept-invite` | yes | consumes an invite token, unauthenticated |
| `GET /api/auth/invite` | yes | **a token oracle**: `security: []`, 200 with the invited email and role for a valid token, 404 otherwise |
| `HEAD /api/auth/invite` | yes | the **same** oracle: Elysia dispatches HEAD to the GET handler, the lookup runs, and the 200/404 is the whole answer |
| `GET /api/auth/me` | no | polled on every page load; would lock the app out of itself |
| `PATCH /api/auth/password` | no | behind a session; including it lets a stolen session lock the owner out of changing their password |
| `POST /api/auth/google` | no | needs a token Google signed, which is not a thing to guess |
| `POST /api/auth/logout` | no | nothing to guess |

Matching is **METHOD + path**, not a path set gated on POST. The first draft said POST-only "because these paths only exist as POST", and review round 2 showed that is false: the credential travels in the query string on `GET /auth/invite`, which is a cheaper oracle than the POST that consumes the same token.

Round 3 found the second half of the same gap: Elysia dispatches `HEAD` to the `GET` handler, so `HEAD /auth/invite` runs the same lookup and answers with the same 200/404, which is everything an oracle is worth. It is folded into `GET` **inside** the matcher rather than listed as another literal, so it widens exactly the routes `GET` already covers and nothing else.

Pairing the method with the path lets that one GET in while keeping every other GET out, which matters because a 404 spends whatever budget covers it. Measured on the real app:

```
GET  /auth/invite?token=      -> 404 limit=20    ← the credential bucket
HEAD /auth/invite?token=      -> 404 limit=20    ← the same oracle, the same bucket
GET  /auth/invite/ (slashed)  -> 404 limit=20
POST /auth/invite (404)       -> 404 limit=600   ← a method the route does not serve
GET  /auth/me                 -> 200 limit=600
HEAD /auth/me                 -> 200 limit=600
GET  /auth/login (404)        -> 404 limit=600   ← no crawler burn on the login budget
HEAD /auth/login (404)        -> 404 limit=600   ← folding HEAD into GET widens nothing else
```

One trailing slash is canonicalized, sharing the helper the DCR limiter already needed since Elysia answers both spellings from the same handler.

## Compose files

They now pass all four rate-limit variables. They listed **none** of them, including the two that already existed, so every ceiling was unreachable in every shipped deployment. That is tolerable for a runaway guard at 600 and not for this one: when a shared office address trips the credential bucket, raising the max is the operator's only remedy. Adding just the new pair beside two that stay unreachable would have left the file incoherent.

This reaches **new** installations. Coolify freezes a `${VAR:-default}` at creation, so an existing installation keeps the compose it was created from and the operator has to add the variable in the UI to raise a ceiling there.

## A budget the limiter cannot honour (review round 1)

The budgets were parsed with `RAW && Number(RAW) > 0`, which accepts `Infinity`, and `1e309` parses to exactly that. Measured:

```
200 reset=NaN rem=1
200 reset=NaN rem=0
429 reset=NaN rem=0
429 reset=NaN rem=0     ← and forever after
```

With an infinite window the limiter advertises `RateLimit-Reset: NaN` and the bucket **never resets**, so the credential endpoints answer 429 permanently once the budget is spent. A config typo would have locked login for good, recoverable only by an edit and a restart.

That shape was on all four budgets, including the two that predate this change, so all four now go through one parser requiring a positive **whole** number. It throws by name rather than falling back, because falling back is how a typo becomes a budget nobody chose, the same reasoning `TRUST_PROXY` already carries in this file.

Round 2 found the other half of the same defect: `Number.isInteger(1e12)` is true, but 1e12 minutes in milliseconds is past `Date`'s range, so a large **finite** window reaches the same invalid reset. The answer is a bound rather than another finiteness check. A window caps at a day (`MAX_WINDOW_MINUTES = 1440`), well past any real throttle and far below anything `Date` cannot represent; the budgets cap at `MAX_BUDGET = 1_000_000` for the mirror-image reason, since an absurd ceiling is a bucket that never trips while reading as a configured one.

## Validation scope

**Proven by test.** `tests/api/middlewares/credentialRateLimit.test.ts` goes through the real app and reads which bucket answered off the ceiling it advertises, so it checks that **both** buckets exist rather than that one of them answers. Reintroducing the collision fails it at `Expected: "20", Received: "600"`.

Those numbers are the shipped defaults, and `tests/setup.ts` now **pins** the four `RATE_LIMIT_*` variables at preload so they stay the numbers under test. Round 5 caught the tests asserting them while this change is what made them configurable: a developer tuning `RATE_LIMIT_CREDENTIAL_MAX` in their `.env` would have watched a correct app fail, and fail with the collision's own signature.

Reading the expectations from `config` instead was the obvious answer and the wrong one, which round 6 rejected: the boot check keeps the (budget, window) **pairs** distinct, not the budgets, so setting the credential budget **to** the global one is supported and boots fine, and then both buckets advertise the same ceiling with nothing able to tell them apart. Pinning is what keeps the signal. Measured with the pin, `RATE_LIMIT_CREDENTIAL_MAX=50`, `=600`, `RATE_LIMIT_USER_PER_MIN=900` and `RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES=1` all run green; measured without it, `RATE_LIMIT_USER_PER_MIN=5` fails five of the eight tests in `rateLimitMetering.test.ts`, the same dependency sitting in a file this change never touched.

Round 7 asked whether the probe route in `rateLimitMetering.test.ts` still routes, since it is registered on the shared app singleton in a `beforeAll` that now runs after this file has already called `listen()` on it. Measured, it does: 404 with the thrown body, alone and under the full suite, in one process shared with the new file. The blind spot behind the question was real, so that test now asserts the status and the body before the cost: an unregistered `/__metering/*` path falls through to the SPA catch-all, answers **200**, and costs exactly the same 1, so the old cost-only assertion would have stayed green while testing nothing. With the path mutated to one that was never registered it now fails at `Expected: 404, Received: 200`.

Full suite green on both trees at this commit: 3152 tests on the source tree and 3112 on the derived public tree, 0 failures on either.

**Not validated live.** No deployment was exercised; every number comes from the app served on a local port.

**Not covered.** This bounds guessing per IP. It is not account lockout, and it does not help against a distributed attempt from many addresses; everyone behind one NAT still shares the bucket, which is the trade `.env.example` states.

---

**No `Fixes #N`**, same deviation as #155, #156 and #157.

