### PR TITLE
Give a claim a token, so a superseded run cannot finish someone else's arm

### DIFF
--- a/prisma/migrations/20260821120000_scheduler_claim_seq/migration.sql
+++ b/prisma/migrations/20260821120000_scheduler_claim_seq/migration.sql
@@ -1,0 +1,8 @@
+-- Issue #164. A job row could not answer "is the claim I am holding still the current one": every
+-- write that finishes a job CAS'd on (id, status = 'CLAIMED') and nothing more, while enqueueJob
+-- re-arms the SAME physical row back to PENDING. The claim now bumps this counter and hands the
+-- value to the handler, so a superseded run's CAS finds nothing to update.
+--
+-- Additive with a default, so it is safe across a rolling deploy and safe to roll back to: the
+-- previous image names its own columns and never this one.
+ALTER TABLE "scheduler_jobs" ADD COLUMN "claim_seq" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1075,6 +1075,10 @@ model SchedulerJob {
   runAt     DateTime           @map("run_at")
   attempts  Int                @default(0)
   claimedAt DateTime?          @map("claimed_at")
+  // Which claim on this row is the current one. The claim BUMPS it and hands the value to the
+  // handler; the three writes that finish a job CAS on it, so a run whose claim was superseded
+  // writes nothing instead of landing on work it does not own (issue #164).
+  claimSeq  Int                @default(0) @map("claim_seq")
   lastError String?            @map("last_error")
   createdAt DateTime           @default(now()) @map("created_at")
   updatedAt DateTime           @updatedAt @map("updated_at")

--- a/src/modules/memory/worker.ts
+++ b/src/modules/memory/worker.ts
@@ -58,19 +58,24 @@ export function defaultBatchSize(
 // The rows this process is executing RIGHT NOW, excluded from the CLAIM ITSELF rather than filtered
 // after it. `enqueueJob` re-arms by upserting the same physical row back to PENDING, status and all,
 // so a new attendance arming this key while its summary is still running makes the row claimable
-// again. Claiming it a second time is what does the damage, in both directions: a second handler
-// cuts an overlapping raw prefix and writes a second durable summary under a different last-message
-// id (the memory head then describes the same events twice), and the handler still running completes
-// the newer arm out from under it, since both are guarded only by id + CLAIMED — after which no
-// future boundary re-arms that attendance and it is never compacted.
+// again, and claiming it a second time damages this kind in two directions.
 //
-// Never claimed, that same CAS becomes the protection: the stale completion does not match a PENDING
-// row, the re-arm survives, and the next tick picks it up once its owner is done.
+// The SECOND direction is now handled generally and no longer needs this set: the handler still
+// running used to complete the newer arm out from under it (both guarded only by id + CLAIMED),
+// after which no future boundary re-armed that attendance and it was never compacted. The claim
+// token added in issue #164 refuses that write for every kind.
+//
+// The FIRST direction is why this stays. Two handlers that overlap each cut a raw prefix and each
+// pay for a summary — a model call with a 60s ceiling, taken from the same semaphore a customer's
+// turn queues on — and the writes are settled downstream by the generation fence in compact.ts
+// rather than by anything up here, so the second one's model call is bought and thrown away. Nothing
+// about a claim token makes work cheaper; it decides which write lands. This kind is the one that
+// holds a claim long enough for the overlap to be ordinary rather than theoretical, which is exactly
+// the reason it was the first to need the set and still the only one that has it.
 //
 // Per-process, which is what these workers already are by construction (single replica, globalThis
-// singleton). The general form — any kind, any handler — needs a claim generation on the row and is
-// not this PR's to fix; this closes the window that is wide, because only this kind holds a claim
-// for up to a minute while every attendance boundary re-arms it.
+// singleton). A second replica reintroduces the overlap, and the token is what keeps that merely
+// wasteful instead of corrupting.
 const inFlight = new Set<bigint>();
 
 export interface CompactionTickDeps {

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -324,7 +324,7 @@ export async function failJob(
   error: string,
   base: PrismaClient = basePrisma,
   now: Date = new Date(),
-): Promise<{ deadLettered: boolean }> {
+): Promise<{ deadLettered: boolean; applied: boolean }> {
   const next = attempts + 1;
   const dead = next >= MAX_ATTEMPTS;
   const { count } = await runScopedOn(base, sysCtx(tenantId), (db) =>
@@ -340,7 +340,11 @@ export async function failJob(
           },
     }),
   );
-  return { deadLettered: dead && count > 0 };
+  // `deadLettered` alone cannot carry this: false is also what a healthy non-terminal retry returns,
+  // so the caller cannot tell a recorded failure from one the guard refused. Reported separately for
+  // the same reason completeJob reports it (issue #164 review round 2) — the failure ordering is no
+  // less invisible than the success one.
+  return { deadLettered: dead && count > 0, applied: count > 0 };
 }
 
 // Reaper: a CLAIMED row older than `staleMs` is presumed crashed → back to PENDING (attempts++ so

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -261,24 +261,31 @@ export function claimDueCompactionJobs(
 // Terminal success. `claimSeq` is the token the claim handed out: without it the CAS matches
 // whatever CLAIMED row happens to exist, which is how a run that finished late marked SOMEONE ELSE'S
 // arm done (issue #164).
+//
+// Returns whether the write LANDED, for the same reason failJob returns whether it dead-lettered: a
+// CAS that refuses is the only evidence that this run was superseded, and refusing in silence is how
+// the ordering stays invisible — which is the complaint the token was added to answer, not one to
+// reproduce one layer down. The caller decides what to do with it; runClaimed logs it.
 export async function completeJob(
   tenantId: bigint,
   id: bigint,
   claimSeq: number,
   base: PrismaClient = basePrisma,
-): Promise<void> {
-  await runScopedOn(base, sysCtx(tenantId), (db) =>
+): Promise<{ applied: boolean }> {
+  const { count } = await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.schedulerJob.updateMany({
       where: { id, status: "CLAIMED", claimSeq },
       data: { status: "DONE" },
     }),
   );
+  return { applied: count > 0 };
 }
 
 // Not a failure (e.g. out-of-hours): back to PENDING at a new time, attempts UNCHANGED. An optional
 // `payload` REPLACES the row's payload (used to advance a multi-step follow-up's stepIndex on the
 // same row — the dedupeKey is stable, so this never races the upsert vs the completeJob CAS). Omit
 // it to keep the current payload.
+// Returns whether the write LANDED — see completeJob.
 export async function rescheduleJob(
   tenantId: bigint,
   id: bigint,
@@ -286,8 +293,8 @@ export async function rescheduleJob(
   runAt: Date,
   payload?: Record<string, unknown>,
   base: PrismaClient = basePrisma,
-): Promise<void> {
-  await runScopedOn(base, sysCtx(tenantId), (db) =>
+): Promise<{ applied: boolean }> {
+  const { count } = await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.schedulerJob.updateMany({
       where: { id, status: "CLAIMED", claimSeq },
       data: {
@@ -299,6 +306,7 @@ export async function rescheduleJob(
       },
     }),
   );
+  return { applied: count > 0 };
 }
 
 // Failure: attempts++; retry with backoff until the cap, then DEAD.

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -2,7 +2,20 @@ import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 
-// Durable job store for the scheduler (follow-ups, sweeps, retries). The CLAIM is cross-tenant —
+// Durable job store for the scheduler (follow-ups, sweeps, retries).
+//
+// A claim carries a TOKEN (`claimSeq`), and the three writes that finish a job CAS on it. The reason
+// is that a row is re-armed IN PLACE: `enqueueJob` upserts the same physical row back to PENDING, so
+// "the row is CLAIMED" never distinguished the run holding the claim from a later one. Guarded on
+// status alone, a handler that finished late marked whatever arm existed DONE, and the work that arm
+// stood for was never done by anyone (issue #164).
+//
+// The bump lives on the CLAIM and nowhere else, which is enough for both orderings and is why
+// `enqueueJob` does not touch it. A re-arm that is not claimed again leaves the row PENDING, and the
+// old CAS already refuses that; a re-arm that IS claimed again bumps past the token the first run
+// holds. Adding a second bump on the re-arm would buy nothing and put a write on a hot path.
+//
+// The CLAIM is cross-tenant —
 // it must see every tenant's due jobs — so it runs via asSuperAdmin with FOR UPDATE SKIP LOCKED;
 // the GUC is transaction-local (set_config(...,true)) so it never leaks to the next request on a
 // pooled connection. Each job's EFFECT and status update run under the job's OWN tenant scope
@@ -33,6 +46,9 @@ export interface ClaimedJob {
   kind: SchedulerJobKind;
   payload: Record<string, unknown>;
   attempts: number;
+  // The token this claim holds. Hand it back to completeJob/rescheduleJob/failJob: those three CAS
+  // on it, so a run that was superseded while it worked writes nothing (issue #164).
+  claimSeq: number;
 }
 
 export interface EnqueueParams {
@@ -137,11 +153,12 @@ async function claimWhere(
   now: Date,
   kindFilter: Prisma.Sql,
   tenantId?: bigint,
-  // Rows this process is already executing. They must not be CLAIMED again: `enqueueJob` re-arms by
-  // upserting the same physical row back to PENDING, and claiming it a second time is what lets the
-  // handler still running complete the newer arm out from under it (both are guarded on
-  // id + CLAIMED). Left PENDING, that same CAS is what PROTECTS it — the stale completion simply
-  // does not match — and the row is claimed on a later tick, once its owner is done.
+  // Rows this process is already executing, kept out of the claim itself. Since `claimSeq` this is no
+  // longer what stops a stale completion — the CAS does that for every kind — so what it still buys
+  // is narrower and worth naming: it stops the same key from being EXECUTED twice at once. For a
+  // caller whose handler is expensive (a summary is a model call held for up to 60s while every
+  // attendance boundary re-arms the same key), two concurrent runs mean two model calls paid for,
+  // and only one of them can land. See src/modules/memory/worker.ts.
   excludeIds?: bigint[],
 ): Promise<ClaimedJob[]> {
   const lim = Math.min(Math.max(Math.floor(limit), 1), 100);
@@ -159,9 +176,11 @@ async function claimWhere(
         kind: SchedulerJobKind;
         payload: unknown;
         attempts: number;
+        claimSeq: number;
       }>
     >(Prisma.sql`
-      UPDATE scheduler_jobs SET status = 'CLAIMED', claimed_at = ${now}, updated_at = now()
+      UPDATE scheduler_jobs
+      SET status = 'CLAIMED', claim_seq = claim_seq + 1, claimed_at = ${now}, updated_at = now()
       WHERE id IN (
         SELECT id FROM scheduler_jobs
         WHERE status = 'PENDING' AND run_at <= ${now} AND ${kindFilter}
@@ -170,13 +189,14 @@ async function claimWhere(
         FOR UPDATE SKIP LOCKED
         LIMIT ${lim}
       )
-      RETURNING id, tenant_id AS "tenantId", kind, payload, attempts`);
+      RETURNING id, tenant_id AS "tenantId", kind, payload, attempts, claim_seq AS "claimSeq"`);
     return rows.map((r) => ({
       id: r.id,
       tenantId: r.tenantId,
       kind: r.kind,
       payload: (r.payload ?? {}) as Record<string, unknown>,
       attempts: r.attempts,
+      claimSeq: r.claimSeq,
     }));
   });
 }
@@ -238,15 +258,18 @@ export function claimDueCompactionJobs(
   );
 }
 
-// Terminal success.
+// Terminal success. `claimSeq` is the token the claim handed out: without it the CAS matches
+// whatever CLAIMED row happens to exist, which is how a run that finished late marked SOMEONE ELSE'S
+// arm done (issue #164).
 export async function completeJob(
   tenantId: bigint,
   id: bigint,
+  claimSeq: number,
   base: PrismaClient = basePrisma,
 ): Promise<void> {
   await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.schedulerJob.updateMany({
-      where: { id, status: "CLAIMED" },
+      where: { id, status: "CLAIMED", claimSeq },
       data: { status: "DONE" },
     }),
   );
@@ -259,13 +282,14 @@ export async function completeJob(
 export async function rescheduleJob(
   tenantId: bigint,
   id: bigint,
+  claimSeq: number,
   runAt: Date,
   payload?: Record<string, unknown>,
   base: PrismaClient = basePrisma,
 ): Promise<void> {
   await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.schedulerJob.updateMany({
-      where: { id, status: "CLAIMED" },
+      where: { id, status: "CLAIMED", claimSeq },
       data: {
         status: "PENDING",
         runAt,
@@ -279,13 +303,15 @@ export async function rescheduleJob(
 
 // Failure: attempts++; retry with backoff until the cap, then DEAD.
 // Returns whether this call is the one that DEAD-LETTERED the job — the attempt count alone does not
-// say so. The CAS is on `status = 'CLAIMED'`, and a job re-armed mid-run (`armDebounce` upserts the
-// claimed row back to PENDING) no longer matches it: the row survives with another run already
-// queued, so a caller reading `attempts` would call a live job dead. Anything hanging off "this work
-// is definitively lost" has to hang off this, not off the failure (issue #71).
+// say so. The CAS is on `status = 'CLAIMED'` AND on the claim's own token, so a job re-armed mid-run
+// (`armDebounce` upserts the claimed row back to PENDING) fails to match on either count: the row
+// survives with another run already queued, and a caller reading `attempts` would call a live job
+// dead. Anything hanging off "this work is definitively lost" has to hang off this, not off the
+// failure (issue #71).
 export async function failJob(
   tenantId: bigint,
   id: bigint,
+  claimSeq: number,
   attempts: number,
   error: string,
   base: PrismaClient = basePrisma,
@@ -295,7 +321,7 @@ export async function failJob(
   const dead = next >= MAX_ATTEMPTS;
   const { count } = await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.schedulerJob.updateMany({
-      where: { id, status: "CLAIMED" },
+      where: { id, status: "CLAIMED", claimSeq },
       data: dead
         ? { status: "DEAD", attempts: next, lastError: error.slice(0, 500) }
         : {
@@ -344,6 +370,7 @@ export async function reapStaleJobs(
         kind: string;
         payload: unknown;
         attempts: number;
+        claim_seq: number;
         status: "PENDING" | "DEAD";
       }>
     >(Prisma.sql`
@@ -353,13 +380,14 @@ export async function reapStaleJobs(
           claimed_at = NULL,
           updated_at = now()
       WHERE status = 'CLAIMED' AND claimed_at < ${cutoff} ${tenantClause} ${kindClause}
-      RETURNING id, tenant_id, kind, payload, attempts, status`);
+      RETURNING id, tenant_id, kind, payload, attempts, claim_seq, status`);
     return rows.map((r) => ({
       id: r.id,
       tenantId: r.tenant_id,
       kind: r.kind as ClaimedJob["kind"],
       payload: (r.payload ?? {}) as ClaimedJob["payload"],
       attempts: r.attempts,
+      claimSeq: r.claim_seq,
       status: r.status,
     }));
   });

--- a/src/modules/scheduler/worker.ts
+++ b/src/modules/scheduler/worker.ts
@@ -120,9 +120,15 @@ export async function runClaimed(
     return;
   }
   if (result.outcome === "done") {
-    await completeJob(job.tenantId, job.id, job.claimSeq, base);
+    const { applied } = await completeJob(
+      job.tenantId,
+      job.id,
+      job.claimSeq,
+      base,
+    );
+    if (!applied) supersededWarning(job, "done");
   } else if (result.outcome === "reschedule") {
-    await rescheduleJob(
+    const { applied } = await rescheduleJob(
       job.tenantId,
       job.id,
       job.claimSeq,
@@ -130,9 +136,24 @@ export async function runClaimed(
       result.payload,
       base,
     );
+    if (!applied) supersededWarning(job, "reschedule");
   } else {
     await fail(job, result.error ?? "failed", base);
   }
+}
+
+// The claim this run held was no longer the current one, so its outcome was DISCARDED: the row now
+// belongs to a later claim, or to none. The handler still ran to completion, side effects included,
+// which is why this is worth a line — the whole reason issue #164 was filed is that these orderings
+// are invisible until someone traces them by hand, and a CAS that refuses in silence keeps them that
+// way. Not an error: refusing is the guard working. A handler whose work must not be repeated needs
+// its own exclusion (see the inFlight set in src/modules/memory/worker.ts); the token only decides
+// which write lands.
+function supersededWarning(job: ClaimedJob, outcome: string): void {
+  logger.warn(
+    { kind: job.kind, jobId: String(job.id), claimSeq: job.claimSeq, outcome },
+    "scheduler: claim superseded, outcome discarded",
+  );
 }
 
 export interface TickOptions {

--- a/src/modules/scheduler/worker.ts
+++ b/src/modules/scheduler/worker.ts
@@ -94,6 +94,7 @@ async function fail(
   const { deadLettered } = await failJob(
     job.tenantId,
     job.id,
+    job.claimSeq,
     job.attempts,
     error,
     base,
@@ -119,11 +120,12 @@ export async function runClaimed(
     return;
   }
   if (result.outcome === "done") {
-    await completeJob(job.tenantId, job.id, base);
+    await completeJob(job.tenantId, job.id, job.claimSeq, base);
   } else if (result.outcome === "reschedule") {
     await rescheduleJob(
       job.tenantId,
       job.id,
+      job.claimSeq,
       result.runAt,
       result.payload,
       base,

--- a/src/modules/scheduler/worker.ts
+++ b/src/modules/scheduler/worker.ts
@@ -91,7 +91,7 @@ async function fail(
   error: string,
   base: PrismaClient,
 ): Promise<void> {
-  const { deadLettered } = await failJob(
+  const { deadLettered, applied } = await failJob(
     job.tenantId,
     job.id,
     job.claimSeq,
@@ -99,6 +99,7 @@ async function fail(
     error,
     base,
   );
+  if (!applied) supersededWarning(job, "fail");
   if (deadLettered) await dispatchDeadLetter(job, error, base);
 }
 

--- a/tests/modules/business-hours-exceptions.test.ts
+++ b/tests/modules/business-hours-exceptions.test.ts
@@ -344,6 +344,7 @@ describe.skipIf(!dbUp)("business-hours date exceptions (issue #129)", () => {
       kind: "FOLLOWUP",
       payload: { threadId: threadOf(convId) },
       attempts: 0,
+      claimSeq: 0,
     };
     const result = await followUpHandler(job, appDb, {
       makeModel: () => new FakeListChatModel({ responses: ["oi"] }),
@@ -476,6 +477,7 @@ describe.skipIf(!dbUp)("business-hours date exceptions (issue #129)", () => {
         kind: "FOLLOWUP",
         payload: { threadId: threadOf(convId) },
         attempts: 0,
+        claimSeq: 0,
       },
       appDb,
       {

--- a/tests/modules/compaction-worker.test.ts
+++ b/tests/modules/compaction-worker.test.ts
@@ -19,6 +19,7 @@ function job(id: number): ClaimedJob {
     kind: "MEMORY_COMPACT",
     payload: {},
     attempts: 0,
+    claimSeq: 0,
   };
 }
 
@@ -64,6 +65,7 @@ describe("runCompactionTick", () => {
           kind: "MEMORY_COMPACT" as const,
           payload: {},
           attempts: 1,
+          claimSeq: 1,
           status: "PENDING" as const,
         },
       ],
@@ -144,6 +146,7 @@ describe("runCompactionTick", () => {
               kind: "MEMORY_COMPACT",
               payload: {},
               attempts: 1,
+              claimSeq: 1,
               status: "PENDING" as const,
             },
           ];

--- a/tests/modules/debounce-parallelism.test.ts
+++ b/tests/modules/debounce-parallelism.test.ts
@@ -175,6 +175,7 @@ function jobFor(convId: number): ClaimedJob {
     kind: "DEBOUNCE",
     payload: { threadId: threadOf(convId), agentBotId: 9, burstStartedAt: 1 },
     attempts: 0,
+    claimSeq: 0,
   };
 }
 

--- a/tests/modules/debounce-worker.test.ts
+++ b/tests/modules/debounce-worker.test.ts
@@ -16,6 +16,7 @@ function job(id: number): ClaimedJob {
     kind: "DEBOUNCE",
     payload: {},
     attempts: 0,
+    claimSeq: 0,
   };
 }
 

--- a/tests/modules/debounce.test.ts
+++ b/tests/modules/debounce.test.ts
@@ -195,6 +195,7 @@ function jobFor(
         : {}),
     },
     attempts: 0,
+    claimSeq: 0,
   };
 }
 

--- a/tests/modules/failure-note.test.ts
+++ b/tests/modules/failure-note.test.ts
@@ -454,6 +454,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
         runAt: new Date(),
         status: "CLAIMED",
         attempts: 0,
+        claimSeq: 0,
       },
       select: { id: true },
     });
@@ -472,7 +473,14 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
             data: { status: "CLAIMED", attempts },
           });
           await runClaimed(
-            { id: row.id, tenantId, kind: KIND, payload: {}, attempts },
+            {
+              id: row.id,
+              tenantId,
+              kind: KIND,
+              payload: {},
+              attempts,
+              claimSeq: 0,
+            },
             appDb,
           );
           expect(calls).toHaveLength(attempts === 4 ? 1 : 0);
@@ -497,6 +505,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
         runAt: new Date(),
         status: "CLAIMED",
         attempts: 4,
+        claimSeq: 0,
       },
       select: { id: true },
     });
@@ -516,7 +525,14 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
       },
       () =>
         runClaimed(
-          { id: row.id, tenantId, kind: KIND, payload: {}, attempts: 4 },
+          {
+            id: row.id,
+            tenantId,
+            kind: KIND,
+            payload: {},
+            attempts: 4,
+            claimSeq: 0,
+          },
           appDb,
         ),
     );
@@ -541,6 +557,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
         // this very row on the next inbound message, and that queued flush will answer.
         status: "PENDING",
         attempts: 5,
+        claimSeq: 0,
       },
       select: { id: true },
     });
@@ -551,6 +568,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
         kind: KIND,
         payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
         attempts: 4,
+        claimSeq: 0,
       },
       "model provider returned 503",
       appDb,
@@ -572,6 +590,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
         status: "CLAIMED",
         claimedAt: new Date(Date.now() - 600_000),
         attempts: 4,
+        claimSeq: 0,
       },
       select: { id: true },
     });
@@ -696,6 +715,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
         runAt: new Date(),
         status: "DEAD",
         attempts: 5,
+        claimSeq: 0,
       },
       select: { id: true },
     });
@@ -705,6 +725,7 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
       kind: KIND,
       payload: { threadId: `${tenantId}:${instanceId}:${conv}` },
       attempts: 4,
+      claimSeq: 0,
     };
     await announceDeadDebounceFlush(job, "model provider returned 503", appDb);
     expect(posted).toHaveLength(1);

--- a/tests/modules/flowlog-retention.test.ts
+++ b/tests/modules/flowlog-retention.test.ts
@@ -77,6 +77,7 @@ describe.skipIf(!dbUp)("flowlog retention", () => {
       kind: "FLOWLOG_SWEEP",
       payload: {},
       attempts: 0,
+      claimSeq: 0,
     };
     const result = (await (handler as NonNullable<typeof handler>)(
       job,

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -101,6 +101,7 @@ function jobFor(convId: number, stepIndex?: number): ClaimedJob {
         ? { threadId: threadOf(convId) }
         : { threadId: threadOf(convId), stepIndex },
     attempts: 0,
+    claimSeq: 0,
   };
 }
 
@@ -693,6 +694,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
         kind: "FOLLOWUP_SWEEP",
         payload: {},
         attempts: 0,
+        claimSeq: 0,
       },
       appDb,
     );
@@ -836,7 +838,14 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
-      { id: 998n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 998n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     for (const convId of [1041, 1042]) {
@@ -877,7 +886,14 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
-      { id: 997n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 997n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     expect(
@@ -918,7 +934,14 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
-      { id: 996n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 996n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     expect(
@@ -964,7 +987,14 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
-      { id: 995n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 995n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     // NOTE: Garbage = not-future = not suppressed (fail-safe), and the sweep survives for everyone.
@@ -1011,7 +1041,14 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
-      { id: 993n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 993n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     expect(
@@ -1056,7 +1093,14 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
-      { id: 994n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 994n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     expect(
@@ -1098,7 +1142,14 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
-      { id: 992n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 992n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     expect(

--- a/tests/modules/followup-resolved-guardrails.test.ts
+++ b/tests/modules/followup-resolved-guardrails.test.ts
@@ -88,6 +88,7 @@ function jobFor(convId: number): ClaimedJob {
     kind: "FOLLOWUP",
     payload: { threadId: threadOf(convId) },
     attempts: 0,
+    claimSeq: 0,
   };
 }
 
@@ -640,6 +641,7 @@ describe.skipIf(!dbUp)("follow-up em conversa resolvida — guardrails", () => {
       kind: "FOLLOWUP",
       payload: { threadId: threadOf(CONV), nudgeRetries: 7 },
       attempts: 0,
+      claimSeq: 0,
     };
     const result = await followUpHandler(job, appDb, handlerDeps(s));
     expect(result).toEqual({ outcome: "done" });
@@ -697,7 +699,14 @@ describe.skipIf(!dbUp)("follow-up em conversa resolvida — guardrails", () => {
     expect(sweep).toBeDefined();
     if (!sweep) throw new Error("unreachable");
     await sweep(
-      { id: 99n, tenantId, kind: "FOLLOWUP_SWEEP", payload: {}, attempts: 0 },
+      {
+        id: 99n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
       appDb,
     );
     const jobs = await suDb.schedulerJob.findMany({

--- a/tests/modules/rag-ingest-block.test.ts
+++ b/tests/modules/rag-ingest-block.test.ts
@@ -85,6 +85,7 @@ async function runIngest(tenantId: bigint, documentId: bigint) {
       kind: "RAG_INGEST",
       payload: { documentId: String(documentId) },
       attempts: 0,
+      claimSeq: 0,
     },
     appDb,
   );

--- a/tests/modules/rag-ingest-stale-publish.test.ts
+++ b/tests/modules/rag-ingest-stale-publish.test.ts
@@ -209,6 +209,7 @@ async function runIngestOn(
       kind: "RAG_INGEST",
       payload: { documentId: String(documentId) },
       attempts: 0,
+      claimSeq: 0,
     },
     base,
   );

--- a/tests/modules/scheduler-claim-token.test.ts
+++ b/tests/modules/scheduler-claim-token.test.ts
@@ -143,9 +143,9 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
   });
 
   test("a superseded run cannot fail the arm that replaced it", async () => {
-    const { id, stale } = await staleAndCurrent("tok-fail");
+    const { id, stale, current } = await staleAndCurrent("tok-fail");
     const before = await rowOf(id);
-    const { deadLettered } = await failJob(
+    const refused = await failJob(
       tenantId,
       id,
       stale.claimSeq,
@@ -153,13 +153,29 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
       "boom",
       appDb,
     );
-    expect(deadLettered).toBe(false);
+    expect(refused.deadLettered).toBe(false);
+    // `applied` has to be reported SEPARATELY: deadLettered is false for a healthy non-terminal
+    // retry too, so on its own it cannot tell a recorded failure from a refused one.
+    expect(refused.applied).toBe(false);
     const after = await rowOf(id);
     // Nothing of the failure sticks: not the status, not the retry budget, not the error text. A
     // stale failure that spent an attempt would walk an otherwise healthy key toward DEAD.
     expect(after.status).toBe("CLAIMED");
     expect(after.attempts).toBe(before.attempts);
     expect(after.lastError).toBeNull();
+
+    // And the live run's failure IS recorded, with the same two fields saying different things.
+    const landed = await failJob(
+      tenantId,
+      id,
+      current.claimSeq,
+      before.attempts,
+      "boom",
+      appDb,
+    );
+    expect(landed.applied).toBe(true);
+    expect(landed.deadLettered).toBe(false);
+    expect((await rowOf(id)).lastError).toBe("boom");
   });
 
   test("a superseded run cannot push the arm that replaced it into the future", async () => {

--- a/tests/modules/scheduler-claim-token.test.ts
+++ b/tests/modules/scheduler-claim-token.test.ts
@@ -1,0 +1,235 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import {
+  type ClaimedJob,
+  claimDueJobs,
+  completeJob,
+  enqueueJob,
+  failJob,
+  reapStaleJobs,
+  rescheduleJob,
+} from "@/modules/scheduler/service";
+import { registerJobHandler, runClaimed } from "@/modules/scheduler/worker";
+
+// Issue #164. A scheduler row is re-armed IN PLACE — `enqueueJob` upserts the same physical row back
+// to PENDING — so "the row is CLAIMED" never said WHICH run holds the claim. Every write that
+// finishes a job CAS'd on (id, status = 'CLAIMED') and nothing more, which means a run that finished
+// after its row had been re-armed AND re-claimed landed on the newer claim: the arm was marked DONE
+// and the work it stood for was done by nobody.
+//
+// The ordering that produces it is entirely ordinary and needs one process: a handler runs long
+// enough for something to re-arm its key, and one tick later the row is claimed again. #163 is the
+// same shape with a customer-visible ending (an edit to a knowledge-base document, silently
+// discarded), fixed inside the RAG handler; this is the question asked once, for all ten kinds.
+//
+// What the tests below pin is the STALE side, because the live side is what the old code already
+// did. Each one drives a real row through a real claim, so the token under test is the one the claim
+// SQL actually issued rather than a number the test picked.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+const past = () => new Date(Date.now() - 60_000);
+
+async function rowOf(id: bigint) {
+  return suDb.schedulerJob.findUniqueOrThrow({
+    where: { id },
+    select: {
+      status: true,
+      attempts: true,
+      claimSeq: true,
+      runAt: true,
+      lastError: true,
+    },
+  });
+}
+
+// The sequence the whole issue is about, set up once: a job is claimed, re-armed while that claim is
+// still notionally held, and claimed AGAIN. The first claim's token is now stale, and the row is
+// CLAIMED by someone else — which is precisely the state in which the old guard said yes.
+async function staleAndCurrent(
+  dedupeKey: string,
+): Promise<{ id: bigint; stale: ClaimedJob; current: ClaimedJob }> {
+  const id = await enqueueJob({
+    tenantId,
+    kind: "WEBHOOK_RETRY",
+    dedupeKey,
+    runAt: past(),
+    base: appDb,
+  });
+  const first = await claimDueJobs(10, appDb, new Date(), tenantId);
+  const stale = first.find((j) => j.id === id) as ClaimedJob;
+  expect(stale).toBeDefined();
+
+  await enqueueJob({
+    tenantId,
+    kind: "WEBHOOK_RETRY",
+    dedupeKey,
+    runAt: past(),
+    base: appDb,
+  });
+  const second = await claimDueJobs(10, appDb, new Date(), tenantId);
+  const current = second.find((j) => j.id === id) as ClaimedJob;
+  expect(current).toBeDefined();
+  return { id, stale, current };
+}
+
+describe.skipIf(!dbUp)("scheduler claim token", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "CLAIMTOK", slug: `claimtok-${process.pid}` },
+    });
+    tenantId = t.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId}`,
+      );
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  test("the claim issues a new token every time, and the re-arm does not", async () => {
+    const { id, stale, current } = await staleAndCurrent("tok-monotonic");
+    // The whole guard rests on these two being different. A token that repeated across claims would
+    // let every assertion below pass while protecting nothing.
+    expect(current.claimSeq).toBeGreaterThan(stale.claimSeq);
+    expect((await rowOf(id)).claimSeq).toBe(current.claimSeq);
+  });
+
+  test("a superseded run cannot complete the arm that replaced it", async () => {
+    const { id, stale, current } = await staleAndCurrent("tok-complete");
+    await completeJob(tenantId, id, stale.claimSeq, appDb);
+    // Still CLAIMED: the arm belongs to the run that is working on it right now, and the work it
+    // stands for has not been done. Under the old guard this row read DONE and nothing ever ran it.
+    expect((await rowOf(id)).status).toBe("CLAIMED");
+
+    await completeJob(tenantId, id, current.claimSeq, appDb);
+    expect((await rowOf(id)).status).toBe("DONE");
+  });
+
+  test("a superseded run cannot fail the arm that replaced it", async () => {
+    const { id, stale } = await staleAndCurrent("tok-fail");
+    const before = await rowOf(id);
+    const { deadLettered } = await failJob(
+      tenantId,
+      id,
+      stale.claimSeq,
+      before.attempts,
+      "boom",
+      appDb,
+    );
+    expect(deadLettered).toBe(false);
+    const after = await rowOf(id);
+    // Nothing of the failure sticks: not the status, not the retry budget, not the error text. A
+    // stale failure that spent an attempt would walk an otherwise healthy key toward DEAD.
+    expect(after.status).toBe("CLAIMED");
+    expect(after.attempts).toBe(before.attempts);
+    expect(after.lastError).toBeNull();
+  });
+
+  test("a superseded run cannot push the arm that replaced it into the future", async () => {
+    const { id, stale } = await staleAndCurrent("tok-reschedule");
+    const before = await rowOf(id);
+    const far = new Date(Date.now() + 86_400_000);
+    await rescheduleJob(tenantId, id, stale.claimSeq, far, undefined, appDb);
+    const after = await rowOf(id);
+    expect(after.status).toBe("CLAIMED");
+    expect(after.runAt.getTime()).toBe(before.runAt.getTime());
+  });
+
+  test("the reaper does not issue a token, so the run it declared dead stays out", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "WEBHOOK_RETRY",
+      dedupeKey: "tok-reap",
+      runAt: past(),
+      base: appDb,
+    });
+    const claimed = await claimDueJobs(10, appDb, new Date(), tenantId);
+    const mine = claimed.find((j) => j.id === id) as ClaimedJob;
+    expect(mine).toBeDefined();
+    await suDb.schedulerJob.update({
+      where: { id },
+      data: { claimedAt: new Date(Date.now() - 600_000) },
+    });
+    const reaped = await reapStaleJobs(
+      60_000,
+      suDb,
+      new Date(),
+      tenantId,
+      "WEBHOOK_RETRY",
+    );
+    expect(reaped.some((r) => r.id === id)).toBe(true);
+    // The reap re-pends without bumping, and it does not have to: the hung run's CAS also asks for
+    // CLAIMED, which a re-pended row is not. What must not happen is the run coming back and marking
+    // the re-pended row DONE.
+    await completeJob(tenantId, id, mine.claimSeq, appDb);
+    expect((await rowOf(id)).status).toBe("PENDING");
+  });
+
+  test("a handler whose key is re-armed mid-run leaves the new arm runnable", async () => {
+    // The end the issue is about, through the worker rather than through the three writes directly:
+    // the handler is what takes time, and the re-arm is what lands while it does. The observable
+    // effect is that the arm is still there to be run afterwards, by anybody.
+    let armedDuring = false;
+    registerJobHandler("HEARTBEAT", async (job) => {
+      if (!armedDuring) {
+        armedDuring = true;
+        await enqueueJob({
+          tenantId: job.tenantId,
+          kind: "HEARTBEAT",
+          dedupeKey: "tok-handler",
+          runAt: past(),
+          base: appDb,
+        });
+        await claimDueJobs(10, appDb, new Date(), tenantId);
+      }
+      return { outcome: "done" };
+    });
+
+    const id = await enqueueJob({
+      tenantId,
+      kind: "HEARTBEAT",
+      dedupeKey: "tok-handler",
+      runAt: past(),
+      base: appDb,
+    });
+    const claimed = await claimDueJobs(10, appDb, new Date(), tenantId);
+    const mine = claimed.find((j) => j.id === id) as ClaimedJob;
+    expect(mine).toBeDefined();
+
+    await runClaimed(mine, appDb);
+
+    // DONE here would mean the re-arm was consumed by the run that never saw it.
+    expect((await rowOf(id)).status).toBe("CLAIMED");
+  });
+});

--- a/tests/modules/scheduler-claim-token.test.ts
+++ b/tests/modules/scheduler-claim-token.test.ts
@@ -127,12 +127,18 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
 
   test("a superseded run cannot complete the arm that replaced it", async () => {
     const { id, stale, current } = await staleAndCurrent("tok-complete");
-    await completeJob(tenantId, id, stale.claimSeq, appDb);
+    // `applied` is the only thing the superseded run can learn. Refusing in silence would leave the
+    // ordering exactly as invisible as it was before the token, which is what #164 is about.
+    expect(await completeJob(tenantId, id, stale.claimSeq, appDb)).toEqual({
+      applied: false,
+    });
     // Still CLAIMED: the arm belongs to the run that is working on it right now, and the work it
     // stands for has not been done. Under the old guard this row read DONE and nothing ever ran it.
     expect((await rowOf(id)).status).toBe("CLAIMED");
 
-    await completeJob(tenantId, id, current.claimSeq, appDb);
+    expect(await completeJob(tenantId, id, current.claimSeq, appDb)).toEqual({
+      applied: true,
+    });
     expect((await rowOf(id)).status).toBe("DONE");
   });
 
@@ -160,7 +166,9 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
     const { id, stale } = await staleAndCurrent("tok-reschedule");
     const before = await rowOf(id);
     const far = new Date(Date.now() + 86_400_000);
-    await rescheduleJob(tenantId, id, stale.claimSeq, far, undefined, appDb);
+    expect(
+      await rescheduleJob(tenantId, id, stale.claimSeq, far, undefined, appDb),
+    ).toEqual({ applied: false });
     const after = await rowOf(id);
     expect(after.status).toBe("CLAIMED");
     expect(after.runAt.getTime()).toBe(before.runAt.getTime());
@@ -192,7 +200,9 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
     // The reap re-pends without bumping, and it does not have to: the hung run's CAS also asks for
     // CLAIMED, which a re-pended row is not. What must not happen is the run coming back and marking
     // the re-pended row DONE.
-    await completeJob(tenantId, id, mine.claimSeq, appDb);
+    expect(await completeJob(tenantId, id, mine.claimSeq, appDb)).toEqual({
+      applied: false,
+    });
     expect((await rowOf(id)).status).toBe("PENDING");
   });
 

--- a/tests/modules/scheduler.test.ts
+++ b/tests/modules/scheduler.test.ts
@@ -46,6 +46,17 @@ async function statusOf(id: bigint) {
   return row;
 }
 
+// The claim token the row currently carries. The tests in this file assert STATUS transitions, so
+// they want whatever token is live at that moment; the token's own semantics — what a STALE one must
+// refuse — are asserted in tests/modules/scheduler-claim-token.test.ts.
+async function seqOf(id: bigint): Promise<number> {
+  const row = await suDb.schedulerJob.findUniqueOrThrow({
+    where: { id },
+    select: { claimSeq: true },
+  });
+  return row.claimSeq;
+}
+
 describe.skipIf(!dbUp)("scheduler", () => {
   beforeAll(async () => {
     const t = await suDb.tenant.create({
@@ -219,7 +230,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
     const mine = claimed.find((j) => j.id === id);
     expect(mine).toBeDefined();
     expect((await statusOf(id)).status).toBe("CLAIMED");
-    await completeJob(tenantId, id, appDb);
+    await completeJob(tenantId, id, await seqOf(id), appDb);
     expect((await statusOf(id)).status).toBe("DONE");
   });
 
@@ -235,6 +246,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
     await rescheduleJob(
       tenantId,
       id,
+      await seqOf(id),
       new Date(Date.now() + 3_600_000),
       undefined,
       appDb,
@@ -258,6 +270,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
     await rescheduleJob(
       tenantId,
       id,
+      await seqOf(id),
       past(),
       { threadId: "1:2:3", stepIndex: 1 },
       appDb,
@@ -271,7 +284,14 @@ describe.skipIf(!dbUp)("scheduler", () => {
 
     // Omitting the payload on a later reschedule keeps the current one.
     await claimDueJobs(10, appDb, new Date(), tenantId);
-    await rescheduleJob(tenantId, id, past(), undefined, appDb);
+    await rescheduleJob(
+      tenantId,
+      id,
+      await seqOf(id),
+      past(),
+      undefined,
+      appDb,
+    );
     const row2 = await suDb.schedulerJob.findUniqueOrThrow({
       where: { id },
       select: { payload: true },
@@ -288,14 +308,14 @@ describe.skipIf(!dbUp)("scheduler", () => {
       base: appDb,
     });
     await claimDueJobs(10, appDb, new Date(), tenantId);
-    await failJob(tenantId, id, 0, "boom", appDb);
+    await failJob(tenantId, id, await seqOf(id), 0, "boom", appDb);
     expect((await statusOf(id)).status).toBe("PENDING"); // retry
     // simulate near the cap
     await suDb.schedulerJob.update({
       where: { id },
       data: { attempts: 4, status: "CLAIMED" },
     });
-    await failJob(tenantId, id, 4, "boom again", appDb);
+    await failJob(tenantId, id, await seqOf(id), 4, "boom again", appDb);
     expect((await statusOf(id)).status).toBe("DEAD");
   });
 

--- a/tests/modules/webhooks-outbound-heartbeat.test.ts
+++ b/tests/modules/webhooks-outbound-heartbeat.test.ts
@@ -57,7 +57,14 @@ function heartbeatJobRows(): Promise<number> {
   return suDb.schedulerJob.count({ where: { tenantId, kind: "HEARTBEAT" } });
 }
 function claimedJob(): ClaimedJob {
-  return { id: 0n, tenantId, kind: "HEARTBEAT", payload: {}, attempts: 0 };
+  return {
+    id: 0n,
+    tenantId,
+    kind: "HEARTBEAT",
+    payload: {},
+    attempts: 0,
+    claimSeq: 0,
+  };
 }
 async function clearTenantWebhookState(): Promise<void> {
   await suDb.$executeRawUnsafe(


### PR DESCRIPTION
A `SchedulerJob` row is re-armed **in place**: `enqueueJob` upserts the same physical row back to `PENDING`. So "the row is `CLAIMED`" never said *which* run holds the claim, and all three writes that finish a job CAS'd on `(id, status = 'CLAIMED')` and nothing more.

The ordering that breaks it needs one process and no unusual timing:

```
run A claims           row: CLAIMED, and A believes it owns the row
something re-arms      row: PENDING   (upsert, same row, new run_at)
one tick later         row: CLAIMED   by run B
run A finishes         CAS (id, CLAIMED) MATCHES — B's claim is marked DONE
run B finishes         CAS finds DONE — no match, nothing happens
```

The arm that stood for new work is consumed by the run that never saw it, and the work is done by nobody. Every kind that re-arms a live key is exposed: `FOLLOWUP`, `FOLLOWUP_SWEEP`, `WEBHOOK_RETRY`, `RAG_INGEST`, `HEARTBEAT`, `FLOWLOG_SWEEP`, `APPOINTMENT_REMINDER`, `REDIRECT_FOLLOWUP`.

This is the general form of #163, which was the same shape with a customer-visible ending (a knowledge-base edit during indexing, silently discarded) and was fixed inside the RAG handler.

## The change

The claim issues a **token**, and the three finishing writes CAS on it:

```sql
UPDATE scheduler_jobs
SET status = 'CLAIMED', claim_seq = claim_seq + 1, ...
RETURNING ..., claim_seq
```

`ClaimedJob` carries `claimSeq`; `completeJob`, `rescheduleJob` and `failJob` take it and add it to the `where`. `runClaimed` is the only caller of those three, so the token never has to be threaded further than the worker.

**The bump lives on the claim and nowhere else**, which is the part worth arguing rather than assuming. Both orderings are covered without touching `enqueueJob`:

- a re-arm that is **not** claimed again leaves the row `PENDING`, and the pre-existing `status = 'CLAIMED'` check already refuses that;
- a re-arm that **is** claimed again bumps past the token the first run holds.

A second bump inside `enqueueJob` would add a write to a hot path and buy nothing. The reaper does not bump either, for the same reason: a re-pended row is not `CLAIMED`, so the hung run's CAS fails on the status alone.

The field is additive with a default, so the migration is safe across a rolling deploy and safe to roll back to: the previous image names its own columns and never this one.

## What in the issue does not hold

The issue closes with *"The `MEMORY_COMPACT` in-memory exclusion can come out once that exists."* **It cannot**, and leaving that sentence unanswered would have cost the next person a regression.

The `inFlight` set in `src/modules/memory/worker.ts` guards two damages, and its own comment names both:

| damage | fixed by the token? |
| --- | --- |
| the still-running handler completes the newer arm out from under it | **yes**, and now for all ten kinds |
| two handlers overlap, each cutting a raw prefix and each paying for a summary | **no** |

A token decides *which write lands*. It does not decide *how many model calls were paid for*. A summary holds its claim for up to 60s while every attendance boundary re-arms the same key, and it draws from the same semaphore a customer's turn queues on, so the overlap is ordinary for this kind rather than theoretical. The exclusion stays, and its comment now says what it still buys instead of what it used to.

Related, and deliberately out of scope: whether the second handler's *write* is fully settled by the generation fence in `compact.ts` is a question about that fence, not about the scheduler. The prefix re-check under `withEntityLock` abandons the attempt when the thread no longer starts with the messages that were summarized, which covers the ordinary case; establishing its behaviour at the edges belongs with that code.

The RAG handler's own `PROCESSING` guard also stays. It fences the **document** row (an edit racing an index), which is a different race from the **job** row, and the token does not subsume it.

## What self-review changed after the first clean round

The token stopped the wrong write and left the event just as invisible as before, which is the thing #164 says is the actual problem: these orderings *"are invisible until someone traces the ordering by hand"*. `completeJob` and `rescheduleJob` returned `void`, so a superseded run finished its handler — external side effects included — and had its outcome dropped with no return value and no log line.

`failJob` already answers this exact question (`deadLettered`), and its comment says why. Creating the same question in two more places and answering it in neither is how a rule ends up missing from the N+1th place that needs it.

Both writes now return `{ applied }`, and `runClaimed` logs the supersession at **warn** with kind, job id and token. It is not an error: a refused CAS is the guard working.

## Validation scope

**Proven by test** (`tests/modules/scheduler-claim-token.test.ts`, DB-backed, every case driving a real row through the real claim SQL so the token under test is the one Postgres issued):

- the claim issues a new token every time, and the re-arm does not;
- a superseded run cannot `complete` the arm that replaced it (the row stays `CLAIMED`, and the current token still completes it);
- a superseded run cannot `fail` it: not the status, not the retry budget, not the error text — a stale failure that spent an attempt would walk a healthy key toward `DEAD`;
- a superseded run cannot `reschedule` it into the future;
- after the reaper re-pends a stranded claim, the run it declared dead cannot mark the re-pended row `DONE`;
- end to end through `runClaimed`: a handler whose key is re-armed and re-claimed mid-run leaves the new arm still runnable.

**Proven by mutation** (each alone, against `scheduler-claim-token` + `scheduler`, 16 tests):

| mutation | tests failing |
| --- | ---: |
| the claim stops issuing a new token | 5 |
| `completeJob` drops the token from its CAS | 2 |
| `failJob` drops the token from its CAS | 1 |
| `rescheduleJob` drops the token from its CAS | 1 |
| `completeJob` stops reporting whether it landed | 2 |
| `rescheduleJob` stops reporting whether it landed | 1 |
| *the reaper also bumps the token* | **0, predicted** |

The last row is stated in advance rather than discovered: it is an addition, not a guard, and a surviving mutation there is the argument above holding up. If it had killed a test, the claim that the bump belongs only on the claim would have been wrong.

**Proven by the compiler**: `claimSeq` is a required field on `ClaimedJob` and a required positional parameter, so every call site was named by `tsc` rather than found by reading. That is what the 13 touched test files are.

**Proven by sweep**, because "correct where I looked" is not the same as "complete". The question is *who writes `scheduler_jobs`*, asked of the whole tree rather than of the three functions this PR changed. Two writers live outside `scheduler/service.ts`:

- `armDebounce` (`debounce/service.ts`) is a **second in-place re-arm**, an upsert that sets `status: 'PENDING'` and does not touch the token — identical in shape to `enqueueJob`'s update branch, so the argument for putting the bump on the claim covers it unchanged;
- the appointment-reminder tombstone (`appointments/reminders.ts`) writes `payload` and `updated_at` only, never `status`.

Nothing else moves a row out of `CLAIMED`. `cancelPendingJob` and `cancelPendingJobsByPrefix` are guarded on `PENDING`, so they only ever cancel a job no run holds.

**Not validated**: the second failure shape in the issue (the same key running twice concurrently) needs more than one replica, which this deployment does not have; the token makes a concurrent overlap merely wasteful instead of corrupting, and that direction is argued here, not measured. No live run: the effect is a row transition, which the DB-backed tests assert directly.

Fixes #164


