### PR TITLE
Refuse a numeric setting the runtime cannot honour, instead of converting it silently

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# NOTE: Every numeric setting in this file must be a positive WHOLE number, and boot REFUSES
+# anything else by name instead of falling back to the default. Falling back is how a typo becomes a
+# value nobody chose: `Number("15s")` is NaN and `Number("1e309")` is Infinity. The five settings
+# that drive a worker's tick pass their value straight to `setInterval`, which cannot represent
+# either and uses 1ms instead, so a line reading "every 15 seconds" becomes about 870 database
+# claims a second. The ones that feed date arithmetic fail more quietly: an Invalid Date cutoff
+# means the daily log sweep deletes nothing. Each setting also has an upper bound, named in the
+# error: a duration caps at what a 32-bit delay can hold, a port at 65535, and so on.
 NODE_ENV=development
 PORT=3000
 PUBLIC_URL=http://localhost:${PORT}

--- a/src/config.ts
+++ b/src/config.ts
@@ -113,21 +113,47 @@ const parseTrustProxy = (raw: string | undefined, envName: string): boolean => {
 // duration Date cannot represent is orders of magnitude over it.
 const MAX_WINDOW_MINUTES = 1440;
 // Generous enough that "effectively unlimited" is still expressible, small enough that a slipped
-// exponent is caught rather than silently disabling a limiter.
-const MAX_BUDGET = 1_000_000;
+// exponent is caught rather than silently disabling a limiter. Used for every count: budgets, pool
+// sizes, concurrency, character caps.
+const MAX_COUNT = 1_000_000;
+// The runtime's own limit for the five that reach `setInterval` (the webhook, scheduler, debounce,
+// compaction and alert workers), and a generous ceiling for the three other millisecond spans.
+// `setInterval` takes a 32-bit signed delay and anything it cannot represent it sets to 1: measured
+// in Bun, twenty ticks at a NaN delay took 23.6ms and twenty at Infinity took 22.8ms, about 1.15ms
+// each, against the 15_000ms the operator wrote. A worker whose tick claims jobs then spins against
+// the database instead of idling. The other three are date and cache arithmetic, where the same
+// values produce an Invalid Date rather than a hot loop; 24 days is past any real span for them too.
+const MAX_DURATION_MS = 2_147_483_647;
+// The protocol's own limit.
+const MAX_PORT = 65_535;
+// A century. Any real retention policy is orders of magnitude under this, and every span whose
+// millisecond value Date cannot represent is orders of magnitude over it.
+const MAX_RETENTION_DAYS = 36_500;
 
-export const parseBudget = (
+// NOTE: every numeric environment variable in this file goes through here, and tests/config.test.ts
+// reads this source to keep that true: it asserts that `raw`, this function's own input, is the only
+// thing the file ever hands to `Number`. The shape this replaced was `RAW ? Number(RAW) : fallback`,
+// which converts and asks nothing, so `Number("15s")` reached consumers as NaN and `Number("1e309")`
+// as Infinity. See MAX_DURATION_MS for what that did to the seven that feed a timer.
+//
+// NOTE: `minimum` is 1 for every setting but one. Zero is admitted only where the CONSUMER treats it
+// as a value rather than as an absence, which is a narrower test than "the old code let it through":
+// the old code let zero through on nine of these, and on eight of the nine it was the pathology, not
+// a setting. `setInterval(fn, 0)` is the same 1ms tick as NaN, a heartbeat due at `now` is a storm,
+// and `PORT=0` binds an ephemeral port nothing can route to.
+export const parseIntSetting = (
   raw: string | undefined,
   envName: string,
   fallback: number,
   consequence: string,
   upperBound: number,
+  minimum = 1,
 ): number => {
   if (raw === undefined || raw.trim() === "") return fallback;
   const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0 || value > upperBound) {
+  if (!Number.isInteger(value) || value < minimum || value > upperBound) {
     throw new Error(
-      `${envName} must be a whole number between 1 and ${upperBound} (got "${raw}"). ${consequence}`,
+      `${envName} must be a whole number between ${minimum} and ${upperBound} (got "${raw}"). ${consequence}`,
     );
   }
   return value;
@@ -146,17 +172,26 @@ const parseHops = (raw: string | undefined, envName: string): number => {
 
 const googleClientId = (GOOGLE_CLIENT_ID ?? "").trim();
 
-// NOTE: strict parse — anything but a finite positive integer (Infinity, NaN, 0, negatives,
-// fractions) falls back to the default, so the prompt-size guard can never be disabled by a
-// malformed value.
-const agentPromptMaxChars = Number(AGENT_PROMPT_MAX_CHARS);
+const agentPromptMaxChars = parseIntSetting(
+  AGENT_PROMPT_MAX_CHARS,
+  "AGENT_PROMPT_MAX_CHARS",
+  100_000,
+  "It is the ceiling on an agent's system prompt, so a malformed value would disable the guard.",
+  MAX_COUNT,
+);
 
 const config = {
   packageInfo: {
     name: packageInfo.name,
     version: packageInfo.version,
   },
-  port: PORT ? Number(PORT) : 3000,
+  port: parseIntSetting(
+    PORT,
+    "PORT",
+    3000,
+    "It is the port the server binds.",
+    MAX_PORT,
+  ),
   publicUrl: PUBLIC_URL || "http://localhost:3000",
   env: (NODE_ENV || "development") as "development" | "production",
   // NOTE: Distribution edition. Single source of truth shared with the frontend bundle
@@ -204,7 +239,13 @@ const config = {
   // parallel without the pool becoming the bottleneck (pairs with agent.modelConcurrency). Total
   // connections per leader replica are ~2×this; keep it under the server's max_connections (pg
   // default 100). To go well beyond ~40, raise max_connections on the Postgres image instead.
-  dbPoolMax: DB_POOL_MAX && Number(DB_POOL_MAX) > 0 ? Number(DB_POOL_MAX) : 30,
+  dbPoolMax: parseIntSetting(
+    DB_POOL_MAX,
+    "DB_POOL_MAX",
+    30,
+    "It sizes both Postgres pools, and total connections per replica are about twice it.",
+    MAX_COUNT,
+  ),
   cdnUrl: CDN_URL ?? "",
   googleClientId,
   googleOAuthEnabled: googleClientId.length > 0,
@@ -229,18 +270,18 @@ const config = {
   // across every entrypoint (debounce/webhook/nudge/playground) so a burst does not hammer the
   // provider. Per-process (single-replica). Pair with dbPoolMax so the DB pool is not the effective cap.
   agent: {
-    modelConcurrency:
-      AGENT_MODEL_CONCURRENCY && Number(AGENT_MODEL_CONCURRENCY) > 0
-        ? Number(AGENT_MODEL_CONCURRENCY)
-        : 20,
+    modelConcurrency: parseIntSetting(
+      AGENT_MODEL_CONCURRENCY,
+      "AGENT_MODEL_CONCURRENCY",
+      20,
+      "It is the only throttle on concurrent model calls, process-wide.",
+      MAX_COUNT,
+    ),
     // NOTE: Hard cap (characters) on an agent's system prompt, enforced at the service layer for
     // every transport (console/REST/MCP) and at import. A deliberate checkpoint, not a technical
     // ceiling: prompts past tens of KB usually hold knowledge-base content and degrade instruction
     // adherence. Intentionally surfaced only as a save error — no UI affordance points here.
-    promptMaxChars:
-      Number.isSafeInteger(agentPromptMaxChars) && agentPromptMaxChars > 0
-        ? agentPromptMaxChars
-        : 100_000,
+    promptMaxChars: agentPromptMaxChars,
   },
   // NOTE: Outbound webhook delivery worker. Single-replica by construction (a reentrancy
   // guard + interval; see docs/deploy.md "Single replica" for the leader pattern when scaling).
@@ -248,18 +289,26 @@ const config = {
   // with full-jitter backoff. Disable for CLIs/one-off scripts that import the app graph.
   webhookWorker: {
     enabled: WEBHOOK_WORKER_ENABLED !== "false",
-    intervalMs: WEBHOOK_WORKER_INTERVAL_MS
-      ? Number(WEBHOOK_WORKER_INTERVAL_MS)
-      : 5_000,
+    intervalMs: parseIntSetting(
+      WEBHOOK_WORKER_INTERVAL_MS,
+      "WEBHOOK_WORKER_INTERVAL_MS",
+      5_000,
+      "It is how often the outbound webhook worker claims due deliveries.",
+      MAX_DURATION_MS,
+    ),
   },
   // NOTE: Follow-up/sweep scheduler worker. Single-replica by construction (a globalThis
   // singleton + non-overlapping tick); the claim uses FOR UPDATE SKIP LOCKED so it is still
   // correct if briefly doubled. Disable for CLIs/one-off scripts that import the app graph.
   schedulerWorker: {
     enabled: SCHEDULER_WORKER_ENABLED !== "false",
-    intervalMs: SCHEDULER_WORKER_INTERVAL_MS
-      ? Number(SCHEDULER_WORKER_INTERVAL_MS)
-      : 15_000,
+    intervalMs: parseIntSetting(
+      SCHEDULER_WORKER_INTERVAL_MS,
+      "SCHEDULER_WORKER_INTERVAL_MS",
+      15_000,
+      "It is how often the scheduler worker claims due jobs.",
+      MAX_DURATION_MS,
+    ),
   },
   // NOTE: Dedicated FAST tick that drains only DEBOUNCE jobs (inbound message coalescing). It is
   // separate from the scheduler so the per-agent debounce window (seconds) is honored without
@@ -267,9 +316,13 @@ const config = {
   // + non-overlapping tick + FOR UPDATE SKIP LOCKED claim). Operational, NOT a per-agent setting.
   debounceWorker: {
     enabled: DEBOUNCE_WORKER_ENABLED !== "false",
-    intervalMs: DEBOUNCE_WORKER_INTERVAL_MS
-      ? Number(DEBOUNCE_WORKER_INTERVAL_MS)
-      : 2_500,
+    intervalMs: parseIntSetting(
+      DEBOUNCE_WORKER_INTERVAL_MS,
+      "DEBOUNCE_WORKER_INTERVAL_MS",
+      2_500,
+      "It is how often the debounce lane drains inbound message coalescing.",
+      MAX_DURATION_MS,
+    ),
   },
   // NOTE: Dedicated tick that drains only MEMORY_COMPACT jobs. Separate from the scheduler for the
   // mirror image of the debounce reason: the scheduler awaits its jobs one at a time, a summary is a
@@ -279,32 +332,60 @@ const config = {
   // setting; the per-agent switch is agent.settings.memory.compaction.
   compactionWorker: {
     enabled: COMPACTION_WORKER_ENABLED !== "false",
-    intervalMs: COMPACTION_WORKER_INTERVAL_MS
-      ? Number(COMPACTION_WORKER_INTERVAL_MS)
-      : 15_000,
+    intervalMs: parseIntSetting(
+      COMPACTION_WORKER_INTERVAL_MS,
+      "COMPACTION_WORKER_INTERVAL_MS",
+      15_000,
+      "It is how often the compaction lane claims MEMORY_COMPACT jobs.",
+      MAX_DURATION_MS,
+    ),
   },
   // NOTE: Cadence of the periodic `heartbeat` outbound webhook (a liveness ping). Runs on the
   // scheduler worker (no separate process); a per-tenant HEARTBEAT job is armed lazily only while
   // the tenant has an enabled subscription to the event, and self-terminates otherwise. Default 1 min.
   heartbeat: {
-    intervalMs: HEARTBEAT_INTERVAL_MS ? Number(HEARTBEAT_INTERVAL_MS) : 60_000,
+    intervalMs: parseIntSetting(
+      HEARTBEAT_INTERVAL_MS,
+      "HEARTBEAT_INTERVAL_MS",
+      60_000,
+      "It is the cadence of the heartbeat outbound webhook.",
+      MAX_DURATION_MS,
+    ),
   },
   // NOTE: External alert delivery worker (execution-flow warnings/errors → Discord / webhook).
   // Same single-replica discipline as the outbound worker; OFF on extra replicas. The coalesce
   // window lets a burst accumulate into one delivery's count before the single POST.
   alertWorker: {
     enabled: ALERT_WORKER_ENABLED !== "false",
-    intervalMs: ALERT_WORKER_INTERVAL_MS
-      ? Number(ALERT_WORKER_INTERVAL_MS)
-      : 10_000,
-    coalesceWindowMs: ALERT_COALESCE_WINDOW_MS
-      ? Number(ALERT_COALESCE_WINDOW_MS)
-      : 30_000,
+    intervalMs: parseIntSetting(
+      ALERT_WORKER_INTERVAL_MS,
+      "ALERT_WORKER_INTERVAL_MS",
+      10_000,
+      "It is how often the alert worker claims due deliveries.",
+      MAX_DURATION_MS,
+    ),
+    // NOTE: the one setting here where ZERO is a value, not an absence. It means deliver without
+    // buffering, the consumer takes it as such (`Math.max(0, Math.floor(ms / 1000))` in claimDue),
+    // and there is no other way to ask for it. Everything else in this file takes a minimum of 1.
+    coalesceWindowMs: parseIntSetting(
+      ALERT_COALESCE_WINDOW_MS,
+      "ALERT_COALESCE_WINDOW_MS",
+      30_000,
+      "It is how long a burst accumulates into one delivery before the POST; 0 delivers without buffering.",
+      MAX_DURATION_MS,
+      0,
+    ),
   },
   // NOTE: Retention for the high-write execution_logs table (+ terminal alert_deliveries). A daily
   // per-tenant FLOWLOG_SWEEP job deletes rows older than this. Default 30 days.
   flowlog: {
-    retentionDays: FLOWLOG_RETENTION_DAYS ? Number(FLOWLOG_RETENTION_DAYS) : 30,
+    retentionDays: parseIntSetting(
+      FLOWLOG_RETENTION_DAYS,
+      "FLOWLOG_RETENTION_DAYS",
+      30,
+      "It is the cutoff the daily sweep deletes execution_logs against, so a malformed value leaves the highest-write table growing forever.",
+      MAX_RETENTION_DAYS,
+    ),
   },
   // NOTE: stdio MCP transport spawns a local process — arbitrary command execution on the host.
   // In multi-tenant hosting that is an RCE vector, so it is OFF by default; enable only on a
@@ -344,28 +425,28 @@ const config = {
   // hour and still absorbs a burst, which is what an office arriving at once looks like through a
   // single NAT.
   rateLimit: {
-    userPerMin: parseBudget(
+    userPerMin: parseIntSetting(
       RATE_LIMIT_USER_PER_MIN,
       "RATE_LIMIT_USER_PER_MIN",
       600,
       "It is the ceiling every request that is not static or MCP transport counts against.",
-      MAX_BUDGET,
+      MAX_COUNT,
     ),
-    mcpPerMin: parseBudget(
+    mcpPerMin: parseIntSetting(
       RATE_LIMIT_MCP_PER_MIN,
       "RATE_LIMIT_MCP_PER_MIN",
       1200,
       "It is the ceiling the MCP JSON-RPC transport counts against.",
-      MAX_BUDGET,
+      MAX_COUNT,
     ),
-    credentialMax: parseBudget(
+    credentialMax: parseIntSetting(
       RATE_LIMIT_CREDENTIAL_MAX,
       "RATE_LIMIT_CREDENTIAL_MAX",
       20,
       "It is how many credential attempts one address gets per window.",
-      MAX_BUDGET,
+      MAX_COUNT,
     ),
-    credentialWindowMinutes: parseBudget(
+    credentialWindowMinutes: parseIntSetting(
       RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES,
       "RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES",
       5,
@@ -386,12 +467,14 @@ const config = {
     // NOTE: Optional override for the VERSION check only (a fork with its own release cadence points
     // this at a URL returning `{ latestVersion, releaseUrl? }`). Empty = derive from `url`.
     updateCheckUrl: (AGENTS_UPDATE_CHECK_URL ?? "").trim().replace(/\/+$/, ""),
-    // NOTE: Cache TTL (ms) for the hub announcements/version fetch. Default 1h. A non-numeric or
-    // non-positive value falls back to the default (Number("x") > 0 is false for NaN), never NaN.
-    updatesTtlMs:
-      HUB_UPDATES_TTL_MS && Number(HUB_UPDATES_TTL_MS) > 0
-        ? Number(HUB_UPDATES_TTL_MS)
-        : 3_600_000,
+    // NOTE: Cache TTL (ms) for the hub announcements/version fetch. Default 1h.
+    updatesTtlMs: parseIntSetting(
+      HUB_UPDATES_TTL_MS,
+      "HUB_UPDATES_TTL_MS",
+      3_600_000,
+      "It is how long the hub announcements and version check are cached.",
+      MAX_DURATION_MS,
+    ),
   },
 };
 

--- a/tests/api/middlewares/credentialRateLimit.test.ts
+++ b/tests/api/middlewares/credentialRateLimit.test.ts
@@ -4,7 +4,7 @@ import app from "@/app";
 import {
   assertCredentialBudgetIsTighter,
   assertLimiterBudgetsAreDistinct,
-  parseBudget,
+  parseIntSetting,
 } from "@/config";
 
 // The credential endpoints had no bucket of their own: `strictRateLimitMiddleware` was written for
@@ -219,7 +219,7 @@ describe("boot refuses a configuration that would delete a bucket", () => {
 
 describe("boot refuses a budget the limiter cannot honour", () => {
   const parse = (raw: string | undefined) =>
-    parseBudget(
+    parseIntSetting(
       raw,
       "RATE_LIMIT_CREDENTIAL_WINDOW_MINUTES",
       5,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { parseIntSetting } from "@/config";
+
+// Every numeric environment variable goes through one validated parser, and this file is what keeps
+// that true as variables are added.
+//
+// The shape being replaced was `RAW ? Number(RAW) : fallback`, which converts and asks nothing.
+// `Number("15s")` is NaN and `Number("1e309")` is Infinity, and both reach whatever consumes them.
+// On the five that feed `setInterval` (the webhook, scheduler, debounce, compaction and alert
+// workers) that is not a slow tick, it is a HOT one: measured in Bun, twenty ticks at a NaN delay
+// took 23.6ms and twenty at Infinity took 22.8ms, about 1.15ms each, against the 15_000ms the
+// operator wrote. `COMPACTION_WORKER_INTERVAL_MS=15s` is a plausible typo, the compaction worker is
+// on by default, and its tick claims jobs against the database. The rest fail quietly instead:
+// `FLOWLOG_RETENTION_DAYS` and `HEARTBEAT_INTERVAL_MS` reach `Date` arithmetic, where the same
+// values give an Invalid Date, so the daily sweep stops deleting and the heartbeat never comes due.
+//
+// Checked on the SOURCE, not by driving config with a hostile environment. `bun test` shares one
+// module registry across files in a worker, so `@/config` is evaluated once with whatever the
+// environment held at that moment, and a later dynamic import returns the cached module. The parser
+// itself is a pure exported function and IS driven with hostile input, in
+// tests/api/middlewares/credentialRateLimit.test.ts, which covers blanks, `Infinity`, `1e309`,
+// fractions, zero, negatives, garbage and the upper bound. What that cannot show is whether
+// config.ts routes through it, which is what this file is for.
+//
+// NOTE: comment lines are dropped before scanning. The NOTEs in config.ts quote the shape being
+// replaced, so scanning the raw text reported `Number("x")` and `Number(RAW)` out of prose and would
+// have tied this test to how the file explains itself. Only whole comment lines are dropped, which
+// is where every mention in that file lives; a `Number(` written after code on the same line is
+// still read as code, and that is the safe direction to be wrong in.
+const isComment = (line: string): boolean => /^\s*(\/\/|\/\*|\*)/.test(line);
+
+const CODE = readFileSync("src/config.ts", "utf8")
+  .split("\n")
+  .filter((line) => !isComment(line))
+  .join("\n");
+const ENV_EXAMPLE = readFileSync(".env.example", "utf8");
+
+// Every `Number(x)` call, by argument. The parser converts its own input, so `raw` is the one
+// argument allowed to appear; anything else is an environment variable being converted without being
+// checked. `Number.isInteger` and `Number.isSafeInteger` do not match, which is deliberate: they are
+// the check, not the conversion.
+const numberCallArguments = (code: string): string[] => {
+  const found = new Set<string>();
+  for (const match of code.matchAll(/\bNumber\(([^)]*)\)/g)) {
+    const argument = (match[1] ?? "").trim();
+    if (argument) found.add(argument);
+  }
+  return [...found].sort();
+};
+
+// Each `parseIntSetting(...)` call, split into its top-level arguments.
+//
+// NOTE: walked rather than matched. A regex reaching for "the last argument" cannot tell the closing
+// paren of the call from one inside it, and cannot tell an argument comma from a comma inside a
+// consequence sentence, which several of these have. The first attempt at the zero test below did
+// exactly that and reported AGENT_PROMPT_MAX_CHARS, whose fallback happens to be the last number on
+// its own line. Tracking depth and quotes is a dozen lines and cannot be wrong in that way.
+interface Call {
+  variable: string;
+  reportedAs: string;
+  fallback: string;
+  minimum: string | undefined;
+}
+
+const parserCalls = (code: string): Call[] => {
+  const calls: Call[] = [];
+  const CALL = "parseIntSetting(";
+  for (
+    let at = code.indexOf(CALL);
+    at !== -1;
+    at = code.indexOf(CALL, at + 1)
+  ) {
+    let depth = 1;
+    let quote: string | undefined;
+    const args: string[] = [];
+    let current = "";
+    let i = at + CALL.length;
+    for (; i < code.length && depth > 0; i++) {
+      const ch = code[i] as string;
+      if (quote) {
+        if (ch === "\\") {
+          current += ch + (code[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (ch === quote) quote = undefined;
+        current += ch;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === "`") {
+        quote = ch;
+        current += ch;
+        continue;
+      }
+      if (ch === "(") depth++;
+      if (ch === ")") {
+        depth--;
+        if (depth === 0) break;
+      }
+      if (ch === "," && depth === 1) {
+        args.push(current.trim());
+        current = "";
+        continue;
+      }
+      current += ch;
+    }
+    if (current.trim()) args.push(current.trim());
+    calls.push({
+      variable: args[0] ?? "",
+      reportedAs: (args[1] ?? "").replaceAll('"', ""),
+      fallback: (args[2] ?? "").replaceAll("_", ""),
+      minimum: args[5],
+    });
+  }
+  return calls;
+};
+
+const CALLS = parserCalls(CODE);
+
+describe("numeric environment parsing", () => {
+  // The guard against the next one. A variable added with the old shape shows up here by name, which
+  // is the failure mode this whole change is about: the shape was not wrong once, it was copied into
+  // thirteen places over time and would have been copied into the fourteenth.
+  test("nothing is converted to a number without being checked", () => {
+    expect(numberCallArguments(CODE)).toEqual(["raw"]);
+  });
+
+  // The mechanical error a thirteen-site change invites: the value of one variable reported under
+  // another's name. The operator then gets an error naming a variable they never set, which is worse
+  // than no message at all, and no type checker can see it because both sides are just strings.
+  test("every parsed variable is reported under its own name", () => {
+    const mismatched = CALLS.filter(
+      (call) => call.variable !== call.reportedAs,
+    ).map((call) => `${call.variable} reported as ${call.reportedAs}`);
+    expect(mismatched).toEqual([]);
+  });
+
+  // The other mechanical error, and the one a reviewer reading a thirteen-site diff is least likely
+  // to catch: a fallback mistyped, so the app runs on a number nobody chose and nothing says so.
+  // Checked against `.env.example` rather than against a list here, because that file is where an
+  // operator reads the default, so the same test also fails when the documentation drifts from the
+  // code, and when a parsed variable is not documented at all. Both sides are literals in different
+  // files, which no type checker can relate.
+  test("every default is the one .env.example documents", () => {
+    const documented = new Map(
+      [...ENV_EXAMPLE.matchAll(/^([A-Z][A-Z0-9_]*)=([0-9]+)\s*$/gm)].map(
+        (match) => [match[1] as string, match[2] as string],
+      ),
+    );
+    const disagreements = CALLS.filter(
+      (call) => documented.get(call.variable) !== call.fallback,
+    ).map(
+      (call) =>
+        `${call.variable}: config.ts says ${call.fallback}, .env.example says ${documented.get(call.variable) ?? "nothing"}`,
+    );
+    expect(disagreements).toEqual([]);
+  });
+
+  // Zero is admitted at exactly one call site, and this names it. The distinction the parser draws is
+  // whether the CONSUMER treats zero as a value or as an absence, which is narrower than "the old
+  // code let it through": it let zero through on nine of the thirteen, and on eight of those it was
+  // the pathology (a 1ms tick, a heartbeat due at `now`, a port nothing can route to). Widening the
+  // exception is therefore a decision, and it fails here until someone makes it deliberately.
+  test("zero is a value at one setting, and this is which", () => {
+    const admitZero = CALLS.filter((call) => call.minimum === "0").map(
+      (call) => call.variable,
+    );
+    expect(admitZero).toEqual(["ALERT_COALESCE_WINDOW_MS"]);
+  });
+
+  // Every variable is checked, so the scan above must be finding calls at all. Without this, deleting
+  // the parser and every call site would leave both tests above green.
+  test("the parser is actually used", () => {
+    expect(CALLS.length).toBeGreaterThanOrEqual(13);
+    expect(new Set(CALLS.map((call) => call.variable)).size).toBe(CALLS.length);
+  });
+});
+
+// Why the timer bound is 2_147_483_647 rather than a number someone picked. Above it the delay is not
+// stretched, it is SET TO 1, so a variable that reads as "tick every 25 days" is a worker spinning
+// against the database. Proven rather than asserted, because the bound is the entire reason a timer
+// variable is refused above it.
+describe("the timer bound is the runtime's, not a policy", () => {
+  test("a delay above it is not honoured, it collapses to about a millisecond", async () => {
+    const firedImmediately = await new Promise<boolean>((resolve) => {
+      // If the runtime honoured this, the callback would be due in about 24.8 days.
+      const interval = setInterval(() => {
+        clearInterval(interval);
+        clearTimeout(guard);
+        resolve(true);
+      }, 2_147_483_648);
+      // Resolves false instead of hanging, so a runtime that ever starts honouring long delays fails
+      // this test in two seconds rather than blocking the suite.
+      const guard = setTimeout(() => {
+        clearInterval(interval);
+        resolve(false);
+      }, 2_000);
+    });
+    expect(firedImmediately).toBe(true);
+  });
+});
+
+// The parser's own handling of the minimum, driven directly. Everything else about it (blanks,
+// `Infinity`, `1e309`, fractions, negatives, garbage, the upper bound) is covered in
+// tests/api/middlewares/credentialRateLimit.test.ts, where it arrived.
+describe("the minimum", () => {
+  test("zero is refused by default and admitted when a setting asks for it", () => {
+    expect(() =>
+      parseIntSetting(
+        "0",
+        "COMPACTION_WORKER_INTERVAL_MS",
+        15_000,
+        "why.",
+        2_147_483_647,
+      ),
+    ).toThrow(/between 1 and/);
+    expect(
+      parseIntSetting(
+        "0",
+        "ALERT_COALESCE_WINDOW_MS",
+        30_000,
+        "why.",
+        2_147_483_647,
+        0,
+      ),
+    ).toBe(0);
+  });
+
+  // The message has to name the minimum it applied, not a constant 1, or the operator who set zero
+  // deliberately is told the opposite of what the setting accepts.
+  test("the error names the minimum that was applied", () => {
+    expect(() =>
+      parseIntSetting(
+        "-1",
+        "ALERT_COALESCE_WINDOW_MS",
+        30_000,
+        "why.",
+        2_147_483_647,
+        0,
+      ),
+    ).toThrow(/between 0 and/);
+  });
+});


### PR DESCRIPTION
Thirteen environment variables were read as `RAW ? Number(RAW) : fallback`, which converts and asks nothing. `Number("15s")` is NaN, `Number("1e309")` is Infinity, and both reached whatever consumed them.

#162 fixed this shape on the four rate-limit budgets and left it in thirteen other places. This is that leftover.

## The five that drive a worker's tick

`WEBHOOK_WORKER_INTERVAL_MS`, `SCHEDULER_WORKER_INTERVAL_MS`, `DEBOUNCE_WORKER_INTERVAL_MS`, `COMPACTION_WORKER_INTERVAL_MS` and `ALERT_WORKER_INTERVAL_MS` pass their value straight to `setInterval`, which takes a **32-bit signed delay** and sets anything it cannot represent to **1**. Measured in Bun:

```
Number("15s") = NaN      20 ticks in 23.6ms  (~1.18ms each)
Number("Infinity")       20 ticks in 22.8ms  (~1.14ms each)
Number("1e309") = Inf    20 ticks in 22.8ms  (~1.14ms each)
15000 (the default)      20 ticks in 317.0ms (~15.85ms each, scaled)
```

So `COMPACTION_WORKER_INTERVAL_MS=15s` is not a slow tick, it is about **870 job claims a second against the database**. The typo is plausible, the compaction worker is **on by default** (`COMPACTION_WORKER_ENABLED !== "false"`), and it landed with #134 two days ago, which is exactly when an operator would be tuning it. The runtime warns once, on stderr, at startup.

## The eight that fail more quietly

| variable | where the bad value lands | what happens |
| --- | --- | --- |
| `FLOWLOG_RETENTION_DAYS` | `new Date(Date.now() - days * 86_400_000)` | Invalid Date cutoff, so the daily sweep stops deleting from the **highest-write table in the schema** |
| `HEARTBEAT_INTERVAL_MS` | `new Date(Date.now() + ms)` on the job's `runAt` | the heartbeat job never comes due |
| `PORT` | `app.listen` | |
| `ALERT_COALESCE_WINDOW_MS` | `Math.floor(ms / 1000)` into the claim | |
| `DB_POOL_MAX`, `AGENT_MODEL_CONCURRENCY`, `HUB_UPDATES_TTL_MS` | a `> 0` guard | catches NaN, **not** Infinity; substitutes the default for anything else |
| `AGENT_PROMPT_MAX_CHARS` | an `isSafeInteger` guard | catches both, still substitutes silently |

Falling back is not the safe side. It is how a typo becomes a value nobody chose, which is the same reasoning `TRUST_PROXY` and the rate-limit budgets already carry in this file.

## One parser, and bounds that are the failure

All thirteen go through the parser #162 added, renamed `parseBudget` → `parseIntSetting` since it is no longer about budgets, nor only about positive numbers. Every call states its own upper bound, and none of the bounds is a number someone picked:

- `MAX_DURATION_MS = 2_147_483_647` is the 32-bit delay above which the runtime substitutes 1.
- `MAX_PORT = 65_535` is the protocol's.
- `MAX_RETENTION_DAYS = 36_500` is a century, past any real policy and far below what `Date` cannot represent.
- `MAX_COUNT = 1_000_000` covers the counts, generous enough that "effectively unlimited" is expressible and small enough to catch a slipped exponent.

## Zero, where the consumer treats it as a value

Round 3 caught the one setting this would otherwise have broken. `ALERT_COALESCE_WINDOW_MS=0` means **deliver without buffering**, `claimDue` takes it as such (`Math.max(0, Math.floor(ms / 1000))`), and nothing else expresses it, so a positive-only parser would have refused to boot a deployment that had been running fine. The parser takes a minimum, 1 everywhere but there.

The test for admitting zero is narrower than "the old code let it through", deliberately. The old code let zero through on nine of the thirteen, and on **eight of those it was the pathology, not a setting**: `setInterval(fn, 0)` is the same 1ms tick as NaN, a heartbeat due at `now` is a storm, and `PORT=0` binds an ephemeral port nothing can route to.

`FLOWLOG_RETENTION_DAYS=0` is the one that could be argued either way, since it would mean "retain nothing" and nothing else says that. It is **refused**, on the grounds that no consumer treats it as a value and `=1` is nearly the same policy without the data-destroying typo. Push back on that if you disagree; a test pins the exception to a single call site by name, so widening it is a decision someone has to make in the open.

## Upgrade note

**An instance running with a malformed value will now refuse to boot**, naming the variable and its bound, where before it ran on NaN (the nine with no guard) or on the default (the four with one). That is the point of the change and it is also the one way it can bite: a deployment that has been quietly running on a default it never chose will stop until someone fixes the line. The fix is one edit and the error says which variable.

Measured end to end:

```
COMPACTION_WORKER_INTERVAL_MS=15s     must be a whole number between 1 and 2147483647 (got "15s")
COMPACTION_WORKER_INTERVAL_MS=1e309   must be a whole number between 1 and 2147483647 (got "1e309")
COMPACTION_WORKER_INTERVAL_MS=0       must be a whole number between 1 and 2147483647 (got "0")
PORT=99999                            must be a whole number between 1 and 65535 (got "99999")
FLOWLOG_RETENTION_DAYS=abc            must be a whole number between 1 and 36500 (got "abc")
HEARTBEAT_INTERVAL_MS=2147483648      must be a whole number between 1 and 2147483647 (got "2147483648")
ALERT_COALESCE_WINDOW_MS=-1           must be a whole number between 0 and 2147483647 (got "-1")   <- names ITS minimum
ALERT_COALESCE_WINDOW_MS=0            BOOTED coalesce= 0
COMPACTION_WORKER_INTERVAL_MS=30000   BOOTED compaction= 30000
```

## Why the tests read the source

`tests/config.test.ts` reads `src/config.ts` and asserts that `raw`, the parser's own input, is the **only** thing the file ever hands to `Number`.

That is deliberate, not a shortcut. `bun test` shares one module registry across files in a worker, so `@/config` is evaluated once with whatever the environment held at that moment and a later dynamic import returns the cached module: config cannot be re-imported under a hostile environment. The parser's own semantics are already driven directly, with blanks, `Infinity`, `1e309`, fractions, zero, negatives, garbage and the bound, in `credentialRateLimit.test.ts`. What that cannot show is whether config.ts routes through it.

It is also the guard against the next one. This shape was not written wrong once, it was **copied into thirteen places over time**, and a fourteenth variable added the old way shows up in the failure by name.

A third test cross-checks every fallback against `.env.example`, which is where an operator actually reads the default. That catches the error a reviewer reading a thirteen-site diff is least likely to catch, a fallback mistyped so the app runs on a number nobody chose, and it fails the same way when the documentation drifts from the code or when a parsed variable is not documented at all. No type checker can relate two literals in different files.

**Mutation-checked**, every way:

```
reverting one site to Number(X)         + "COMPACTION_WORKER_INTERVAL_MS"
reporting a variable under another name + "ALERT_WORKER_INTERVAL_MS reported as HEARTBEAT_INTERVAL_MS"
mistyping a default in the code         + "DEBOUNCE_WORKER_INTERVAL_MS: config.ts says 250, .env.example says 2500"
letting .env.example drift              + "DB_POOL_MAX: config.ts says 30, .env.example says 50"
widening the zero exception             + "FLOWLOG_RETENTION_DAYS"
```

The scans walk the call's arguments rather than matching them. A regex reaching for "the last argument" cannot tell the call's closing paren from one inside it, nor an argument comma from a comma inside a consequence sentence, and the first attempt at the zero test did exactly that and reported the wrong variable.

A fourth test proves the duration bound is the runtime's and not a policy, by showing a delay one above it fires immediately rather than in 24 days. It resolves `false` on a 2s guard instead of hanging, so a runtime that ever starts honouring long delays fails the test rather than blocking the suite.

## Validation scope

**Proven by test.** Source scan (five tests, every mutation caught), the parser's minimum driven directly, plus the runtime bound. Full suite green on both trees at this commit: 3197 tests on the source tree and 3157 on the derived public tree, 0 failures on either.

**Measured, not tested.** The `setInterval` collapse numbers and the five refusals above come from probes against this tree, recorded here and in the code comments. They are not committed as tests: the collapse is a timing measurement, and the refusals need a hostile environment at import, which the shared module registry rules out.

**Not validated live.** No deployment was exercised.

---

**No `Fixes #N`**, same deviation as #155, #156, #157 and #162.
