### PR TITLE
Let only the run that still owns the document publish its index

### DIFF
--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -492,12 +492,13 @@ async function runIngestJobForTenant(
 ): Promise<JobResult> {
   // 1. Load document + KB config (scoped read, no network).
   const loaded = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+    // NOTE: the content is deliberately NOT read here. It is read by the claim below, in the same
+    // transaction that takes the mark — see there for why the two cannot be separated.
     const doc = await db.knowledgeDocument.findUnique({
       where: { id: documentId },
       select: {
         id: true,
         status: true,
-        content: true,
         knowledgeBaseId: true,
       },
     });
@@ -546,15 +547,24 @@ async function runIngestJobForTenant(
     return { outcome: "done" };
   }
 
-  // Take the document: PENDING → PROCESSING marks it as owned by THIS run. The mark is what every
-  // write below is conditional on, so it is not just a badge for the console — see the release in
-  // step 4.
-  await runScopedOn(base, sysCtx(tenantId), (db) =>
-    db.knowledgeDocument.updateMany({
+  // Claim the document: PENDING → PROCESSING marks it as owned by THIS run, and the text to index
+  // is read back under the same transaction. The two are one step because an edit landing between
+  // them leaves the row PENDING — the value it already had — so a claim taken on separately-read
+  // text still succeeds, and the run would go on to index text the document no longer has while
+  // holding a mark that says it may publish. The UPDATE holds this row's lock for the rest of the
+  // transaction, so the content read after it is the content as of the claim.
+  const claimed = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+    const { count } = await db.knowledgeDocument.updateMany({
       where: { id: documentId, status: "PENDING" },
       data: { status: "PROCESSING" },
-    }),
-  );
+    });
+    if (count === 0) return null;
+    return db.knowledgeDocument.findUnique({
+      where: { id: documentId },
+      select: { content: true },
+    });
+  });
+  if (!claimed) return { outcome: "done" };
   broadcastDocumentEvent(tenantId, {
     knowledgeBaseId: String(doc.knowledgeBaseId),
     documentId: String(documentId),
@@ -564,7 +574,7 @@ async function runIngestJobForTenant(
   try {
     // 2. Chunk + embed (NO transaction, network I/O). Embedding config came from the prerequisite
     // check above.
-    const chunks = await chunkText(doc.content, {
+    const chunks = await chunkText(claimed.content, {
       chunkSize: kb.chunkSize,
       chunkOverlap: kb.chunkOverlap,
     });

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -547,11 +547,11 @@ async function runIngestJobForTenant(
     return { outcome: "done" };
   }
 
-  // Claim the document: PENDING → PROCESSING marks it as owned by THIS run, and the text to index
-  // is read back under the same transaction. The two are one step because an edit landing between
-  // them leaves the row PENDING — the value it already had — so a claim taken on separately-read
-  // text still succeeds, and the run would go on to index text the document no longer has while
-  // holding a mark that says it may publish. The UPDATE holds this row's lock for the rest of the
+  // NOTE: PENDING → PROCESSING marks the document as owned by THIS run, and the text to index is
+  // read back under the same transaction. The two are one step because an edit landing between them
+  // leaves the row PENDING — the value it already had — so a claim taken on separately-read text
+  // still succeeds, and the run would go on to index text the document no longer has while holding
+  // a mark that says it may publish. The UPDATE holds this row's lock for the rest of the
   // transaction, so the content read after it is the content as of the claim.
   const claimed = await runScopedOn(base, sysCtx(tenantId), async (db) => {
     const { count } = await db.knowledgeDocument.updateMany({
@@ -580,7 +580,7 @@ async function runIngestJobForTenant(
     });
     const vectors = chunks.length ? await embedTexts(chunks, emb.config) : [];
 
-    // 4. Publish: release the mark, then replace the chunks (one scoped transaction).
+    // NOTE: step 4, publish — release the mark, then replace the chunks (one scoped transaction).
     const published = await runScopedOn(base, sysCtx(tenantId), async (db) => {
       // NOTE: only the run still holding the mark may publish (issue #163). An edit landing during
       // the embed above sets the row back to PENDING to ask for a re-index, and an unconditional
@@ -624,10 +624,10 @@ async function runIngestJobForTenant(
           ? err.message.slice(0, 500)
           : String(err);
     logger.error({ err, documentId: String(documentId) }, "RAG ingest failed");
-    // The same release, and for the same reason: a failure belongs to the content this run read, so
-    // stamping it on a document that has since been edited both reports the wrong thing and buries
-    // the re-index (FAILED is no more PENDING than READY is, and the re-armed job returns on it).
-    // Leaving the row PENDING lets the re-armed job try the new content and report on its own.
+    // NOTE: the same release, and for the same reason. A failure belongs to the content this run
+    // read, so stamping it on a document that has since been edited both reports the wrong thing
+    // and buries the re-index (FAILED is no more PENDING than READY is, and the re-armed job
+    // returns on it). Leaving the row PENDING lets the re-armed job try the new content instead.
     const stamped = await runScopedOn(base, sysCtx(tenantId), (db) =>
       db.knowledgeDocument.updateMany({
         where: { id: documentId, status: "PROCESSING" },

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -546,7 +546,9 @@ async function runIngestJobForTenant(
     return { outcome: "done" };
   }
 
-  // Mark PROCESSING + emit event.
+  // Take the document: PENDING → PROCESSING marks it as owned by THIS run. The mark is what every
+  // write below is conditional on, so it is not just a badge for the console — see the release in
+  // step 4.
   await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.knowledgeDocument.updateMany({
       where: { id: documentId, status: "PENDING" },
@@ -568,8 +570,19 @@ async function runIngestJobForTenant(
     });
     const vectors = chunks.length ? await embedTexts(chunks, emb.config) : [];
 
-    // 4. Replace chunks + mark READY (scoped write).
-    await runScopedOn(base, sysCtx(tenantId), async (db) => {
+    // 4. Publish: release the mark, then replace the chunks (one scoped transaction).
+    const published = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+      // NOTE: only the run still holding the mark may publish (issue #163). An edit landing during
+      // the embed above sets the row back to PENDING to ask for a re-index, and an unconditional
+      // `READY` erased that marker, leaving the new text in the row and the old text in the index.
+      // Releasing BEFORE the chunk writes is the rest of it: a stale run returns having written
+      // nothing, so the previous index survives until the re-armed job replaces it, and a live run
+      // holds this row lock for the rest of the transaction, so no edit lands mid-write.
+      const released = await db.knowledgeDocument.updateMany({
+        where: { id: documentId, status: "PROCESSING" },
+        data: { status: "READY", chunkCount: chunks.length, error: null },
+      });
+      if (released.count === 0) return false;
       // Delete old chunks for this document.
       await db.knowledgeChunk.deleteMany({ where: { documentId } });
       // Insert new chunks with documentId.
@@ -579,11 +592,9 @@ async function runIngestJobForTenant(
           INSERT INTO knowledge_chunks (tenant_id, knowledge_base_id, document_id, content, embedding, metadata, created_at)
           VALUES (${tenantId}, ${doc.knowledgeBaseId}, ${documentId}, ${chunks[i]}, ${vec}::vector, ${JSON.stringify({ documentId: String(documentId) })}::jsonb, now())`;
       }
-      await db.knowledgeDocument.updateMany({
-        where: { id: documentId },
-        data: { status: "READY", chunkCount: chunks.length, error: null },
-      });
+      return true;
     });
+    if (!published) return { outcome: "done" };
 
     broadcastDocumentEvent(tenantId, {
       knowledgeBaseId: String(doc.knowledgeBaseId),
@@ -603,18 +614,24 @@ async function runIngestJobForTenant(
           ? err.message.slice(0, 500)
           : String(err);
     logger.error({ err, documentId: String(documentId) }, "RAG ingest failed");
-    await runScopedOn(base, sysCtx(tenantId), (db) =>
+    // The same release, and for the same reason: a failure belongs to the content this run read, so
+    // stamping it on a document that has since been edited both reports the wrong thing and buries
+    // the re-index (FAILED is no more PENDING than READY is, and the re-armed job returns on it).
+    // Leaving the row PENDING lets the re-armed job try the new content and report on its own.
+    const stamped = await runScopedOn(base, sysCtx(tenantId), (db) =>
       db.knowledgeDocument.updateMany({
-        where: { id: documentId },
+        where: { id: documentId, status: "PROCESSING" },
         data: { status: "FAILED", error: message },
       }),
     );
-    broadcastDocumentEvent(tenantId, {
-      knowledgeBaseId: String(doc.knowledgeBaseId),
-      documentId: String(documentId),
-      status: "FAILED",
-      error: message,
-    });
+    if (stamped.count > 0) {
+      broadcastDocumentEvent(tenantId, {
+        knowledgeBaseId: String(doc.knowledgeBaseId),
+        documentId: String(documentId),
+        status: "FAILED",
+        error: message,
+      });
+    }
     return { outcome: "fail", error: message };
   }
 }

--- a/tests/modules/rag-ingest-stale-publish.test.ts
+++ b/tests/modules/rag-ingest-stale-publish.test.ts
@@ -24,6 +24,11 @@ import { updateEmbeddingSettings } from "@/modules/tenant-settings/service";
 // while it is still the run that owns the document. It runs FIRST inside the replace-chunks
 // transaction, so a stale run also writes no chunks at all and search keeps answering from the last
 // consistent index instead of going wrong for a while.
+//
+// The embed is not the only window, and the last test here covers the other one: the text to index
+// and the PROCESSING mark are read in ONE transaction, because an edit landing between a separate
+// read and the mark leaves the row PENDING (the value it already had) — so the mark is taken
+// successfully, over text the document no longer has.
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
 const suUrl = process.env.MIGRATION_DATABASE_URL;
@@ -47,6 +52,15 @@ if (appUrl && suUrl) {
 }
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
+// A SECOND app connection. The edit injected mid-run has to commit while the job's own transaction
+// is still open, which one client cannot do with itself.
+const editDb = dbUp
+  ? new PrismaClient({
+      adapter: new PrismaPg({
+        connectionString: process.env.TEST_APP_DATABASE_URL as string,
+      }),
+    })
+  : (undefined as unknown as PrismaClient);
 
 function ctx(tenantId: bigint): TenantContext {
   return { tenantId, userId: null, role: "TENANT_ADMIN" };
@@ -180,7 +194,11 @@ async function seedTenant(slug: string): Promise<{ id: bigint; kb: bigint }> {
 }
 
 // The REAL job handler, the same entry point the scheduler uses.
-async function runIngest(tenantId: bigint, documentId: bigint) {
+async function runIngestOn(
+  base: PrismaClient,
+  tenantId: bigint,
+  documentId: bigint,
+) {
   registerRagIngestHandler();
   const handler = getJobHandler("RAG_INGEST");
   if (!handler) throw new Error("RAG_INGEST handler not registered");
@@ -192,8 +210,12 @@ async function runIngest(tenantId: bigint, documentId: bigint) {
       payload: { documentId: String(documentId) },
       attempts: 0,
     },
-    appDb,
+    base,
   );
+}
+
+async function runIngest(tenantId: bigint, documentId: bigint) {
+  return runIngestOn(appDb, tenantId, documentId);
 }
 
 async function readDoc(tenantId: bigint, id: bigint) {
@@ -227,6 +249,7 @@ afterAll(async () => {
   }
   await su?.$disconnect();
   await app?.$disconnect();
+  await editDb?.$disconnect();
 });
 
 describe.skipIf(!dbUp)(
@@ -339,6 +362,51 @@ describe.skipIf(!dbUp)(
 
       await runIngest(id, doc.id);
       expect(await readChunks(id, doc.id)).toEqual(["THIRD TEXT"]);
+    });
+
+    // Round 1 review, P2: the embed is not the only window. The run reads the document's text and
+    // takes the mark in two separate steps, and an edit landing BETWEEN them leaves the row PENDING
+    // (the value it already had), so the claim still succeeds — carrying text the document no
+    // longer has. The run then indexes the old text and publishes it legitimately, which is the
+    // same permanent divergence through a narrower door.
+    test("what gets indexed is the text the claim froze, not the text read before it", async () => {
+      const { id, kb } = await seedTenant("rag-claim");
+      const doc = await createDocument({
+        tenantId: id,
+        knowledgeBaseId: kb,
+        title: "policy",
+        sourceType: "text",
+        text: "ORIGINAL TEXT",
+        base: appDb,
+      });
+
+      // There is no network in this gap, so it needs a seam rather than the embedding double. The
+      // knowledge-base config read sits inside it, right after the document read.
+      let fired = false;
+      const hooked = appDb.$extends({
+        query: {
+          knowledgeBase: {
+            async findUnique({ args, query }) {
+              if (!fired) {
+                fired = true;
+                await updateDocument(
+                  id,
+                  doc.id,
+                  { text: "EDITED TEXT" },
+                  editDb,
+                );
+              }
+              return query(args);
+            },
+          },
+        },
+      }) as unknown as PrismaClient;
+
+      await runIngestOn(hooked, id, doc.id);
+      expect(fired).toBe(true);
+
+      expect(await readChunks(id, doc.id)).toEqual(["EDITED TEXT"]);
+      expect((await readDoc(id, doc.id)).status).toBe("READY");
     });
   },
 );

--- a/tests/modules/rag-ingest-stale-publish.test.ts
+++ b/tests/modules/rag-ingest-stale-publish.test.ts
@@ -1,0 +1,344 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import {
+  createDocument,
+  registerRagIngestHandler,
+  updateDocument,
+} from "@/modules/rag/documents";
+import { EMBEDDING_DIM } from "@/modules/rag/embeddings";
+import { getJobHandler } from "@/modules/scheduler/worker";
+import { updateEmbeddingSettings } from "@/modules/tenant-settings/service";
+
+// Issue #163: editing a document WHILE it is being indexed used to discard the edit, silently.
+//
+// Chunking and embedding run outside any transaction (they are network I/O), which is minutes of
+// window on a large document. An edit landing in that window sets the row back to PENDING — that is
+// how a re-index is requested — and the in-flight run then published `READY` with no status guard,
+// erasing the marker the re-armed job needed. The re-armed job re-read the row, saw READY, and
+// returned; the row kept the new text and search kept the chunks built from the old one, forever.
+//
+// The guard is the publish itself: a run may only publish while the row is still PROCESSING, i.e.
+// while it is still the run that owns the document. It runs FIRST inside the replace-chunks
+// transaction, so a stale run also writes no chunks at all and search keeps answering from the last
+// consistent index instead of going wrong for a while.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+function ctx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}
+
+// The embedding provider, personified: an OpenAI-compatible /embeddings endpoint. It exists to hold
+// the request open, because the window this issue is about IS the duration of that call — a double
+// that returned instantly would never let an edit land mid-run.
+let embedServer: ReturnType<typeof Bun.serve> | undefined;
+let baseURL = "";
+// Fires once, while a request is in flight. This is the operator typing.
+let duringEmbed: (() => Promise<void>) | null = null;
+// 400 is deliberate: the OpenAI SDK retries 5xx, so a 500 would fire the run several times.
+let embedMode: "ok" | "reject" = "ok";
+const embedded: string[][] = [];
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+// happy-dom replaces the global Response, and Bun's TCP socket layer does not recognize the spec
+// one — tests/dom-setup.ts captures the native constructor for exactly this case.
+const BunRes = (globalThis as { BunResponse?: typeof Response })
+  .BunResponse as typeof Response;
+
+function json(body: unknown, status = 200): Response {
+  return new BunRes(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...cors },
+  });
+}
+
+function fakeVector(seed: number): number[] {
+  return Array.from({ length: EMBEDDING_DIM }, (_, i) =>
+    Number((((seed + 1) * (i + 1)) % 97) / 97),
+  );
+}
+
+// The OpenAI SDK asks for `encoding_format: "base64"` and decodes a Float32Array out of it. A double
+// that always answered with a plain number array would be decoded as garbage of the wrong width, so
+// the double answers in whichever format was asked for, the way the real endpoint does.
+function toBase64(vec: number[]): string {
+  const buf = new Float32Array(vec);
+  return Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength).toString(
+    "base64",
+  );
+}
+
+beforeAll(() => {
+  if (!dbUp) return;
+  embedServer = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      // The suite preloads happy-dom, so the OpenAI SDK takes the browser path and preflights.
+      if (req.method === "OPTIONS") {
+        return new BunRes(null, { status: 204, headers: cors });
+      }
+      if (!url.pathname.endsWith("/embeddings")) {
+        return new BunRes("not found", { status: 404, headers: cors });
+      }
+      const body = (await req.json()) as {
+        input: string[] | string;
+        encoding_format?: string;
+      };
+      const inputs = Array.isArray(body.input) ? body.input : [body.input];
+      embedded.push(inputs);
+      if (duringEmbed) {
+        const hook = duringEmbed;
+        duringEmbed = null;
+        await hook();
+      }
+      if (embedMode === "reject") {
+        return json(
+          { error: { message: "embedding rejected", type: "invalid_request" } },
+          400,
+        );
+      }
+      return json({
+        object: "list",
+        model: "text-embedding-3-small",
+        data: inputs.map((_, i) => ({
+          object: "embedding",
+          index: i,
+          embedding:
+            body.encoding_format === "base64"
+              ? toBase64(fakeVector(i))
+              : fakeVector(i),
+        })),
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      });
+    },
+  });
+  baseURL = `http://127.0.0.1:${embedServer.port}/v1`;
+});
+
+const tenants: bigint[] = [];
+
+async function seedTenant(slug: string): Promise<{ id: bigint; kb: bigint }> {
+  const t = await suDb.tenant.create({
+    data: { name: slug, slug: `${slug}-${process.pid}` },
+  });
+  tenants.push(t.id);
+  // The credential carries the baseURL (resolveEmbeddingStatus reads it off the secret), which is
+  // what points the ingest at the double above without unlocking the settings block.
+  const cred = await suDb.vaultEntry.create({
+    data: {
+      tenantId: t.id,
+      name: `${slug}-embed`,
+      kind: "generic",
+      status: "active",
+      secret: encryptJson({ apiKey: "test-key", baseURL }),
+    },
+  });
+  await updateEmbeddingSettings(
+    ctx(t.id),
+    { credentialRef: `vault:${cred.id}` },
+    appDb,
+  );
+  const kb = await suDb.knowledgeBase.create({
+    data: {
+      tenantId: t.id,
+      name: `${slug}-kb`,
+      embeddingModel: "text-embedding-3-small",
+      chunkSize: 1000,
+      chunkOverlap: 0,
+    },
+  });
+  return { id: t.id, kb: kb.id };
+}
+
+// The REAL job handler, the same entry point the scheduler uses.
+async function runIngest(tenantId: bigint, documentId: bigint) {
+  registerRagIngestHandler();
+  const handler = getJobHandler("RAG_INGEST");
+  if (!handler) throw new Error("RAG_INGEST handler not registered");
+  return handler(
+    {
+      id: 0n,
+      tenantId,
+      kind: "RAG_INGEST",
+      payload: { documentId: String(documentId) },
+      attempts: 0,
+    },
+    appDb,
+  );
+}
+
+async function readDoc(tenantId: bigint, id: bigint) {
+  return runScopedOn(appDb, ctx(tenantId), (db) =>
+    db.knowledgeDocument.findUniqueOrThrow({
+      where: { id },
+      select: { status: true, content: true, chunkCount: true },
+    }),
+  );
+}
+
+// What search actually reads. The document row is not the answer to this issue — the chunks are.
+async function readChunks(tenantId: bigint, id: bigint): Promise<string[]> {
+  const rows = await suDb.$queryRaw<{ content: string }[]>`
+    SELECT content FROM knowledge_chunks
+    WHERE tenant_id = ${tenantId} AND document_id = ${id}
+    ORDER BY id`;
+  return rows.map((r) => r.content);
+}
+
+afterAll(async () => {
+  embedServer?.stop(true);
+  if (!dbUp) return;
+  for (const id of tenants) {
+    await suDb.$executeRaw`DELETE FROM knowledge_chunks WHERE tenant_id = ${id}`;
+    await suDb.$executeRaw`DELETE FROM knowledge_documents WHERE tenant_id = ${id}`;
+    await suDb.$executeRaw`DELETE FROM knowledge_bases WHERE tenant_id = ${id}`;
+    await suDb.$executeRaw`DELETE FROM vault_entries WHERE tenant_id = ${id}`;
+    await suDb.$executeRaw`DELETE FROM scheduler_jobs WHERE tenant_id = ${id}`;
+    await suDb.$executeRaw`DELETE FROM tenants WHERE id = ${id}`;
+  }
+  await su?.$disconnect();
+  await app?.$disconnect();
+});
+
+describe.skipIf(!dbUp)(
+  "RAG ingest: an edit during indexing is not discarded",
+  () => {
+    test("baseline: an uncontended ingest indexes the document", async () => {
+      const { id, kb } = await seedTenant("rag-base");
+      const doc = await createDocument({
+        tenantId: id,
+        knowledgeBaseId: kb,
+        title: "policy",
+        sourceType: "text",
+        text: "ORIGINAL TEXT",
+        base: appDb,
+      });
+
+      await runIngest(id, doc.id);
+
+      expect(await readChunks(id, doc.id)).toEqual(["ORIGINAL TEXT"]);
+      const row = await readDoc(id, doc.id);
+      expect(row.status).toBe("READY");
+      expect(row.chunkCount).toBe(1);
+    });
+
+    // The issue's sequence, end to end: the effect it names is that search keeps reading the old text
+    // forever, so the assertion is on the chunks after the re-armed job has had its turn.
+    test("the edit lands in the index, not just in the row", async () => {
+      const { id, kb } = await seedTenant("rag-edit");
+      const doc = await createDocument({
+        tenantId: id,
+        knowledgeBaseId: kb,
+        title: "policy",
+        sourceType: "text",
+        text: "ORIGINAL TEXT",
+        base: appDb,
+      });
+
+      duringEmbed = async () => {
+        await updateDocument(id, doc.id, { text: "EDITED TEXT" }, appDb);
+      };
+      await runIngest(id, doc.id);
+
+      // The in-flight run must not have published: the row still carries the operator's re-index
+      // marker, which is the only thing that makes the re-armed job do any work.
+      const midway = await readDoc(id, doc.id);
+      expect(midway.content).toBe("EDITED TEXT");
+      expect(midway.status).toBe("PENDING");
+
+      // The re-armed job (step 6 of the issue) — the one that used to find READY and return.
+      await runIngest(id, doc.id);
+
+      expect(await readChunks(id, doc.id)).toEqual(["EDITED TEXT"]);
+      expect((await readDoc(id, doc.id)).status).toBe("READY");
+    });
+
+    // The same question one branch over: the FAILED write had no status guard either, so a stale run
+    // that errored stamped a failure for content the document no longer holds — and FAILED is just as
+    // effective at swallowing the re-index marker as READY is.
+    test("a stale run that fails does not stamp its failure on the edited document", async () => {
+      const { id, kb } = await seedTenant("rag-fail");
+      const doc = await createDocument({
+        tenantId: id,
+        knowledgeBaseId: kb,
+        title: "policy",
+        sourceType: "text",
+        text: "ORIGINAL TEXT",
+        base: appDb,
+      });
+
+      embedMode = "reject";
+      duringEmbed = async () => {
+        await updateDocument(id, doc.id, { text: "EDITED TEXT" }, appDb);
+      };
+      await runIngest(id, doc.id);
+      embedMode = "ok";
+
+      const midway = await readDoc(id, doc.id);
+      expect(midway.content).toBe("EDITED TEXT");
+      expect(midway.status).toBe("PENDING");
+
+      await runIngest(id, doc.id);
+
+      expect(await readChunks(id, doc.id)).toEqual(["EDITED TEXT"]);
+      expect((await readDoc(id, doc.id)).status).toBe("READY");
+    });
+
+    // Why the guard runs FIRST in the transaction rather than last: a stale run that publishes nothing
+    // must also delete nothing, or every edit would blank the index for as long as the re-index takes.
+    test("a stale run leaves the previous index intact while the re-index runs", async () => {
+      const { id, kb } = await seedTenant("rag-keep");
+      const doc = await createDocument({
+        tenantId: id,
+        knowledgeBaseId: kb,
+        title: "policy",
+        sourceType: "text",
+        text: "FIRST TEXT",
+        base: appDb,
+      });
+      await runIngest(id, doc.id);
+      expect(await readChunks(id, doc.id)).toEqual(["FIRST TEXT"]);
+
+      await updateDocument(id, doc.id, { text: "SECOND TEXT" }, appDb);
+      duringEmbed = async () => {
+        await updateDocument(id, doc.id, { text: "THIRD TEXT" }, appDb);
+      };
+      await runIngest(id, doc.id);
+
+      // Search still answers from the last index that was consistent with a real document version.
+      expect(await readChunks(id, doc.id)).toEqual(["FIRST TEXT"]);
+
+      await runIngest(id, doc.id);
+      expect(await readChunks(id, doc.id)).toEqual(["THIRD TEXT"]);
+    });
+  },
+);

--- a/tests/modules/rag-ingest-stale-publish.test.ts
+++ b/tests/modules/rag-ingest-stale-publish.test.ts
@@ -116,7 +116,7 @@ beforeAll(() => {
     port: 0,
     async fetch(req) {
       const url = new URL(req.url);
-      // The suite preloads happy-dom, so the OpenAI SDK takes the browser path and preflights.
+      // NOTE: The suite preloads happy-dom, so the OpenAI SDK takes the browser path and preflights.
       if (req.method === "OPTIONS") {
         return new BunRes(null, { status: 204, headers: cors });
       }
@@ -165,7 +165,7 @@ async function seedTenant(slug: string): Promise<{ id: bigint; kb: bigint }> {
     data: { name: slug, slug: `${slug}-${process.pid}` },
   });
   tenants.push(t.id);
-  // The credential carries the baseURL (resolveEmbeddingStatus reads it off the secret), which is
+  // NOTE: the credential carries the baseURL (resolveEmbeddingStatus reads it off the secret), which is
   // what points the ingest at the double above without unlocking the settings block.
   const cred = await suDb.vaultEntry.create({
     data: {
@@ -274,7 +274,7 @@ describe.skipIf(!dbUp)(
       expect(row.chunkCount).toBe(1);
     });
 
-    // The issue's sequence, end to end: the effect it names is that search keeps reading the old text
+    // NOTE: The issue's sequence, end to end: the effect it names is that search keeps reading the old text
     // forever, so the assertion is on the chunks after the re-armed job has had its turn.
     test("the edit lands in the index, not just in the row", async () => {
       const { id, kb } = await seedTenant("rag-edit");
@@ -292,20 +292,20 @@ describe.skipIf(!dbUp)(
       };
       await runIngest(id, doc.id);
 
-      // The in-flight run must not have published: the row still carries the operator's re-index
+      // NOTE: The in-flight run must not have published: the row still carries the operator's re-index
       // marker, which is the only thing that makes the re-armed job do any work.
       const midway = await readDoc(id, doc.id);
       expect(midway.content).toBe("EDITED TEXT");
       expect(midway.status).toBe("PENDING");
 
-      // The re-armed job (step 6 of the issue) — the one that used to find READY and return.
+      // NOTE: The re-armed job (step 6 of the issue) — the one that used to find READY and return.
       await runIngest(id, doc.id);
 
       expect(await readChunks(id, doc.id)).toEqual(["EDITED TEXT"]);
       expect((await readDoc(id, doc.id)).status).toBe("READY");
     });
 
-    // The same question one branch over: the FAILED write had no status guard either, so a stale run
+    // NOTE: The same question one branch over: the FAILED write had no status guard either, so a stale run
     // that errored stamped a failure for content the document no longer holds — and FAILED is just as
     // effective at swallowing the re-index marker as READY is.
     test("a stale run that fails does not stamp its failure on the edited document", async () => {
@@ -336,7 +336,7 @@ describe.skipIf(!dbUp)(
       expect((await readDoc(id, doc.id)).status).toBe("READY");
     });
 
-    // Why the guard runs FIRST in the transaction rather than last: a stale run that publishes nothing
+    // NOTE: Why the guard runs FIRST in the transaction rather than last: a stale run that publishes nothing
     // must also delete nothing, or every edit would blank the index for as long as the re-index takes.
     test("a stale run leaves the previous index intact while the re-index runs", async () => {
       const { id, kb } = await seedTenant("rag-keep");
@@ -357,14 +357,14 @@ describe.skipIf(!dbUp)(
       };
       await runIngest(id, doc.id);
 
-      // Search still answers from the last index that was consistent with a real document version.
+      // NOTE: Search still answers from the last index that was consistent with a real document version.
       expect(await readChunks(id, doc.id)).toEqual(["FIRST TEXT"]);
 
       await runIngest(id, doc.id);
       expect(await readChunks(id, doc.id)).toEqual(["THIRD TEXT"]);
     });
 
-    // Round 1 review, P2: the embed is not the only window. The run reads the document's text and
+    // NOTE: Round 1 review, P2: the embed is not the only window. The run reads the document's text and
     // takes the mark in two separate steps, and an edit landing BETWEEN them leaves the row PENDING
     // (the value it already had), so the claim still succeeds — carrying text the document no
     // longer has. The run then indexes the old text and publishes it legitimately, which is the
@@ -380,7 +380,7 @@ describe.skipIf(!dbUp)(
         base: appDb,
       });
 
-      // There is no network in this gap, so it needs a seam rather than the embedding double. The
+      // NOTE: There is no network in this gap, so it needs a seam rather than the embedding double. The
       // knowledge-base config read sits inside it, right after the document read.
       let fired = false;
       const hooked = appDb.$extends({


### PR DESCRIPTION
Editing a knowledge-base document **while it is being indexed** discarded the edit, silently and permanently.

## What was happening

Chunking and embedding run outside any transaction, deliberately — they are network I/O, and on a large document that is minutes. An edit landing in that window is not an accident: `updateDocument` writes the new text and sets `status = "PENDING"`, because setting the row back to PENDING *is* how a re-index is requested, and it re-arms the `RAG_INGEST` job on the same dedupe key.

The in-flight run then finished and committed:

```ts
db.knowledgeDocument.updateMany({
  where: { id: documentId },                       // no status guard
  data: { status: "READY", chunkCount, error: null },
})
```

That overwrote the `PENDING` the edit had just written. The scheduler side was fine — `completeJob` CASes on `CLAIMED`, so the re-arm survived — but the next tick's run re-read the document, found `READY`, and returned at `if (doc.status !== "PENDING") return null`.

The re-arm was consumed by a run that did nothing, because the previous run had erased the marker that run needed. The end state: the row holds the **new** text with `status = READY`, and the chunks search actually reads are the ones built from the **old** text. Nothing is left pending, no error is recorded, and the divergence is permanent until somebody edits the document again with different text.

The existing guard looks like it covers this and does not. `if (doc.status !== "PENDING") return null` exists to make a duplicate job harmless, and it does that correctly. What defeats it here is that the operator's edit sets the row back to `PENDING` **on purpose**, so the guard's input is written by the very event that needs to be honored, and then overwritten by the run that was already in flight.

## The change

`PENDING → PROCESSING` was already taken at the start of a run. It is now treated as a mark of ownership rather than a badge for the console: **a run may only act on the document while it still holds the mark.** That applies at both ends of the run.

**Taking it.** The mark and the text to index come from one transaction:

```ts
const claimed = await runScopedOn(base, sysCtx(tenantId), async (db) => {
  const { count } = await db.knowledgeDocument.updateMany({
    where: { id: documentId, status: "PENDING" },
    data: { status: "PROCESSING" },
  });
  if (count === 0) return null;
  return db.knowledgeDocument.findUnique({ where: { id: documentId }, select: { content: true } });
});
```

Reading them apart leaves a second window with the same outcome through a narrower door: an edit landing between a separate read and the mark leaves the row `PENDING` — the value it already had — so the claim still succeeds, over text the document no longer has. The `UPDATE` holds the row lock for the rest of the transaction, so the content read after it is the content as of the claim. The initial load no longer selects `content` at all, so no stale copy is left in scope. (This one came out of review, not the original report.)

**Releasing it.** The publish is conditional on the mark, and runs before the chunk writes:

```ts
const released = await db.knowledgeDocument.updateMany({
  where: { id: documentId, status: "PROCESSING" },
  data: { status: "READY", chunkCount: chunks.length, error: null },
});
if (released.count === 0) return false;
```

The order is load-bearing. A stale run returns having written nothing at all, so the previous index survives intact until the re-armed job replaces it — search keeps answering from the last consistent version instead of going empty for as long as a re-index takes. Guarding only the final status would still have run `deleteMany` + insert with the stale chunks. A live run holds that row lock for the rest of the transaction, so an edit cannot land between the release and the chunk writes it authorized.

**The `FAILED` write carries the same guard**, because it is the same question one branch over. A failure belongs to the content the run read; stamping it on a document that has since been edited reports the wrong thing *and* buries the re-index, since `FAILED` is no more `PENDING` than `READY` is and the re-armed job returns on it just the same. Leaving the row `PENDING` lets the re-armed job try the new content and report on its own. Its broadcast is gated on the write having landed, so the console is never told a status that was not written.

The guard also covers the bulk reindex, which sets `PENDING` across a base the same way an edit does, without needing to know about it.

## Validation scope

**Proven by test** (`tests/modules/rag-ingest-stale-publish.test.ts`, DB-backed, running the real `RAG_INGEST` handler through `getJobHandler`):

- an edit during indexing ends up **in the index**, not just in the row — asserted on the chunk contents after the re-armed job has had its turn, which is the effect the issue names;
- a stale run whose embedding **fails** does not stamp that failure on the edited document, and the re-armed job indexes the new text;
- a stale run leaves the **previous index intact** while the re-index runs (the reason the release is ordered first);
- what gets indexed is the text the **claim** froze, not text read before it — the edit is injected through a `$extends` query hook on the knowledge-base config read, from a second connection, because that read sits in the load→claim gap and there is no network in it to hook otherwise;
- an uncontended ingest still indexes normally.

The embedding provider is personified by an OpenAI-compatible `/embeddings` endpoint on a real socket, answering in `base64` like the real one. That is what creates the larger window: the test performs the operator's edit from inside the in-flight request, which is exactly where it happens in production. A double that returned instantly could not reproduce this at all.

Red before the change, with the issue's signature: `READY` where `PENDING` was expected, and the index permanently holding `ORIGINAL TEXT` while the row held `EDITED TEXT`.

**Proven by mutation** (each applied alone, against the final HEAD): dropping the status guard on the `READY` write kills 2 tests; dropping it on the `FAILED` write kills 1; making the release stop short-circuiting the chunk writes kills 1; restoring the separate content read kills 1. Full suite green (3194 pass, 0 fail).

**Removed rather than kept:** an early return when the `PENDING → PROCESSING` update itself matched no row. Mutation testing showed it killed no test, and reading the path back confirmed why — the load step already returns on any non-`PENDING` status, and in the only case that reaches it the publish guard produces the same outcome one step later. The `count === 0` check that remains is a different thing: it is what makes `claimed` null, which is what stops the run from using content it does not own.

**Not validated:** no live installation was involved. The issue was derived from the code path rather than from an observed report, and this change is verified the same way — the sequence is reproduced against a real Postgres and a real socket, but nobody has confirmed the divergence occurred in the field.

**Out of scope:** the scheduler-level cause, filed separately as #164 — a claimed row that is re-armed cannot be told apart from the claim still running it. This fix does not need it resolved, and does not resolve it.

Fixes #163
