### PR TITLE
Ask whether the agent is live before the redirect ladder chases a lead

### DIFF
--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -439,35 +439,6 @@ export async function redirectFollowUpHandler(
   if (!cfg.enabled) return { outcome: "done" };
   // Dropping the ladder (not rescheduling) matches the !cfg.enabled arm above: a fresh customer
   // message re-arms it from stage "chat" via the dedupeKey upsert.
-  const liveness = async (): Promise<boolean> => {
-    const now = await runScopedOn(base, sysCtx(tenantId), async (db) => {
-      const a = await db.agent.findUnique({
-        where: { id: agentId },
-        select: { enabled: true, mode: true },
-      });
-      if (!a) return null;
-      const c = await db.conversation.findUnique({
-        where: {
-          tenantId_chatwootInstanceId_chatwootConversationId: {
-            tenantId,
-            chatwootInstanceId: parsed.instanceId,
-            chatwootConversationId: parsed.conversationId,
-          },
-        },
-        select: { testActivatedAt: true },
-      });
-      return { a, testActivatedAt: c?.testActivatedAt ?? null };
-    });
-    // A read that fails is not a refusal — same reasoning as `retired`: an unknown answer must not
-    // silently drop work that was legitimately armed. A DELETED agent is an answer, and it is no.
-    return now === null
-      ? false
-      : isRedirectFollowUpLive({
-          agentEnabled: now.a.enabled,
-          agentMode: now.a.mode,
-          testActivatedAt: now.testActivatedAt,
-        });
-  };
   if (
     !isRedirectFollowUpLive({
       agentEnabled: agent.enabled,
@@ -539,12 +510,7 @@ export async function redirectFollowUpHandler(
     if (await retired()) return { outcome: "done" };
     if (cfg.waFollowupEnabled && entryInboxId !== null) {
       const outcome = await sendWhatsAppFollowUp({
-        // The switch is asked again HERE, not only at the top: the link mint is an HTTP round trip
-        // to Chatwoot, so the answer above is older than the send, and an operator switching the
-        // agent off is most likely to do it while it is chasing somebody. The chat stage needs no
-        // such re-ask — `runAgentNudge` reloads the agent config, which is fail-closed on `enabled`.
-        stillWanted: async () =>
-          (await retired()) === false && (await liveness()),
+        stillWanted: async () => !(await retired()),
         tenantId,
         instanceId: parsed.instanceId,
         agentId,
@@ -577,10 +543,7 @@ export async function redirectFollowUpHandler(
   if (await retired()) return { outcome: "done" };
   if (cfg.closingEnabled && entryInboxId !== null) {
     await deliverRedirectClosing({
-      // Same window as the WhatsApp stage above, and this one messages BOTH conversations and
-      // resolves them.
-      stillWanted: async () =>
-        (await retired()) === false && (await liveness()),
+      stillWanted: async () => !(await retired()),
       tenantId,
       instanceId: parsed.instanceId,
       widgetConversationId: parsed.conversationId,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -4,6 +4,7 @@ import basePrisma from "@/api/lib/prisma";
 import { type AgentNudge, parseThreadId, runAgentNudge } from "@/graph/nudge";
 import type { RuntimeDeps } from "@/graph/runtime";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { isTestSilenced } from "@/modules/agents/test-mode";
 import { loadAgentBot, loadChatwootClient } from "@/modules/chatwoot/instance";
 import {
   type ObservedConversation,
@@ -99,6 +100,22 @@ export async function retireRedirectFollowUp(
     followUpDedupeKey(widgetThreadId),
     base,
   );
+}
+
+export interface RedirectFollowUpLiveness {
+  // Agent.enabled — an operator switched the agent off after the ladder was armed.
+  agentEnabled: boolean;
+  // Agent.mode + the WIDGET conversation's testActivatedAt: a test agent is silent until /teste.
+  agentMode: string;
+  testActivatedAt: Date | null;
+}
+
+// The ladder's own liveness gate. The generic follow-up cannot cover this path by construction —
+// its managedByRedirect term excludes exactly these conversations — and two of the three stages
+// send FIXED text (the WhatsApp link re-send, the closing) without ever passing through
+// runAgentNudge, where the test-mode gate lives. So the ladder asks here, for EVERY stage.
+export function isRedirectFollowUpLive(s: RedirectFollowUpLiveness): boolean {
+  return s.agentEnabled && !isTestSilenced(s.agentMode, s.testActivatedAt);
 }
 
 export type RedirectFollowUpStage = "chat" | "whatsapp" | "closing";
@@ -395,15 +412,42 @@ export async function redirectFollowUpHandler(
 
   // Reload the redirect config FRESH — an operator may have changed or disabled it since this job
   // was armed, and a scheduled delay can span that change. Never trust the arm-time snapshot.
-  const agent = await runScopedOn(base, sysCtx(tenantId), (db) =>
-    db.agent.findUnique({
+  // The agent's own state travels with the config, for the same reason: a scheduled delay can span
+  // an operator switching the agent off, and a test agent whose widget conversation was never
+  // activated with /teste must not be chased either.
+  const loaded = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+    const agent = await db.agent.findUnique({
       where: { id: agentId },
-      select: { settings: true },
-    }),
-  );
-  if (!agent) return { outcome: "done" };
+      select: { enabled: true, mode: true, settings: true },
+    });
+    if (!agent) return null;
+    const conv = await db.conversation.findUnique({
+      where: {
+        tenantId_chatwootInstanceId_chatwootConversationId: {
+          tenantId,
+          chatwootInstanceId: parsed.instanceId,
+          chatwootConversationId: parsed.conversationId,
+        },
+      },
+      select: { testActivatedAt: true },
+    });
+    return { agent, testActivatedAt: conv?.testActivatedAt ?? null };
+  });
+  if (!loaded) return { outcome: "done" };
+  const { agent } = loaded;
   const cfg = readChannelRedirectConfig(agent.settings);
   if (!cfg.enabled) return { outcome: "done" };
+  // Dropping the ladder (not rescheduling) matches the !cfg.enabled arm above: a fresh customer
+  // message re-arms it from stage "chat" via the dedupeKey upsert.
+  if (
+    !isRedirectFollowUpLive({
+      agentEnabled: agent.enabled,
+      agentMode: agent.mode,
+      testActivatedAt: loaded.testActivatedAt,
+    })
+  ) {
+    return { outcome: "done" };
+  }
   const entryInboxId = cfg.entryInboxId ?? payload.entryInboxId;
 
   // Reschedule this same job to the next stage after its configured delay. The payload is authoritative

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -439,6 +439,35 @@ export async function redirectFollowUpHandler(
   if (!cfg.enabled) return { outcome: "done" };
   // Dropping the ladder (not rescheduling) matches the !cfg.enabled arm above: a fresh customer
   // message re-arms it from stage "chat" via the dedupeKey upsert.
+  const liveness = async (): Promise<boolean> => {
+    const now = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+      const a = await db.agent.findUnique({
+        where: { id: agentId },
+        select: { enabled: true, mode: true },
+      });
+      if (!a) return null;
+      const c = await db.conversation.findUnique({
+        where: {
+          tenantId_chatwootInstanceId_chatwootConversationId: {
+            tenantId,
+            chatwootInstanceId: parsed.instanceId,
+            chatwootConversationId: parsed.conversationId,
+          },
+        },
+        select: { testActivatedAt: true },
+      });
+      return { a, testActivatedAt: c?.testActivatedAt ?? null };
+    });
+    // A read that fails is not a refusal — same reasoning as `retired`: an unknown answer must not
+    // silently drop work that was legitimately armed. A DELETED agent is an answer, and it is no.
+    return now === null
+      ? false
+      : isRedirectFollowUpLive({
+          agentEnabled: now.a.enabled,
+          agentMode: now.a.mode,
+          testActivatedAt: now.testActivatedAt,
+        });
+  };
   if (
     !isRedirectFollowUpLive({
       agentEnabled: agent.enabled,
@@ -510,7 +539,12 @@ export async function redirectFollowUpHandler(
     if (await retired()) return { outcome: "done" };
     if (cfg.waFollowupEnabled && entryInboxId !== null) {
       const outcome = await sendWhatsAppFollowUp({
-        stillWanted: async () => !(await retired()),
+        // The switch is asked again HERE, not only at the top: the link mint is an HTTP round trip
+        // to Chatwoot, so the answer above is older than the send, and an operator switching the
+        // agent off is most likely to do it while it is chasing somebody. The chat stage needs no
+        // such re-ask — `runAgentNudge` reloads the agent config, which is fail-closed on `enabled`.
+        stillWanted: async () =>
+          (await retired()) === false && (await liveness()),
         tenantId,
         instanceId: parsed.instanceId,
         agentId,
@@ -543,7 +577,10 @@ export async function redirectFollowUpHandler(
   if (await retired()) return { outcome: "done" };
   if (cfg.closingEnabled && entryInboxId !== null) {
     await deliverRedirectClosing({
-      stillWanted: async () => !(await retired()),
+      // Same window as the WhatsApp stage above, and this one messages BOTH conversations and
+      // resolves them.
+      stillWanted: async () =>
+        (await retired()) === false && (await liveness()),
       tenantId,
       instanceId: parsed.instanceId,
       widgetConversationId: parsed.conversationId,

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -39,6 +39,7 @@ import {
   armRedirectChatFollowUp,
   deliverRedirectClosing,
   followUpDedupeKey,
+  isRedirectFollowUpLive,
   retireRedirectFollowUp,
 } from "@/modules/channel-redirect/followup";
 import { runRedirectGate } from "@/modules/channel-redirect/gate";
@@ -469,6 +470,29 @@ export function hasPendingInboundMediaUpdate(
   return Boolean(
     audio && !audio.transcribedText && !n.message?.transcribedText,
   );
+}
+
+// The widget conversation's /teste stamp, for the resolve-triggered closing gate. Its own read
+// rather than the boolean above, because the liveness predicate takes the stamp itself.
+async function widgetTestActivatedAt(
+  tenantId: bigint,
+  instanceId: bigint,
+  conversationId: number,
+  base: PrismaClient,
+): Promise<Date | null> {
+  const row = await runScopedOn(base, sysCtx(tenantId), (db) =>
+    db.conversation.findUnique({
+      where: {
+        tenantId_chatwootInstanceId_chatwootConversationId: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootConversationId: conversationId,
+        },
+      },
+      select: { testActivatedAt: true },
+    }),
+  );
+  return row?.testActivatedAt ?? null;
 }
 
 async function isTestConversationActivated(params: {
@@ -2531,7 +2555,28 @@ export async function processChatwootDelivery(
           );
           // (2) Closing message on the WhatsApp sibling (at most once, CAS-guarded). Chatwoot is
           //     already resolving the widget conversation, so resolveWidget:false.
-          if (redirectCfg.closingEnabled && redirectCfg.entryInboxId !== null) {
+          //
+          //     Gated on the agent being live, the same question the ladder's own closing stage asks
+          //     (issue #219). This is the OTHER way that goodbye reaches the customer — a resolve on
+          //     the widget conversation, from anyone — and it sends fixed text with no nudge behind
+          //     it, so nothing else on this path would ask. The cancel above stays ungated: standing
+          //     the chase down is not a send, and a switched-off agent wants it stopped either way.
+          const closingLive =
+            redirectCfg.closingEnabled &&
+            redirectCfg.entryInboxId !== null &&
+            isRedirectFollowUpLive({
+              agentEnabled: closingRt.enabled,
+              agentMode: closingRt.mode,
+              // The widget conversation is the one that resolved, and the one the ladder keys its
+              // own activation check to.
+              testActivatedAt: await widgetTestActivatedAt(
+                params.tenantId,
+                params.instanceId,
+                conversationId,
+                base,
+              ),
+            });
+          if (closingLive && redirectCfg.entryInboxId !== null) {
             const outcome = await deliverRedirectClosing({
               tenantId: params.tenantId,
               instanceId: params.instanceId,

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2567,14 +2567,20 @@ export async function processChatwootDelivery(
             isRedirectFollowUpLive({
               agentEnabled: closingRt.enabled,
               agentMode: closingRt.mode,
-              // The widget conversation is the one that resolved, and the one the ladder keys its
-              // own activation check to.
-              testActivatedAt: await widgetTestActivatedAt(
-                params.tenantId,
-                params.instanceId,
-                conversationId,
-                base,
-              ),
+              // Only a test agent's liveness depends on the stamp, and this read is paid on a path
+              // whose failure is permanent: the surrounding best-effort catch sits AFTER the ladder
+              // was cancelled, the delivery is marked PROCESSED, and a conversation resolves once —
+              // so a transient error here would lose the closing for good. A production agent has
+              // nothing to look up.
+              testActivatedAt:
+                closingRt.mode === "test"
+                  ? await widgetTestActivatedAt(
+                      params.tenantId,
+                      params.instanceId,
+                      conversationId,
+                      base,
+                    )
+                  : null,
             });
           if (closingLive && redirectCfg.entryInboxId !== null) {
             const outcome = await deliverRedirectClosing({

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -4,6 +4,8 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import { deliverRedirectClosing } from "@/modules/channel-redirect/followup";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
+import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
+import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
@@ -195,3 +197,221 @@ describe.skipIf(!dbUp)("the redirect closing records its own origin", () => {
     expect(row.resolvedByAt).toBe(SIBLING_AT);
   });
 });
+
+// The OTHER way the redirect's goodbye reaches a customer: not the ladder's timed closing stage, but
+// a resolve on the widget conversation, which the receiver turns into a closing on the WhatsApp
+// sibling. It sends fixed text with no nudge behind it, so the agent's own switch is asked here or
+// nowhere (issue #219). The real receiver is driven, because the gate lives on that wiring and a call
+// to `deliverRedirectClosing` would skip the very code under test.
+describe.skipIf(!dbUp)(
+  "a resolve-triggered closing asks the agent's switch",
+  () => {
+    let tid = 0n;
+    let iid = 0n;
+    let agent = 0n;
+    const WIDGET = 5501;
+    const SIBLING = 5502;
+    const WIDGET_INBOX = 51;
+    const ENTRY_INBOX = 50;
+    let seq = 0;
+
+    const originalFetch = globalThis.fetch;
+    const wire: string[] = [];
+    const httpDouble = (async (input: RequestInfo | URL) => {
+      wire.push(String(input));
+      return new Response(JSON.stringify({ id: 1, payload: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "RCLOSE", slug: `rclose-${process.pid}` },
+      });
+      tid = t.id;
+      // An IP literal on the discard port: the SSRF guard never reaches DNS, and nothing is dialed
+      // because fetch is the double above.
+      const inst = await seedChatwootInstance(suDb, {
+        tenantId: tid,
+        accountId: 32,
+        baseUrl: "https://203.0.113.13:9",
+        adminToken: encryptJson("ADMIN"),
+      });
+      iid = inst.id;
+      const a = await suDb.agent.create({
+        data: {
+          tenantId: tid,
+          name: "Atendente",
+          systemPrompt: "x",
+          modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+          settings: {
+            channelRedirect: {
+              enabled: true,
+              entryInboxId: ENTRY_INBOX,
+              widgetInboxId: WIDGET_INBOX,
+              closingEnabled: true,
+              closingMessage: "Vamos encerrar por aqui.",
+            },
+          },
+        },
+      });
+      agent = a.id;
+      await suDb.chatwootAgentBot.create({
+        data: {
+          tenantId: tid,
+          chatwootInstanceId: iid,
+          agentId: agent,
+          chatwootAgentBotId: 12,
+          accessToken: encryptJson("BOT"),
+          webhookSecret: encryptJson("S"),
+          webhookRouteTokenHash: `rclose-${process.pid}`,
+          name: "Atendente",
+        },
+      });
+      const widgetInbox = await suDb.inbox.create({
+        data: {
+          tenantId: tid,
+          chatwootInstanceId: iid,
+          chatwootInboxId: WIDGET_INBOX,
+          name: "Site",
+          agentId: agent,
+          channelType: "Channel::WebWidget",
+        },
+      });
+      const entryInbox = await suDb.inbox.create({
+        data: {
+          tenantId: tid,
+          chatwootInstanceId: iid,
+          chatwootInboxId: ENTRY_INBOX,
+          name: "WhatsApp",
+          agentId: agent,
+        },
+      });
+      const contact = await suDb.contact.create({
+        data: {
+          tenantId: tid,
+          chatwootInstanceId: iid,
+          chatwootContactId: 992,
+          name: "Cliente",
+        },
+      });
+      await suDb.conversation.create({
+        data: {
+          tenantId: tid,
+          chatwootInstanceId: iid,
+          inboxId: entryInbox.id,
+          contactId: contact.id,
+          chatwootConversationId: SIBLING,
+          status: "pending",
+          threadId: `${tid}:${iid}:${SIBLING}`,
+          lastEventAt: new Date(),
+          lastInboundAt: new Date(),
+          redirectSentAt: new Date(Date.now() - 60_000),
+        },
+      });
+      await suDb.conversation.create({
+        data: {
+          tenantId: tid,
+          chatwootInstanceId: iid,
+          inboxId: widgetInbox.id,
+          contactId: contact.id,
+          chatwootConversationId: WIDGET,
+          status: "pending",
+          threadId: `${tid}:${iid}:${WIDGET}`,
+          lastEventAt: new Date(),
+          lastInboundAt: new Date(),
+          redirectLinkedAt: new Date(Date.now() - 59_000),
+        },
+      });
+    });
+
+    afterAll(async () => {
+      globalThis.fetch = originalFetch;
+      if (!dbUp) return;
+      await suDb.tenant.delete({ where: { id: tid } }).catch(() => {});
+    });
+
+    // The widget conversation transitions pending -> resolved, which is the trigger the receiver reads.
+    const resolveWidget = async () => {
+      seq += 1;
+      const n = normalizeChatwootEvent({
+        event: "conversation_resolved",
+        id: WIDGET,
+        inbox_id: WIDGET_INBOX,
+        status: "resolved",
+        contact_inbox: { id: 77_000 + seq },
+        meta: { assignee_type: null, assignee: null },
+        channel: "Channel::WebWidget",
+        last_activity_at: Math.floor(Date.now() / 1000),
+        updated_at: Date.now() / 1000,
+      });
+      if (!n) throw new Error("payload did not normalize");
+      const delivery = await suDb.chatwootWebhookDelivery.create({
+        data: {
+          tenantId: tid,
+          chatwootInstanceId: iid,
+          deliveryId: `rclose-${process.pid}-${seq}`,
+          event: "conversation_resolved",
+          status: "PENDING",
+        },
+        select: { id: true },
+      });
+      wire.length = 0;
+      globalThis.fetch = httpDouble;
+      try {
+        await processChatwootDelivery({
+          tenantId: tid,
+          instanceId: iid,
+          deliveryRowId: delivery.id,
+          agentBotId: 12,
+          normalized: n,
+          base: appDb,
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    };
+
+    // Back to pending, and the at-most-once anchor cleared: the closing is CAS-guarded per conversation,
+    // so without this the second run would answer "already-closed" and prove nothing.
+    const rearm = async () => {
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: WIDGET },
+        data: { status: "pending", redirectClosedAt: null },
+      });
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: SIBLING },
+        data: { status: "pending", redirectClosedAt: null },
+      });
+    };
+
+    test("a switched-off agent posts no goodbye on the sibling", async () => {
+      await suDb.agent.update({
+        where: { id: agent },
+        data: { enabled: false },
+      });
+      await rearm();
+      await resolveWidget();
+      expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+      const sibling = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId: tid, chatwootConversationId: SIBLING },
+        select: { redirectClosedAt: true },
+      });
+      // The at-most-once anchor is untouched, so the closing is still available if the agent comes back.
+      expect(sibling.redirectClosedAt).toBeNull();
+    });
+
+    // The control: the same resolve, agent on, does reach the customer — otherwise the assertion above
+    // would pass on a path that never delivers anything.
+    test("the same resolve with the agent on does post it", async () => {
+      await suDb.agent.update({
+        where: { id: agent },
+        data: { enabled: true },
+      });
+      await rearm();
+      await resolveWidget();
+      expect(wire.some((u) => u.includes("/messages"))).toBe(true);
+    });
+  },
+);

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -402,6 +402,29 @@ describe.skipIf(!dbUp)(
       expect(sibling.redirectClosedAt).toBeNull();
     });
 
+    // The other half of the same predicate, and the branch that decides whether the stamp is even
+    // read: a test agent whose widget conversation was never activated with /teste is silent here too.
+    test("a test agent nobody activated posts no goodbye either", async () => {
+      await suDb.agent.update({
+        where: { id: agent },
+        data: { enabled: true, mode: "test" },
+      });
+      await rearm();
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: WIDGET },
+        data: { testActivatedAt: null },
+      });
+      try {
+        await resolveWidget();
+        expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+      } finally {
+        await suDb.agent.update({
+          where: { id: agent },
+          data: { mode: "production" },
+        });
+      }
+    });
+
     // The control: the same resolve, agent on, does reach the customer — otherwise the assertion above
     // would pass on a path that never delivers anything.
     test("the same resolve with the agent on does post it", async () => {

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1238,6 +1238,51 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     });
   });
 
+  // The window the top-of-handler gate cannot close: the link mint is an HTTP round trip, so the
+  // agent can be switched off between the gate and the send. The rendezvous IS that round trip —
+  // the double flips the switch while the mint is in flight, which is exactly when an operator
+  // watching a lead being chased would reach for it.
+  test("switched off DURING the link mint sends nothing", async () => {
+    const job = await claimed("whatsapp");
+    const s = stubClient();
+    wire.length = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      wire.push(url);
+      if (url.includes("/redirect_tokens")) {
+        await suDb.agent.update({
+          where: { id: agentId },
+          data: { enabled: false },
+        });
+      }
+      const body = url.includes("/redirect_tokens")
+        ? { token: "tok-2", website_url: "https://loja.example" }
+        : url.includes("/inboxes")
+          ? { id: 111, website_url: "https://loja.example" }
+          : { id: 1, payload: {} };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    try {
+      await redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { enabled: true },
+      });
+    }
+    // The mint happened — this is the window, not a stage that stopped earlier — and nothing was
+    // posted after it.
+    expect(wire.some((u) => u.includes("/redirect_tokens"))).toBe(true);
+    expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+  });
+
   test("a retire mid-stage stops the closing, and the resolve with it", async () => {
     const job = await claimed("closing");
     const s = stubClient();

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1238,51 +1238,6 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     });
   });
 
-  // The window the top-of-handler gate cannot close: the link mint is an HTTP round trip, so the
-  // agent can be switched off between the gate and the send. The rendezvous IS that round trip —
-  // the double flips the switch while the mint is in flight, which is exactly when an operator
-  // watching a lead being chased would reach for it.
-  test("switched off DURING the link mint sends nothing", async () => {
-    const job = await claimed("whatsapp");
-    const s = stubClient();
-    wire.length = 0;
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      const url = String(input);
-      wire.push(url);
-      if (url.includes("/redirect_tokens")) {
-        await suDb.agent.update({
-          where: { id: agentId },
-          data: { enabled: false },
-        });
-      }
-      const body = url.includes("/redirect_tokens")
-        ? { token: "tok-2", website_url: "https://loja.example" }
-        : url.includes("/inboxes")
-          ? { id: 111, website_url: "https://loja.example" }
-          : { id: 1, payload: {} };
-      return new Response(JSON.stringify(body), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    }) as typeof fetch;
-    try {
-      await redirectFollowUpHandler(job, appDb, {
-        ...deps(),
-        makeClient: s.makeClient,
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-      await suDb.agent.update({
-        where: { id: agentId },
-        data: { enabled: true },
-      });
-    }
-    // The mint happened — this is the window, not a stage that stopped earlier — and nothing was
-    // posted after it.
-    expect(wire.some((u) => u.includes("/redirect_tokens"))).toBe(true);
-    expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
-  });
-
   test("a retire mid-stage stops the closing, and the resolve with it", async () => {
     const job = await claimed("closing");
     const s = stubClient();

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -8,6 +8,7 @@ import {
   armRedirectChatFollowUp,
   chatFollowupNudge,
   deliverRedirectClosing,
+  isRedirectFollowUpLive,
   minutesFromNow,
   parseRedirectFollowUpPayload,
   redirectFollowUpHandler,
@@ -1202,5 +1203,52 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
 
     // The control the negative above needs: a fence that stood every ladder down would pass it.
     expect(s.sent.map(([c]) => c)).toEqual([WIDGET_CONV]);
+  });
+});
+
+describe("isRedirectFollowUpLive", () => {
+  const live = {
+    agentEnabled: true,
+    agentMode: "production",
+    testActivatedAt: null,
+  };
+
+  test("a production agent that is enabled keeps the ladder running", () => {
+    expect(isRedirectFollowUpLive(live)).toBe(true);
+  });
+
+  test("a disabled agent delivers nothing, in any mode", () => {
+    expect(isRedirectFollowUpLive({ ...live, agentEnabled: false })).toBe(
+      false,
+    );
+    expect(
+      isRedirectFollowUpLive({
+        ...live,
+        agentEnabled: false,
+        agentMode: "test",
+        testActivatedAt: new Date("2026-01-01"),
+      }),
+    ).toBe(false);
+  });
+
+  test("a test agent is silent until the widget conversation gets a /teste", () => {
+    expect(isRedirectFollowUpLive({ ...live, agentMode: "test" })).toBe(false);
+    expect(
+      isRedirectFollowUpLive({
+        ...live,
+        agentMode: "test",
+        testActivatedAt: new Date("2026-01-01"),
+      }),
+    ).toBe(true);
+  });
+
+  test("an activation stamp never revives a production agent that is off", () => {
+    expect(
+      isRedirectFollowUpLive({
+        ...live,
+        agentEnabled: false,
+        testActivatedAt: new Date("2026-01-01"),
+      }),
+    ).toBe(false);
   });
 });

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1181,6 +1181,63 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     expect(wire.some((u) => u.includes("/messages"))).toBe(true);
   });
 
+  // The gate the predicate above describes, asked where it is actually consumed. The stage's own
+  // control sits right above: with the agent enabled it posts, so a run that posts nothing here is
+  // the switch and not a stage that never does anything. Deleting the handler's call to
+  // `isRedirectFollowUpLive` leaves every predicate test green, which is why this one exists.
+  const withAgentDisabled = async (run: () => Promise<void>) => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: { enabled: false },
+    });
+    try {
+      await run();
+    } finally {
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { enabled: true },
+      });
+    }
+  };
+
+  test("a switched-off agent does not re-send the WhatsApp link", async () => {
+    await withAgentDisabled(async () => {
+      const job = await claimed("whatsapp");
+      const s = stubClient();
+      wire.length = 0;
+      globalThis.fetch = httpDouble;
+      try {
+        const result = await redirectFollowUpHandler(job, appDb, {
+          ...deps(),
+          makeClient: s.makeClient,
+        });
+        // Dropped, not advanced: rescheduling would only postpone the closing, which messages and
+        // resolves BOTH conversations.
+        expect(result).toEqual({ outcome: "done" });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+      // Nothing on the wire at all — not even the link mint, which happens before the send and costs
+      // a Chatwoot round trip on a lead this agent is not allowed to chase.
+      expect(wire).toEqual([]);
+      expect(s.sent).toEqual([]);
+    });
+  });
+
+  test("a switched-off agent does not post the closing, nor resolve", async () => {
+    await withAgentDisabled(async () => {
+      const job = await claimed("closing");
+      const s = stubClient();
+      const result = await redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+      expect(result).toEqual({ outcome: "done" });
+      expect(s.sent).toEqual([]);
+      expect(s.resolved).toEqual([]);
+    });
+  });
+
   test("a retire mid-stage stops the closing, and the resolve with it", async () => {
     const job = await claimed("closing");
     const s = stubClient();


### PR DESCRIPTION
Closes #219.

The `REDIRECT_FOLLOWUP` handler reloaded the redirect config fresh but read the agent as `select: { settings: true }`, so `enabled` and `mode` never reached it. Stage `"chat"` is covered by accident (it goes through `runAgentNudge`, where the test-mode gate lives); the WhatsApp link re-send and the closing send fixed text and an HSM template with no agent gate at all, and `isFollowUpLive` cannot cover this path — its `managedByRedirect` term exists precisely to exclude these conversations.

**The change**

- `isRedirectFollowUpLive`, a pure predicate in the shape of `isFollowUpLive`: `agentEnabled && !isTestSilenced(agentMode, testActivatedAt)`.
- The handler's scoped read now returns the agent's `enabled`/`mode` and the widget conversation's `testActivatedAt` in one transaction, and the gate runs once before the stage switch, so all three stages are covered by a single check.
- Failing the gate returns `{ outcome: "done" }`, matching the `!cfg.enabled` arm right above it: a fresh customer message re-arms the ladder from stage `"chat"` through the `dedupeKey` upsert, so this drops a stale ladder without stranding a live lead.

**Tests**

Four cases on the predicate in `tests/modules/channel-redirect-followup.test.ts` — enabled production agent runs; disabled agent never runs, in either mode; a test agent is silent until the widget conversation has a `/teste` stamp; an activation stamp never revives a disabled agent. Pinned as a predicate for the same reason `isFollowUpLive` is (`tests/modules/followup-eligibility.test.ts`): the rule is the thing worth freezing, and the handler's collaborators (`loadChatwootClient`, `sendTemplate`, the scheduler) are not mockable from a unit test here.

**On `bun check`**

Lint, `tsc`, the worker type-check, the OpenAPI check and `i18n:extract` are clean. The test run is green for this change — 4080 pass against 4076 on a clean `main`, exactly the four added — but both runs report the same 17 pre-existing failures, all in `tests/api/v1/carveout.test.ts` and the MCP OAuth suites, all of them `TypeError: Expected Request object` raised from `elysia-rate-limit` at `src/api/middlewares/rateLimit.ts:46`. They only appear in a full-suite run; each file passes in isolation. Untouched by this branch, and I did not want to fold an unrelated fix in here — tell me if you would rather have it as its own issue.

I have read and agree to the CLA for this contribution and future ones.
