### PR TITLE
Stop the thread's critical section from holding a transaction across a second pool

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -45,6 +45,10 @@ Destructive migrations (enum changes, `ACCESS EXCLUSIVE` on `users`) want a main
 
 The realtime pub/sub, the scheduler tick, the debounce worker, the outbound-webhook worker, and the alert-delivery worker are single-process by construction (in-process state + reentrancy guards). **Run one replica.** To scale the web tier: run the extra replicas with `SCHEDULER_WORKER_ENABLED=false`, `WEBHOOK_WORKER_ENABLED=false`, `DEBOUNCE_WORKER_ENABLED=false`, and `ALERT_WORKER_ENABLED=false` (workers off), and keep exactly one "leader" replica with them on. Scaling with workers on every replica causes double-fires and lost cross-replica realtime events (a durable claim / leader election / Redis pub/sub bridge is the post-MVP path).
 
+**One more thing now depends on the single process.** The `ingest:<threadId>` critical section (held by continuous ingestion, a reactive turn, the proactive nudge, memory compaction and `/reset`, all on the same key) is serialized by an in-process queue (`withKeyedQueue`), not by the Postgres advisory lock it used before. That lock had to go: those sections span the LangGraph checkpointer, which is a **separate** connection pool, and holding a Prisma transaction open across it drained the main pool and made unrelated queries fail on `maxWait` (issue #225). The in-flight turn registry (`src/graph/inflight.ts`) was already in-process, so the invariant is not new; its scope is wider. On a genuinely scaled web tier two replicas can now interleave a thread's channel read-modify-write, which is issue #203.
+
+`/reset` is the one member that still holds a transaction across the checkpointer, deliberately: there the rollback is what keeps a failed checkpoint delete from leaving an operator told the memory was cleared while the thread still answers from it (`src/modules/memory/reset.ts`).
+
 ### 5. CSP / build
 
 Production serves `dist/index.html`; its inline-script hashes are baked into the CSP at build time. Rebuild (`bun run build`) after editing any inline script. Per-tenant theming uses `setProperty` (DOM API, no inline `<style>`) precisely so it does not break the CSP hash.

--- a/src/graph/ingest-job.ts
+++ b/src/graph/ingest-job.ts
@@ -2,10 +2,15 @@ import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import { decryptJson, encryptJson } from "@/api/lib/crypto";
 import logger from "@/api/lib/logger";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { armCompaction } from "@/modules/memory/compact";
 import { type ClaimedJob, enqueueJob } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import { type IngestRole, ingestMessageIntoThread } from "./ingest";
+
+function sysCtx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}
 
 // Continuous ingestion as a scheduler job, instead of an append made inline while the webhook is
 // being acked (issue #194).
@@ -169,13 +174,18 @@ export async function ingestHandler(
     // row and bumps it — the later enqueue wins, and standing down here is what lets it, since that
     // re-armed row carries the same message and will run again.
     //
-    // Read on the connection the ingestion transaction already holds. Opening a second one here
-    // would let a busy shared lane deadlock on its own pool (see ./ingest.ts, stillWanted).
-    stillWanted: async (db) => {
-      const row = await db.schedulerJob.findUnique({
-        where: { id: job.id },
-        select: { status: true, claimSeq: true },
-      });
+    // Its own short transaction. This used to have to run on the ingestion transaction's connection,
+    // because that transaction stayed open across the whole critical section and a second one here
+    // could deadlock a busy shared lane against its own pool. The section holds no transaction while
+    // this runs any more (issue #225), so the read stands on its own; what still matters is that it
+    // happens INSIDE the critical section, which is what makes it exclusive with the reset.
+    stillWanted: async () => {
+      const row = await runScopedOn(base, sysCtx(tenantId), (db) =>
+        db.schedulerJob.findUnique({
+          where: { id: job.id },
+          select: { status: true, claimSeq: true },
+        }),
+      );
       return row?.status === "CLAIMED" && row.claimSeq === job.claimSeq;
     },
     tenantId,

--- a/src/graph/ingest.ts
+++ b/src/graph/ingest.ts
@@ -2,8 +2,8 @@ import { type BaseMessage, HumanMessage } from "@langchain/core/messages";
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
-import { withEntityLock } from "@/lib/locks";
-import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { withKeyedQueue } from "@/lib/locks";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
   attendanceHasStarted,
   claimAttendanceBoundary,
@@ -167,7 +167,7 @@ export interface IngestMessageParams {
   // a callback that opened a transaction of its own would have every handler waiting for a
   // connection only another handler could release — all of them timing out, retrying, and
   // dead-lettering a customer's message on a pool that was merely busy.
-  stillWanted?: (db: ScopedDb) => Promise<boolean>;
+  stillWanted?: () => Promise<boolean>;
 }
 
 export async function ingestMessageIntoThread(
@@ -186,16 +186,22 @@ export async function ingestMessageIntoThread(
   const checkpointer = params.checkpointer ?? (await getCheckpointer());
   const graph = buildThreadStateGraph(checkpointer);
 
-  const done = await runScopedOn(base, sysCtx(tenantId), (db) =>
-    withEntityLock(db, `ingest:${graphThreadId}`, async () => {
-      const key = {
-        tenantId_chatwootInstanceId_contactInboxId: {
-          tenantId,
-          chatwootInstanceId: instanceId,
-          contactInboxId,
-        },
-      };
-      const row = await db.agentThread.findUnique({
+  // Serialized by the process-local queue, not by a transaction-scoped advisory lock. This section
+  // reads and writes the checkpointer, which is a SEPARATE Postgres pool, and holding a Prisma
+  // transaction open across those round-trips drained the main pool: every other query in the
+  // process, the webhook ack included, then waited out `maxWait` and failed (issue #225). The row
+  // read and the row write are short transactions of their own now, and the ordering between them,
+  // which is what the lock was really providing, comes from the queue.
+  const done = await withKeyedQueue(`ingest:${graphThreadId}`, async () => {
+    const key = {
+      tenantId_chatwootInstanceId_contactInboxId: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        contactInboxId,
+      },
+    };
+    const row = await runScopedOn(base, sysCtx(tenantId), (db) =>
+      db.agentThread.findUnique({
         where: key,
         select: {
           lastSyncedMessageId: true,
@@ -204,163 +210,164 @@ export async function ingestMessageIntoThread(
           recentAgentMessageIds: true,
           lastConversationId: true,
         },
-      });
-      // Never re-append a message already folded into the thread. The decision is membership in the
-      // ids this direction remembers, NOT a comparison against the highest one: within a direction
-      // the ids arrive out of order too, and a mark read the later-arriving lower id as handled
-      // (./ingest-dedup.ts, issue #194). ONE SET PER DIRECTION for the older half of the same
-      // reason: the two writers do not share a latency at all, so an attendant answering a voice
-      // note lands before the note itself.
-      const recent =
-        params.role === "human_agent"
-          ? (row?.recentAgentMessageIds ?? [])
-          : (row?.recentSyncedMessageIds ?? []);
-      const prevMark =
-        (params.role === "human_agent"
-          ? row?.lastAgentMessageId
-          : row?.lastSyncedMessageId) ?? null;
-      if (ingestVerdict(recent, messageId) !== "new") {
-        return { outcome: "skipped" as const, closedConversationId: null };
-      }
+      }),
+    );
+    // Never re-append a message already folded into the thread. The decision is membership in the
+    // ids this direction remembers, NOT a comparison against the highest one: within a direction
+    // the ids arrive out of order too, and a mark read the later-arriving lower id as handled
+    // (./ingest-dedup.ts, issue #194). ONE SET PER DIRECTION for the older half of the same
+    // reason: the two writers do not share a latency at all, so an attendant answering a voice
+    // note lands before the note itself.
+    const recent =
+      params.role === "human_agent"
+        ? (row?.recentAgentMessageIds ?? [])
+        : (row?.recentSyncedMessageIds ?? []);
+    const prevMark =
+      (params.role === "human_agent"
+        ? row?.lastAgentMessageId
+        : row?.lastSyncedMessageId) ?? null;
+    if (ingestVerdict(recent, messageId) !== "new") {
+      return { outcome: "skipped" as const, closedConversationId: null };
+    }
 
-      // STAND DOWN, and do it from IN HERE. A turn owning the channel undoes anything appended
-      // beside it, and the caller cannot ask this question for us: a check made before the lock is
-      // only staggered, not exclusive — the turn can take the lock, mark itself and release between
-      // that check and this one, and the append then lands inside the invoke after all. Turns mark
-      // themselves under this same lock (./inflight.ts, ../graph/runtime.ts), so asking here is what
-      // makes the two mutually exclusive.
-      //
-      // Nothing is written on this path, watermark included: the message has to stay OWED. Recording
-      // it as handled and not having it is the exact shape of the loss this whole change is about.
-      //
-      // PROCESS-LOCAL, like the two consumers of that claim that came before this one. It holds under
-      // the invariant ./inflight.ts states and docs/deploy.md §4 asks for (one replica, or one leader
-      // sharing the process with the scheduler worker) and not on a scaled web tier, where turns run
-      // wherever the webhook landed. What is new here is that this consumer's cross-process failure
-      // is the irreversible one, so it is written down: issue #203, for the module rather than for
-      // this call site.
-      if (params.deferIfTurnInFlight && isTurnInFlight(graphThreadId)) {
-        return { outcome: "deferred" as const, closedConversationId: null };
-      }
+    // STAND DOWN, and do it from IN HERE. A turn owning the channel undoes anything appended
+    // beside it, and the caller cannot ask this question for us: a check made before the lock is
+    // only staggered, not exclusive — the turn can take the lock, mark itself and release between
+    // that check and this one, and the append then lands inside the invoke after all. Turns mark
+    // themselves under this same lock (./inflight.ts, ../graph/runtime.ts), so asking here is what
+    // makes the two mutually exclusive.
+    //
+    // Nothing is written on this path, watermark included: the message has to stay OWED. Recording
+    // it as handled and not having it is the exact shape of the loss this whole change is about.
+    //
+    // PROCESS-LOCAL, like the two consumers of that claim that came before this one. It holds under
+    // the invariant ./inflight.ts states and docs/deploy.md §4 asks for (one replica, or one leader
+    // sharing the process with the scheduler worker) and not on a scaled web tier, where turns run
+    // wherever the webhook landed. What is new here is that this consumer's cross-process failure
+    // is the irreversible one, so it is written down: issue #203, for the module rather than for
+    // this call site.
+    if (params.deferIfTurnInFlight && isTurnInFlight(graphThreadId)) {
+      return { outcome: "deferred" as const, closedConversationId: null };
+    }
 
-      // REVOKED WHILE WE WAITED. Checked here and not before the lock, for the same reason the
-      // deferral above is: /reset does its clearing while holding this lock, so a check made outside
-      // it answers about a thread that may be cleared a microsecond later. "Skipped" and not
-      // "deferred" — the work is not owed later, it is not wanted at all.
-      if (params.stillWanted && !(await params.stillWanted(db))) {
-        return { outcome: "skipped" as const, closedConversationId: null };
-      }
+    // REVOKED WHILE WE WAITED. Checked here and not before the lock, for the same reason the
+    // deferral above is: /reset does its clearing while holding this lock, so a check made outside
+    // it answers about a thread that may be cleared a microsecond later. "Skipped" and not
+    // "deferred" — the work is not owed later, it is not wanted at all.
+    if (params.stillWanted && !(await params.stillWanted())) {
+      return { outcome: "skipped" as const, closedConversationId: null };
+    }
 
-      // A LATE ARRIVAL DOES NOT MOVE THE FRONTIER, and the frontier is the THREAD'S — the newest id
-      // either writer has folded in, not the newest of the arriving one's own direction. The rule
-      // and both hazards it closes live in ./attendance-boundary.ts; what matters here is that the
-      // marks go in as a pair, because reading only this direction's is what let a delayed customer
-      // message close the live conversation an attendant had just opened.
-      //
-      // A late message is appended with its own conversation stamp — which is all the compaction cut
-      // needs to file it correctly — and nothing else.
-      const movesFrontier = movesAttendanceFrontier(
-        [row?.lastSyncedMessageId, row?.lastAgentMessageId],
-        messageId,
-      );
+    // A LATE ARRIVAL DOES NOT MOVE THE FRONTIER, and the frontier is the THREAD'S — the newest id
+    // either writer has folded in, not the newest of the arriving one's own direction. The rule
+    // and both hazards it closes live in ./attendance-boundary.ts; what matters here is that the
+    // marks go in as a pair, because reading only this direction's is what let a delayed customer
+    // message close the live conversation an attendant had just opened.
+    //
+    // A late message is appended with its own conversation stamp — which is all the compaction cut
+    // needs to file it correctly — and nothing else.
+    const movesFrontier = movesAttendanceFrontier(
+      [row?.lastSyncedMessageId, row?.lastAgentMessageId],
+      messageId,
+    );
 
-      // Which attendance this message belongs to, and what that costs the thread. One decision,
-      // shared with the reactive turn and the proactive nudge (./attendance-boundary.ts). Human-agent
-      // messages count as a start: an agent who opens the conversation sends its first message, and
-      // skipping them here left that message sitting inside the PREVIOUS attendance, summarized and
-      // removed with it when the customer finally replied.
-      const prevConv = row?.lastConversationId ?? null;
-      const anotherInvokeIsReading = isTurnInFlight(graphThreadId);
-      const alreadyStarted =
-        movesFrontier &&
-        needsAttendanceStartProbe(
-          prevConv,
+    // Which attendance this message belongs to, and what that costs the thread. One decision,
+    // shared with the reactive turn and the proactive nudge (./attendance-boundary.ts). Human-agent
+    // messages count as a start: an agent who opens the conversation sends its first message, and
+    // skipping them here left that message sitting inside the PREVIOUS attendance, summarized and
+    // removed with it when the customer finally replied.
+    const prevConv = row?.lastConversationId ?? null;
+    const anotherInvokeIsReading = isTurnInFlight(graphThreadId);
+    const alreadyStarted =
+      movesFrontier &&
+      needsAttendanceStartProbe(
+        prevConv,
+        conversationId,
+        anotherInvokeIsReading,
+      )
+        ? attendanceHasStarted(
+            (
+              (
+                await graph.getState({
+                  configurable: { thread_id: graphThreadId },
+                })
+              ).values as { messages?: BaseMessage[] } | undefined
+            )?.messages ?? [],
+            conversationId,
+          )
+        : false;
+    const claim = !movesFrontier
+      ? // Appended, and nothing else: no divider, no marker move, no compaction armed.
+        {
+          writeDivider: false,
+          advanceMarker: false,
+          closedConversationId: null,
+        }
+      : claimAttendanceBoundary({
+          previousConversationId: prevConv,
           conversationId,
           anotherInvokeIsReading,
-        )
-          ? attendanceHasStarted(
-              (
-                (
-                  await graph.getState({
-                    configurable: { thread_id: graphThreadId },
-                  })
-                ).values as { messages?: BaseMessage[] } | undefined
-              )?.messages ?? [],
-              conversationId,
-            )
-          : false;
-      const claim = !movesFrontier
-        ? // Appended, and nothing else: no divider, no marker move, no compaction armed.
-          {
-            writeDivider: false,
-            advanceMarker: false,
-            closedConversationId: null,
-          }
-        : claimAttendanceBoundary({
-            previousConversationId: prevConv,
-            conversationId,
-            anotherInvokeIsReading,
-            attendanceAlreadyStarted: alreadyStarted,
-          });
+          attendanceAlreadyStarted: alreadyStarted,
+        });
 
-      // A RETRY REPAIRING ITS OWN HALF-DONE ATTEMPT MUST NOT REWRITE THE MESSAGE. The append and the
-      // row that records it are not atomic, so attempt 2 can find attempt 1's message already in the
-      // channel — and it would not write the same thing twice over: the boundary claim now sees this
-      // conversation's stamp already present, so `writeDivider` is false, and the derived id makes
-      // the reducer REPLACE the divider-bearing message with a plain one. The attendance boundary
-      // would be silently erased by the retry that was supposed to be idempotent.
-      //
-      // So the append is skipped outright when its id is already there. Only the row write is owed,
-      // which is exactly what failed the first time.
-      // ASKED OF THE CHANNEL, EVERY TIME. The first version gated this on the scheduler's attempt
-      // count, which is a different question wearing the same clothes: "has this job run before"
-      // does not answer "is this message already in the thread". A duplicate delivery re-arming the
-      // row while it is CLAIMED flips it back to PENDING, `failJob`'s CAS then refuses, and attempts
-      // stays at zero — so a run that IS repairing a half-done append announced itself as the first
-      // one, and went on to replace the divider-bearing message with a plain one. One channel read
-      // is the price of asking the question that is actually being asked.
-      const alreadyAppended = (
+    // A RETRY REPAIRING ITS OWN HALF-DONE ATTEMPT MUST NOT REWRITE THE MESSAGE. The append and the
+    // row that records it are not atomic, so attempt 2 can find attempt 1's message already in the
+    // channel — and it would not write the same thing twice over: the boundary claim now sees this
+    // conversation's stamp already present, so `writeDivider` is false, and the derived id makes
+    // the reducer REPLACE the divider-bearing message with a plain one. The attendance boundary
+    // would be silently erased by the retry that was supposed to be idempotent.
+    //
+    // So the append is skipped outright when its id is already there. Only the row write is owed,
+    // which is exactly what failed the first time.
+    // ASKED OF THE CHANNEL, EVERY TIME. The first version gated this on the scheduler's attempt
+    // count, which is a different question wearing the same clothes: "has this job run before"
+    // does not answer "is this message already in the thread". A duplicate delivery re-arming the
+    // row while it is CLAIMED flips it back to PENDING, `failJob`'s CAS then refuses, and attempts
+    // stays at zero — so a run that IS repairing a half-done append announced itself as the first
+    // one, and went on to replace the divider-bearing message with a plain one. One channel read
+    // is the price of asking the question that is actually being asked.
+    const alreadyAppended = (
+      (
         (
-          (
-            await graph.getState({
-              configurable: { thread_id: graphThreadId },
-            })
-          ).values as { messages?: BaseMessage[] } | undefined
-        )?.messages ?? []
-      ).some((m) => m.id === `ingest:${messageId}`);
+          await graph.getState({
+            configurable: { thread_id: graphThreadId },
+          })
+        ).values as { messages?: BaseMessage[] } | undefined
+      )?.messages ?? []
+    ).some((m) => m.id === `ingest:${messageId}`);
 
-      // Every message carries the conversation it belongs to, which is what the compaction cut reads.
-      // Markers go through their factories because nothing else can make a message COUNT as one —
-      // the text alone never does, or a customer could type it (src/graph/markers.ts).
-      if (!alreadyAppended)
-        await graph.updateState(
-          { configurable: { thread_id: graphThreadId } },
-          {
-            messages: ingestedMessages(
-              params.role,
-              params.text,
-              // The whole late-arrival rule, spent here: a message that does not move the frontier
-              // claims NOTHING — not the divider, not the marker, not the attendance stamp.
-              movesFrontier ? conversationId : null,
-              claim.writeDivider,
-              messageId,
-            ),
-          },
-          THREAD_STATE_NODE,
-        );
+    // Every message carries the conversation it belongs to, which is what the compaction cut reads.
+    // Markers go through their factories because nothing else can make a message COUNT as one —
+    // the text alone never does, or a customer could type it (src/graph/markers.ts).
+    if (!alreadyAppended)
+      await graph.updateState(
+        { configurable: { thread_id: graphThreadId } },
+        {
+          messages: ingestedMessages(
+            params.role,
+            params.text,
+            // The whole late-arrival rule, spent here: a message that does not move the frontier
+            // claims NOTHING — not the divider, not the marker, not the attendance stamp.
+            movesFrontier ? conversationId : null,
+            claim.writeDivider,
+            messageId,
+          ),
+        },
+        THREAD_STATE_NODE,
+      );
 
-      // Remember THIS direction's message, and only it. The scalar stays the HIGHEST id folded in,
-      // which is now a `max` rather than an assignment: a message ingested out of order must not
-      // walk the mark backwards, or the next reader would read the thread as less complete than it
-      // is. Both messages also advance the divider marker (turns do the same).
-      const mark =
-        prevMark === null ? messageId : Math.max(prevMark, messageId);
-      const remembered = rememberIngested(recent, messageId);
-      const advance =
-        params.role === "human_agent"
-          ? { lastAgentMessageId: mark, recentAgentMessageIds: remembered }
-          : { lastSyncedMessageId: mark, recentSyncedMessageIds: remembered };
-      await db.agentThread.upsert({
+    // Remember THIS direction's message, and only it. The scalar stays the HIGHEST id folded in,
+    // which is now a `max` rather than an assignment: a message ingested out of order must not
+    // walk the mark backwards, or the next reader would read the thread as less complete than it
+    // is. Both messages also advance the divider marker (turns do the same).
+    const mark = prevMark === null ? messageId : Math.max(prevMark, messageId);
+    const remembered = rememberIngested(recent, messageId);
+    const advance =
+      params.role === "human_agent"
+        ? { lastAgentMessageId: mark, recentAgentMessageIds: remembered }
+        : { lastSyncedMessageId: mark, recentSyncedMessageIds: remembered };
+    await runScopedOn(base, sysCtx(tenantId), (db) =>
+      db.agentThread.upsert({
         where: key,
         create: {
           tenantId,
@@ -377,17 +384,17 @@ export async function ingestMessageIntoThread(
           // lost divider for a duplicated message.
           lastConversationId: claim.advanceMarker ? conversationId : prevConv,
         },
-      });
-      return {
-        outcome: "ingested" as const,
-        // Armed even when the boundary was not consumed. The attendance that just ended is
-        // compactable right now — its boundary lives on the messages, not on the divider this call
-        // declined to write — and withholding the arm would make it wait on a next message that may
-        // never come.
-        closedConversationId: claim.closedConversationId,
-      };
-    }),
-  );
+      }),
+    );
+    return {
+      outcome: "ingested" as const,
+      // Armed even when the boundary was not consumed. The attendance that just ended is
+      // compactable right now — its boundary lives on the messages, not on the divider this call
+      // declined to write — and withholding the arm would make it wait on a next message that may
+      // never come.
+      closedConversationId: claim.closedConversationId,
+    };
+  });
 
   if (done.closedConversationId !== null) {
     await params.onAttendanceClosed?.(done.closedConversationId);

--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -2,8 +2,8 @@ import type { BaseMessage } from "@langchain/core/messages";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
-import { withEntityLock } from "@/lib/locks";
-import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { withKeyedQueue } from "@/lib/locks";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { clipText } from "@/lib/text";
 import { isTestSilenced } from "@/modules/agents/test-mode";
 import { loadChatwootClient } from "@/modules/chatwoot/instance";
@@ -142,7 +142,7 @@ export interface RunAgentNudgeParams {
   // second connection there stalls on an exhausted pool while holding the lock, and `DB_POOL_MAX=1`
   // is supported; the ingestion barrier takes the same argument for the same reason. Optional
   // because the other six asks are outside any transaction and have nothing to hand over.
-  stillWanted?: (db?: ScopedDb) => Promise<boolean>;
+  stillWanted?: (opts: { strict: boolean }) => Promise<boolean>;
   base?: PrismaClient;
   deps?: RuntimeDeps;
 }
@@ -468,8 +468,11 @@ export async function runAgentNudge(
   }
 
   // Absent, the answer is yes: every caller that does not schedule work has nothing to retire.
-  const stillWanted = async (db?: ScopedDb): Promise<boolean> =>
-    params.stillWanted === undefined || (await params.stillWanted(db));
+  // `strict` selects which question is being asked; see RunAgentTurnParams.stillWanted. Only the ask
+  // inside the thread's critical section, before anything is written, wants an unreadable answer to
+  // stop the run.
+  const stillWanted = async (strict = false): Promise<boolean> =>
+    params.stillWanted === undefined || (await params.stillWanted({ strict }));
 
   // THE RULE for the asks below, because a check placed by intuition is a check the next branch is
   // born without: ONE ask per stretch of I/O that precedes a write, and never any I/O between an ask
@@ -929,95 +932,105 @@ export async function runAgentNudge(
     // ingestion still owed writes one message without one line of context, and the next reader gets
     // it. See ./ingest-drain.ts for the reader that cannot make that trade.
     await drainPendingIngest(tenantId, graphThreadId, base);
-    // Taken INSIDE the try, and released only if it was actually taken: the transaction can reject
-    // after its callback ran (a failed commit, a lost connection), and a claim made on the way to a
-    // rejection that skips the `finally` never comes back — every later compaction on this thread
-    // would read it as busy and reschedule until the process restarts.
-    const claim = await runScopedOn(base, sysCtx(tenantId), (db) =>
-      withEntityLock(db, `ingest:${graphThreadId}`, async () => {
-        // The one ask that has to happen HERE and cannot be hoisted out: everything below writes the
-        // thread (the divider, the marker, and then the invoke), and /reset clears exactly those
-        // under this same lock. Outside it the answer decays — the authorization call and the drain
-        // above both take time, and a reset that lands in either window clears the memory and then
-        // has this run write it back, leaving the operator told the conversation was cleared and the
-        // agent still answering from it. Inside the lock there is no such window in either
-        // direction: either this claims the thread first (and the clear refuses on isTurnInFlight)
-        // or the clear ran first (and this sees the tombstone). Asked BEFORE markTurnInFlight, so a
-        // retired run takes no claim it would then have to release.
-        if (!(await stillWanted(db))) return null;
-        // A thread keyed by CONVERSATION rather than by contact-inbox (resolveGraphThreadId, when the
-        // contact-inbox is unknown) carries a single attendance by construction: there is no earlier
-        // one for a divider to separate this from, and no sidecar row keyed by contact-inbox to
-        // advance. Claim the thread against a compaction rewrite all the same — the invoke below is
-        // still a read-modify-write of the whole channel.
-        if (contactInboxId === null) {
-          markTurnInFlight(graphThreadId);
-          claimedGraphThread = true;
-          return {
-            writeDivider: false,
-            advanceMarker: false,
-            closedConversationId: null,
-          };
-        }
-        const key = {
-          tenantId_chatwootInstanceId_contactInboxId: {
-            tenantId,
-            chatwootInstanceId: instanceId,
-            contactInboxId,
-          },
-        };
-        const existing = await db.agentThread.findUnique({
-          where: key,
-          select: { lastConversationId: true },
-        });
-        // Read BEFORE this nudge marks its own claim: what matters is whether some OTHER invoke is
-        // mid-flight (./attendance-boundary.ts, case 1).
-        const anotherInvokeIsReading = isTurnInFlight(graphThreadId);
+    // Taken INSIDE the try, and released only if it was actually taken: a claim made on the way to
+    // a rejection that skips the `finally` never comes back, and every later compaction on this
+    // thread would then read it as busy and reschedule until the process restarts.
+    //
+    // Serialized by the process-local queue rather than by a transaction-scoped advisory lock. The
+    // work below spans the checkpointer, which is a SEPARATE Postgres pool, and holding a Prisma
+    // transaction open across it is what drained the main pool and made every other query in the
+    // process wait out `maxWait` (issue #225). The two reads and the one write are short
+    // transactions of their own now; the ordering between them is what the queue provides.
+    const claim = await withKeyedQueue(`ingest:${graphThreadId}`, async () => {
+      // The one ask that has to happen HERE and cannot be hoisted out: everything below writes the
+      // thread (the divider, the marker, and then the invoke), and /reset clears exactly those
+      // inside this same critical section. Outside it the answer decays — the authorization call
+      // and the drain above both take time, and a reset that lands in either window clears the
+      // memory and then has this run write it back, leaving the operator told the conversation was
+      // cleared and the agent still answering from it. Inside there is no such window in either
+      // direction: either this claims the thread first (and the clear refuses on isTurnInFlight) or
+      // the clear ran first (and this sees the tombstone). Asked BEFORE markTurnInFlight, so a
+      // retired run takes no claim it would then have to release.
+      //
+      // It no longer borrows an enclosing transaction's connection, because there is no longer one
+      // to borrow: what makes this exclusive is the queue, not a transaction-scoped lock.
+      if (!(await stillWanted(true))) return null;
+      // A thread keyed by CONVERSATION rather than by contact-inbox (resolveGraphThreadId, when the
+      // contact-inbox is unknown) carries a single attendance by construction: there is no earlier
+      // one for a divider to separate this from, and no sidecar row keyed by contact-inbox to
+      // advance. Claim the thread against a compaction rewrite all the same — the invoke below is
+      // still a read-modify-write of the whole channel.
+      if (contactInboxId === null) {
         markTurnInFlight(graphThreadId);
         claimedGraphThread = true;
-        const previous = existing?.lastConversationId ?? null;
-        const alreadyStarted = needsAttendanceStartProbe(
-          previous,
-          conversationId,
-          anotherInvokeIsReading,
-        )
-          ? attendanceHasStarted(
-              (
-                (await graph.getState(invokeConfig)).values as
-                  | { messages?: BaseMessage[] }
-                  | undefined
-              )?.messages ?? [],
-              conversationId,
-            )
-          : false;
-        const decided = claimAttendanceBoundary({
-          previousConversationId: previous,
-          conversationId,
-          anotherInvokeIsReading,
-          attendanceAlreadyStarted: alreadyStarted,
-        });
-        // The divider goes in BEFORE the marker moves, and inside the claim — the same order and the
-        // same lock the reactive turn uses (./runtime.ts). It used to ride in this nudge's own invoke
-        // instead, which advanced the marker on a divider that did not exist yet: a turn arriving
-        // during the generation read the conversation as already recorded, declined to write one of
-        // its own, and then this invoke appended ours AFTER that turn's messages — a divider in the
-        // middle of the attendance, which is worse than none. An invoke that never succeeded left the
-        // marker advanced and no divider at all.
-        //
-        // The invoke below does not erase it either: an invoke saves the channel it LOADED, and this
-        // one has not started yet, so it loads the divider along with everything else.
-        if (decided.writeDivider) {
-          await buildThreadStateGraph(checkpointer).updateState(
-            { configurable: { thread_id: graphThreadId } },
-            { messages: [conversationDividerMessage(conversationId)] },
-            THREAD_STATE_NODE,
-          );
-        }
-        // The sidecar row is what resolve-time compaction reads to know which attendance the thread
-        // is on. A nudge that opens a conversation used to leave it absent, and the job then exited
-        // at its generation fence with the attendance never summarized.
-        if (decided.advanceMarker) {
-          await db.agentThread.upsert({
+        return {
+          writeDivider: false,
+          advanceMarker: false,
+          closedConversationId: null,
+        };
+      }
+      const key = {
+        tenantId_chatwootInstanceId_contactInboxId: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          contactInboxId,
+        },
+      };
+      const existing = await runScopedOn(base, sysCtx(tenantId), (db) =>
+        db.agentThread.findUnique({
+          where: key,
+          select: { lastConversationId: true },
+        }),
+      );
+      // Read BEFORE this nudge marks its own claim: what matters is whether some OTHER invoke is
+      // mid-flight (./attendance-boundary.ts, case 1).
+      const anotherInvokeIsReading = isTurnInFlight(graphThreadId);
+      markTurnInFlight(graphThreadId);
+      claimedGraphThread = true;
+      const previous = existing?.lastConversationId ?? null;
+      const alreadyStarted = needsAttendanceStartProbe(
+        previous,
+        conversationId,
+        anotherInvokeIsReading,
+      )
+        ? attendanceHasStarted(
+            (
+              (await graph.getState(invokeConfig)).values as
+                | { messages?: BaseMessage[] }
+                | undefined
+            )?.messages ?? [],
+            conversationId,
+          )
+        : false;
+      const decided = claimAttendanceBoundary({
+        previousConversationId: previous,
+        conversationId,
+        anotherInvokeIsReading,
+        attendanceAlreadyStarted: alreadyStarted,
+      });
+      // The divider goes in BEFORE the marker moves, and inside the claim — the same order and the
+      // same lock the reactive turn uses (./runtime.ts). It used to ride in this nudge's own invoke
+      // instead, which advanced the marker on a divider that did not exist yet: a turn arriving
+      // during the generation read the conversation as already recorded, declined to write one of
+      // its own, and then this invoke appended ours AFTER that turn's messages — a divider in the
+      // middle of the attendance, which is worse than none. An invoke that never succeeded left the
+      // marker advanced and no divider at all.
+      //
+      // The invoke below does not erase it either: an invoke saves the channel it LOADED, and this
+      // one has not started yet, so it loads the divider along with everything else.
+      if (decided.writeDivider) {
+        await buildThreadStateGraph(checkpointer).updateState(
+          { configurable: { thread_id: graphThreadId } },
+          { messages: [conversationDividerMessage(conversationId)] },
+          THREAD_STATE_NODE,
+        );
+      }
+      // The sidecar row is what resolve-time compaction reads to know which attendance the thread
+      // is on. A nudge that opens a conversation used to leave it absent, and the job then exited
+      // at its generation fence with the attendance never summarized.
+      if (decided.advanceMarker) {
+        await runScopedOn(base, sysCtx(tenantId), (db) =>
+          db.agentThread.upsert({
             where: key,
             create: {
               tenantId,
@@ -1027,15 +1040,16 @@ export async function runAgentNudge(
               lastConversationId: conversationId,
             },
             update: { lastConversationId: conversationId },
-          });
-        }
-        return decided;
-      }),
-    );
+          }),
+        );
+      }
+      return decided;
+    });
+    // `stillWanted` said no inside the critical section: the run was retired while this got here.
     if (claim === null) return "stale";
     if (claim.closedConversationId !== null && contactInboxId !== null) {
-      // Outside the lock: this opens its own transaction, and nesting one inside an advisory-lock
-      // transaction would hold that lock across a second connection's work.
+      // Outside the critical section: this arms a job of its own and has no business inside the
+      // ordering the queue exists to provide.
       await armCompaction({
         tenantId,
         instanceId,

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -4,8 +4,8 @@ import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
-import { withEntityLock } from "@/lib/locks";
-import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { withKeyedQueue } from "@/lib/locks";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { overlayMediaAnnotations } from "@/modules/chatwoot/annotations";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { loadChatwootClient } from "@/modules/chatwoot/instance";
@@ -170,14 +170,24 @@ export interface RunLoadedTurnParams {
   // false suppresses the reply (outcome "superseded"). Used by the debounce flush to drop a reply
   // when a newer message arrived mid-turn; the re-armed flush then answers the full burst.
   shouldPost?: () => Promise<boolean>;
-  // Whether the run that queued this turn is still wanted. Asked INSIDE the `ingest:` lock, on that
-  // transaction's own connection, and again immediately before each post — the two moments this
-  // function writes something the customer or the next turn can see.
+  // Whether the run that queued this turn is still wanted. Asked INSIDE the `ingest:` critical
+  // section, and again immediately before each post — the two moments this function writes
+  // something the customer or the next turn can see.
+  //
+  // It takes no `db`: the section is a process-local queue now rather than one pinned transaction,
+  // so the ask opens its own short scope instead of borrowing an enclosing connection.
+  //
+  // `strict` says WHICH of the two questions is being asked, because they want opposite answers when
+  // the read itself fails. Inside the critical section, before anything is written, an unreadable
+  // answer must stop the run: guessing "still wanted" there recreates the state /reset just cleared,
+  // and no later fence catches it. Everywhere else the ask guards a SEND, and throwing would abandon
+  // the bookkeeping of a message already delivered, so an unreadable answer lets the run continue and
+  // be fenced by the CAS at the end.
   //
   // REQUIRED and nullable rather than optional, because the compiler is the only thing that will ask
   // a future caller the question. `null` is the honest answer for a turn that arrives straight from
   // a webhook: there is no job to call it off, and nothing else names this run.
-  stillWanted: ((db?: ScopedDb) => Promise<boolean>) | null;
+  stillWanted: ((opts: { strict: boolean }) => Promise<boolean>) | null;
 }
 
 // Applies a deferred resolve_conversation intent AFTER the reply is delivered. The tool only
@@ -451,7 +461,8 @@ export async function runLoadedTurn(
   // Adjacency is not something a call site can be trusted to keep — it has to be where the question
   // is asked.
   const writeCalledOff = async (): Promise<boolean> =>
-    params.stillWanted !== null && !(await params.stillWanted());
+    params.stillWanted !== null &&
+    !(await params.stillWanted({ strict: false }));
 
   // The two gates that stand between this turn and a post, and neither is the fence — the fences are
   // the asks at the sends themselves. This is where a run that is already called off stops before
@@ -820,114 +831,125 @@ export async function runLoadedTurn(
       const checkpointerForDivider =
         params.deps?.checkpointer ?? (await getCheckpointer());
       const dividerGraph = buildThreadStateGraph(checkpointerForDivider);
-      const closedConversationId = await runScopedOn(
-        base,
-        sysCtx(tenantId),
-        (db) =>
-          withEntityLock(db, `ingest:${graphThreadId}`, async () => {
-            // THE ASK, and this is the boundary it belongs at: everything below writes — the divider
-            // is a real message, the claim arms compaction, and the invoke that follows persists the
-            // channel. A turn queued by a job the command retired must not recreate the thread the
-            // command just cleared, with input from before it.
-            //
-            // Inside the lock and on THIS transaction's connection, for both halves of the reason
-            // the nudge states: the lock is what makes the answer exclusive with a compaction
-            // rewrite, and `runScopedOn` has pinned this pooled connection, so a nested scope would
-            // ask the pool for a second one and time out under `DB_POOL_MAX=1`.
-            if (params.stillWanted && !(await params.stillWanted(db))) {
-              calledOff = true;
-              return null;
-            }
-            // Per-THREAD marker (AgentThread keyed by contact-inbox): a different display_id ⇒ a new
-            // conversation reusing the thread. Per-thread and not per-contact, so a multi-channel
-            // contact never gets a spurious divider from activity on another channel.
-            const key = {
-              tenantId_chatwootInstanceId_contactInboxId: {
-                tenantId,
-                chatwootInstanceId: instanceId,
-                contactInboxId,
-              },
-            };
-            const existing = await db.agentThread.findUnique({
+      // Serialized by the process-local queue, not by a transaction-scoped advisory lock. The
+      // section below spans the checkpointer, which is a SEPARATE Postgres pool, and holding a Prisma
+      // transaction open across it drained the main pool and made every other query in the process
+      // wait out `maxWait` (issue #225). The reads and the write are short transactions of their own
+      // now; the ordering between them is what the queue provides.
+      const closedConversationId = await withKeyedQueue(
+        `ingest:${graphThreadId}`,
+        async () => {
+          // THE ASK, and this is the boundary it belongs at: everything below writes — the divider
+          // is a real message, the claim arms compaction, and the invoke that follows persists the
+          // channel. A turn queued by a job the command retired must not recreate the thread the
+          // command just cleared, with input from before it.
+          //
+          // Still inside the critical section, which is what the exclusion needs; what changed is
+          // that the section is no longer one pinned transaction. The reason #202 gave for running
+          // this on the enclosing transaction's connection was that `runScopedOn` had pinned it and
+          // a nested scope would ask the pool for a second one and time out under `DB_POOL_MAX=1`.
+          // With the queue there is no enclosing transaction to nest inside, so the ask opens its
+          // own short one and the hazard it was avoiding cannot arise.
+          if (
+            params.stillWanted &&
+            !(await params.stillWanted({ strict: true }))
+          ) {
+            calledOff = true;
+            return null;
+          }
+          // Per-THREAD marker (AgentThread keyed by contact-inbox): a different display_id ⇒ a new
+          // conversation reusing the thread. Per-thread and not per-contact, so a multi-channel
+          // contact never gets a spurious divider from activity on another channel.
+          const key = {
+            tenantId_chatwootInstanceId_contactInboxId: {
+              tenantId,
+              chatwootInstanceId: instanceId,
+              contactInboxId,
+            },
+          };
+          const existing = await runScopedOn(base, sysCtx(tenantId), (db) =>
+            db.agentThread.findUnique({
               where: key,
               select: {
                 lastConversationId: true,
                 lastSyncedMessageId: true,
               },
-            });
-            // Read BEFORE this turn adds its own claim: what matters is whether some OTHER invoke
-            // is mid-flight on this thread (./attendance-boundary.ts, case 1).
-            const anotherInvokeIsReading = isTurnInFlight(graphThreadId);
-            // Claim the thread against a memory-compaction rewrite, under the lock the rewrite also
-            // holds while it checks. That makes the two exclusive rather than merely staggered: the
-            // rewrite either completes before this claim — and the invoke below then loads the
-            // rewritten channel — or it finds the thread claimed and stands down. Claimed for EVERY
-            // turn, not only the ones that cross a boundary, because what has to be excluded is the
-            // invoke, and every turn has one. Released in the `finally` below, on every exit.
-            markTurnInFlight(graphThreadId);
-            claimedGraphThread = true;
-            const prev = existing?.lastConversationId ?? null;
-            const alreadyStarted = needsAttendanceStartProbe(
-              prev,
-              conversationId,
-              anotherInvokeIsReading,
-            )
-              ? attendanceHasStarted(
+            }),
+          );
+          // Read BEFORE this turn adds its own claim: what matters is whether some OTHER invoke
+          // is mid-flight on this thread (./attendance-boundary.ts, case 1).
+          const anotherInvokeIsReading = isTurnInFlight(graphThreadId);
+          // Claim the thread against a memory-compaction rewrite, inside the critical section the
+          // rewrite also enters while it checks. That makes the two exclusive rather than merely staggered: the
+          // rewrite either completes before this claim — and the invoke below then loads the
+          // rewritten channel — or it finds the thread claimed and stands down. Claimed for EVERY
+          // turn, not only the ones that cross a boundary, because what has to be excluded is the
+          // invoke, and every turn has one. Released in the `finally` below, on every exit.
+          markTurnInFlight(graphThreadId);
+          claimedGraphThread = true;
+          const prev = existing?.lastConversationId ?? null;
+          const alreadyStarted = needsAttendanceStartProbe(
+            prev,
+            conversationId,
+            anotherInvokeIsReading,
+          )
+            ? attendanceHasStarted(
+                (
                   (
-                    (
-                      await dividerGraph.getState({
-                        configurable: { thread_id: graphThreadId },
-                      })
-                    ).values as { messages?: BaseMessage[] } | undefined
-                  )?.messages ?? [],
-                  conversationId,
-                )
-              : false;
-            const claim = claimAttendanceBoundary({
-              previousConversationId: prev,
-              conversationId,
-              anotherInvokeIsReading,
-              attendanceAlreadyStarted: alreadyStarted,
-            });
-            if (claim.writeDivider) {
-              await dividerGraph.updateState(
-                { configurable: { thread_id: graphThreadId } },
-                { messages: [conversationDividerMessage(conversationId)] },
-                THREAD_STATE_NODE,
-              );
-            }
-            // THE TURN RECORDS THE INBOUND ID IT HANDLED (issue #194). Ingestion decides whether an
-            // out-of-order message may still speak for the thread's attendance by comparing it with
-            // the newest inbound id the thread has seen (./attendance-boundary.ts,
-            // movesAttendanceFrontier), and this writer used to leave no id at all — so the frontier
-            // was blind to the most ordinary way a new attendance opens, which is the customer
-            // writing and the bot ANSWERING. A delayed message from the previous conversation then
-            // compared newer than a stale mark, walked the marker back and armed compaction for the
-            // conversation being served.
-            //
-            // ON EVERY HANDLED TURN, and `lastConversationId` alone stays conditional. An earlier
-            // round cut this back to boundaries only, reasoning that the frontier merely suppresses a
-            // boundary claim — which was already false by then, because the same change had given it
-            // a second job: it also decides whether the message may carry an attendance STAMP. And
-            // `advanceMarker` is false in two different situations, not one. The second is a boundary
-            // DEFERRED because another invoke is reading (./attendance-boundary.ts, case 1): the
-            // conversation really is new, this turn really is handling its first message, and the
-            // marker deliberately stays behind. Recording nothing there leaves the frontier back in
-            // the previous attendance, so a delayed message from it reads as current, stamps itself
-            // at the end of the channel, and the compaction cut then treats the live conversation as
-            // the closed prefix.
-            //
-            // The scalar only. `recentSyncedMessageIds` is ingestion's own ledger of what IT folded
-            // in, and the two never overlap by construction — a message a turn answers is never
-            // ingested (../modules/chatwoot/webhook.ts) — so putting a turn's id in that set would
-            // describe an append that never happened.
-            const inboundId = params.messageId;
-            const markedId =
-              inboundId === undefined
-                ? null
-                : Math.max(existing?.lastSyncedMessageId ?? 0, inboundId);
-            if (claim.advanceMarker || markedId !== null) {
-              await db.agentThread.upsert({
+                    await dividerGraph.getState({
+                      configurable: { thread_id: graphThreadId },
+                    })
+                  ).values as { messages?: BaseMessage[] } | undefined
+                )?.messages ?? [],
+                conversationId,
+              )
+            : false;
+          const claim = claimAttendanceBoundary({
+            previousConversationId: prev,
+            conversationId,
+            anotherInvokeIsReading,
+            attendanceAlreadyStarted: alreadyStarted,
+          });
+          if (claim.writeDivider) {
+            await dividerGraph.updateState(
+              { configurable: { thread_id: graphThreadId } },
+              { messages: [conversationDividerMessage(conversationId)] },
+              THREAD_STATE_NODE,
+            );
+          }
+          // THE TURN RECORDS THE INBOUND ID IT HANDLED (issue #194). Ingestion decides whether an
+          // out-of-order message may still speak for the thread's attendance by comparing it with
+          // the newest inbound id the thread has seen (./attendance-boundary.ts,
+          // movesAttendanceFrontier), and this writer used to leave no id at all — so the frontier
+          // was blind to the most ordinary way a new attendance opens, which is the customer
+          // writing and the bot ANSWERING. A delayed message from the previous conversation then
+          // compared newer than a stale mark, walked the marker back and armed compaction for the
+          // conversation being served.
+          //
+          // ON EVERY HANDLED TURN, and `lastConversationId` alone stays conditional. An earlier
+          // round cut this back to boundaries only, reasoning that the frontier merely suppresses a
+          // boundary claim — which was already false by then, because the same change had given it
+          // a second job: it also decides whether the message may carry an attendance STAMP. And
+          // `advanceMarker` is false in two different situations, not one. The second is a boundary
+          // DEFERRED because another invoke is reading (./attendance-boundary.ts, case 1): the
+          // conversation really is new, this turn really is handling its first message, and the
+          // marker deliberately stays behind. Recording nothing there leaves the frontier back in
+          // the previous attendance, so a delayed message from it reads as current, stamps itself
+          // at the end of the channel, and the compaction cut then treats the live conversation as
+          // the closed prefix.
+          //
+          // The scalar only. `recentSyncedMessageIds` is ingestion's own ledger of what IT folded
+          // in, and the two never overlap by construction — a message a turn answers is never
+          // ingested (../modules/chatwoot/webhook.ts) — so putting a turn's id in that set would
+          // describe an append that never happened.
+          const inboundId = params.messageId;
+          const markedId =
+            inboundId === undefined
+              ? null
+              : Math.max(existing?.lastSyncedMessageId ?? 0, inboundId);
+          if (claim.advanceMarker || markedId !== null) {
+            await runScopedOn(base, sysCtx(tenantId), (db) =>
+              db.agentThread.upsert({
                 where: key,
                 create: {
                   tenantId,
@@ -947,10 +969,11 @@ export async function runLoadedTurn(
                     ? {}
                     : { lastSyncedMessageId: markedId }),
                 },
-              });
-            }
-            return claim.closedConversationId;
-          }),
+              }),
+            );
+          }
+          return claim.closedConversationId;
+        },
       );
       // Out here, where the lock's transaction has committed: nothing was claimed, nothing was
       // written, and the thread stays as the command left it.
@@ -1007,7 +1030,7 @@ export async function runLoadedTurn(
     // state read, the toolset build and the prompt resolution, and on a conversation with no
     // contact-inbox the lock block does not run at all — so an invoke that inherited the lock's
     // answer would be a turn fenced only where it happens to have been convenient.
-    if (params.stillWanted && !(await params.stillWanted())) {
+    if (params.stillWanted && !(await params.stillWanted({ strict: false }))) {
       logger.info(
         "turn: the run was retired before the invoke (conv=%s), standing down",
         String(conversationId),

--- a/src/lib/tenancy/multi-tenant.ts
+++ b/src/lib/tenancy/multi-tenant.ts
@@ -118,8 +118,27 @@ async function requireTenantExists(
 // NOTE: no network/LLM await inside `fn` — the transaction pins a pooled connection and
 // long I/O would exhaust the pool. Keep fn to DB work; do network I/O outside.
 //
+// "Network" includes A SECOND POSTGRES. The `ingest:<threadId>` sections used to await the LangGraph
+// checkpointer, which has its own pool and its own connections, from in here, and the rule read as satisfied
+// because nothing was calling an HTTP API. It cost the same: a connection held idle-in-transaction
+// across another pool's round-trips, this pool drained, and every unrelated query failing on
+// `maxWait` (issue #225). If `fn` awaits anything that is not this transaction, it does not belong.
+//
 // `...On` variants take the base client explicitly so integration tests can pass their own
 // (real) client instead of the singleton, which unit tests mock globally.
+// Stated rather than inherited. These ARE the Prisma defaults, and that is the problem: the two
+// failures a drained pool produces name these exact numbers ("Unable to start a transaction in the
+// given time" is `maxWait`; "a query cannot be executed on an expired transaction" is `timeout`),
+// and neither number appeared anywhere in this repository. Naming them here is what makes the
+// budget greppable from the error, and tunable in one place if it ever has to move.
+export const SCOPED_TX_OPTIONS = {
+  // Time to WAIT for a free connection before giving up.
+  maxWait: 2_000,
+  // Time the transaction may stay open once it has one. Every section in here is DB-only work by the
+  // rule above, so this is a ceiling on a pathology, not a budget anything should approach.
+  timeout: 5_000,
+} as const;
+
 export async function runScopedOn<T>(
   base: TransactionCapable,
   ctx: TenantContext,
@@ -137,7 +156,7 @@ export async function runScopedOn<T>(
     const db = tx as unknown as ScopedDb;
     if (ctx.role === "SUPER_ADMIN") await requireTenantExists(db, tenantId);
     return fn(db);
-  });
+  }, SCOPED_TX_OPTIONS);
 }
 
 export async function runScoped<T>(
@@ -157,7 +176,7 @@ export async function asSuperAdminOn<T>(
   return base.$transaction(async (tx) => {
     await tx.$executeRaw`SELECT set_config('app.is_super_admin', 'on', true)`;
     return fn(tx as unknown as ScopedDb);
-  });
+  }, SCOPED_TX_OPTIONS);
 }
 
 export async function asSuperAdmin<T>(

--- a/src/modules/appointments/reminders.ts
+++ b/src/modules/appointments/reminders.ts
@@ -4,13 +4,14 @@ import basePrisma from "@/api/lib/prisma";
 import { type AgentNudge, parseThreadId, runAgentNudge } from "@/graph/nudge";
 import type { RuntimeDeps } from "@/graph/runtime";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
-import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
   type ClaimedJob,
   cancelPendingJobsByPrefix,
   enqueueJob,
   jobRetired,
+  jobRetiredStrict,
 } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import { ensureFreshGoogleAccessToken } from "@/modules/vault/google-oauth";
@@ -355,11 +356,14 @@ export async function appointmentReminderHandler(
   // Re-read rather than trusted from `job.payload`: that snapshot is from claim time, which is
   // exactly the moment before the stamp lands. A read that fails does NOT suppress the reminder —
   // an unknown answer must not silently drop a customer-facing message that was legitimately armed.
-  // Takes the caller's connection when there is one: asked from inside the nudge's thread claim,
-  // which runs in an advisory-lock transaction, a second connection would stall the lock (see
-  // jobRetired).
-  const retired = (scoped?: ScopedDb): Promise<boolean> =>
-    jobRetired(job, base, scoped);
+  // Opens its own short scope. It used to take the caller's connection, because the nudge's thread
+  // claim ran inside an advisory-lock transaction and a second connection there would stall the lock
+  // under DB_POOL_MAX=1. That claim holds no transaction any more (issue #225), so there is nothing
+  // to borrow and nothing to stall.
+  const retired = (): Promise<boolean> => jobRetired(job, base);
+  // Strict at the thread claim, where guessing wrong recreates state /reset cleared (see
+  // jobRetiredStrict). The two asks above it can afford the lenient answer.
+  const retiredStrict = (): Promise<boolean> => jobRetiredStrict(job, base);
 
   // NOTE: Asked TWICE, and the two calls buy different things. Here it saves the Google round trip, which
   // holds this handler for up to ten seconds. After it — see below — is where the window actually
@@ -397,7 +401,8 @@ export async function appointmentReminderHandler(
     // And once more inside, where the nudge re-asks its own questions across the model call. Three
     // reads is not belt-and-braces: each covers a different slow step (the Google fetch, the nudge's
     // setup, the judge's call), and the stamp can land in any of them.
-    stillWanted: async (scoped) => !(await retired(scoped)),
+    stillWanted: async ({ strict }) =>
+      !(await (strict ? retiredStrict() : retired())),
     nudge: reminderNudge({
       isLast,
       askConfirmation,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -14,6 +14,7 @@ import {
   type ClaimedJob,
   enqueueJob,
   jobRetired,
+  jobRetiredStrict,
   retireJobsByDedupeKey,
 } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
@@ -410,8 +411,9 @@ export async function redirectFollowUpHandler(
   // was legitimately armed.
   // Takes the caller's connection when there is one — see jobRetired: asked from inside the nudge's
   // thread claim, a second connection would stall on the pool while the advisory lock is held.
-  const retired = (scoped?: ScopedDb): Promise<boolean> =>
-    jobRetired(job, base, scoped);
+  // Its own short scope: the nudge's thread claim no longer holds a transaction to borrow one from
+  // (issue #225).
+  const retired = (): Promise<boolean> => jobRetired(job, base);
   if (await retired()) return { outcome: "done" };
   const parsed = parseThreadId(payload.widgetThreadId);
   if (!parsed || parsed.tenantId !== job.tenantId) return { outcome: "done" };
@@ -476,10 +478,20 @@ export async function redirectFollowUpHandler(
   // a snapshot (`runScopedOn` uses the default isolation), which leaves a gap of one statement with no
   // network in it — narrower than the window this whole fence exists to close.
   //
-  // Takes the caller's connection when there is one — the same rule `jobRetired` states and for the
-  // same reason: asked from inside the nudge's thread claim, a second connection would stall on an
-  // exhausted pool while the advisory lock is held, and `DB_POOL_MAX=1` is a supported setting.
-  const fence = async (scoped?: ScopedDb): Promise<LadderVerdict> => {
+  // Opens its own transaction, always. It used to take the nudge's connection when the nudge had one,
+  // because a claim that HELD a transaction across a checkpointer round trip could drain the pool a
+  // second connection then had to wait on. That claim holds no transaction any more — the critical
+  // section is a process-local queue with short transactions inside it — so there is no caller
+  // connection to inherit, and the branch that inherited one was unreachable.
+  const fence = async (
+    // Which question is being asked, in the sense `runAgentNudge` means it. The default is the one
+    // every send-time ask wants: an unreadable answer is "go", because unwinding past a delivered
+    // message abandons its watermark and the customer gets it twice. `strict` is the ask that runs
+    // BEFORE anything is written — inside the thread's critical section, ahead of the divider and
+    // the checkpoint — where guessing recreates the memory /reset just cleared and nothing later
+    // catches it. Only the RETIREMENT half changes: liveness stays fail-open in both.
+    opts: { strict?: boolean } = {},
+  ): Promise<LadderVerdict> => {
     const read = async (db: ScopedDb) => {
       // NOTE: The retirement read goes LAST, and that ordering is the whole of what the transaction
       // can offer: the two statements share a connection but not a snapshot (default READ COMMITTED),
@@ -505,7 +517,12 @@ export async function redirectFollowUpHandler(
       // The cost is that for a TEST agent the retirement answer is one statement older than the send
       // instead of the last thing read. For every other agent nothing moves: the stamp is not read at
       // all, so retirement stays last.
-      if (await jobRetired(job, base, db)) return "retired" as const;
+      if (
+        await (opts.strict
+          ? jobRetiredStrict(job, base, db)
+          : jobRetired(job, base, db))
+      )
+        return "retired" as const;
       if (a.mode !== "test") return "go" as const;
       // NOTE: The stamp lookup fails open ON ITS OWN: unknown liveness is live, and the answer that
       // matters more — retirement — is already decided above.
@@ -536,27 +553,25 @@ export async function redirectFollowUpHandler(
         return "go" as const;
       }
     };
-    const answer = await (scoped
-      ? read(scoped)
-      : runScopedOn(base, sysCtx(tenantId), read)
-    ).catch(async (err: unknown) => {
-      logger.warn(
-        "channel-redirect: could not re-read the ladder's fence (widget thread=%s): %s",
-        payload.widgetThreadId,
-        err instanceof Error ? err.message : String(err),
-      );
-      // NOTE: The liveness half is unknown here, and unknown is live. Retirement is not allowed to be
-      // unknown by association: a statement the server rejects leaves the transaction aborted, so it
-      // cannot be asked in THAT one — it gets a fresh one. A /reset is the strongest fence in this
-      // file and it must not be overtaken by a question that was added on top of it.
-      //
-      // Not when the caller handed us its connection: opening a second one inside the nudge's
-      // advisory lock is the pool inversion `jobRetired` warns about, and that path keeps its own
-      // retirement fences either side of this one.
-      if (scoped) return "go" as const;
-      const stillRetired = await jobRetired(job, base).catch(() => false);
-      return stillRetired ? ("retired" as const) : ("go" as const);
-    });
+    const answer = await runScopedOn(base, sysCtx(tenantId), read).catch(
+      async (err: unknown) => {
+        // The strict ask does not get an answer it could not read. Its caller is about to write, so
+        // "go" here is the guess this whole distinction exists to refuse: the scheduler's own bounded
+        // retry carries the job instead.
+        if (opts.strict) throw err;
+        logger.warn(
+          "channel-redirect: could not re-read the ladder's fence (widget thread=%s): %s",
+          payload.widgetThreadId,
+          err instanceof Error ? err.message : String(err),
+        );
+        // NOTE: The liveness half is unknown here, and unknown is live. Retirement is not allowed to be
+        // unknown by association: a statement the server rejects leaves the transaction aborted, so it
+        // cannot be asked in THAT one — it gets a fresh one. A /reset is the strongest fence in this
+        // file and it must not be overtaken by a question that was added on top of it.
+        const stillRetired = await jobRetired(job, base).catch(() => false);
+        return stillRetired ? ("retired" as const) : ("go" as const);
+      },
+    );
     return answer;
   };
   const entryInboxId = cfg.entryInboxId ?? payload.entryInboxId;
@@ -592,7 +607,7 @@ export async function redirectFollowUpHandler(
         threadId: payload.widgetThreadId,
         nudge: chatFollowupNudge(cfg.chatFollowupInstructions),
         base,
-        // NOTE: The composite fence, on the nudge's own connection. This stage's window is the widest
+        // NOTE: The composite fence. This stage's window is the widest
         // in the ladder — the config load is fail-closed on `enabled`, but the model turn runs after
         // it and the post comes after that — so a switch flipped mid-turn would otherwise reach the
         // customer from an agent that is already off.
@@ -606,7 +621,7 @@ export async function redirectFollowUpHandler(
         // fence again, so an agent still off there ends the ladder anyway; what is left uncovered is
         // an operator switching OFF during the turn and back ON inside the milliseconds before that
         // ask, and an agent that is live again by then has a defensible claim to the next stage.
-        stillWanted: async (scoped) => (await fence(scoped)) === "go",
+        stillWanted: async ({ strict }) => (await fence({ strict })) === "go",
         deps,
       });
     }

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -18,7 +18,7 @@ import type { IngestRole } from "@/graph/ingest";
 import { armIngest } from "@/graph/ingest-job";
 import { type RuntimeDeps, runAgentTurn } from "@/graph/runtime";
 import { AppError, UnauthorizedError } from "@/lib/errors";
-import { withEntityLock } from "@/lib/locks";
+import { withKeyedQueue } from "@/lib/locks";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { shouldRunReset } from "@/modules/agents/test-mode";
 import { cancelThreadAppointmentReminders } from "@/modules/appointments/reminders";
@@ -1644,19 +1644,28 @@ async function maybeConsumeCommandOrGate(params: {
       //     of the three, because the operator sees the reset confirmed and the agent keeps
       //     answering from the memory they just cleared.
       //
-      // Under the shared lock the job either finished before this ran (and this deletes everything it
-      // wrote) or it finds the AgentThread row gone and drops the summary. The checkpointer call is a
-      // separate connection, which is exactly why the advisory lock — and not the transaction — is
-      // what serializes here.
+      // Inside the shared critical section the job either finished before this ran (and this deletes
+      // everything it wrote) or it finds the AgentThread row gone and drops the summary.
+      //
+      // THE ONLY MEMBER OF THIS FAMILY THAT STILL HOLDS A TRANSACTION ACROSS THE CHECKPOINTER, and
+      // deliberately. Everywhere else that hold was removed because it drained the pool (issue #225);
+      // here the transaction IS the safety net. `clearContactMemory` deletes the rows first and the
+      // checkpoint last precisely so a failed checkpoint delete rolls the rows back and leaves /reset
+      // a clean retry (../memory/reset.ts spells out why the reverse order is worse). Moving the
+      // checkpointer call outside would commit the rows and then possibly fail, leaving the operator
+      // told the memory was cleared while the thread still answers from it. This is an operator
+      // action, not a hot path, so the one held connection is not what starves anything.
+      //
+      // The queue is what keeps it exclusive with ingestion, the turn, the nudge and compaction now
+      // that they no longer take the advisory lock.
       //
       // The order the three deletions run in is load-bearing and lives with its reasoning in
       // src/modules/memory/reset.ts.
       await step("clear agent memory", "memória", () =>
-        runScopedOn(base, sysCtx(tenantId), (db) =>
-          withEntityLock(
-            db,
-            `ingest:${contactInboxThreadId(tenantId, instanceId, contactInboxId)}`,
-            async () => {
+        withKeyedQueue(
+          `ingest:${contactInboxThreadId(tenantId, instanceId, contactInboxId)}`,
+          () =>
+            runScopedOn(base, sysCtx(tenantId), async (db) => {
               const graphThreadId = contactInboxThreadId(
                 tenantId,
                 instanceId,
@@ -1692,12 +1701,12 @@ async function maybeConsumeCommandOrGate(params: {
               // just told had been cleared.
               //
               // Inside the critical section, not as a step after it, because the window between
-              // releasing the lock and cancelling is exactly where a claimed job takes the lock.
-              // Retiring the rows is half; a run already in memory re-reads its own row under this
-              // lock and stands down (../../graph/ingest-job.ts, stillWanted).
+              // leaving it and cancelling is exactly where a claimed job enters it. Retiring the
+              // rows is half; a run already in memory re-reads its own row inside the section and
+              // stands down (../../graph/ingest-job.ts, stillWanted).
               // On `db`, the connection this step already holds. A helper that opened its own
               // transaction would wait for a connection this one cannot release until it returns,
-              // and `DB_POOL_MAX=1` is a supported setting — the reset would time out and report a
+              // and `DB_POOL_MAX=1` is a supported setting: the reset would time out and report a
               // partial failure of the very step that had nothing wrong with it.
               await revokeJobsByKeyPrefixOn(
                 db,
@@ -1712,8 +1721,7 @@ async function maybeConsumeCommandOrGate(params: {
                 contactInboxId,
                 threadId: graphThreadId,
               });
-            },
-          ),
+            }),
         ),
       );
       // The compacted memory of past attendances lives in its own table, not in the thread, so

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -7,7 +7,7 @@ import {
   type RuntimeDeps,
   runLoadedTurn,
 } from "@/graph/runtime";
-import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { overlayMediaAnnotations } from "@/modules/chatwoot/annotations";
 import { loadChatwootClient } from "@/modules/chatwoot/instance";
 import {
@@ -32,7 +32,11 @@ import {
 import { announceFailedTurn } from "@/modules/conversations/failure-note";
 import { emitFlowEvent } from "@/modules/flowlog/service";
 import type { FlowStage } from "@/modules/flowlog/stages";
-import { type ClaimedJob, jobRetired } from "@/modules/scheduler/service";
+import {
+  type ClaimedJob,
+  jobRetired,
+  jobRetiredStrict,
+} from "@/modules/scheduler/service";
 import {
   type JobResult,
   registerDeadLetterHandler,
@@ -85,7 +89,7 @@ export interface CoalesceTurnContext {
   // Whether the run that queued this turn is still wanted, handed straight to `runLoadedTurn`,
   // which asks it inside the `ingest:` lock and again before each post. REQUIRED and nullable so a
   // future caller has to answer it: `null` says "nothing queued this, nothing can call it off".
-  stillWanted: ((db?: ScopedDb) => Promise<boolean>) | null;
+  stillWanted: ((opts: { strict: boolean }) => Promise<boolean>) | null;
   // Label for the single summary log line ("debounce flush" / "reengage").
   label: string;
   // When set (the debounce flush passes "debounce"), emit a flow line for the coalescing under the
@@ -504,7 +508,10 @@ export async function flushDebounceJob(
         // the model — all waits the command lands inside — and the run would still recreate the
         // thread. `runLoadedTurn` asks it inside the `ingest:` lock, which is the boundary the
         // divider and the claim are written at, and again before each post.
-        stillWanted: async (scoped) => !(await jobRetired(job, base, scoped)),
+        stillWanted: async ({ strict }) =>
+          !(await (strict
+            ? jobRetiredStrict(job, base)
+            : jobRetired(job, base))),
         authContext,
         // Re-read, not the value captured before the authorization call: that call is a round-trip
         // to somebody else's endpoint with a ceiling of ten seconds, and a message that arrived and

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -19,6 +19,7 @@ import {
   enqueueJob,
   jobNotRetiredSql,
   jobRetired,
+  jobRetiredStrict,
 } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import {
@@ -472,7 +473,8 @@ export async function followUpHandler(
     // operator resets, which returns the conversation to the agent, and the second probe then finds
     // it bot-owned again and posts a nudge from the episode that was just erased. The tombstone is
     // the question the hand-back cannot answer yes to.
-    stillWanted: async (scoped) => !(await jobRetired(job, base, scoped)),
+    stillWanted: async ({ strict }) =>
+      !(await (strict ? jobRetiredStrict(job, base) : jobRetired(job, base))),
     base,
     deps,
   });

--- a/src/modules/memory/compact.ts
+++ b/src/modules/memory/compact.ts
@@ -17,7 +17,7 @@ import { resolveModelOverride } from "@/graph/model-override";
 import { createChatModel, type ResolvedModelConfig } from "@/graph/models";
 import { buildCallbacks, loadAgentConfig } from "@/graph/prepare";
 import { buildThreadStateGraph, THREAD_STATE_NODE } from "@/graph/thread-state";
-import { withEntityLock } from "@/lib/locks";
+import { withKeyedQueue } from "@/lib/locks";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { emitFlowEvent } from "@/modules/flowlog/service";
 import { type ClaimedJob, enqueueJob } from "@/modules/scheduler/service";
@@ -591,8 +591,8 @@ export async function runCompaction(
   // recreates it with a NEW id, so the id this job started with is the generation token — already in
   // the schema, one indexed read, nothing new to thread through.
   if (summary) {
-    const wrote = await runScopedOn(base, sysCtx(tenantId), (db) =>
-      withEntityLock(db, `ingest:${graphThreadId}`, async () => {
+    const wrote = await withKeyedQueue(`ingest:${graphThreadId}`, () =>
+      runScopedOn(base, sysCtx(tenantId), async (db) => {
         // GENERATION FENCE, second half: the row this job started with is gone, so a /reset ran
         // while the provider call was in flight. Non-null by the check right after the load.
         const stillThere = await db.agentThread.count({
@@ -627,41 +627,44 @@ export async function runCompaction(
     }
   }
 
-  const rewrite = await runScopedOn(base, sysCtx(tenantId), (db) =>
-    // The lock ingestion also takes, so an ingested message cannot interleave with the rewrite.
-    // It is NOT the whole story: a graph TURN writes to this thread without taking any lock, which
-    // is why the update below names the messages it removes instead of clearing the channel.
-    withEntityLock(db, `ingest:${graphThreadId}`, async () => {
-      // The check that actually makes this safe. A graph invoke is a read-modify-write of the WHOLE
-      // message channel — it saves the state it loaded at the start plus its own messages — so a
-      // rewrite that lands while one is running is silently undone the moment it finishes: the raw
-      // turns come back, the memory head disappears, and the next cut summarizes a segment that ends
-      // one message later, writing a SECOND row that says the same thing. Removing messages by id
-      // does not help, because the loser here is this whole checkpoint, not individual writes.
-      //
-      // Turns mark themselves under this same lock (src/graph/runtime.ts, src/graph/nudge.ts), so
-      // reading the registry from inside it is exclusive: either no turn has started reading, or
-      // this attempt stands down and comes back.
-      if (isTurnInFlight(graphThreadId)) return "busy" as const;
-      const fresh = await graph.getState(threadCfg);
-      const current = ((
-        fresh.values as { messages?: BaseMessage[] } | undefined
-      )?.messages ?? []) as BaseMessage[];
-      const consumed = [...(cut.head ? [cut.head] : []), ...cut.closed];
-      // The thread is append-only between the read and this write, so the messages we summarized
-      // must still be its prefix. If they are not, something rewrote the thread underneath us (the
-      // /reset command deletes it outright) and the safe move is to abandon this attempt rather than
-      // delete messages we never read. A shorter thread is covered by the same comparison: past its
-      // end `current[i]` is undefined, which never equals an id.
-      for (let i = 0; i < consumed.length; i++) {
-        if (current[i]?.id !== consumed[i]?.id) return "changed" as const;
-      }
-      // Only what the head can render. The rows are kept forever by design (the head bounds what the
-      // MODEL reads, not what the table stores), so a contact with years of history would otherwise
-      // have every one of them loaded and sorted on every compaction to keep the newest twenty.
-      // Newest-first with a limit, then back to chronological order, which is how the head reads.
-      const rows = (
-        await db.attendanceSummary.findMany({
+  // The critical section ingestion also enters, so an ingested message cannot interleave with the
+  // rewrite. It is NOT the whole story: a graph TURN writes to this thread without entering it,
+  // which is why the update below names the messages it removes instead of clearing the channel.
+  //
+  // A process-local queue rather than a transaction-scoped advisory lock: the section reads and
+  // writes the checkpointer, a SEPARATE Postgres pool, and holding a Prisma transaction open across
+  // that is what drained the main pool for everything else in the process (issue #225).
+  const rewrite = await withKeyedQueue(`ingest:${graphThreadId}`, async () => {
+    // The check that actually makes this safe. A graph invoke is a read-modify-write of the WHOLE
+    // message channel — it saves the state it loaded at the start plus its own messages — so a
+    // rewrite that lands while one is running is silently undone the moment it finishes: the raw
+    // turns come back, the memory head disappears, and the next cut summarizes a segment that ends
+    // one message later, writing a SECOND row that says the same thing. Removing messages by id
+    // does not help, because the loser here is this whole checkpoint, not individual writes.
+    //
+    // Turns mark themselves under this same lock (src/graph/runtime.ts, src/graph/nudge.ts), so
+    // reading the registry from inside it is exclusive: either no turn has started reading, or
+    // this attempt stands down and comes back.
+    if (isTurnInFlight(graphThreadId)) return "busy" as const;
+    const fresh = await graph.getState(threadCfg);
+    const current = ((fresh.values as { messages?: BaseMessage[] } | undefined)
+      ?.messages ?? []) as BaseMessage[];
+    const consumed = [...(cut.head ? [cut.head] : []), ...cut.closed];
+    // The thread is append-only between the read and this write, so the messages we summarized
+    // must still be its prefix. If they are not, something rewrote the thread underneath us (the
+    // /reset command deletes it outright) and the safe move is to abandon this attempt rather than
+    // delete messages we never read. A shorter thread is covered by the same comparison: past its
+    // end `current[i]` is undefined, which never equals an id.
+    for (let i = 0; i < consumed.length; i++) {
+      if (current[i]?.id !== consumed[i]?.id) return "changed" as const;
+    }
+    // Only what the head can render. The rows are kept forever by design (the head bounds what the
+    // MODEL reads, not what the table stores), so a contact with years of history would otherwise
+    // have every one of them loaded and sorted on every compaction to keep the newest twenty.
+    // Newest-first with a limit, then back to chronological order, which is how the head reads.
+    const rows = (
+      await runScopedOn(base, sysCtx(tenantId), (db) =>
+        db.attendanceSummary.findMany({
           where: {
             tenantId,
             chatwootInstanceId: instanceId,
@@ -676,43 +679,43 @@ export async function runCompaction(
           ],
           take: MEMORY_HEAD_MAX_ATTENDANCES,
           select: { conversationId: true, summary: true, attendanceAt: true },
-        })
-      ).reverse();
-      const head = renderMemoryHead(rows, cfg.timezone);
-      // The update REMOVES BY ID and never clears the channel. REMOVE_ALL_MESSAGES would have been
-      // shorter, and wrong: it replaces the whole list with what this update carries, so a message
-      // appended between the read above and this write would be erased. Ingestion is held off by the
-      // lock, but a graph TURN takes no lock and writes to this same thread, so that window is real
-      // and a customer's message is what falls into it. Naming the ids leaves everything else alone,
-      // whenever it arrived.
-      //
-      // The head reuses the id of the FIRST message it replaces, which is what keeps it at the front:
-      // the reducer replaces a same-id message in place and appends an unknown-id one at the end, and
-      // a memory head sitting after the conversation is not a header, it is a footnote.
-      const survivorId = consumed[0]?.id;
-      const dropped = consumed.filter((m) => m.id !== survivorId);
-      await graph.updateState(
-        threadCfg,
-        {
-          messages: [
-            ...(head && survivorId
-              ? [memoryHeadMessage(contentToText(head.content), survivorId)]
+        }),
+      )
+    ).reverse();
+    const head = renderMemoryHead(rows, cfg.timezone);
+    // The update REMOVES BY ID and never clears the channel. REMOVE_ALL_MESSAGES would have been
+    // shorter, and wrong: it replaces the whole list with what this update carries, so a message
+    // appended between the read above and this write would be erased. Ingestion is held off by the
+    // lock, but a graph TURN takes no lock and writes to this same thread, so that window is real
+    // and a customer's message is what falls into it. Naming the ids leaves everything else alone,
+    // whenever it arrived.
+    //
+    // The head reuses the id of the FIRST message it replaces, which is what keeps it at the front:
+    // the reducer replaces a same-id message in place and appends an unknown-id one at the end, and
+    // a memory head sitting after the conversation is not a header, it is a footnote.
+    const survivorId = consumed[0]?.id;
+    const dropped = consumed.filter((m) => m.id !== survivorId);
+    await graph.updateState(
+      threadCfg,
+      {
+        messages: [
+          ...(head && survivorId
+            ? [memoryHeadMessage(contentToText(head.content), survivorId)]
+            : []),
+          ...dropped.map((m) => new RemoveMessage({ id: m.id as string })),
+          // NOTE: With no head to keep (every summary came back empty), the survivor has nothing
+          // to become, so it is removed like the rest.
+          ...(head
+            ? []
+            : survivorId
+              ? [new RemoveMessage({ id: survivorId })]
               : []),
-            ...dropped.map((m) => new RemoveMessage({ id: m.id as string })),
-            // NOTE: With no head to keep (every summary came back empty), the survivor has nothing
-            // to become, so it is removed like the rest.
-            ...(head
-              ? []
-              : survivorId
-                ? [new RemoveMessage({ id: survivorId })]
-                : []),
-          ],
-        },
-        THREAD_STATE_NODE,
-      );
-      return "ok" as const;
-    }),
-  );
+        ],
+      },
+      THREAD_STATE_NODE,
+    );
+    return "ok" as const;
+  });
   if (rewrite === "busy") {
     return deferForTurn(graphThreadId, "at the rewrite");
   }

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -236,39 +236,23 @@ export async function retireJobsByDedupeKey(
   });
 }
 
-// The other half of the tombstone, for the handler holding the claim: has this run been superseded
-// while it worked? Re-READ rather than trusted from `job.payload`, because that snapshot is from
-// claim time, which is exactly the moment before a stamp would land.
-//
-// Unreadable is NOT retired. An unknown must not silently drop a customer-facing message that was
-// legitimately armed — the caller asks this to withhold work, so the uncertain answer is the one that
-// lets it proceed and be fenced by the CAS at the end.
-export async function jobRetired(
+function readJobRetirement(
   job: ClaimedJob,
-  base: PrismaClient = basePrisma,
-  // The connection to read on, when the caller already holds one. Required in practice wherever this
-  // is asked from inside an advisory-lock transaction: opening a second connection there stalls on
-  // an exhausted pool while still holding the lock, and `DB_POOL_MAX=1` is a supported setting. The
-  // ingestion barrier states the same rule for the same reason (../../graph/ingest.ts, stillWanted).
+  base: PrismaClient,
   scoped?: ScopedDb,
-): Promise<boolean> {
+): Promise<{ payload: unknown; claimSeq: number } | null> {
   const read = (db: ScopedDb) =>
     db.schedulerJob.findUnique({
       where: { id: job.id },
       select: { payload: true, claimSeq: true },
     });
-  const row = await (scoped
-    ? read(scoped)
-    : runScopedOn(base, sysCtx(job.tenantId), read)
-  ).catch((err: unknown) => {
-    logger.warn(
-      "scheduler: could not re-read the retirement of a claimed job (kind=%s job=%s): %s",
-      job.kind,
-      String(job.id),
-      err instanceof Error ? err.message : String(err),
-    );
-    return null;
-  });
+  return scoped ? read(scoped) : runScopedOn(base, sysCtx(job.tenantId), read);
+}
+
+function isRetired(
+  job: ClaimedJob,
+  row: { payload: unknown; claimSeq: number } | null,
+): boolean {
   if (!row) return false;
   const retired =
     (row.payload as { cancelledAt?: unknown } | null)?.cancelledAt != null ||
@@ -281,6 +265,60 @@ export async function jobRetired(
     );
   }
   return retired;
+}
+
+// The other half of the tombstone, for the handler holding the claim: has this run been superseded
+// while it worked? Re-READ rather than trusted from `job.payload`, because that snapshot is from
+// claim time, which is exactly the moment before a stamp would land.
+//
+// Unreadable is NOT retired. An unknown must not silently drop a customer-facing message that was
+// legitimately armed — the caller asks this to withhold work, so the uncertain answer is the one that
+// lets it proceed and be fenced by the CAS at the end. `jobRetiredStrict` is for the callers whose
+// fence comes BEFORE that one and cannot afford the guess.
+export async function jobRetired(
+  job: ClaimedJob,
+  base: PrismaClient = basePrisma,
+  // The connection to read on, when the caller already holds one. No production caller does since the
+  // thread's critical section stopped being one long transaction (issue #225), so every `stillWanted`
+  // now opens its own short scope. Kept, and kept tested, because the rule it encodes still binds
+  // anything asked from inside a transaction: opening a second connection there stalls on an
+  // exhausted pool while still holding the lock, and `DB_POOL_MAX=1` is a supported setting.
+  scoped?: ScopedDb,
+): Promise<boolean> {
+  const row = await readJobRetirement(job, base, scoped).catch(
+    (err: unknown) => {
+      logger.warn(
+        "scheduler: could not re-read the retirement of a claimed job (kind=%s job=%s): %s",
+        job.kind,
+        String(job.id),
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    },
+  );
+  return isRetired(job, row);
+}
+
+// THE SAME QUESTION, ASKED WHERE A GUESS IS THE EXPENSIVE ANSWER. `jobRetired` swallows an
+// unreadable row as "still wanted" because for most callers the cost of guessing wrong is a message
+// sent one time too many, fenced later by the CAS. Inside the thread's critical section the cost is
+// the opposite and it lands before any fence: the run recreates the graph state /reset just cleared,
+// and the operator is told the conversation was wiped while the agent keeps answering from it.
+//
+// The read can now fail where it could not before. It used to borrow the enclosing transaction's live
+// connection; since that transaction is gone (issue #225) it opens its own short scope, which can
+// exhaust `maxWait` under exactly the pool pressure this whole change is about. Propagating sends the
+// job back through the scheduler's own bounded retry (worker.ts `fail`), which is what an unknown
+// deserves here.
+export async function jobRetiredStrict(
+  job: ClaimedJob,
+  base: PrismaClient = basePrisma,
+  // Same connection rule as the lenient probe above. The redirect ladder's composite fence asks from
+  // inside its own read, and a second connection opened there would be a round trip this question
+  // does not need.
+  scoped?: ScopedDb,
+): Promise<boolean> {
+  return isRetired(job, await readJobRetirement(job, base, scoped));
 }
 
 // The SAME question as a SQL predicate, for the one caller that cannot ask it and then act: a write

--- a/tests/graph/nudge.test.ts
+++ b/tests/graph/nudge.test.ts
@@ -551,11 +551,11 @@ describe.skipIf(!dbUp)("runAgentNudge", () => {
     expect(seen[0] ?? "").toContain(OWED);
   });
 
-  // The claim is taken inside a transaction, and a transaction can reject AFTER its callback ran (a
-  // failed commit, a lost connection). A claim made on the way to a rejection that skips the release
-  // never comes back: every later compaction on this thread reads it as busy and reschedules until
-  // the process restarts.
-  test("a claim taken on a transaction that then rejects is still released", async () => {
+  // The claim is taken inside the thread's critical section, and anything in there can fail after
+  // the mark is set: a short transaction, the checkpointer write, a lost connection. A claim made on
+  // the way to a rejection that skips the release never comes back, and every later compaction on
+  // this thread reads it as busy and reschedules until the process restarts.
+  test("a claim taken in a section that then fails is still released", async () => {
     const contactInboxId = 8803;
     await seedConv(914, null, new Date(), contactInboxId);
     const graphThreadId = contactInboxThreadId(
@@ -563,55 +563,54 @@ describe.skipIf(!dbUp)("runAgentNudge", () => {
       instanceId,
       contactInboxId,
     );
-    // Fails ONLY the transaction that takes the claim, and only on the way OUT — the callback, and
-    // the mark inside it, already ran. That transaction is the one that acquires the advisory lock,
-    // which is how it is told apart from the scoped reads the nudge makes before it; failing all of
-    // them would abort the nudge before it ever claimed, and the test would pass with the bug in.
+    // Fails ONLY the transaction that writes the sidecar row, and only on the way OUT: that write is
+    // the one piece of work that runs AFTER the mark is set, so it is what tells the post-claim
+    // transaction apart from the reads the nudge makes before it. Failing by count instead was the
+    // first attempt and it proved nothing: the nudge opens several transactions before the section,
+    // so the count tripped early, the nudge aborted before it ever claimed, and the test passed with
+    // the release deleted.
     // biome-ignore lint/suspicious/noExplicitAny: proxying Prisma's client surface
-    const failCommitOnLock = (client: any): any =>
+    const failAfterClaim = (client: any): any =>
       new Proxy(client, {
         get(target, prop, receiver) {
           if (prop === "$extends") {
             return (...args: unknown[]) =>
-              failCommitOnLock(target.$extends(...args));
+              failAfterClaim(target.$extends(...args));
           }
           if (prop === "$transaction") {
             return async (fn: (tx: unknown) => Promise<unknown>) => {
-              let tookTheLock = false;
+              let wroteTheMarker = false;
               // biome-ignore lint/suspicious/noExplicitAny: proxying Prisma's client surface
               const out = await target.$transaction((tx: any) =>
                 fn(
                   new Proxy(tx, {
                     // biome-ignore lint/suspicious/noExplicitAny: same
                     get(t2: any, p2: string | symbol, r2: unknown) {
-                      if (p2 === "$executeRaw") {
-                        return (
-                          strings: TemplateStringsArray,
-                          ...v: unknown[]
-                        ) => {
-                          if (
-                            String(strings?.[0]).includes(
-                              "pg_advisory_xact_lock",
-                            )
-                          ) {
-                            tookTheLock = true;
-                          }
-                          return t2.$executeRaw(strings, ...v);
-                        };
+                      if (p2 === "agentThread") {
+                        const model = Reflect.get(t2, p2, r2);
+                        return new Proxy(model, {
+                          // biome-ignore lint/suspicious/noExplicitAny: same
+                          get(m: any, mp: string | symbol, mr: unknown) {
+                            if (mp === "upsert") {
+                              wroteTheMarker = true;
+                            }
+                            return Reflect.get(m, mp, mr);
+                          },
+                        });
                       }
                       return Reflect.get(t2, p2, r2);
                     },
                   }),
                 ),
               );
-              if (tookTheLock) throw new Error("connection lost on commit");
+              if (wroteTheMarker) throw new Error("connection lost on commit");
               return out;
             };
           }
           return Reflect.get(target, prop, receiver);
         },
       });
-    const rejectingBase = failCommitOnLock(appDb) as typeof appDb;
+    const rejectingBase = failAfterClaim(appDb) as typeof appDb;
     const s2 = stub();
 
     await expect(

--- a/tests/graph/pool-inversion.test.ts
+++ b/tests/graph/pool-inversion.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { MemorySaver } from "@langchain/langgraph";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { contactInboxThreadId } from "@/graph/checkpointer";
+import { ingestMessageIntoThread } from "@/graph/ingest";
+import { seedChatwootInstance } from "../utils/chatwoot";
+import { countingBase } from "../utils/counting-base";
+
+// THE POOL INVERSION (issue #225).
+//
+// The checkpointer is a SEPARATE Postgres pool from Prisma's. The `ingest:<threadId>` critical
+// section used to run inside a Prisma transaction, so a connection from pool A sat idle-in-
+// transaction for the length of two or three round-trips to pool B (one of them rewriting the whole
+// thread channel). Under load pool A drained and every unrelated query in the process, the Chatwoot
+// webhook ack included, waited out `maxWait` and failed. That is what took the bot off conversations
+// it was about to answer correctly.
+//
+// The property is structural, so the test is too: count transactions that are OPEN at the moment the
+// checkpointer is touched. Timing assertions would be flaky and would pass for the wrong reason on a
+// fast machine.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let instanceId = 0n;
+
+// A checkpointer that samples the transaction counter on every call the ingestion makes.
+class SamplingSaver extends MemorySaver {
+  readonly samples: Array<{ call: string; open: number }> = [];
+  constructor(private readonly openTx: () => number) {
+    super();
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: matching the saver's own signatures
+  override async getTuple(...args: any[]): Promise<any> {
+    this.samples.push({ call: "getTuple", open: this.openTx() });
+    // biome-ignore lint/suspicious/noExplicitAny: same
+    return (MemorySaver.prototype.getTuple as any).apply(this, args);
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: same
+  override async put(...args: any[]): Promise<any> {
+    this.samples.push({ call: "put", open: this.openTx() });
+    // biome-ignore lint/suspicious/noExplicitAny: same
+    return (MemorySaver.prototype.put as any).apply(this, args);
+  }
+}
+
+describe.skipIf(!dbUp)("no Prisma transaction spans the checkpointer", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "PI", slug: `pi-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 9,
+      baseUrl: "https://chat.example.com",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const table of ["agent_threads", "chatwoot_instances"]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  test("ingestion reads and writes the thread channel with no transaction held", async () => {
+    const contactInboxId = 7301;
+    const graphThreadId = contactInboxThreadId(
+      tenantId,
+      instanceId,
+      contactInboxId,
+    );
+    const counting = countingBase(appDb);
+    const saver = new SamplingSaver(counting.open);
+
+    // Two messages on one thread: the first opens the attendance (divider + marker), the second goes
+    // through the dedupe read. Between them they exercise every checkpointer call the section makes.
+    for (const [messageId, text] of [
+      [1, "primeira dúvida"],
+      [2, "segunda dúvida"],
+    ] as const) {
+      const outcome = await ingestMessageIntoThread({
+        tenantId,
+        instanceId,
+        conversationId: 7880,
+        contactInboxId,
+        graphThreadId,
+        base: counting.base,
+        checkpointer: saver,
+        role: "customer",
+        messageId,
+        text,
+      });
+      expect(outcome).toBe("ingested");
+    }
+
+    // The section really did touch the checkpointer, or the assertion below would be vacuous.
+    expect(saver.samples.length).toBeGreaterThan(0);
+    expect(saver.samples.some((s) => s.call === "put")).toBe(true);
+    expect(saver.samples.filter((s) => s.open !== 0)).toEqual([]);
+    // And it left nothing open behind it.
+    expect(counting.open()).toBe(0);
+  });
+});

--- a/tests/graph/still-wanted-strictness.test.ts
+++ b/tests/graph/still-wanted-strictness.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+// THE TWO QUESTIONS `stillWanted` ANSWERS, and they want opposite things when the read itself fails.
+//
+// The ask inside the thread's critical section runs before anything is written, so an unreadable
+// answer has to STOP the run: guessing "still wanted" there recreates the graph state /reset just
+// cleared, the operator is told the conversation was wiped, and the agent keeps answering from it.
+// No later fence catches that. Every other ask guards a SEND, and there an unreadable answer must
+// NOT throw: unwinding past a delivered message abandons its watermark and its job completion, so
+// the scheduler retries the step and the customer gets it twice.
+//
+// The rule is per CALL SITE, not per function, so the test reads the source. A table-driven test of
+// the callback would prove the callback and say nothing about which of the eleven asks passes
+// `strict: true` — and the one that matters is reached only through `runLoadedTurn`, which the
+// webhook path never uses (it passes `stillWanted: null`, having no job to retire).
+const FILES = [
+  "src/graph/runtime.ts",
+  "src/graph/nudge.ts",
+  "src/modules/channel-redirect/followup.ts",
+];
+
+// The redirect ladder asks most of its questions through the composite `fence` now (issues #246,
+// #250), which answers a verdict rather than a boolean and folds the retirement half in. That does
+// not weaken the rule, it moves where the rule is broken: a callback handed to `runAgentNudge`
+// receives `{ strict }` and can simply DROP it, which compiles, passes every behavioural test whose
+// database answers, and fails open on the one ask that runs before a write. That is exactly what a
+// rebase onto the composite fence did here, and only a reviewer caught it.
+//
+// So the walk asks the question of the call site that matters: the `stillWanted` inside
+// `runAgentNudge({ ... })` must thread `strict` through. Callbacks handed to the fixed-text senders
+// are not policed — every ask they make surrounds a send, where fail-open is the correct answer.
+const NUDGE_CALLERS = ["src/modules/channel-redirect/followup.ts"];
+
+// The `stillWanted` entry of the `runAgentNudge({ ... })` object literal, as written.
+function nudgeStillWanted(src: string): string | undefined {
+  const at = src.indexOf("runAgentNudge({");
+  if (at === -1) return undefined;
+  return src
+    .slice(at)
+    .split("\n")
+    .find((l) => /^\s*stillWanted:/.test(l));
+}
+
+function asks(src: string): Array<{ line: number; strict: boolean }> {
+  const out: Array<{ line: number; strict: boolean }> = [];
+  src.split("\n").forEach((text, i) => {
+    if (!/\bstillWanted\s*\(/.test(text)) return;
+    // The declaration and the local wrapper are not asks.
+    if (/(?:const|function|:\s*\(|\?:)\s*stillWanted/.test(text)) return;
+    out.push({
+      line: i + 1,
+      strict: /\bstrict:\s*true\b|stillWanted\(true\)/.test(text),
+    });
+  });
+  return out;
+}
+
+describe("stillWanted strictness, per call site", () => {
+  test("the source walk finds the asks it is meant to police", () => {
+    for (const f of FILES) {
+      expect(asks(readFileSync(f, "utf8")).length).toBeGreaterThan(0);
+    }
+  });
+
+  test.each(NUDGE_CALLERS)("%s threads strict into runAgentNudge", (f) => {
+    const line = nudgeStillWanted(readFileSync(f as string, "utf8"));
+    // The walk found the call site at all — without this, a rename turns the assertion below into a
+    // test that proves nothing while still passing.
+    expect(line).toBeDefined();
+    expect(line).toContain("strict");
+  });
+
+  // Exactly one per file, and only in the two files that hold a critical section. The redirect
+  // follow-up has none: every ask it makes is around a send.
+  test.each([
+    ["src/graph/runtime.ts", 1],
+    ["src/graph/nudge.ts", 1],
+    ["src/modules/channel-redirect/followup.ts", 0],
+  ])("%s has %i strict ask(s)", (file, expected) => {
+    const strict = asks(readFileSync(file as string, "utf8")).filter(
+      (a) => a.strict,
+    );
+    expect(strict).toHaveLength(expected as number);
+  });
+
+  // And the strict one is inside the critical section, not merely somewhere in the file. Anchored on
+  // `withKeyedQueue`, which is what the section is: an ask that drifts out of it stops being the
+  // pre-write fence and starts being a probe that can abort a delivered message.
+  test.each([["src/graph/runtime.ts"], ["src/graph/nudge.ts"]])(
+    "%s asks strictly inside withKeyedQueue",
+    (file) => {
+      const src = readFileSync(file as string, "utf8");
+      const lines = src.split("\n");
+      const strict = asks(src).filter((a) => a.strict);
+      expect(strict).toHaveLength(1);
+      const queueOpens = lines.findIndex((l) => /withKeyedQueue\(/.test(l));
+      expect(queueOpens).toBeGreaterThan(-1);
+      // After the section opens, and before the first ask that follows the section's own writes.
+      expect(strict[0]?.line).toBeGreaterThan(queueOpens + 1);
+    },
+  );
+});

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -955,6 +955,51 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     expect(s.resolved).toEqual([]);
   });
 
+  // AND THE SAME WINDOW WITH THE DATABASE GONE, which is the pair the incident actually reported:
+  // a /reset, and a pool too exhausted to answer whether it happened. The lenient probe answers "not
+  // retired" to an unreadable row — right for a send it must not abandon halfway, wrong here, because
+  // the ask inside the thread's critical section runs BEFORE the divider and the checkpoint. Guessing
+  // there writes the memory back after the operator was told it was cleared, and no later fence
+  // catches it. `runAgentNudge` marks that one ask `{ strict: true }`, and this callback has to carry
+  // it through: the liveness half stays fail-open, the retirement half stops failing open.
+  test("a retirement read that fails after the reset does not write the memory back", async () => {
+    const job = await claimed();
+    let reads = 0;
+    const failing = appDb.$extends({
+      query: {
+        schedulerJob: {
+          async findUnique({ args, query }) {
+            reads += 1;
+            // The first answer is the one the handler takes before any work: it has to succeed and
+            // say "still wanted", or the run stands down for the wrong reason and proves nothing.
+            if (reads === 1) {
+              const res = await query(args);
+              await retireRedirectFollowUp(tenantId, widgetThread, appDb);
+              return res;
+            }
+            throw new Error(
+              "Timed out fetching a new connection from the pool",
+            );
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    const s = stubClient();
+
+    await redirectFollowUpHandler(job, failing, {
+      ...deps(),
+      makeClient: s.makeClient,
+    }).catch(() => {
+      // The strict ask propagates, and the scheduler's own bounded retry is what carries the job.
+      // Whether it surfaces as a throw or a stand-down is the handler's business; what this test is
+      // about is the line below.
+    });
+
+    // Nothing left, and nothing was written back over the reset.
+    expect(s.sent).toEqual([]);
+    expect(s.resolved).toEqual([]);
+  });
+
   // The window INSIDE the stage. The ladder advances by replacing the row's payload, which would
   // wipe the very stamp that retires it — so a /reset landing mid-stage would be undone by the stage
   // it interrupted, and the ladder would go on to its closing. The rendezvous is the fence's own

--- a/tests/modules/chatwoot-reset.test.ts
+++ b/tests/modules/chatwoot-reset.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@/graph/checkpointer";
 import { clearTurnInFlight, markTurnInFlight } from "@/graph/inflight";
 import { buildThreadStateGraph, THREAD_STATE_NODE } from "@/graph/thread-state";
+import { withKeyedQueue } from "@/lib/locks";
 import { CHATWOOT_AUTH_HEADER } from "@/modules/chatwoot/constants";
 import {
   receiveChatwootWebhook,
@@ -502,7 +503,7 @@ describe.skipIf(!dbUp)(
     //
     // Held from another connection, the lock proves the ordering directly: while it is held, nothing
     // of the memory may be gone.
-    test("the checkpoint is deleted under the lock, not before it", async () => {
+    test("the checkpoint is deleted inside the critical section, not before it", async () => {
       const threadId = contactInboxThreadId(tenantId, instanceId, 301);
       const cp = await getCheckpointer();
       await buildThreadStateGraph(cp).updateState(
@@ -528,13 +529,15 @@ describe.skipIf(!dbUp)(
       const cw = fakeChatwoot();
       globalThis.fetch = cw.impl;
       const survived: boolean[] = [];
-      // Kept OUT of the transaction's return value on purpose: returning it would make Prisma await
-      // the reset before committing, and the reset is waiting on the lock that commit releases.
       let running: Promise<void> = Promise.resolve();
       let resetFailed: unknown;
-      // The memory step is the FIRST of the reset, so it blocks here almost immediately.
-      await suDb.$transaction(async (tx) => {
-        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`ingest:${threadId}`})::bigint)`;
+      // Occupies the thread's critical section the way ingestion, a turn, the nudge and compaction
+      // all do now: the process-local queue, not a `pg_advisory_xact_lock`. The lock was what an
+      // earlier version of this test held, and it stopped meaning anything the moment this family
+      // moved off it (issue #225): the reset would have sailed straight past it and deleted the
+      // checkpoint while a peer was mid-read, which is the exact failure being pinned here.
+      await withKeyedQueue(`ingest:${threadId}`, async () => {
+        // The memory step is the FIRST of the reset, so it blocks here almost immediately.
         running = sendReset().catch((err) => {
           resetFailed = err;
         });

--- a/tests/modules/contact-auth-nudge.test.ts
+++ b/tests/modules/contact-auth-nudge.test.ts
@@ -15,6 +15,7 @@ import { runAgentNudge } from "@/graph/nudge";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { clearContactAuthState } from "@/modules/contact-auth/state";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { countingBase } from "../utils/counting-base";
 import { PromptCapturingModel } from "../utils/scripted-models";
 
 // The gate on the PROACTIVE side: a follow-up is a turn the agent starts, so a contact the reactive
@@ -261,21 +262,27 @@ describe.skipIf(!dbUp)("contact authorization on the proactive nudge", () => {
       wanted = false;
       return new Response('{"authorized":true}', { status: 200 });
     });
-    // Recorded per ask: the one made inside the thread claim runs in an advisory-lock transaction,
-    // so it must arrive WITH a connection to read on. A provider that opens its own there asks a
-    // pinned pool for a second one, which on `DB_POOL_MAX=1` fails — and jobRetired swallows a
-    // failed read as "not retired", so the fence would go quiet exactly where it matters.
-    const gotDb: boolean[] = [];
+    // Recorded per ask, and what is recorded is how many Prisma transactions are OPEN at that moment.
+    // The ask made inside the thread claim used to have to arrive WITH a connection, because the
+    // claim was one long advisory-lock transaction and a provider opening its own there asked a
+    // pinned pool for a second one, which fails under `DB_POOL_MAX=1` — and jobRetired swallows a
+    // failed read as "not retired", so the fence went quiet exactly where it mattered. The claim
+    // holds no transaction any more (issue #225), so the invariant that replaces it is the stronger
+    // one: the ask is free to open its own scope precisely because nothing is pinned.
+    const openTxAtAsk: number[] = [];
+    const strictness: boolean[] = [];
+    const counted = countingBase(appDb);
     const outcome = await runAgentNudge({
       tenantId,
       threadId: `${tenantId}:${instanceId}:9413`,
       nudge: { source: "followup", kind: "inactivity" },
       postActions: { assignLabels: ["seguimento"] },
-      stillWanted: async (scoped) => {
-        gotDb.push(scoped !== undefined);
+      stillWanted: async ({ strict }) => {
+        openTxAtAsk.push(counted.open());
+        strictness.push(strict);
         return wanted;
       },
-      base: appDb,
+      base: counted.base,
       deps: {
         makeModel: () => new FakeListChatModel({ responses: ["Tudo certo?"] }),
         makeClient: s.makeClient,
@@ -287,9 +294,16 @@ describe.skipIf(!dbUp)("contact authorization on the proactive nudge", () => {
 
     expect(outcome).toBe("stale");
     expect(auth.calls).toHaveLength(1);
-    // The entry ask has no transaction to share; the last one is the claim's, and it does.
-    expect(gotDb[0]).toBe(false);
-    expect(gotDb.at(-1)).toBe(true);
+    // Asked at both moments it has to be: on entry, and again inside the thread claim, which is what
+    // makes it exclusive with a /reset. And no ask, the claim's included, finds a transaction open.
+    expect(openTxAtAsk.length).toBeGreaterThanOrEqual(2);
+    expect(openTxAtAsk.filter((n) => n !== 0)).toEqual([]);
+    // EXACTLY ONE of them asks strictly, and it is not the entry one. The two want opposite answers
+    // when the read itself fails: before the write an unreadable answer has to stop the run, and
+    // around a send it must not, because throwing there abandons the bookkeeping of a message the
+    // customer already has.
+    expect(strictness[0]).toBe(false);
+    expect(strictness.filter(Boolean)).toHaveLength(1);
     // The durable half: had the run gone on, this row would name the conversation the reset cleared.
     const row = await suDb.agentThread.findUnique({
       where: {

--- a/tests/modules/scheduler.test.ts
+++ b/tests/modules/scheduler.test.ts
@@ -12,6 +12,7 @@ import {
   failJob,
   jobNotRetiredSql,
   jobRetired,
+  jobRetiredStrict,
   reapStaleJobs,
   rescheduleJob,
   retireJobsByDedupeKey,
@@ -522,9 +523,38 @@ describe.skipIf(!dbUp)("scheduler", () => {
       );
       expect(answers.shared).toBe(true);
       expect(answers.own).toBe(false);
+
+      // THE STRICT VARIANT REFUSES TO GUESS. Same unreadable read, and it propagates instead of
+      // reporting "not retired". That is what the thread's critical section asks, because there the
+      // wrong guess recreates the graph state /reset just cleared, and no later fence catches it.
+      await expect(
+        runScopedOn(
+          onePool,
+          { tenantId, userId: null, role: "SUPER_ADMIN" } as never,
+          async () => jobRetiredStrict(job, onePool),
+        ),
+      ).rejects.toThrow();
     } finally {
       await onePool.$disconnect();
     }
+  });
+
+  // Strict is only about the UNREADABLE case: on a readable row it answers exactly like the lenient
+  // one, so swapping it in at a call site does not change the ordinary path.
+  test("the strict probe still answers when the read succeeds", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "FOLLOWUP",
+      dedupeKey: "dk-strict-ok",
+      runAt: past(),
+      base: appDb,
+    });
+    const [job] = await claimDueJobs(1, appDb, new Date(), tenantId);
+    if (!job || job.id !== id)
+      throw new Error("claim did not return dk-strict-ok");
+    expect(await jobRetiredStrict(job, appDb)).toBe(false);
+    await retireJobsByDedupeKey(tenantId, "FOLLOWUP", "dk-strict-ok", appDb);
+    expect(await jobRetiredStrict(job, appDb)).toBe(true);
   });
 
   test("reaper requeues a stranded CLAIMED job", async () => {

--- a/tests/utils/counting-base.ts
+++ b/tests/utils/counting-base.ts
@@ -1,0 +1,31 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+
+// Counts Prisma transactions currently open. Survives `$extends`, which `runScopedOn` calls before
+// `$transaction`, so the count follows the client the scoped helper actually uses.
+export function countingBase(client: PrismaClient): {
+  base: PrismaClient;
+  open: () => number;
+} {
+  let open = 0;
+  // biome-ignore lint/suspicious/noExplicitAny: proxying Prisma's client surface
+  const wrap = (target: any): any =>
+    new Proxy(target, {
+      get(t, prop, receiver) {
+        if (prop === "$extends") {
+          return (...args: unknown[]) => wrap(t.$extends(...args));
+        }
+        if (prop === "$transaction") {
+          return async (fn: unknown, ...rest: unknown[]) => {
+            open += 1;
+            try {
+              return await t.$transaction(fn, ...rest);
+            } finally {
+              open -= 1;
+            }
+          };
+        }
+        return Reflect.get(t, prop, receiver);
+      },
+    });
+  return { base: wrap(client) as PrismaClient, open: () => open };
+}


### PR DESCRIPTION
Fixes #225

## What broke

Two Postgres pools, both sized `dbPoolMax`: Prisma's and the LangGraph checkpointer's. In five places the `ingest:<threadId>` critical section ran **inside** a Prisma transaction, so a connection from pool A sat `idle in transaction` for the length of two or three round trips to pool B, one of them rewriting the whole thread channel, while also holding a `pg_advisory_xact_lock`. Under load pool A drained and every unrelated query in the process waited out `maxWait` (2s) and failed. The Chatwoot webhook ack is one of those queries, and a late ack costs the conversation its bot.

`multi-tenant.ts` already warned "no network/LLM await inside fn", and the invariant was respected to the letter: no transaction in the repo calls Chatwoot, an LLM, or `fetch`. What escaped is that a checkpointer call **is** that await, to a second Postgres.

## What changed

The five sites take a process-local queue (`withKeyedQueue`) instead of a transaction-scoped advisory lock, with short transactions inside. `runScopedOn`/`asSuperAdminOn` also pass explicit transaction options rather than inheriting Prisma's defaults, which were the two numbers in the original report.

Removing the enclosing transaction moved a question that used to be free. The retirement probe inside the critical section borrowed that transaction's live connection; on its own it can now exhaust `maxWait`, and `jobRetired` swallows an unreadable row as "still wanted". That guess is the expensive one **there**: the run recreates the graph state `/reset` just cleared, the operator is told the conversation was wiped, and the agent keeps answering from it, with no later fence to catch it. `jobRetiredStrict` propagates the read failure instead, sending the job back through the scheduler's own bounded retry.

And `stillWanted` turned out to answer **two** questions. Only the ask inside the critical section runs before anything is written; the rest guard a send, where throwing abandons the bookkeeping of a message the customer already has (the follow-up skips its watermark and job completion and the scheduler resends; the redirect closing leaves `redirectClosedAt` set so the retry loses its claim and the terminal messages are dropped for good). The callback now takes which question is being asked.

## Risk that has to stay written down

The old lock was `pg_advisory_xact_lock`, **cross-process**. `withKeyedQueue` is process-local. Under the deploy contract (`docs/deploy.md` §4, one replica or one leader with the workers) this regresses nothing: `isTurnInFlight` is already an in-memory `Map`. But there was margin **beyond** the contract, and this spends it: in a scaled tier the advisory lock still serialized the `AgentThread` read-and-write and the channel append across replicas. Issue #203 tracks the process-local claim failing there; this widens its scope from the claim to the whole critical section, and #203 has been commented to say so. The path back to cross-process safety is the CAS watermark, deliberately not in this change.

## Validation scope

**Proven by test.** A new `pool-inversion.test.ts` counts Prisma transactions open at the moment the checkpointer is touched and asserts the count is zero; on the original code all four samples report one. The existing dedupe and attendance-boundary suites are the gate on behaviour being unchanged. `scheduler.test.ts` pins that the strict probe propagates an unreadable read where the lenient one reports "not retired", and that both agree when the read succeeds. `contact-auth-nudge.test.ts` had asserted the OLD invariant (the probe arrives WITH a connection); it now asserts the one that replaces it, that no ask finds a transaction open, and that exactly one ask is strict and it is not the entry one.

The strictness rule is per **call site**, so a source walk polices it: one strict ask per file that owns a critical section, none in the file whose every ask surrounds a send, and the strict one inside `withKeyedQueue` rather than merely somewhere in the file. A table-driven test of the callback would prove the callback and say nothing about which of the eleven asks passes `strict: true`, and the one that matters is reached only through `runLoadedTurn`, which the webhook path never uses (`stillWanted: null`, having no job to retire). Full suite 4817 pass / 0 fail.

**Not validated.** No production measurement. Nobody has confirmed which call site dominated the original incident, or that the ack was in fact what exhausted the pool; `pg_stat_activity` filtered on `idle in transaction` during an incident would answer it and has not been run. The concurrency the queue provides is asserted structurally, not under real parallel load: a timing test here would pass on a fast machine for the wrong reason. And the cross-process regression above is reasoned from the deploy contract, not measured against a scaled deployment.

