### PR TITLE
Move the calendarId console note out of the model's turn

### DIFF
--- a/src/client/lib/toolpackTools.ts
+++ b/src/client/lib/toolpackTools.ts
@@ -34,6 +34,47 @@ export const TOOLPACK_TOOL_ICONS: Record<string, LucideIcon> = {
   drive_send_file: Send,
 };
 
+// An operator-only note about one ARGUMENT, shown on that argument's pill in the console.
+//
+// It lives here rather than in the tool's zod `.describe()` because the two audiences want opposite
+// things from that field: the model reads it on EVERY turn the tool is bound, and the operator reads
+// it once, in a list the console builds from the STATIC schema. `calendarId` is the case that made
+// the difference concrete (issue #118): `calendarArgSchema` removes the argument whenever the
+// integration has exactly one calendar, so the only context in which a model can read "this arg only
+// appears when there are several" is the one where it is already true — tokens spent every turn to
+// state a condition guaranteed by the fact that it can be read at all. The console shows the
+// argument regardless (it is keyed by catalogType, not by instance), so without this note an
+// operator has no way to know why their agent never receives an argument they can see documented.
+export function toolpackArgNote(
+  toolName: string,
+  argName: string,
+  t: TFunction,
+): string | null {
+  if (argName === "calendarId" && toolName.startsWith("calendar_")) {
+    return t(
+      "toolpackTools.argNote.calendarId",
+      "The agent only receives this argument when the integration allows several calendars; with a single one it is used automatically.",
+    );
+  }
+  return null;
+}
+
+// The backend's arg list (zod-derived) with the operator notes above folded into the description the
+// pill shows on hover. Every place that renders toolpack args goes through this, so a note is never
+// half-applied.
+export function withToolpackArgNotes<
+  A extends { name: string; description?: string | null },
+>(toolName: string, args: A[], t: TFunction): A[] {
+  return args.map((a) => {
+    const note = toolpackArgNote(toolName, a.name, t);
+    if (!note) return a;
+    return {
+      ...a,
+      description: a.description ? `${a.description} ${note}` : note,
+    };
+  });
+}
+
 export interface ToolpackToolMeta {
   label: string;
   description: string;

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1842,6 +1842,9 @@
     "light": "Light"
   },
   "toolpackTools": {
+    "argNote": {
+      "calendarId": "The agent only receives this argument when the integration allows several calendars; with a single one it is used automatically."
+    },
     "asaas_create_pix_charge": {
       "desc": "Open a PIX charge and return the copy-and-paste code plus the payment page.",
       "label": "PIX charge"

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1849,6 +1849,9 @@
     "light": "Claro"
   },
   "toolpackTools": {
+    "argNote": {
+      "calendarId": "O agente só recebe este argumento quando a integração permite vários calendários; com um só, ele é usado automaticamente."
+    },
     "asaas_create_pix_charge": {
       "desc": "Abre uma cobrança PIX e retorna o código copia-e-cola e a página de pagamento.",
       "label": "Gerar cobrança PIX"

--- a/src/client/pages/agents/ToolGrantsEditor.tsx
+++ b/src/client/pages/agents/ToolGrantsEditor.tsx
@@ -32,7 +32,10 @@ import {
 } from "@/client/components/mcp/DiscoveredMcpTools";
 import { api } from "@/client/lib/api";
 import { nativeToolMeta } from "@/client/lib/nativeTools";
-import { toolpackToolMeta } from "@/client/lib/toolpackTools";
+import {
+  toolpackToolMeta,
+  withToolpackArgNotes,
+} from "@/client/lib/toolpackTools";
 import { cn } from "@/client/lib/utils";
 import { IntegrationEditModal } from "@/client/pages/resources/IntegrationEditModal";
 import { McpEditModal } from "@/client/pages/resources/McpEditModal";
@@ -1105,7 +1108,13 @@ export function ToolGrantsEditor({
                                   <span>{meta.description}</span>
                                 )}
                                 {tool.args.length > 0 && (
-                                  <ToolArgPills args={tool.args} />
+                                  <ToolArgPills
+                                    args={withToolpackArgNotes(
+                                      tool.name,
+                                      tool.args,
+                                      t,
+                                    )}
+                                  />
                                 )}
                               </span>
                             }

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -35,7 +35,10 @@ import {
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { api } from "@/client/lib/api";
 import { credentialCompat } from "@/client/lib/credentialCompat";
-import { toolpackToolMeta } from "@/client/lib/toolpackTools";
+import {
+  toolpackToolMeta,
+  withToolpackArgNotes,
+} from "@/client/lib/toolpackTools";
 
 type CatalogData = Awaited<
   ReturnType<typeof api.api.v1.integrations.catalog.get>
@@ -1705,7 +1708,9 @@ export function IntegrationEditModal({
                           {meta.description}
                         </p>
                         {tool.args.length > 0 && (
-                          <ToolArgPills args={tool.args} />
+                          <ToolArgPills
+                            args={withToolpackArgNotes(tool.name, tool.args, t)}
+                          />
                         )}
                       </div>
                     );

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -517,10 +517,11 @@ const FOREIGN_EVENT =
 
 // NOTE: zod-optional but never optional in practice, for the tools that ACT on one calendar: the arg
 // is only ever EXPOSED when the integration allows several (calendarArgSchema), and then one of them
-// must be named or pickCalendarId refuses. The trailing sentence is for the operator reading the arg
-// list in the console, which is per-catalog and therefore always shows this field.
+// must be named or pickCalendarId refuses. What the model reads here is only what it needs to fill
+// the argument; the console's own explanation of WHY the arg can be absent is operator text and
+// lives in the frontend, translated, at `toolpackArgNote` (issue #118).
 const CALENDAR_ID_DESC =
-  "Which calendar to act on: name or id of one of the calendars in `<allowed_calendars>`. This arg only appears when the integration allows several calendars; with a single one it is used automatically.";
+  "Which calendar to act on: name or id of one of the calendars in `<allowed_calendars>`.";
 
 // NOTE: Availability is the ONE tool where omitting this is not a mistake but the default, and the
 // arg description is where that has to be said. The tool description already says so, but the model

--- a/tests/client/lib/toolpack-arg-notes.test.ts
+++ b/tests/client/lib/toolpack-arg-notes.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import type { TFunction } from "i18next";
+import {
+  toolpackArgNote,
+  withToolpackArgNotes,
+} from "@/client/lib/toolpackTools";
+import { getToolpackToolViews } from "@/modules/integrations/toolpacks";
+import "@/modules/integrations/toolpacks/google-calendar";
+
+// Issue #118. A toolpack argument's `.describe()` is read by two audiences with opposite needs: the
+// model, on every turn the tool is bound, and the operator, once, in the console's argument list.
+// The `calendarId` sentence about when the argument appears belonged only to the second one, and was
+// being paid for by the first.
+
+// The console passes i18next's `t`, which falls back to the default string when a key is missing.
+const t = ((_key: string, fallback: string) =>
+  fallback) as unknown as TFunction;
+
+const CALENDAR_TOOLS = [
+  "calendar_list_events",
+  "calendar_check_availability",
+  "calendar_create_event",
+  "calendar_update_event",
+  "calendar_cancel_event",
+  "calendar_confirm_appointment",
+];
+
+describe("the calendarId argument's two audiences", () => {
+  // NOTE: the tautology, stated as a property rather than as a string match on the old sentence: the
+  // model can only ever READ this text in the case where the condition it describes is already true,
+  // because calendarArgSchema removes the argument whenever the integration has one calendar.
+  test("no calendar tool's schema explains when the argument appears", () => {
+    const views = getToolpackToolViews("GOOGLE_CALENDAR");
+    expect(views.length).toBeGreaterThan(0);
+    for (const view of views) {
+      const arg = view.args.find((a) => a.name === "calendarId");
+      if (!arg?.description) continue;
+      expect(arg.description).not.toContain("only appears");
+      expect(arg.description).not.toContain("integration allows");
+    }
+  });
+
+  test("every calendar tool that takes the argument still tells the model how to fill it", () => {
+    const views = getToolpackToolViews("GOOGLE_CALENDAR");
+    const withArg = views.filter((v) =>
+      v.args.some((a) => a.name === "calendarId"),
+    );
+    expect(withArg.length).toBeGreaterThan(0);
+    for (const view of withArg) {
+      const arg = view.args.find((a) => a.name === "calendarId");
+      expect(arg?.description).toContain("<allowed_calendars>");
+    }
+  });
+
+  test("the operator's half is served by the note, on every calendar tool", () => {
+    for (const name of CALENDAR_TOOLS) {
+      expect(toolpackArgNote(name, "calendarId", t)).toContain(
+        "several calendars",
+      );
+    }
+  });
+
+  test("the note is scoped: not another argument, not another toolpack", () => {
+    expect(toolpackArgNote("calendar_create_event", "start", t)).toBeNull();
+    expect(toolpackArgNote("asaas_create_pix_charge", "calendarId", t)).toBe(
+      null,
+    );
+  });
+
+  // NOTE: the console renders the arg description as the pill's tooltip, so the note has to arrive
+  // fused with it — a note kept in a separate field would simply not be shown.
+  test("the note is appended to the description the pill shows", () => {
+    const [withNote, untouched] = withToolpackArgNotes(
+      "calendar_create_event",
+      [
+        { name: "calendarId", description: "Which calendar to act on." },
+        { name: "start", description: "ISO 8601." },
+      ],
+      t,
+    );
+    expect(withNote?.description).toStartWith("Which calendar to act on.");
+    expect(withNote?.description).toContain("several calendars");
+    expect(untouched?.description).toBe("ISO 8601.");
+  });
+
+  test("an argument with no description of its own still gets the note", () => {
+    const [only] = withToolpackArgNotes(
+      "calendar_cancel_event",
+      [{ name: "calendarId" } as { name: string; description?: string }],
+      t,
+    );
+    expect(only?.description).toContain("several calendars");
+  });
+});


### PR DESCRIPTION
`CALENDAR_ID_DESC` carried a sentence written for the operator and paid for by the model, on every turn six tools were bound:

> Which calendar to act on: name or id of one of the calendars in `<allowed_calendars>`. **This arg only appears when the integration allows several calendars; with a single one it is used automatically.**

The bolded half is tautological where the model reads it. `calendarArgSchema` removes `calendarId` from the schema whenever the instance has exactly one calendar, so the only context in which a model can read that sentence is the one where its condition is already true. Tokens spent every turn to state something guaranteed by the fact that it can be read at all.

For the operator it is genuinely load-bearing, and that is why it moves rather than being deleted. The console builds its argument list from the **static** schema (`getToolpackToolViews` → `argsFromZod`), keyed by `catalogType` rather than by instance, so it shows `calendarId` even for an integration with a single calendar. Without that sentence there is no way to find out why the agent never receives an argument the console documents.

## The change

`toolpackArgNote` in `src/client/lib/toolpackTools.ts` — beside `toolpackToolMeta`, which is already the translated home for operator-facing text about toolpack tools. The console renders an argument's description as the pill's tooltip, so the note is **fused into** that description by `withToolpackArgNotes` rather than kept in a field nothing renders; both places that show toolpack args go through it.

The zod `.describe()` keeps only what the model needs to fill the argument. Its comment now points at where the other half went, so the next person to wonder about the missing sentence finds it.

## Measured before deleting

This is prompt-facing, so the deletion was measured rather than assumed — a deletion is not free just because it removes text, and `calendar_create_event` / `calendar_cancel_event` have a real cost if the argument goes wrong.

Live, `gpt-5.4-mini`, three allowed calendars with friendly labels, n=16 per fixture across 4 fixtures (64 calls per arm), tools built through the real toolpack and bound to the model:

| | sentence kept | sentence removed |
| --- | ---: | ---: |
| booked the calendar the customer named | 58/64 | 61/64 |
| **named the wrong calendar** | **0** | **0** |
| **invented one outside `<allowed_calendars>`** | **0/16** | **0/16** |

Every miss in both arms is the same thing and it is not a wrong calendar: on the fixture where another allowed professional is named first as context ("the Dra. Ana saw me last year, but this time I'd like Dr. Bruno"), the model sometimes asks before booking instead of booking immediately. That is defensible behaviour and the sentence has nothing to do with it.

**The honest caveat:** correct-calendar-given-a-call is 100% in both arms (58/58 and 61/61), so the instrument is saturated on the property that matters and could not have shown a small effect. What the battery supports is "no wrong or invented calendar in 119 calls across both arms", not "provably identical".

The fourth fixture exists because the first three saturate at 16/16 on their own: it asks for a professional who is **not** in the allowed list, where the failure mode is the one this argument's description actually guards against (the #98 shape — inventing a value that never resolves, so the tool refuses on a calendar it could have used). Zero in both arms.

## Validation scope

**Proven by test** (`tests/client/lib/toolpack-arg-notes.test.ts`): no calendar tool's schema explains when the argument appears; every calendar tool that exposes it still tells the model how to fill it (`<allowed_calendars>`); the note is returned for `calendarId` on all six calendar tools and for nothing else; and it arrives fused into the description the pill renders, including for an argument with no description of its own.

**Proven by mutation** (each alone): letting the operator sentence creep back into the schema fails 1; deleting the model's half as well fails 1; unscoping the note from calendar tools fails 2; keeping the note out of the rendered description fails 2.

**The wider sweep the issue asked for**, over every toolpack argument description: nothing else explains the console. The remaining long ones tell the model how to decide the call — "defaults to the integration's setting" says omitting is safe and yields a sensible default, "never shown back to the customer" is an instruction about the reply, and `AVAILABILITY_CALENDAR_ID_DESC` argues for omission on the one tool where omitting is the point.

**Not validated:** the battery ran on one model from one vendor. A different or smaller model could weigh the argument description differently, and n=64 per arm cannot resolve a small difference.

Fixes #118
