### PR TITLE
Merge a settings patch all the way down, not just the top of a block

### DIFF
--- a/src/modules/agents/behavior-settings.ts
+++ b/src/modules/agents/behavior-settings.ts
@@ -143,20 +143,55 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 // An ARRAY replaces, deliberately: a list patch means the new list. Merging element by element
 // would make a shorter `followUp.steps` or a smaller attribute scope impossible to express, which
 // is the opposite of what sending one means.
+// How deep the merge will follow a patch before it stops descending and simply replaces. Both halves
+// of that are load-bearing.
+//
+// It is BOUNDED because the settings bag is caller-supplied on both sides — the stored value and the
+// patch — and `agentUpdateSchema.settings` accepts arbitrary nested `unknown`. Recursing once per
+// level turns "store a deep object, then patch it" into `RangeError: Maximum call stack size
+// exceeded` (measured against this tree: 5_000 levels merge fine, 20_000 throw), and since the throw
+// escapes the write, the agent's settings would stay unwritable until the row was repaired by hand.
+//
+// The number comes from the shape the readers actually produce, not from the stack: the deepest is
+// `guardrails.input.checks.toxicity`, at 4. Eight is double that and four orders of magnitude short
+// of where the stack gives out. `mergeMaxDepthCoversReaders` in the tests ties the two together, so
+// a block that grows deeper than this fails there rather than silently losing values past the cap.
+//
+// Past the cap it REPLACES, which is what the merge did at every level before it learned to descend.
+// Nothing that used to work changes shape; only the runaway stops.
+const MERGE_MAX_DEPTH = 8;
+
 function mergeBlock(
   before: Record<string, unknown>,
   patch: Record<string, unknown>,
+  depth = 1,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = { ...before };
   for (const [key, value] of Object.entries(patch)) {
     const prev = out[key];
     out[key] =
-      isPlainObject(prev) && isPlainObject(value)
-        ? mergeBlock(prev, value)
+      depth < MERGE_MAX_DEPTH && isPlainObject(prev) && isPlainObject(value)
+        ? mergeBlock(prev, value, depth + 1)
         : value;
   }
   return out;
 }
+
+// The deepest path any behavior reader produces, so the test can assert the cap clears it.
+export function behaviorSettingsMaxDepth(): number {
+  let deepest = 0;
+  const walk = (v: unknown, d: number): void => {
+    if (!isPlainObject(v)) {
+      if (d > deepest) deepest = d;
+      return;
+    }
+    for (const child of Object.values(v)) walk(child, d + 1);
+  };
+  walk(readBehaviorSettings({}) as unknown as Record<string, unknown>, 0);
+  return deepest;
+}
+
+export const MERGE_MAX_DEPTH_FOR_TESTS = MERGE_MAX_DEPTH;
 
 // Merge a behavior patch into the existing raw settings bag, then RE-READ each touched block through
 // its typed reader so the persisted value is always normalized + clamped (never the raw patch).

--- a/src/modules/agents/behavior-settings.ts
+++ b/src/modules/agents/behavior-settings.ts
@@ -126,6 +126,38 @@ export interface BehaviorSettingsPatch {
   memory?: Record<string, unknown>;
 }
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// Merge a patch into a stored block key by key, at ANY depth (issue #184). Two objects merge;
+// anything else replaces.
+//
+// The depth is the whole point. One shallow spread kept the "untouched keys preserved" promise at
+// the top level of a block and broke it one step in, and the break was silent rather than loud:
+// each block is re-read through its typed reader afterwards, so a sub-object the patch replaced
+// came back FILLED WITH DEFAULTS instead of absent. Turning off a guardrail direction returned a
+// complete, plausible direction with the operator's refusal text swapped for the product's and
+// `action: "silent"` — send nothing — swapped for `template` — send this.
+//
+// An ARRAY replaces, deliberately: a list patch means the new list. Merging element by element
+// would make a shorter `followUp.steps` or a smaller attribute scope impossible to express, which
+// is the opposite of what sending one means.
+function mergeBlock(
+  before: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...before };
+  for (const [key, value] of Object.entries(patch)) {
+    const prev = out[key];
+    out[key] =
+      isPlainObject(prev) && isPlainObject(value)
+        ? mergeBlock(prev, value)
+        : value;
+  }
+  return out;
+}
+
 // Merge a behavior patch into the existing raw settings bag, then RE-READ each touched block through
 // its typed reader so the persisted value is always normalized + clamped (never the raw patch).
 // Untouched keys in the bag (and untouched blocks) are preserved verbatim — the REST/UI merge
@@ -149,7 +181,7 @@ export function mergeBehaviorSettings(
       current[key] && typeof current[key] === "object"
         ? (current[key] as Record<string, unknown>)
         : {};
-    next[key] = { ...before, ...sub };
+    next[key] = mergeBlock(before, sub);
   }
 
   // Re-read through the typed readers to clamp/validate, then write the normalized blocks back.

--- a/tests/modules/behavior-settings.test.ts
+++ b/tests/modules/behavior-settings.test.ts
@@ -119,3 +119,82 @@ describe("behavior-settings — observability", () => {
     expect(next.limits).toEqual({ maxToolCalls: 7, maxHistoryTokens: null });
   });
 });
+
+// The merge contract goes all the way down (issue #184). One shallow spread per block kept the
+// promise at the top level of a block and broke it one step in: a patch that named a SUB-object
+// replaced it whole, and because each block is then re-read through its typed reader, the hole came
+// back filled with defaults rather than absent — a complete, plausible block with the operator's
+// values gone.
+describe("behavior-settings — a patch into a nested block", () => {
+  const configured = {
+    guardrails: {
+      enabled: true,
+      input: {
+        enabled: true,
+        action: "silent",
+        templateMessage: "Vou chamar um atendente para você.",
+        checks: { toxicity: false, competitorMentions: true },
+      },
+    },
+  };
+
+  test("turning a direction off keeps everything else the operator set", () => {
+    const next = mergeBehaviorSettings(configured, {
+      guardrails: { input: { enabled: false } },
+    });
+    const input = (next.guardrails as Record<string, unknown>).input as Record<
+      string,
+      unknown
+    >;
+    expect(input.enabled).toBe(false);
+    // The two that reach the customer. `silent` means send NOTHING on a violation; letting it fall
+    // back to `template` makes the agent start replying where silence was chosen, with the
+    // product's own wording in place of the operator's sentence.
+    expect(input.action).toBe("silent");
+    expect(input.templateMessage).toBe("Vou chamar um atendente para você.");
+    expect(input.checks).toMatchObject({
+      toxicity: false,
+      competitorMentions: true,
+    });
+  });
+
+  test("a nested patch still overrides what it does name", () => {
+    const next = mergeBehaviorSettings(configured, {
+      guardrails: { input: { templateMessage: "Só um instante." } },
+    });
+    const input = (next.guardrails as Record<string, unknown>).input as Record<
+      string,
+      unknown
+    >;
+    expect(input.templateMessage).toBe("Só um instante.");
+    expect(input.action).toBe("silent");
+  });
+
+  test("an untouched sibling direction is left alone", () => {
+    const next = mergeBehaviorSettings(
+      {
+        guardrails: {
+          ...configured.guardrails,
+          output: { enabled: true, templateMessage: "Não posso responder." },
+        },
+      },
+      { guardrails: { input: { enabled: false } } },
+    );
+    const output = (next.guardrails as Record<string, unknown>)
+      .output as Record<string, unknown>;
+    expect(output.templateMessage).toBe("Não posso responder.");
+  });
+
+  // A list patch means the new list. Deep-merging arrays would make a shorter `steps` or a smaller
+  // attribute scope impossible to express, which is the opposite of what an operator means by
+  // sending one.
+  test("a list is still replaced wholesale, not merged element by element", () => {
+    const next = mergeBehaviorSettings(
+      { attributeContext: { conversation: ["a", "b", "c"] } },
+      { attributeContext: { conversation: ["a"] } },
+    );
+    expect(
+      (next.attributeContext as Record<string, unknown>).conversation,
+    ).toEqual(["a"]);
+  });
+});

--- a/tests/modules/behavior-settings.test.ts
+++ b/tests/modules/behavior-settings.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   BEHAVIOR_SETTINGS_KEYS,
+  behaviorSettingsMaxDepth,
+  MERGE_MAX_DEPTH_FOR_TESTS,
   mergeBehaviorSettings,
   readBehaviorSettings,
 } from "@/modules/agents/behavior-settings";
@@ -183,6 +185,32 @@ describe("behavior-settings — a patch into a nested block", () => {
     const output = (next.guardrails as Record<string, unknown>)
       .output as Record<string, unknown>;
     expect(output.templateMessage).toBe("Não posso responder.");
+  });
+
+  // The descent is BOUNDED. Both sides of the merge are caller-supplied and the settings schema
+  // accepts arbitrary nested `unknown`, so an unbounded recursion turns "store a deep object, then
+  // patch it" into a RangeError that escapes the write — and, because it escapes the write, leaves
+  // the agent's settings unwritable until the row is repaired by hand. Measured against this tree
+  // before the cap: 5_000 levels merged, 20_000 threw.
+  test("a pathologically deep patch is bounded instead of blowing the stack", () => {
+    const deep = (n: number): Record<string, unknown> => {
+      let o: Record<string, unknown> = { leaf: 1 };
+      for (let i = 0; i < n; i++) o = { k: o };
+      return o;
+    };
+    expect(() =>
+      mergeBehaviorSettings(
+        { memory: { compaction: deep(50_000) } },
+        { memory: { compaction: deep(50_000) } },
+      ),
+    ).not.toThrow();
+  });
+
+  // The cap is not a number someone liked: it has to clear the deepest shape the readers actually
+  // produce, or a block nested past it would silently lose the values this whole change exists to
+  // keep. Growing a deeper block fails HERE, where the fix is one constant, instead of in the field.
+  test("the depth cap clears the deepest shape the readers produce", () => {
+    expect(behaviorSettingsMaxDepth()).toBeLessThan(MERGE_MAX_DEPTH_FOR_TESTS);
   });
 
   // A list patch means the new list. Deep-merging arrays would make a shorter `steps` or a smaller


### PR DESCRIPTION
`mergeBehaviorSettings` promises that a partial patch preserves untouched keys, and the `agent_settings_set` tool description repeats the promise to the model: *"Each block is a PARTIAL patch MERGED into the existing settings (untouched keys preserved)"*. That held for the top level of a block and stopped there.

The merge was one shallow spread per block:

```ts
next[key] = { ...before, ...sub };
```

So a patch naming a block's **sub-object** replaced it whole.

## Why it was invisible

Each block is re-read through its typed reader after the merge, so the sub-object the patch replaced came back **filled with defaults** rather than absent. The block returned complete and plausible, with the operator's values gone. Nothing in the response, the logs or the editor says a value was dropped.

## What it cost

Two blocks hold a nested object: `guardrails` (`input`, `output`) and `memory` (`compaction`). `memory.compaction` carries only a boolean, so nothing there can be lost. Guardrails is the one with something to lose.

Measured on `main`, patching `guardrails: { input: { enabled: false } }` over an input direction the operator had set to `silent` with their own refusal text:

| | before | after |
| --- | --- | --- |
| `action` | `silent` | `template` |
| `templateMessage` | the operator's sentence | `"Desculpe, não consigo ajudar com isso."` |
| `checks` | as configured | all back to defaults |

The first two reach the customer, and neither was asked for:

- `silent` means **send nothing** on a violation; `template` means **send this**. The flip makes the agent start replying where the operator chose silence.
- the refusal text is the sentence the customer reads. It came back in the product's wording instead of theirs.

The damage lands when the guardrail is turned back **on**, which is the natural end of "let me disable this for a minute".

## Not reachable from the console

The agent editor sends the whole `guardrails` object on every save, so the console was never affected. This is the REST and MCP partial-patch path, which is exactly the path whose contract advertises the merge.

## The fix, and the half that stays

A patch now merges into a nested object the way it merges into the block: two plain objects merge key by key; anything else replaces.

### The descent is bounded, and that came out of review

The first version of this descended without a bound, which the review round caught as a regression this PR would have introduced. Both sides are caller-supplied, so the recursion is as deep as the payload: re-measured on this tree, the unbounded version merges a 15,000-level patch and throws `RangeError: Maximum call stack size exceeded` at 20,000. The throw escapes the write, so the outcome is worse than the bug being fixed: the agent's settings become unwritable until someone edits the row by hand.

The cap is **8**, and the number is not a preference. The deepest shape any behavior reader produces is `guardrails.input.checks.toxicity`, at 4; eight is double that and four orders of magnitude short of where the stack gives out. Past the cap it replaces, which is exactly what the merge did at every level before it learned to descend, so nothing that used to work changes shape.

A test ties the constant to the measurement rather than to a number someone liked: it walks the readers' own output and asserts the deepest path clears the cap. A block that grows deeper than this fails there, where the fix is one constant, instead of silently losing values in the field.

**Arrays still replace wholesale**, deliberately. A list patch means the new list — merging element by element would make a shorter `followUp.steps` or a smaller `attributeContext` scope impossible to express, which is the opposite of what sending one means. That half is pinned by its own test, and the pre-existing `attributeContext` scope test agrees.

## Validation scope

**Proven by test.** Six cases over the merge: a nested patch preserves the siblings it does not name, still overrides the ones it does, leaves an untouched sibling direction alone, replaces a list wholesale, survives a 50,000-level patch instead of blowing the stack, and holds the cap above the deepest shape the readers produce. Full suite green on the source tree and on the derived public tree.

Mutation-checked:

```
back to the shallow spread    + "keeps everything else the operator set"
                              + "a nested patch still overrides what it does name"
arrays merged as objects too  + "a list is still replaced wholesale"
                              + the pre-existing attributeContext scope test
```

**Measured, not committed as a test.** The before/after table above comes from driving `mergeBehaviorSettings` directly against this tree. The 15,000/20,000 stack figures come from running the unbounded shape against this tree as well; what is committed is the bound and the 50,000-level case that proves it holds, since the exact level where a stack gives out is a property of the runtime rather than of this code.

**Not validated live.** No deployment was exercised, and no MCP client was driven end to end: the defect and the fix are both in the merge function, and the REST and MCP paths reach it through the same call.

Fixes #184

