### PR TITLE
Retire risk_tier from the client, so the column can be dropped next release

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -839,12 +839,23 @@ model ToolDefinition {
   body          Json     @default("{}")
   credentialRef String?  @map("credential_ref")
   enabled       Boolean  @default(true)
-  // NOTE: RETIRED and unread. Nothing selects, writes or projects this any more (issue #137); the
-  // column survives one release on purpose, because an operator who rolls the image back would
-  // otherwise land a build that still selects it and gets `undefined_column` on every tool screen,
-  // with no way back except rolling forward. The default keeps inserts working for the code that no
-  // longer sets it. Dropped by migration in the release after this one; see issue #149.
-  riskTier      String   @default("medium") @map("risk_tier")
+  // NOTE: RETIRED (issue #137). `@ignore` is what retires it: the field leaves the generated client
+  // entirely, so no query this build sends NAMES the column and reading it is a compile error, while
+  // the column itself stays in the database and in the migration history (`migrate diff` across this
+  // attribute is an empty migration).
+  //
+  // Not naming it is the point, and it is a stronger condition than not reading it: a Prisma query
+  // without an explicit `select` asks for every scalar column of the model, and so does a relation
+  // pulled in as `toolDefinition: true`, so a call site that never touches the field still puts it
+  // in the SQL. An older image running such a query after the column is dropped answers
+  // `undefined_column`. Measured on v1.9.0 against a database with the column already gone: the
+  // agent export and saving a tool both failed, and only the one read with an explicit select kept
+  // working, which is the opposite of what auditing the SELECT lists suggests (issue #149).
+  //
+  // So the drop belongs one release after THIS attribute, not one release after #137: rolling back
+  // now lands on a build that still asks for the column. Dropping it is then this line's removal
+  // plus the migration `migrate diff` already writes.
+  riskTier      String   @default("medium") @map("risk_tier") @ignore
   // HTTP statuses this tool declares as RESULTS rather than integration failures. Empty (the
   // default) keeps issue #40's behavior, where every non-2xx is logged warn and reaches the alert
   // channels. A declarative lookup that answers 404 for "no record" lists it here so a healthy turn

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -87,6 +87,12 @@ const exportedGrantSchema = z.discriminatedUnion("source", [
 // import). Knowledge bases carry metadata; their documents' SOURCE TEXT is bundled only with the
 // separate ?documents opt-in (re-chunked + re-embedded at the destination — embeddings/chunks, being
 // derived and model-specific, are never exported).
+// Wire-format constant, not data. `tool_definitions.risk_tier` is `@ignore`d in the schema (issue
+// #149), so the field is not on the row here and reading it would not compile: the export writes
+// this instead. The KEY stays on the wire for the reason spelled out on `riskTier` below, and the
+// value is arbitrary because no build in any supported version acts on it.
+const RETIRED_RISK_TIER = "medium";
+
 const exportedHttpToolSchema = z.object({
   name: z.string(),
   label: z.string().nullable().optional(),
@@ -100,12 +106,16 @@ const exportedHttpToolSchema = z.object({
   // Optional so exports produced before query existed still import (defaults to {}).
   query: z.record(z.string(), z.unknown()).optional(),
   body: z.record(z.string(), z.unknown()),
-  // Retired (issue #137) and read by nothing. Still ECHOED on export, and optional here, because
-  // the bundle format is versioned as a whole (`version: z.literal(1)`): an instance one release
-  // behind still requires this key, so omitting it would make every bundle this build produces
-  // unimportable there, and bumping the version would only trade that for a cleaner refusal while
-  // also making THIS build reject every v1 bundle. Optional in both directions, so a bundle written
-  // after #149 drops the column still imports. Never written back — the column keeps its default.
+  // Retired (issue #137) and read by nothing. The KEY outlives the column, and outlives the schema
+  // ignoring it, because they are different compatibility surfaces. A rollback is one operator on one instance minutes apart,
+  // which is what #149's one-release wait bounds; a bundle is a file handed to ANOTHER instance at
+  // an arbitrary version, and the format is versioned as a whole (`version: z.literal(1)`), so an
+  // instance one release behind parses our bundle with a schema where this key is REQUIRED.
+  // Omitting it would make every bundle this build writes unimportable there, and bumping the
+  // version would only trade that for a cleaner refusal while also making THIS build reject every
+  // v1 bundle. So the export echoes RETIRED_RISK_TIER instead of the row, and this stays optional
+  // in both directions: a bundle written after the column is dropped still imports, and one written
+  // before it does too, with the value discarded on the way in.
   riskTier: z.string().optional(),
   ackEnabled: z.boolean(),
   ackMessage: z.string().nullable().optional(),
@@ -600,7 +610,7 @@ export async function exportAgent(
           outputSchema: (r.outputSchema ?? {}) as Record<string, unknown>,
           query: (r.query ?? {}) as Record<string, unknown>,
           body: (r.body ?? {}) as Record<string, unknown>,
-          riskTier: r.riskTier,
+          riskTier: RETIRED_RISK_TIER,
           ackEnabled: r.ackEnabled,
           ackMessage: r.ackMessage,
           credentialRef: r.credentialRef,

--- a/tests/modules/agent-transfer.test.ts
+++ b/tests/modules/agent-transfer.test.ts
@@ -778,11 +778,15 @@ describe.skipIf(!dbUp)("agent export/import with components", () => {
     });
   });
 
-  test("a bundle this build produces still carries riskTier, for an older importer (issue #137)", async () => {
-    // The other direction of the same compatibility. The bundle format is versioned as a whole, so
-    // an instance one release behind parses OUR bundle with a schema where `riskTier` is REQUIRED —
-    // dropping the key from the export would make every bundle this build writes unimportable there.
-    // The literal below stands in for that older required-field check.
+  test("a bundle this build produces still carries riskTier, for an older importer (issues #137, #149)", async () => {
+    // The other direction of the same compatibility, and the reason the KEY outlives the column.
+    // The bundle format is versioned as a whole, so an instance one release behind parses OUR bundle
+    // with a schema where `riskTier` is REQUIRED — dropping the key from the export would make every
+    // bundle this build writes unimportable there. Since #149 the value is a constant rather than
+    // the row's, because the schema `@ignore`s the column so this build never names it in SQL, which
+    // is what lets the next release drop it. What this pins is the SHAPE the
+    // older importer requires, which is all that stands between a bundle and a validation failure at
+    // the destination. The literal below stands in for that older required-field check.
     const exp = await exportAgent(srcCtx(), srcAgentId, appDb, {
       includeComponents: true,
     });

--- a/tests/modules/tool-definition-column-naming.test.ts
+++ b/tests/modules/tool-definition-column-naming.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+
+// `tool_definitions.risk_tier` is retired (issue #137) and comes out one release after the schema
+// stopped naming it (issue #149). What makes that drop safe is NOT that no code reads the value: it
+// is that no query this build sends NAMES the column, because an operator who rolls back, or whose
+// platform overlaps containers during a rolling deploy, runs THIS build against a database where
+// the column is already gone.
+//
+// The two are easy to confuse, and the first attempt at #149 did: it read the tool-definitions
+// service's explicit SELECT list, found nothing, and concluded the column was unnamed. A Prisma
+// query without an explicit `select` asks for every scalar column of the model, and a relation
+// pulled in as `toolDefinition: true` does the same, so three queries were naming it.
+//
+// `@ignore` on the field is what fixes that, and it is checked here rather than trusted: it removes
+// the field from the generated client, so the column cannot appear in any query shape and reading it
+// does not compile. The cases below are the four shapes that were, or could have been, naming it.
+
+// Driven with the migration role, which is not subject to row security. What is under test is the
+// SQL the CLIENT composes, which the connecting role does not change, and the alternative is that a
+// write rejected by RLS emits no query event at all (Prisma only reports statements that succeeded),
+// so the insert below would silently assert on an empty list.
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let client: PrismaClient | undefined;
+let tenantId = 0n;
+const sql: string[] = [];
+if (suUrl) {
+  try {
+    client = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+      log: [{ emit: "event", level: "query" }],
+    });
+    // @ts-expect-error the event map is only typed when `log` is a literal on the constructor type
+    client.$on("query", (e: { query: string }) => sql.push(e.query));
+    await client.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const db = client as PrismaClient;
+
+beforeAll(async () => {
+  if (!dbUp) return;
+  const tenant = await db.tenant.create({
+    data: { name: "RT", slug: `rt-${process.pid}` },
+  });
+  tenantId = tenant.id;
+});
+
+afterAll(async () => {
+  if (dbUp && tenantId) {
+    await db.tenant.delete({ where: { id: tenantId } });
+  }
+  await client?.$disconnect();
+});
+
+// What is under test is the SQL the client SENDS, not what comes back, so the reads below match
+// nothing on purpose. The insert is the exception: a statement the database rejects emits no query
+// event, so it has to succeed, and it is cleaned up with the tenant it hangs off.
+const sqlFor = async (fn: () => Promise<unknown>): Promise<string[]> => {
+  sql.length = 0;
+  await fn().catch(() => undefined);
+  return sql.filter((q) => q.includes("tool_definitions"));
+};
+
+describe.skipIf(!dbUp)("no query names the retired column", () => {
+  test("a read that lets Prisma choose the columns", async () => {
+    const queries = await sqlFor(() =>
+      db.toolDefinition.findMany({ where: { id: { in: [-1n] } } }),
+    );
+    expect(queries.length).toBeGreaterThan(0);
+    expect(queries.some((q) => q.includes("risk_tier"))).toBe(false);
+  });
+
+  test("a write whose returned row nobody reads", async () => {
+    const queries = await sqlFor(() =>
+      db.toolDefinition.update({ where: { id: -1n }, data: { label: "x" } }),
+    );
+    expect(queries.length).toBeGreaterThan(0);
+    expect(queries.some((q) => q.includes("risk_tier"))).toBe(false);
+  });
+
+  // The shape that matches no call-site pattern, so no source-level guard would find it, and the one
+  // the customer-facing turn path uses to load an agent's granted tools.
+  test("a relation pulled in whole", async () => {
+    const queries = await sqlFor(() =>
+      db.agentToolSelection.findMany({
+        where: { agentId: -1n },
+        include: { toolDefinition: true },
+      }),
+    );
+    expect(queries.length).toBeGreaterThan(0);
+    expect(queries.some((q) => q.includes("risk_tier"))).toBe(false);
+  });
+
+  // An INSERT names its columns too, and this one is reached by importing an agent bundle. The row
+  // still gets the column's default in the database; it is the statement that must not mention it.
+  test("an insert", async () => {
+    const queries = await sqlFor(() =>
+      db.toolDefinition.create({
+        data: {
+          tenantId,
+          name: `probe-${process.pid}`,
+          label: "probe",
+          urlTemplate: "https://example.invalid",
+          allowedHosts: [],
+        },
+      }),
+    );
+    expect(queries.length).toBeGreaterThan(0);
+    expect(queries.some((q) => q.includes("risk_tier"))).toBe(false);
+  });
+
+  // The control. Without it every assertion above would also pass on a client that had stopped
+  // querying this table at all, or on a filter that stopped matching the table's name.
+  test("and the check itself can see the column when it is there", async () => {
+    const queries = await sqlFor(
+      () => db.$queryRaw`SELECT risk_tier FROM tool_definitions WHERE id = -1`,
+    );
+    expect(queries.some((q) => q.includes("risk_tier"))).toBe(true);
+  });
+});


### PR DESCRIPTION
> **This PR changed shape twice.** It opened as the `DROP COLUMN` #149 asks for; round 1 refuted the premise; round 2 found a hole in the first fix. What it does now is one schema attribute, and the drop itself moves to the next release with #149 staying open. The discarded versions are kept below because the wrong ones are the informative part.

## What was wrong

`tool_definitions.risk_tier` has been unread since #137, so dropping it looked like a one-line migration. The check I ran was the tool-definitions service's explicit `SELECT` list, which does not name the column, and I concluded that v1.9.0, the build an operator lands on when rolling back, never asks for it.

**A Prisma query without an explicit `select` asks for every scalar column of the model**, and a relation pulled in as `toolDefinition: true` does the same. A call site that never touches the field still names it in the SQL, so "no code reads the value" is not the condition that makes a drop safe.

Measured, with the v1.9.0 client against a database where the column is already dropped:

```
FAILS  transfer.ts:  findMany without select (agent export)
       The column `tool_definitions.risk_tier` does not exist in the current database.
FAILS  service.ts:   update without select (saving a tool)
       The column `tool_definitions.risk_tier` does not exist in the current database.
OK     service.ts:   findMany with an explicit select (the tools screen)
```

So both cases #137's one-release wait exists for, a rollback to v1.9.0 and the container overlap of a rolling deploy, break on the agent export and on saving a tool. The screen that auditing the SELECT lists points at is the one that keeps working.

## What this does

One attribute. `@ignore` removes the field from the generated client, so no query shape can name the column and reading it does not compile, while the column stays in the database and in the migration history:

```
migrate diff  across @ignore            -- This is an empty migration.
migrate diff  across the field's removal  ALTER TABLE "tool_definitions" DROP COLUMN "risk_tier";
```

The second line is what the next release carries, once rolling back lands on this build.

**Chosen over explicit `select`s at each call site**, which is what the first fix did (three of them, plus a source scan to keep the next one honest). That version has to enumerate the shapes that name a column, and round 2 found the one it missed: a relation written as `toolDefinition: true`, which matches no call-site pattern. The schema attribute makes the invariant true by construction rather than policing call sites, and it covers the ones nobody has written yet.

Prisma's global `omit` on the client was the other candidate and is worse here: it re-types `PrismaClient` with the omit config, which does not match the bare `PrismaClient` this codebase threads through **89 files**, and a call site can still override it with an explicit `select` or `omit: { field: false }`. `@ignore` has neither problem.

The export now writes a constant where it echoed the row's value, because the field is not on the row any more, and the compiler says so:

```
error TS2339: Property 'riskTier' does not exist on type '{ id: bigint; … }'
```

The wire key is untouched: still written on every bundle, for the older importer whose schema requires it. A bundle imported on v1.8.0 or earlier records `"medium"` rather than the source's tier, which is metadata no surface on that build acted on either (#137).

## The test

It drives the four shapes that were, or could have been, naming the column, and asserts on the SQL the client **sends** rather than on what comes back:

| shape | reached by |
| --- | --- |
| a read that lets Prisma choose the columns | the agent export |
| a write whose returned row nobody reads | saving a tool |
| a relation pulled in whole | loading an agent's granted tools, on the customer-facing turn |
| an insert | importing an agent bundle |

Plus a raw `SELECT risk_tier` as the control, so the check cannot pass by having stopped looking at the table. Removing `@ignore` fails all four and leaves the control green.

Two things that shaped it: the insert has to succeed, because a statement the database rejects emits no query event at all and the assertion would then be made against an empty list; and it runs as the migration role for the same reason, since row security rejects the write.

## Validation scope

**Proven by test.** Full suite green on both trees at this commit: 3340 on the source tree, 3306 on the derived public tree. Plus the two bundle-compatibility tests #137 left, which still pass unchanged.

**Measured, not committed as a test.** The rollback failures at the top need two builds at once (the v1.9.0 client against a v1.10.0 database), so they are recorded here and on #149 rather than in the suite. The `migrate diff` output above is reproducible from this tree.

**Not validated live.** No deployment was exercised.

Part of #149.
