### PR TITLE
Warn when Chatwoot already answers out of hours on an inbox the agent is bound to

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6097,6 +6097,97 @@
         "operationId": "getV1AgentsByIdGuardrailsHealth"
       }
     },
+    "/v1/agents/{id}/inboxes/out-of-office": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "List inboxes that answer out of hours",
+        "description": "The agent's bound inboxes whose Chatwoot inbox-level out-of-office reply is configured (working hours enabled AND a message set), read live from Chatwoot. Chatwoot's schedule is keyed on the day of the week alone, so it cannot express the dated closures this product's business hours can: the two calendars disagree on holidays by construction. An inbox on an unreachable Chatwoot account is omitted rather than reported, so an empty list means \"nothing found\", not \"nothing to find\".",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Agent id, a BigInt encoded as a decimal string.",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getV1AgentsByIdInboxesOut-of-office"
+      }
+    },
     "/v1/agents/{id}/clone": {
       "post": {
         "tags": [

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -24,6 +24,7 @@ import {
   updateAgent,
 } from "@/modules/agents/service";
 import { exportAgent, importAgent } from "@/modules/agents/transfer";
+import { listOutOfOfficeInboxes } from "@/modules/chatwoot/management";
 import {
   GUARDRAIL_HEALTH_WINDOW_HOURS,
   guardrailHealthWindowStart,
@@ -272,6 +273,32 @@ export const agentsController = new Elysia({
         "Counts the guardrail analyses that could not run for this agent in the recent window, with the most recent one and the error it carried. Analysis is fail-open, so a check counted here caught nothing and held nothing back. It does not follow that the turn went out unscreened: the other direction may still have screened it, and a split output analysis can carry an error from one half and a violation from the other.",
       ),
       response: errors(400, 401, 403, 404),
+      requireRole: "TENANT_ADMIN",
+      params: t.Object({
+        id: t.String({
+          description: "Agent id, a BigInt encoded as a decimal string.",
+        }),
+      }),
+    },
+  )
+  // Which of this agent's bound inboxes ALREADY answer out of hours from Chatwoot's side. The editor's
+  // warning panel needs it for the same reason it needs guardrail health: the answer is not in this
+  // product's configuration at all, and the collision it warns about is invisible from either console.
+  .get(
+    "/:id/inboxes/out-of-office",
+    async ({ tenantContext, params }) => ({
+      instance: instanceIdentity,
+      inboxes: await listOutOfOfficeInboxes(
+        ctxOrThrow(tenantContext),
+        BigInt(params.id),
+      ),
+    }),
+    {
+      detail: doc(
+        "List inboxes that answer out of hours",
+        'The agent\'s bound inboxes whose Chatwoot inbox-level out-of-office reply is configured (working hours enabled AND a message set), read live from Chatwoot. Chatwoot\'s schedule is keyed on the day of the week alone, so it cannot express the dated closures this product\'s business hours can: the two calendars disagree on holidays by construction. An inbox on an unreachable Chatwoot account is omitted rather than reported, so an empty list means "nothing found", not "nothing to find".',
+      ),
+      response: errors(400, 401, 403),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -142,6 +142,13 @@ export interface ConfigHealthInput {
   // which is a question about what the General tab is about to save.
   modelProvider: string;
   modelCredentialRef: string;
+  // The agent's own on/off, AS SAVED. Required rather than optional, and read by exactly one check:
+  // the out-of-hours collision is the only line in this panel that claims something about what the
+  // CUSTOMER receives. Every other line describes the configuration ("on, but no key"), which stays
+  // true of an agent nobody has switched on; a disabled agent, though, says nothing to anybody, so
+  // both spellings of that collision would be false. Required because the only thing that could
+  // catch a caller dropping it is the compiler — no test mounts the editor.
+  agentEnabled: boolean;
   // The agent's model as STORED, with its EFFECTIVE endpoint (a credential that carries one wins
   // over the typed field). Separate from the pair above on purpose: the speech rewrite inherits
   // from the SAVED model, because the editor's tabs save independently and a Behavior save carries
@@ -472,7 +479,7 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   // configuration that does not exist yet. The same reading the runtime uses, because a second
   // reading of the same bag is a second answer waiting to happen.
   const outOfOffice = input.outOfOfficeInboxes ?? [];
-  if (outOfOffice.length > 0) {
+  if (input.agentEnabled && outOfOffice.length > 0) {
     const away = readAvailabilityConfig(input.settings);
     // The switch and the copy are only two thirds of it. The away message rides the SAME gate that
     // silences replies, so an agent whose schedule never closes — none picked, or one with no windows

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -5,6 +5,10 @@ import {
 import { isValidHttpUrl } from "@/client/lib/validation";
 import { collectOversizedTextChanges } from "@/modules/agents/text-caps";
 import { readAvailabilityConfig } from "@/modules/availability/away";
+import {
+  type Schedule,
+  scheduleCanClose,
+} from "@/modules/business-hours/hours";
 import { resolveNormalizeModel } from "@/modules/tts/normalize-model";
 
 // Live configuration-health checks for the agent editor (item 1): detect features that are turned on
@@ -203,6 +207,10 @@ export interface ConfigHealthInput {
   // deliberately the same value: a Chatwoot that could not be read reports no inboxes, and a warning
   // invented by an outage is worse than one that arrives a page load late.
   outOfOfficeInboxes?: { id: string; name: string }[];
+  // The schedule the agent is bound to AS SAVED, or null for "always on". Needed to answer which of
+  // the two collisions this is: the away message is gated by the same schedule that gates replies, so
+  // an agent that never closes never sends it however the block is configured.
+  savedSchedule?: Schedule | null;
 }
 
 // The three ways one credentialed feature can be unrunnable. Every credential ref on the agent goes
@@ -466,11 +474,18 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   const outOfOffice = input.outOfOfficeInboxes ?? [];
   if (outOfOffice.length > 0) {
     const away = readAvailabilityConfig(input.settings);
+    // The switch and the copy are only two thirds of it. The away message rides the SAME gate that
+    // silences replies, so an agent whose schedule never closes — none picked, or one with no windows
+    // — sends nothing out of hours no matter what the block says, and calling that the duplicate
+    // would describe two messages where the customer gets a closure notice and then normal service.
+    // The condition is asked of the schedule module rather than restated here, because a console that
+    // re-derives the gate's rule is a console that will disagree with it.
+    const agentAlsoReplies =
+      scheduleCanClose(input.savedSchedule) &&
+      away.enabled &&
+      away.awayMessage.trim() !== "";
     issues.push({
-      key:
-        away.enabled && away.awayMessage.trim() !== ""
-          ? "outOfHoursBoth"
-          : "outOfHoursChatwoot",
+      key: agentAlsoReplies ? "outOfHoursBoth" : "outOfHoursChatwoot",
       tab: "behavior",
       // The section holds both halves of the answer: the schedule the agent follows and the switch
       // for its own message. Neither is the whole fix — Chatwoot's side is the other product's

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -4,6 +4,7 @@ import {
 } from "@/client/lib/credentialRef";
 import { isValidHttpUrl } from "@/client/lib/validation";
 import { collectOversizedTextChanges } from "@/modules/agents/text-caps";
+import { readAvailabilityConfig } from "@/modules/availability/away";
 import { resolveNormalizeModel } from "@/modules/tts/normalize-model";
 
 // Live configuration-health checks for the agent editor (item 1): detect features that are turned on
@@ -22,6 +23,12 @@ export type ConfigIssueKey =
   | "knowledge"
   | "embedding"
   | "redirect"
+  // Two spellings of one collision, because the customer sees two different things and the operator
+  // has two different fixes. "Both" is the duplicate: Chatwoot's inbox reply and the agent's away
+  // message, back to back. "Chatwoot" is the contradiction: Chatwoot announces the closure and the
+  // agent, which reads a schedule Chatwoot cannot see, serves the customer through it.
+  | "outOfHoursBoth"
+  | "outOfHoursChatwoot"
   | "textCap";
 
 export interface ConfigIssue {
@@ -56,6 +63,10 @@ export interface ConfigIssue {
   // the timestamp is what lets an operator who just fixed it see the count stop.
   failures?: number;
   lastFailureAt?: string;
+  // For the out-of-hours issues: the inboxes that answer out of hours from Chatwoot's side, by the
+  // name CHATWOOT gives them. Named rather than counted because the fix is on the other product's
+  // screen, and "two of your inboxes" does not tell anyone which two to open.
+  inboxNames?: string[];
 }
 
 // Where a capped field is edited, by the path the walker reports. A path with no entry has no control
@@ -187,6 +198,11 @@ export interface ConfigHealthInput {
   redirectEnabled?: boolean;
   redirectEntryInboxId?: string;
   redirectWidgetInboxId?: number | null;
+  // The agent's bound inboxes on which Chatwoot sends an out-of-hours reply of its own, read live by
+  // the server (chatwoot/management.ts). Absent or empty raises nothing, and the two cases are
+  // deliberately the same value: a Chatwoot that could not be read reports no inboxes, and a warning
+  // invented by an outage is worse than one that arrives a page load late.
+  outOfOfficeInboxes?: { id: string; name: string }[];
 }
 
 // The three ways one credentialed feature can be unrunnable. Every credential ref on the agent goes
@@ -437,6 +453,30 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
       key: "redirect",
       tab: "channelRedirect",
       sectionId: "cr-entry",
+    });
+  }
+  // Chatwoot answers out of hours on an inbox this agent is bound to. Unlike every other check here
+  // this one is not about a feature that cannot run: both features run, and it is the customer who
+  // gets the wrong experience — two messages, or a closure notice followed by service.
+  //
+  // Which of the two is decided by the agent's SAVED availability block, never by what the operator
+  // is typing: a warning that changed while a message is half-written would be describing a
+  // configuration that does not exist yet. The same reading the runtime uses, because a second
+  // reading of the same bag is a second answer waiting to happen.
+  const outOfOffice = input.outOfOfficeInboxes ?? [];
+  if (outOfOffice.length > 0) {
+    const away = readAvailabilityConfig(input.settings);
+    issues.push({
+      key:
+        away.enabled && away.awayMessage.trim() !== ""
+          ? "outOfHoursBoth"
+          : "outOfHoursChatwoot",
+      tab: "behavior",
+      // The section holds both halves of the answer: the schedule the agent follows and the switch
+      // for its own message. Neither is the whole fix — Chatwoot's side is the other product's
+      // screen — but every move the operator can make from this console starts there.
+      sectionId: "availability",
+      inboxNames: outOfOffice.map((i) => i.name),
     });
   }
   // Last: these are about text already in the row, not about a feature that cannot run, so they read

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -688,6 +688,8 @@
     "configIssueGuardrailsFailing": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. Check the model, the endpoint and the key.",
     "configIssueGuardrailsFailingCause": "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. The last one said: {{error}}",
     "configIssueKnowledge": "Knowledge base \"{{name}}\" has documents that need indexing.",
+    "configIssueOutOfHoursBoth": "Chatwoot already replies out of hours on {{inboxes}}, and this agent's out-of-hours message is on as well, so the customer gets both. The two schedules are set in different products and Chatwoot's has no dates in it, so on a holiday they will disagree too.",
+    "configIssueOutOfHoursChatwoot": "Chatwoot replies out of hours on {{inboxes}}, and this agent does not read that schedule: it answers whenever its own says it is open. The customer can be told the business is closed and served in the same breath.",
     "configIssuePending": {
       "embedding": "A knowledge base needs indexing, but the embedding credential is not filled in yet.",
       "guardrails": "The guardrails credential is referenced but not filled in yet, so messages go out unscreened.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -690,6 +690,8 @@
     "configIssueGuardrailsFailing": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). A análise é fail-open, então verificação que não rodou não pegou nada e não segurou nada. Confira o modelo, o endpoint e a chave.",
     "configIssueGuardrailsFailingCause": "Os guardrails estão ligados, mas {{failures}} das verificações não conseguiram rodar nas últimas {{hours}} horas (a mais recente {{when}}). A análise é fail-open, então verificação que não rodou não pegou nada e não segurou nada. A última respondeu: {{error}}",
     "configIssueKnowledge": "A base de conhecimento \"{{name}}\" tem documentos que precisam ser indexados.",
+    "configIssueOutOfHoursBoth": "O Chatwoot já responde fora do horário em {{inboxes}}, e a mensagem de fora do horário deste agente também está ligada, então o cliente recebe as duas. Os dois horários são configurados em produtos diferentes e o do Chatwoot não tem datas, então em feriado eles também vão divergir.",
+    "configIssueOutOfHoursChatwoot": "O Chatwoot responde fora do horário em {{inboxes}}, e este agente não lê esse horário: ele responde sempre que o dele diz que está aberto. O cliente pode ouvir que está fechado e ser atendido logo em seguida.",
     "configIssuePending": {
       "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding ainda não foi preenchida.",
       "guardrails": "A credencial dos guardrails está referenciada, mas ainda não foi preenchida, então as mensagens saem sem triagem.",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1311,6 +1311,37 @@ function AgentEditor() {
     };
   }, [id, guardrailsOn, serverSyncTick]);
 
+  // Chatwoot's OWN out-of-hours reply, on the inboxes this agent is bound to. Same snapshot rule as
+  // the reading above, and live on the server rather than read off the inbox mirror: the mirror is
+  // only as fresh as the last time somebody pressed Sync, so a mirrored copy would keep warning
+  // about a reply that was switched off weeks ago and there would be nowhere on this page to clear
+  // it. An unreachable Chatwoot comes back as an empty list, which is silence.
+  //
+  // NOT gated on this agent's own away message being on, because the collision does not need it: an
+  // agent with nothing to say out of hours still answers through the closure Chatwoot just announced.
+  const [outOfOfficeInboxes, setOutOfOfficeInboxes] = useState<
+    { id: string; name: string }[]
+  >([]);
+  useEffect(() => {
+    if (!id || serverSyncTick === 0) {
+      setOutOfOfficeInboxes([]);
+      return;
+    }
+    let alive = true;
+    api.api.v1
+      .agents({ id })
+      .inboxes["out-of-office"].get()
+      .then(({ data }) => {
+        if (alive) setOutOfOfficeInboxes(data?.inboxes ?? []);
+      })
+      .catch(() => {
+        if (alive) setOutOfOfficeInboxes([]);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [id, serverSyncTick]);
+
   // Live config-health (item 1): features turned on but missing the credential they need to run, OR
   // referencing a credential whose secret is not filled in yet (pending). The import that strips
   // secrets is the common trigger; each issue deep-links to its tab + section, or to the vault fill
@@ -1387,6 +1418,7 @@ function AgentEditor() {
     redirectEnabled: channelRedirect.enabled,
     redirectEntryInboxId: channelRedirect.entryInboxId,
     redirectWidgetInboxId: channelRedirect.widgetInboxId,
+    outOfOfficeInboxes,
   });
 
   // Deep-link to a config issue. For a PENDING credential the fix lives in the vault, so jump to the
@@ -1497,6 +1529,23 @@ function AgentEditor() {
             "editor.configIssueGuardrailsFailing",
             "Guardrails are on, but {{failures}} of their checks could not run in the last {{hours}} hours (the most recent {{when}}). Analysis is fail-open, so a check that could not run caught nothing and held nothing back. Check the model, the endpoint and the key.",
             params,
+          );
+    }
+    // Two out-of-hours messages on one inbox, or one announcing a closure the other serves through.
+    // The inboxes are NAMED, not counted: half of every fix is on Chatwoot's screen, and "two of
+    // your inboxes" does not tell anyone which two to open there.
+    if (issue.key === "outOfHoursBoth" || issue.key === "outOfHoursChatwoot") {
+      const inboxes = (issue.inboxNames ?? []).join(", ");
+      return issue.key === "outOfHoursBoth"
+        ? t(
+            "editor.configIssueOutOfHoursBoth",
+            "Chatwoot already replies out of hours on {{inboxes}}, and this agent's out-of-hours message is on as well, so the customer gets both. The two schedules are set in different products and Chatwoot's has no dates in it, so on a holiday they will disagree too.",
+            { inboxes },
+          )
+        : t(
+            "editor.configIssueOutOfHoursChatwoot",
+            "Chatwoot replies out of hours on {{inboxes}}, and this agent does not read that schedule: it answers whenever its own says it is open. The customer can be told the business is closed and served in the same breath.",
+            { inboxes },
           );
     }
     if (issue.pending) {
@@ -2656,7 +2705,13 @@ function AgentEditor() {
             )}
 
             {tab === "channels" && (
-              <ChannelsTab agentId={id} agentName={name} />
+              <ChannelsTab
+                agentId={id}
+                agentName={name}
+                onBindingChanged={() => {
+                  setServerSyncTick((n) => n + 1);
+                }}
+              />
             )}
 
             {tab === "tools" && (

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -101,6 +101,24 @@ import type {
 } from "./types";
 import { usePlaygroundChat } from "./usePlaygroundChat";
 
+// The Schedule a saved businessHoursId points at, built field by field rather than passed through:
+// rows can come back without windows/exceptions (the sibling picker guards them the same way), and
+// the question asked of it — can this schedule ever close — must not turn on that.
+function scheduleOf(
+  hours: Hours[],
+  businessHoursId: string | null | undefined,
+): Schedule | null {
+  if (!businessHoursId) return null;
+  const h = hours.find((x) => String(x.id) === String(businessHoursId));
+  return h
+    ? {
+        windows: (h.windows ?? []) as Schedule["windows"],
+        exceptions: (h.exceptions ?? []) as Schedule["exceptions"],
+        timezone: h.timezone,
+      }
+    : null;
+}
+
 type AgentResp = Awaited<
   ReturnType<ReturnType<typeof api.api.v1.agents>["get"]>
 >;
@@ -1419,6 +1437,9 @@ function AgentEditor() {
     redirectEntryInboxId: channelRedirect.entryInboxId,
     redirectWidgetInboxId: channelRedirect.widgetInboxId,
     outOfOfficeInboxes,
+    // The SAVED schedule, next to the saved settings above and for the same reason: the panel
+    // describes the row, and a schedule picked but not saved gates nothing yet.
+    savedSchedule: scheduleOf(hours, syncedAgentRef.current?.businessHoursId),
   });
 
   // Deep-link to a config issue. For a PENDING credential the fix lives in the vault, so jump to the

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1409,6 +1409,9 @@ function AgentEditor() {
     vaultBaseUrl(savedModel.credentialRef) ?? savedModel.baseURL;
   const configIssues = computeConfigIssues({
     settings: syncedAgentRef.current?.settings,
+    // Saved, like the settings above. Absent only before the first load lands, and nothing that
+    // reads it can be non-empty that early.
+    agentEnabled: syncedAgentRef.current?.enabled ?? true,
     modelProvider: model.provider,
     modelCredentialRef: model.credentialRef,
     sttEnabled: stt.enabled,

--- a/src/client/pages/agents/ChannelsTab.tsx
+++ b/src/client/pages/agents/ChannelsTab.tsx
@@ -36,9 +36,15 @@ type AgentLite = NonNullable<AgentsData>["agents"][number];
 export function ChannelsTab({
   agentId,
   agentName,
+  onBindingChanged,
 }: {
   agentId: string;
   agentName: string;
+  // Binding acts immediately, with no save to piggyback on, and the editor's warning panel asks a
+  // question whose answer is per-BOUND-inbox (whether Chatwoot already replies out of hours there).
+  // Without this the panel would only catch up on the next load, which is the one moment the
+  // operator has already stopped looking for it.
+  onBindingChanged?: () => void;
 }) {
   const { t } = useTranslation();
   const { showToast } = useToast();
@@ -116,6 +122,7 @@ export function ChannelsTab({
         return next;
       });
       showToast(t("channels.bound", "Inbox updated."), "success");
+      onBindingChanged?.();
     } catch {
       showToast(
         t("channels.bindError", "Could not update the inbox."),

--- a/src/modules/business-hours/hours.ts
+++ b/src/modules/business-hours/hours.ts
@@ -244,13 +244,30 @@ export function isOpenAt(schedule: Schedule, at: Date): boolean {
   );
 }
 
+// Can this schedule ever close? A schedule that does not exist and one with no windows are the same
+// answer — always open — and everything downstream of the reactive gate (the operator's private note,
+// the customer's away message) therefore never runs for either.
+//
+// Named because two very different places need it and only one of them is the gate. The console has
+// to say whether the away message an operator wrote can go out at all, and re-deriving "no windows
+// means always open" over there is how a console starts describing a runtime it no longer matches.
+//
+// Typed as a guard rather than a boolean, so the gate that asks it keeps the narrowing its old inline
+// null-check gave it. True is a stronger claim than the name promises — there IS a schedule, and it
+// closes — which is exactly the pair every caller needs before doing anything with it.
+export function scheduleCanClose(
+  schedule: Schedule | null | undefined,
+): schedule is Schedule {
+  return !!schedule && schedule.windows.length > 0;
+}
+
 // "Is this schedule currently CLOSED?" — true only when an availability schedule is configured (≥1
 // weekly window) AND `at` falls outside every range in force. No windows = always-on, so never out of
 // hours: an exception alone cannot close an always-on agent, because there is no schedule to except
 // from. Shared by the operator-facing "out of hours" badge (conversation header, lists) and the
 // reactive gate.
 export function isOutOfHoursNow(schedule: Schedule, at: Date): boolean {
-  if (schedule.windows.length === 0) return false;
+  if (!scheduleCanClose(schedule)) return false;
   return !isOpenAt(schedule, at);
 }
 

--- a/src/modules/chatwoot/management.ts
+++ b/src/modules/chatwoot/management.ts
@@ -12,6 +12,7 @@ import {
 } from "@/modules/channel-redirect/link";
 import { type ChatwootClient, fetchChatwootProfile } from "./client";
 import { type LoadChatwootClientDeps, loadChatwootClient } from "./instance";
+import { chatwootAutoRepliesOutOfHours } from "./out-of-office";
 import { ensureAgentBot } from "./provisioning";
 
 // Chatwoot deployment + account + inbox management (per-tenant). A DEPLOYMENT (base URL + shared admin
@@ -664,6 +665,70 @@ export async function listInboxes(
   return rows.map(toInboxDto);
 }
 
+// The agent's bound inboxes on which CHATWOOT sends an out-of-hours reply of its own, read LIVE from
+// Chatwoot rather than from the mirror. Feeds one configuration warning in the agent editor: the
+// customer can be told the business is closed by one product and then served by the other, and nothing
+// in either console says so, because the two settings live on opposite sides of the boundary.
+//
+// Live, and not a column on Inbox, because of what the warning IS. `syncInboxes` runs when an account
+// is connected and when an operator presses the button, so a mirrored copy of this flag would keep
+// warning about an inbox whose out-of-hours reply was switched off weeks ago, and the only way to
+// clear it would be to find a sync button on another page. A warning that outlives the thing it names
+// is how a whole panel gets ignored.
+//
+// An instance that cannot be read contributes NOTHING instead of failing the call: a Chatwoot that is
+// down is not evidence that anything is misconfigured, and this is a warning nobody is waiting on. The
+// same call answers "checked, all clear" and "could not check" with an empty list on purpose — both
+// render as silence, so a status field here would exist only to be ignored.
+export async function listOutOfOfficeInboxes(
+  ctx: TenantContext,
+  agentId: bigint,
+  deps: LoadChatwootClientDeps = {},
+  base: PrismaClient = basePrisma,
+): Promise<{ id: string; name: string }[]> {
+  if (ctx.tenantId === null) throw new AppError("tenant required", 400);
+  const tenantId = ctx.tenantId;
+  const bound = await runScopedOn(base, ctx, (db) =>
+    db.inbox.findMany({
+      where: { agentId },
+      orderBy: { id: "asc" },
+      select: { id: true, chatwootInstanceId: true, chatwootInboxId: true },
+    }),
+  );
+
+  // One list call per distinct instance, not per inbox: GET /inboxes is account-wide, and an agent
+  // bound to six inboxes of one account must not cost six round trips.
+  const armedByInstance = new Map<bigint, Map<number, string>>();
+  for (const instanceId of new Set(bound.map((b) => b.chatwootInstanceId))) {
+    try {
+      const client = await loadChatwootClient(tenantId, instanceId, {
+        base,
+        makeClient: deps.makeClient,
+      });
+      const armed = new Map<number, string>();
+      for (const remote of parseInboxList(await client.listInboxes())) {
+        if (chatwootAutoRepliesOutOfHours(remote)) {
+          armed.set(remote.chatwootInboxId, remote.name);
+        }
+      }
+      armedByInstance.set(instanceId, armed);
+    } catch {
+      // unreachable / unauthorized — say nothing about this account's inboxes
+    }
+  }
+
+  // Chatwoot's name, not the mirror's: this reading exists because the mirror can be stale, and the
+  // inbox the operator has to go find is the one named on the other side.
+  const out: { id: string; name: string }[] = [];
+  for (const row of bound) {
+    const name = armedByInstance
+      .get(row.chatwootInstanceId)
+      ?.get(row.chatwootInboxId);
+    if (name !== undefined) out.push({ id: String(row.id), name });
+  }
+  return out;
+}
+
 export type { WidgetHealth, WidgetHealthStatus };
 
 // Live health of a web-widget inbox's website_url (the WhatsApp→website-chat redirect target).
@@ -1199,6 +1264,12 @@ export interface RemoteInbox {
   // WhatsApp provider (whatsapp_cloud | default | baileys | zapi) — only meaningful for
   // Channel::Whatsapp; null otherwise. Surfaced by the inbox serializer (json.provider).
   provider: string | null;
+  // Chatwoot's OWN out-of-hours auto-reply, the two halves of it that are configuration
+  // (json.working_hours_enabled / json.out_of_office_message on the same serializer). Kept because an
+  // agent can be bound to an inbox that already answers out of hours on a schedule this product
+  // cannot see — chatwootAutoRepliesOutOfHours (./out-of-office.ts) is the rule that reads them.
+  workingHoursEnabled: boolean;
+  outOfOfficeMessage: string | null;
 }
 
 // Pure parse of the Chatwoot inbox-list response. Confirmed against the chatwoot-pro fork:
@@ -1223,6 +1294,14 @@ export function parseInboxList(raw: unknown): RemoteInbox[] {
       channelType:
         typeof item.channel_type === "string" ? item.channel_type : null,
       provider: typeof item.provider === "string" ? item.provider : null,
+      // Strict boolean, like every other operator switch read off a wire we do not own: absent,
+      // "true" and 1 all read as off, so a shape change can only ever stop the warning, never invent
+      // one about an inbox that answers nothing.
+      workingHoursEnabled: item.working_hours_enabled === true,
+      outOfOfficeMessage:
+        typeof item.out_of_office_message === "string"
+          ? item.out_of_office_message
+          : null,
     });
   }
   return out;

--- a/src/modules/chatwoot/management.ts
+++ b/src/modules/chatwoot/management.ts
@@ -696,26 +696,42 @@ export async function listOutOfOfficeInboxes(
     }),
   );
 
-  // One list call per distinct instance, not per inbox: GET /inboxes is account-wide, and an agent
+  // One list call per distinct account, not per inbox: GET /inboxes is account-wide, and an agent
   // bound to six inboxes of one account must not cost six round trips.
-  const armedByInstance = new Map<bigint, Map<number, string>>();
-  for (const instanceId of new Set(bound.map((b) => b.chatwootInstanceId))) {
-    try {
-      const client = await loadChatwootClient(tenantId, instanceId, {
-        base,
-        makeClient: deps.makeClient,
-      });
-      const armed = new Map<number, string>();
-      for (const remote of parseInboxList(await client.listInboxes())) {
-        if (chatwootAutoRepliesOutOfHours(remote)) {
-          armed.set(remote.chatwootInboxId, remote.name);
-        }
-      }
-      armedByInstance.set(instanceId, armed);
-    } catch {
-      // unreachable / unauthorized — say nothing about this account's inboxes
-    }
-  }
+  //
+  // Concurrent, because the ceiling here is a timeout and not a duration. Every Chatwoot request
+  // carries a 15s abort, so reading two accounts in sequence makes an unreachable server cost 30s of
+  // an editor-load request that is producing a warning nobody is waiting on — and the second account
+  // being healthy would not help, it would just be answered late. Unbounded on purpose: the fan-out
+  // is the number of Chatwoot accounts the operator connected, a small number they chose, not
+  // anything that grows with traffic.
+  const armedByInstance = new Map(
+    (
+      await Promise.all(
+        [...new Set(bound.map((b) => b.chatwootInstanceId))].map(
+          async (instanceId) => {
+            try {
+              const client = await loadChatwootClient(tenantId, instanceId, {
+                base,
+                makeClient: deps.makeClient,
+              });
+              const armed = new Map<number, string>();
+              for (const remote of parseInboxList(await client.listInboxes())) {
+                if (chatwootAutoRepliesOutOfHours(remote)) {
+                  armed.set(remote.chatwootInboxId, remote.name);
+                }
+              }
+              return [instanceId, armed] as const;
+            } catch {
+              // unreachable / unauthorized — say nothing about this account's inboxes, and do not
+              // let it decide the answer for the others
+              return null;
+            }
+          },
+        ),
+      )
+    ).filter((entry) => entry !== null),
+  );
 
   // Chatwoot's name, not the mirror's: this reading exists because the mirror can be stale, and the
   // inbox the operator has to go find is the one named on the other side.

--- a/src/modules/chatwoot/out-of-office.ts
+++ b/src/modules/chatwoot/out-of-office.ts
@@ -1,0 +1,26 @@
+// Whether CHATWOOT ITSELF answers out of hours on an inbox. This is the auto-reply configured inside
+// Chatwoot, on the inbox — a different message, on a different schedule, from the agent's own away
+// message (modules/availability/away.ts), and neither product can see the other's.
+//
+// The rule is Chatwoot's, mirrored here from the fork's source so a version bump has one place to be
+// re-checked against: `MessageTemplates::HookExecutionService#should_send_out_of_office_message?`
+// gates on `inbox.out_of_office? && inbox.out_of_office_message.present?`, and
+// `OutOfOffisable#out_of_office?` is `working_hours_enabled? && working_hours.today.closed_now?`.
+//
+// Only two of those three are configuration. `closed_now?` is the WHEN and needs the clock; the other
+// two are the WHETHER, and they are the half an operator can be told about before a customer sees the
+// collision. So a true here means "this inbox sends its own out-of-hours reply", never "it is sending
+// one right now".
+//
+// `present?` is Rails' — nil and whitespace-only are both blank — which is why the trim is not
+// decoration: a message field holding a single space is configured in the console and dead in Chatwoot.
+export function chatwootAutoRepliesOutOfHours(inbox: {
+  workingHoursEnabled: boolean;
+  outOfOfficeMessage: string | null;
+}): boolean {
+  return (
+    inbox.workingHoursEnabled &&
+    inbox.outOfOfficeMessage !== null &&
+    inbox.outOfOfficeMessage.trim() !== ""
+  );
+}

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -29,6 +29,7 @@ import {
   NEXT_OPEN_SCAN_DAYS,
   parseSchedule,
   type Schedule,
+  scheduleCanClose,
 } from "@/modules/business-hours/hours";
 import { linkRedirectConversations } from "@/modules/channel-redirect/cross-link";
 import {
@@ -576,7 +577,7 @@ export function outOfHoursGate(
   now: Date,
   noticeAlreadySent: boolean,
 ): { silence: boolean; postNote: boolean } {
-  if (!hours || hours.windows.length === 0) {
+  if (!scheduleCanClose(hours)) {
     return { silence: false, postNote: false };
   }
   if (isOpenAt(hours, now)) {

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -924,6 +924,92 @@ describe("computeConfigIssues — which endpoint refusals wait for the vault", (
 // only place it can surface. It has to surface from OUTSIDE the field: the boundary deliberately
 // lets an untouched legacy value save, and the field itself may not be on screen — several of these
 // notes have no control in the editor at all, and the sections that do only render when switched on.
+// Issue #166. The one check here that is not about a feature failing to run: both features run, and
+// it is the customer who gets the wrong experience. The list of inboxes comes from the server (a live
+// Chatwoot read), so everything below is about what the panel DOES with it.
+describe("computeConfigIssues — Chatwoot already answers out of hours", () => {
+  const ONE = [{ id: "5", name: "WhatsApp Vendas" }];
+
+  test("no inboxes, or an empty list, raises nothing", () => {
+    expect(computeConfigIssues(base)).toEqual([]);
+    expect(computeConfigIssues({ ...base, outOfOfficeInboxes: [] })).toEqual(
+      [],
+    );
+  });
+
+  // With the agent silent out of hours, the customer is told the business is closed and then served
+  // by a bot that reads a different calendar. Nothing about the agent's own message is needed for
+  // that, which is why this fires with the availability block untouched.
+  test("Chatwoot's alone → the contradiction, deep-linked to behavior/availability", () => {
+    expect(computeConfigIssues({ ...base, outOfOfficeInboxes: ONE })).toEqual([
+      {
+        key: "outOfHoursChatwoot",
+        tab: "behavior",
+        sectionId: "availability",
+        inboxNames: ["WhatsApp Vendas"],
+      },
+    ]);
+  });
+
+  test("both on → the duplicate, and the inboxes are named in order", () => {
+    const issues = computeConfigIssues({
+      ...base,
+      settings: {
+        availability: { enabled: true, awayMessage: "Estamos fechados." },
+      },
+      outOfOfficeInboxes: [
+        { id: "5", name: "WhatsApp Vendas" },
+        { id: "9", name: "Instagram" },
+      ],
+    });
+    expect(issues).toEqual([
+      {
+        key: "outOfHoursBoth",
+        tab: "behavior",
+        sectionId: "availability",
+        inboxNames: ["WhatsApp Vendas", "Instagram"],
+      },
+    ]);
+  });
+
+  // The switch is what the operator flipped; the copy is what actually goes out. Either one missing
+  // means the agent says nothing, so the collision is the contradiction and not the duplicate — and
+  // a bag that spells the switch any other way is off (readAvailabilityConfig is strict on purpose).
+  const SILENT: Array<[string, unknown]> = [
+    ["switched off", { enabled: false, awayMessage: "Estamos fechados." }],
+    ["no copy", { enabled: true, awayMessage: "" }],
+    ["copy that is only whitespace", { enabled: true, awayMessage: "   " }],
+    ["the switch as a string", { enabled: "true", awayMessage: "Fechados." }],
+    ["no availability block at all", undefined],
+  ];
+  for (const [label, availability] of SILENT) {
+    test(`an agent with ${label} gets the contradiction, not the duplicate`, () => {
+      const issues = computeConfigIssues({
+        ...base,
+        settings: availability === undefined ? {} : { availability },
+        outOfOfficeInboxes: ONE,
+      });
+      expect(issues.map((i) => i.key)).toEqual(["outOfHoursChatwoot"]);
+    });
+  }
+
+  // Every other line in the panel offers a fix; these two must as well, or the operator reads a
+  // problem with no way in.
+  test("both spellings offer an action", () => {
+    for (const settings of [
+      {},
+      { availability: { enabled: true, awayMessage: "x" } },
+    ]) {
+      const issue = computeConfigIssues({
+        ...base,
+        settings,
+        outOfOfficeInboxes: ONE,
+      })[0];
+      expect(issue && issueHasAction(issue)).toBe(true);
+    }
+  });
+});
+
 describe("computeConfigIssues — text stored over its cap", () => {
   const bag = (settings: Record<string, unknown>) => ({ ...base, settings });
 

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -929,6 +929,16 @@ describe("computeConfigIssues — which endpoint refusals wait for the vault", (
 // Chatwoot read), so everything below is about what the panel DOES with it.
 describe("computeConfigIssues — Chatwoot already answers out of hours", () => {
   const ONE = [{ id: "5", name: "WhatsApp Vendas" }];
+  // A schedule that actually closes. Without one the reactive gate never silences the agent, so its
+  // away message never goes out however the block is configured — which is review round 1's finding.
+  const CLOSES = {
+    windows: [{ day: 1, start: "09:00", end: "17:00" }],
+    exceptions: [],
+    timezone: "UTC",
+  };
+  const AWAY_ON = {
+    availability: { enabled: true, awayMessage: "Estamos fechados." },
+  };
 
   test("no inboxes, or an empty list, raises nothing", () => {
     expect(computeConfigIssues(base)).toEqual([]);
@@ -954,9 +964,8 @@ describe("computeConfigIssues — Chatwoot already answers out of hours", () => 
   test("both on → the duplicate, and the inboxes are named in order", () => {
     const issues = computeConfigIssues({
       ...base,
-      settings: {
-        availability: { enabled: true, awayMessage: "Estamos fechados." },
-      },
+      settings: AWAY_ON,
+      savedSchedule: CLOSES,
       outOfOfficeInboxes: [
         { id: "5", name: "WhatsApp Vendas" },
         { id: "9", name: "Instagram" },
@@ -987,11 +996,45 @@ describe("computeConfigIssues — Chatwoot already answers out of hours", () => 
       const issues = computeConfigIssues({
         ...base,
         settings: availability === undefined ? {} : { availability },
+        // A schedule that closes, so this row isolates the availability block: the only reason the
+        // agent stays quiet is the block itself.
+        savedSchedule: CLOSES,
         outOfOfficeInboxes: ONE,
       });
       expect(issues.map((i) => i.key)).toEqual(["outOfHoursChatwoot"]);
     });
   }
+
+  // Review round 1. The away message rides the SAME gate that silences replies, so an agent that
+  // never closes sends nothing out of hours with the switch on and the copy written. Claiming the
+  // duplicate there describes two messages where the customer gets a closure notice and then normal
+  // service — the contradiction, and the worse of the two.
+  const NEVER_CLOSES: Array<[string, unknown]> = [
+    ["no schedule at all (always on)", null],
+    ["a schedule with no windows", { ...CLOSES, windows: [] }],
+  ];
+  for (const [label, savedSchedule] of NEVER_CLOSES) {
+    test(`away copy on but ${label} → the contradiction`, () => {
+      const issues = computeConfigIssues({
+        ...base,
+        settings: AWAY_ON,
+        savedSchedule: savedSchedule as never,
+        outOfOfficeInboxes: ONE,
+      });
+      expect(issues.map((i) => i.key)).toEqual(["outOfHoursChatwoot"]);
+    });
+  }
+
+  // The mirror of the pair above: the schedule alone does not make it the duplicate either.
+  test("a closing schedule with the away message off is still the contradiction", () => {
+    const issues = computeConfigIssues({
+      ...base,
+      settings: { availability: { enabled: false, awayMessage: "Fechados." } },
+      savedSchedule: CLOSES,
+      outOfOfficeInboxes: ONE,
+    });
+    expect(issues.map((i) => i.key)).toEqual(["outOfHoursChatwoot"]);
+  });
 
   // Every other line in the panel offers a fix; these two must as well, or the operator reads a
   // problem with no way in.
@@ -1003,6 +1046,7 @@ describe("computeConfigIssues — Chatwoot already answers out of hours", () => 
       const issue = computeConfigIssues({
         ...base,
         settings,
+        savedSchedule: CLOSES,
         outOfOfficeInboxes: ONE,
       })[0];
       expect(issue && issueHasAction(issue)).toBe(true);

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -4,6 +4,9 @@ import { computeConfigIssues, issueHasAction } from "@/client/lib/configHealth";
 // Phase E: detect features turned on without the credential they need (the import that strips
 // secrets is the common trigger), each carrying a deep-link target (tab + section anchor).
 const base = {
+  // The agent's saved on/off. Only the out-of-hours collision reads it (see the interface), and this
+  // fixture is the enabled case; the rows that turn it off say so.
+  agentEnabled: true,
   modelProvider: "openai",
   modelCredentialRef: "vault:1",
   // What the rewrite inherits is the STORED model, which is a different input from the one above
@@ -1035,6 +1038,28 @@ describe("computeConfigIssues — Chatwoot already answers out of hours", () => 
     });
     expect(issues.map((i) => i.key)).toEqual(["outOfHoursChatwoot"]);
   });
+
+  // Review round 2. A disabled agent says nothing to the customer at all — the runtime gates the away
+  // message on it and refuses the turn a few lines later — so Chatwoot's message is the only one that
+  // arrives and NEITHER spelling is true. This is the one line in this panel that claims something
+  // about what the customer receives rather than about the configuration, which is why it is also the
+  // only one that has to care.
+  for (const [label, settings] of [
+    ["with its away message on", AWAY_ON],
+    ["with nothing of its own to say", {}],
+  ] as Array<[string, unknown]>) {
+    test(`a disabled agent ${label} raises nothing`, () => {
+      expect(
+        computeConfigIssues({
+          ...base,
+          agentEnabled: false,
+          settings,
+          savedSchedule: CLOSES,
+          outOfOfficeInboxes: ONE,
+        }),
+      ).toEqual([]);
+    });
+  }
 
   // Every other line in the panel offers a fix; these two must as well, or the operator reads a
   // problem with no way in.

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -2385,6 +2385,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       expect(health.failures).toBeGreaterThan(0);
       expect(
         computeConfigIssues({
+          agentEnabled: true,
           modelProvider: "openai",
           modelCredentialRef: "vault:1",
           savedModelProvider: "openai",

--- a/tests/modules/chatwoot-out-of-office.test.ts
+++ b/tests/modules/chatwoot-out-of-office.test.ts
@@ -304,6 +304,56 @@ describe.skipIf(!dbUp)("listOutOfOfficeInboxes", () => {
     expect(calls.sort()).toEqual([1, 2]);
   });
 
+  // Review round 1. Every Chatwoot request carries a 15s abort, so reading the accounts one after the
+  // other makes an unreachable server cost 15s PER ACCOUNT on a request the editor fires on load.
+  //
+  // Proved by deadlock, and by a rendezvous both sides announce: each account's list call publishes
+  // its own start and then waits for the other's, so a serial drain hangs whichever account it picks
+  // first. A one-sided version (only account 2 waits) would pass on a serial implementation that
+  // happened to read account 1 first, which is the shape of a temporal test that never goes red.
+  test("the accounts are read concurrently, not one timeout after another", async () => {
+    const arrive: Record<number, () => void> = {};
+    const started = new Map<number, Promise<void>>();
+    for (const id of [1, 2]) {
+      started.set(
+        id,
+        new Promise<void>((resolve) => {
+          arrive[id] = resolve;
+        }),
+      );
+    }
+    const makeClient = async (cfg: { accountId: number }) =>
+      ({
+        listInboxes: async () => {
+          arrive[cfg.accountId]?.();
+          await started.get(cfg.accountId === 1 ? 2 : 1);
+          return cfg.accountId === 1 ? ACCOUNT_1 : ACCOUNT_2;
+        },
+      }) as unknown as ChatwootClient;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const found = await Promise.race([
+        listOutOfOfficeInboxes(ctx(tenantA), agent1, { makeClient }, appDb),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new Error("serial: the second account never got to start"),
+              ),
+            5_000,
+          );
+        }),
+      ]);
+      expect(found.map((f) => f.name)).toEqual([
+        "WhatsApp Vendas (Chatwoot)",
+        "Instagram (Chatwoot)",
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  });
+
   test("an agent with no bound inbox costs no call at all", async () => {
     const lonely = (
       await suDb.agent.create({

--- a/tests/modules/chatwoot-out-of-office.test.ts
+++ b/tests/modules/chatwoot-out-of-office.test.ts
@@ -1,0 +1,334 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import type { TenantContext } from "@/lib/tenancy";
+import type { ChatwootClient } from "@/modules/chatwoot/client";
+import { listOutOfOfficeInboxes } from "@/modules/chatwoot/management";
+import { chatwootAutoRepliesOutOfHours } from "@/modules/chatwoot/out-of-office";
+
+// Issue #166. Two products can both answer out of hours on the same inbox, on schedules neither can
+// see, and until this reading existed nothing in either console said so.
+
+// ── the rule, as a table ──
+//
+// Written out rather than derived from the Ruby: the point of a mirrored rule is that it can be
+// compared against its source by eye. `present?` is the half that surprises — Rails treats a
+// whitespace-only string as blank, so a message field holding a space is configured in Chatwoot's
+// console and dead in its runtime.
+describe("chatwootAutoRepliesOutOfHours", () => {
+  const CASES: Array<[boolean, string | null, boolean]> = [
+    // workingHoursEnabled, outOfOfficeMessage, replies?
+    [true, "Estamos fechados.", true],
+    [true, "", false],
+    [true, "   ", false],
+    [true, null, false],
+    [false, "Estamos fechados.", false],
+    [false, "", false],
+    [false, null, false],
+  ];
+  for (const [workingHoursEnabled, outOfOfficeMessage, expected] of CASES) {
+    test(`hours=${workingHoursEnabled} message=${JSON.stringify(outOfOfficeMessage)} → ${expected}`, () => {
+      expect(
+        chatwootAutoRepliesOutOfHours({
+          workingHoursEnabled,
+          outOfOfficeMessage,
+        }),
+      ).toBe(expected);
+    });
+  }
+});
+
+// ── the reading, against a real database ──
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const suDb = su as PrismaClient;
+const appDb = app as PrismaClient;
+
+function ctx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}
+
+const SLUG = `oooff-${process.pid}`;
+
+let tenantA = 0n;
+let tenantB = 0n;
+let instance1 = 0n;
+let instance2 = 0n;
+let agent1 = 0n;
+let agent2 = 0n;
+let agentB = 0n;
+// Mirror ids, so the assertions can name the rows rather than the order they came back in.
+let ib1 = 0n;
+let ib4 = 0n;
+
+// What Chatwoot answers for each account. `1` has four inboxes; `2` has one. Both carry an inbox the
+// mirror does not know about, which is the direction that must never widen the result.
+const ACCOUNT_1 = {
+  payload: [
+    {
+      id: 101,
+      name: "WhatsApp Vendas (Chatwoot)",
+      working_hours_enabled: true,
+      out_of_office_message: "Estamos fechados.",
+    },
+    // Working hours on, no message: Chatwoot sends nothing, so neither do we.
+    {
+      id: 102,
+      name: "WhatsApp Suporte",
+      working_hours_enabled: true,
+      out_of_office_message: "",
+    },
+    // Armed, but bound to the OTHER agent.
+    {
+      id: 103,
+      name: "Site",
+      working_hours_enabled: true,
+      out_of_office_message: "Fechado.",
+    },
+    // Armed, and not in the mirror at all.
+    {
+      id: 199,
+      name: "Never synced",
+      working_hours_enabled: true,
+      out_of_office_message: "Fechado.",
+    },
+  ],
+};
+const ACCOUNT_2 = {
+  payload: [
+    {
+      id: 201,
+      name: "Instagram (Chatwoot)",
+      working_hours_enabled: true,
+      out_of_office_message: "Fechado.",
+    },
+  ],
+};
+
+// Counts the list calls so "one per ACCOUNT, not one per inbox" is an assertion and not a hope: an
+// agent bound to four inboxes of one account must cost one round trip.
+function fakeChatwoot(byAccount: Record<number, unknown>) {
+  const calls: number[] = [];
+  const makeClient = async (cfg: { accountId: number }) => {
+    const payload = byAccount[cfg.accountId];
+    return {
+      listInboxes: async () => {
+        calls.push(cfg.accountId);
+        if (payload === undefined) throw new Error("chatwoot unreachable");
+        return payload;
+      },
+    } as unknown as ChatwootClient;
+  };
+  return { makeClient, calls };
+}
+
+describe.skipIf(!dbUp)("listOutOfOfficeInboxes", () => {
+  beforeAll(async () => {
+    const tA = await suDb.tenant.create({
+      data: { name: `${SLUG}-a`, slug: `${SLUG}-a` },
+    });
+    const tB = await suDb.tenant.create({
+      data: { name: `${SLUG}-b`, slug: `${SLUG}-b` },
+    });
+    tenantA = tA.id;
+    tenantB = tB.id;
+
+    // A real encrypted token, because loadChatwootClient decrypts BEFORE it reaches the injected
+    // factory: a placeholder would throw there, land in the catch that swallows an unreachable
+    // account, and every assertion below would pass on an empty list for the wrong reason.
+    const depA = await suDb.chatwootDeployment.create({
+      data: {
+        tenantId: tenantA,
+        baseUrl: `https://cw-${SLUG}.test.local`,
+        adminToken: encryptJson("ADMIN"),
+      },
+    });
+    const depB = await suDb.chatwootDeployment.create({
+      data: {
+        tenantId: tenantB,
+        baseUrl: `https://cw-${SLUG}-b.test.local`,
+        adminToken: encryptJson("ADMIN"),
+      },
+    });
+    const i1 = await suDb.chatwootInstance.create({
+      data: {
+        tenantId: tenantA,
+        deploymentId: depA.id,
+        accountId: 1,
+        serverKey: `cw-${SLUG}.test.local`,
+      },
+    });
+    const i2 = await suDb.chatwootInstance.create({
+      data: {
+        tenantId: tenantA,
+        deploymentId: depA.id,
+        accountId: 2,
+        serverKey: `cw-${SLUG}.test.local`,
+      },
+    });
+    const iB = await suDb.chatwootInstance.create({
+      data: {
+        tenantId: tenantB,
+        deploymentId: depB.id,
+        accountId: 1,
+        serverKey: `cw-${SLUG}-b.test.local`,
+      },
+    });
+    instance1 = i1.id;
+    instance2 = i2.id;
+
+    const mkAgent = async (tenantId: bigint, name: string) =>
+      (await suDb.agent.create({ data: { tenantId, name, systemPrompt: "x" } }))
+        .id;
+    agent1 = await mkAgent(tenantA, `${SLUG}-1`);
+    agent2 = await mkAgent(tenantA, `${SLUG}-2`);
+    agentB = await mkAgent(tenantB, `${SLUG}-b`);
+
+    const mkInbox = async (args: {
+      tenantId: bigint;
+      chatwootInstanceId: bigint;
+      chatwootInboxId: number;
+      name: string;
+      agentId: bigint | null;
+    }) => (await suDb.inbox.create({ data: args })).id;
+
+    // The mirror's name is deliberately NOT Chatwoot's: the reading is live, and the inbox the
+    // operator has to open is the one named on the other side.
+    ib1 = await mkInbox({
+      tenantId: tenantA,
+      chatwootInstanceId: instance1,
+      chatwootInboxId: 101,
+      name: "WhatsApp Vendas (stale mirror name)",
+      agentId: agent1,
+    });
+    await mkInbox({
+      tenantId: tenantA,
+      chatwootInstanceId: instance1,
+      chatwootInboxId: 102,
+      name: "WhatsApp Suporte",
+      agentId: agent1,
+    });
+    await mkInbox({
+      tenantId: tenantA,
+      chatwootInstanceId: instance1,
+      chatwootInboxId: 103,
+      name: "Site",
+      agentId: agent2,
+    });
+    // Bound, armed, and on an account the fake refuses to answer for in one of the tests.
+    ib4 = await mkInbox({
+      tenantId: tenantA,
+      chatwootInstanceId: instance2,
+      chatwootInboxId: 201,
+      name: "Instagram",
+      agentId: agent1,
+    });
+    // Same agent id would be a cross-tenant hit if the read were not scoped.
+    await mkInbox({
+      tenantId: tenantB,
+      chatwootInstanceId: iB.id,
+      chatwootInboxId: 101,
+      name: "Outro tenant",
+      agentId: agentB,
+    });
+  });
+
+  afterAll(async () => {
+    if (!dbUp) return;
+    for (const t of [tenantA, tenantB]) {
+      if (t) await suDb.tenant.delete({ where: { id: t } }).catch(() => {});
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  test("names the bound inboxes Chatwoot answers for, by CHATWOOT's name", async () => {
+    const { makeClient, calls } = fakeChatwoot({ 1: ACCOUNT_1, 2: ACCOUNT_2 });
+    const found = await listOutOfOfficeInboxes(
+      ctx(tenantA),
+      agent1,
+      { makeClient },
+      appDb,
+    );
+    expect(found).toEqual([
+      { id: String(ib1), name: "WhatsApp Vendas (Chatwoot)" },
+      { id: String(ib4), name: "Instagram (Chatwoot)" },
+    ]);
+    // One call per ACCOUNT: three of this agent's inboxes live on account 1.
+    expect(calls.sort()).toEqual([1, 2]);
+  });
+
+  test("the other agent's inbox is its own, even on the same account", async () => {
+    const { makeClient } = fakeChatwoot({ 1: ACCOUNT_1, 2: ACCOUNT_2 });
+    const found = await listOutOfOfficeInboxes(
+      ctx(tenantA),
+      agent2,
+      { makeClient },
+      appDb,
+    );
+    expect(found.map((f) => f.name)).toEqual(["Site"]);
+  });
+
+  test("an account that cannot be read says nothing, and does not sink the others", async () => {
+    // Account 2 has no payload → its listInboxes throws.
+    const { makeClient, calls } = fakeChatwoot({ 1: ACCOUNT_1 });
+    const found = await listOutOfOfficeInboxes(
+      ctx(tenantA),
+      agent1,
+      { makeClient },
+      appDb,
+    );
+    expect(found).toEqual([
+      { id: String(ib1), name: "WhatsApp Vendas (Chatwoot)" },
+    ]);
+    expect(calls.sort()).toEqual([1, 2]);
+  });
+
+  test("an agent with no bound inbox costs no call at all", async () => {
+    const lonely = (
+      await suDb.agent.create({
+        data: { tenantId: tenantA, name: `${SLUG}-lonely`, systemPrompt: "x" },
+      })
+    ).id;
+    const { makeClient, calls } = fakeChatwoot({ 1: ACCOUNT_1, 2: ACCOUNT_2 });
+    expect(
+      await listOutOfOfficeInboxes(ctx(tenantA), lonely, { makeClient }, appDb),
+    ).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  // The whole chain refuses another tenant's agent, and this test cannot say WHICH link refused —
+  // measured, not assumed: swapping the scoped read for a super-admin one leaves all twelve tests
+  // green. The rows come back, and `loadChatwootClient` then does its own scoped read of the
+  // instance and throws, which lands in the catch that already exists for an unreachable account.
+  // So the scope on the bound-inbox read is the first of two fences and the second is load-bearing
+  // today. It stays because it is the read that hands rows to the caller, and because a fence whose
+  // only guarantee is a downstream detail is one refactor away from not being a fence at all.
+  test("another tenant's context sees nothing, agent id or not", async () => {
+    const { makeClient, calls } = fakeChatwoot({ 1: ACCOUNT_1, 2: ACCOUNT_2 });
+    expect(
+      await listOutOfOfficeInboxes(ctx(tenantB), agent1, { makeClient }, appDb),
+    ).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+});

--- a/tests/modules/chatwoot-webhook.test.ts
+++ b/tests/modules/chatwoot-webhook.test.ts
@@ -546,6 +546,10 @@ describe("parseInboxList", () => {
           name: "WhatsApp Vendas",
           channel_type: "Channel::Whatsapp",
           provider: "whatsapp_cloud",
+          // Chatwoot's own out-of-hours reply, both halves of it, on the same serializer
+          // (app/views/api/v1/models/_inbox.json.jbuilder in the fork).
+          working_hours_enabled: true,
+          out_of_office_message: "Estamos fechados.",
         },
         // baileys is a Channel::Whatsapp too, but an unofficial provider (no window).
         {
@@ -553,6 +557,8 @@ describe("parseInboxList", () => {
           name: "WhatsApp Bridge",
           channel_type: "Channel::Whatsapp",
           provider: "baileys",
+          working_hours_enabled: false,
+          out_of_office_message: "",
         },
         { id: 3, name: "Site", channel_type: "Channel::WebWidget" },
       ],
@@ -563,19 +569,50 @@ describe("parseInboxList", () => {
         name: "WhatsApp Vendas",
         channelType: "Channel::Whatsapp",
         provider: "whatsapp_cloud",
+        workingHoursEnabled: true,
+        outOfOfficeMessage: "Estamos fechados.",
       },
       {
         chatwootInboxId: 2,
         name: "WhatsApp Bridge",
         channelType: "Channel::Whatsapp",
         provider: "baileys",
+        workingHoursEnabled: false,
+        outOfOfficeMessage: "",
       },
       {
         chatwootInboxId: 3,
         name: "Site",
         channelType: "Channel::WebWidget",
         provider: null,
+        workingHoursEnabled: false,
+        outOfOfficeMessage: null,
       },
+    ]);
+  });
+
+  // The out-of-hours pair comes off a wire this product does not own, and the warning it feeds is
+  // about someone else's product. Anything but a real `true` reads as off, so a serializer that
+  // starts sending "true" can only make the warning disappear — never make one up about an inbox
+  // that answers nothing.
+  test("reads the out-of-hours switch strictly, and a non-string message as absent", () => {
+    const raw = [
+      { id: 1, working_hours_enabled: "true", out_of_office_message: "hi" },
+      { id: 2, working_hours_enabled: 1, out_of_office_message: "hi" },
+      { id: 3, working_hours_enabled: true, out_of_office_message: null },
+      { id: 4, working_hours_enabled: true, out_of_office_message: 42 },
+    ];
+    expect(
+      parseInboxList(raw).map((i) => [
+        i.chatwootInboxId,
+        i.workingHoursEnabled,
+        i.outOfOfficeMessage,
+      ]),
+    ).toEqual([
+      [1, false, "hi"],
+      [2, false, "hi"],
+      [3, true, null],
+      [4, true, null],
     ]);
   });
 
@@ -592,12 +629,16 @@ describe("parseInboxList", () => {
         name: "Stringy",
         channelType: null,
         provider: null,
+        workingHoursEnabled: false,
+        outOfOfficeMessage: null,
       },
       {
         chatwootInboxId: 9,
         name: "Inbox 9",
         channelType: null,
         provider: null,
+        workingHoursEnabled: false,
+        outOfOfficeMessage: null,
       },
     ]);
   });

--- a/tests/modules/vault/dangling-ref.test.ts
+++ b/tests/modules/vault/dangling-ref.test.ts
@@ -123,6 +123,7 @@ describe.skipIf(!dbUp)("a vault entry deleted out from under an agent", () => {
   test("the editor's health panel flags it from the vault list alone", async () => {
     const rows = await listVaultEntryInfos(ctx(), appDb);
     const issues = computeConfigIssues({
+      agentEnabled: true,
       modelProvider: "openai",
       modelCredentialRef: ref(keyId),
       savedModelProvider: "openai",


### PR DESCRIPTION
The issue asks for a warning, not a behavior change: two products can both answer out of hours on one inbox, on schedules neither can see, and nothing in either console says so.

## What the measurement decided

**The condition is Chatwoot's, and it is two fields rather than three.** Read off the fork's source rather than inferred: `MessageTemplates::HookExecutionService#should_send_out_of_office_message?` gates on `inbox.out_of_office? && inbox.out_of_office_message.present?`, and `OutOfOffisable#out_of_office?` is `working_hours_enabled? && working_hours.today.closed_now?`. Only two of those three are configuration — `closed_now?` is the clock — so what an operator can be warned about is "this inbox sends its own out-of-hours reply", never "it is sending one right now". `present?` is Rails', so a message field holding a single space is configured in Chatwoot's console and dead in its runtime.

**The issue is right that the payload costs nothing and wrong that the mirror does.** `GET /inboxes` already carries both fields, but `syncInboxes` runs on account connect and when an operator presses a button, so a column filled from it would keep warning about a reply switched off weeks ago — and the only way to clear it would be to find a sync button on another page. A warning that outlives the thing it names is how a whole panel gets ignored, which is a rule this same file already writes down for the vault list. So the reading is **live**, following `getWidgetInboxHealth`, which exists for exactly this class of question and for the same reason.

**A nuance the issue does not have, and it bounds the damage rather than enlarging it.** Chatwoot suppresses its own out-of-office when a non-private outgoing message went out in the last five minutes, and sends at most one template per conversation per day. The agent's away message is also once per local day per conversation. So the duplicate is one pair per conversation per day, on the first inbound after a quiet stretch — not one per message. The contradiction case is untouched by that rule: the template fires on the inbound, and the agent answers after it.

## The change

**The rule, in `src/modules/chatwoot/out-of-office.ts`**, with the Ruby it mirrors cited in its header, so a Chatwoot version bump has one place to be re-checked against.

**`parseInboxList` keeps the pair**, read strictly: anything but a real `true` is off, so a serializer change can only ever make the warning disappear, never invent one about an inbox that answers nothing.

**`listOutOfOfficeInboxes`** returns the agent's bound inboxes that Chatwoot answers for, by **Chatwoot's** name — the reading is live precisely because the mirror can be stale, and the inbox the operator has to open is the one named on the other side. One list call per **account**, not per inbox. An account that cannot be read contributes nothing instead of failing the call: a Chatwoot that is down is not evidence of a misconfiguration, and "checked, all clear" and "could not check" both render as silence, so a status field would exist only to be ignored.

**One warning, two spellings**, because the customer sees two different things and the operator has two different fixes:

- *both on* — Chatwoot's inbox reply and the agent's away message, back to back;
- *Chatwoot's alone* — Chatwoot announces the closure and the agent, reading a calendar Chatwoot cannot express, serves the customer through it.

The second is not gated on the agent having a message of its own, and that is the point the issue makes: an agent with nothing to say out of hours still answers through the announcement.

**A switched-off agent raises nothing**, which is review round 2. It says nothing to the customer at all — the runtime gates the away message on it and refuses the turn a few lines later — so Chatwoot's message is the only one that arrives and neither spelling is true. This is the only line in that panel making a claim about what the customer *receives*; every other one describes the configuration ("on, but no key"), which stays true of an agent nobody switched on. That asymmetry is why it is also the only one that reads the switch, and why `agentEnabled` is a required field rather than an optional one: nothing mounts the editor in a test, so the compiler is the only thing that could catch a caller dropping it.

**Which of the two is not a question about the availability block alone**, which is what review round 1 corrected. The away message rides the *same* gate that silences replies, so an agent with no schedule — or one whose schedule has no windows — is never silenced and never sends it, however the block is configured. Announcing the duplicate there would describe two messages where the customer gets a closure notice and then normal service, which is the worse of the two cases. The condition moved into `business-hours` as `scheduleCanClose`, and both readers of that rule — `outOfHoursGate` and `isOutOfHoursNow` — now ask it instead of spelling it inline, so the console cannot drift from the gate. Neither of those two changes behavior; they are the same comparison under a name.

Two test files outside this feature (`tests/graph/runtime.test.ts`, `tests/modules/vault/dangling-ref.test.ts`) are touched for one line each, and only because `agentEnabled` is required: they build a `ConfigHealthInput` by hand rather than from the shared fixture.

**Binding an inbox re-ticks the panel.** Binding acts immediately with no save to piggyback on, and it is the one gesture that can create this collision; without it the warning would only appear on the next load.

## What this does not do

**It does not compare the two calendars.** Naming the date they disagree on needs Chatwoot's weekly grid and this product's dated exceptions side by side; the issue's scope is to warn, and the copy says the two are independent rather than pretending to have diffed them.

**It does not start writing `Inbox.workingHours`.** The issue notes that column is read nowhere, and it still is. The warning does not need the grid, and filling a column nothing reads is dead data with a maintenance cost.

**It costs one Chatwoot call per connected account per editor load** for an agent with bound inboxes (none at all for an agent without: no account is read when nothing is bound). The accounts are read **concurrently**, which round 1 also asked for and for a sharper reason than throughput: every Chatwoot request carries a 15s abort, so in sequence an unreachable server would cost 15s *per account* on a request the editor fires on load, and a healthy second account would not help — it would just be answered late. The fan-out is bounded by the number of accounts the operator connected, which is a small number they chose rather than anything that grows with traffic.

The reading is uncached, and does not follow live traffic — the same trade the guardrail-health reading already makes, for the same reason: polling costs a request a minute on every open editor to shorten a wait that ends the next time anybody loads or saves.

**The warning cannot be dismissed**, like every other line in that panel. It describes a live state and it disappears when either side is switched off.

## Validation scope

**Proven by test:**

- *the rule*, as a decision table over both inputs, written out rather than derived from the Ruby — including the whitespace-only message, which is the half of `present?` that surprises;
- *the wire*, in `parseInboxList`: both fields carried through, the switch read strictly, a non-string message read as absent;
- *the reading*, DB-backed with a fake Chatwoot: which inboxes come back and under **Chatwoot's** name rather than the mirror's (the fixture gives the mirror a deliberately stale name); another agent's inbox on the same account staying its own; one call per account for an agent with three inboxes there; an unreachable account saying nothing without sinking the others; an agent with no bound inbox costing no call at all;
- *the panel rule*, including the five ways an agent can be silent out of hours (switch off, empty copy, whitespace copy, the switch spelled as a string, no block at all) and the two ways its schedule can fail to close it (none picked, or one with no windows) — all of which are the contradiction and not the duplicate — and the agent being switched off, which is neither;
- *the concurrency*, by deadlock, with a rendezvous **both** accounts announce: each list call publishes its own start and then waits for the other's, so a serial read hangs on whichever account it happens to pick first. A one-sided version would pass on a serial implementation that read the right account first, which is the shape of a temporal test that never goes red.

**Proven by mutation** (each alone, against the four suites, 170 tests):

| mutation | tests failing |
| --- | ---: |
| the empty list still raises a warning | 68 |
| always the duplicate, never the contradiction | 9 |
| a whitespace-only message counts as configured | 5 |
| the reported name is the mirror's, not Chatwoot's | 3 |
| one list call per inbox instead of per account | 2 |
| the away copy is ignored, only the switch decides | 2 |
| the schedule is ignored when choosing the spelling | 2 |
| a schedule with no windows counts as closing | 2 |
| the inbox names are dropped from the issue | 2 |
| the agent being switched off is ignored | 2 |
| the working-hours switch is ignored | 1 |
| the switch is read loosely (truthy) | 1 |
| an unreachable account fails the whole call | 1 |
| always the contradiction, never the duplicate | 1 |
| the accounts are read one after the other again | 1 |

Two mutations survived and both changed the diff rather than the report:

- an early `return []` for an agent with no bound inboxes was **dead** — the loop over an empty set already does nothing — and is gone. The test that pins the no-network property stayed, because that property is worth a regression guard even when nothing today can break it.
- swapping the scoped read of the bound inboxes for a super-admin one leaves every test green, and the write-up says so rather than claiming a fence it cannot separate. The rows do come back; `loadChatwootClient` then does its own scoped read of the instance and throws, landing in the catch that already exists for an unreachable account. The scope stays: it is the read that hands rows to the caller, and a fence whose only guarantee is a downstream detail is one refactor away from not being one.

**Proven live**, against a local Chatwoot: `GET /api/v1/accounts/:id/inboxes` returns both fields on every inbox and `parseInboxList` reads them, including an inbox carrying an out-of-office message with working hours **off** — the pair whose whole point is that Chatwoot sends nothing. The serializer emits both unconditionally (`app/views/api/v1/models/_inbox.json.jbuilder`, no `if` around either), which is what makes the shape a property of the endpoint rather than of that server's data.

**Not validated:** the armed combination (hours on **and** a message set) was not exercised against a live Chatwoot — no inbox on that server has both, and arming one would have meant writing to an environment this change has no business touching. The console panel has no render test in this repo, so the rendered sentence is covered by the locale keys existing and by the issue object feeding them, not by a mounted editor. The added latency was not measured.

Fixes #166
