### PR TITLE
Stop a lost unique race from aborting the whole agent import

### DIFF
--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -1255,7 +1255,7 @@ async function createMissingComponents(
     });
     // `createMany({ skipDuplicates })` rather than `create`, for the reason spelled out on the
     // document-template loop below: the pre-check above can answer "free" and a concurrent writer
-    // commit before this insert, and a P2002 here does not cost one tool — the whole import runs
+    // commit before this insert, and a P2002 here does not cost one tool: the whole import runs
     // inside ONE `runScopedOn` transaction, so it aborts that transaction and every statement after
     // it fails with "current transaction is aborted" (issue #221).
     const { count } = await db.toolDefinition.createMany({
@@ -1407,7 +1407,7 @@ async function createMissingComponents(
     // `createMany({ skipDuplicates })` for the same reason as the loops above: a lost race on
     // `@@unique([tenantId, catalogType, name])` would abort the enclosing transaction and take the
     // whole import with it (issue #221). `routeTokenHash` is unique too and also covered by the
-    // ON CONFLICT, but it is 32 fresh random bytes hashed — a skip here is the name, in practice.
+    // ON CONFLICT, but it is 32 fresh random bytes hashed, so a skip here is the name, in practice.
     const { count } = await db.integrationInstance.createMany({
       data: [
         {

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -1246,13 +1246,6 @@ async function createMissingComponents(
     // for a body with no recognized mode, and would switch a `{mode:"raw", …, extra}` tool to the
     // fields assembly — changing what it sends (issue #150).
     const badBody = unsupportedBodyShape(tdef.body);
-    if (badBody) {
-      warnings.push({
-        code: "httpToolBodyIgnored",
-        params: { name: tdef.name },
-        target: { kind: "tool", name: tdef.name },
-      });
-    }
     const { shapes } = normalizeToolShapes({
       urlTemplate: tdef.urlTemplate,
       query: tdef.query ?? {},
@@ -1260,30 +1253,56 @@ async function createMissingComponents(
       body: badBody ? canonicalBodyShape(tdef.body) : tdef.body,
       inputSchema: tdef.inputSchema,
     });
-    await db.toolDefinition.create({
-      data: {
-        tenantId,
-        name: tdef.name,
-        // label is required now; legacy exports without one fall back to the identifier.
-        label: tdef.label ?? tdef.name,
-        description: tdef.description ?? null,
-        method: tdef.method,
-        urlTemplate: (shapes.urlTemplate ?? tdef.urlTemplate) as string,
-        allowedHosts: tdef.allowedHosts,
-        headers: shapes.headers as Prisma.InputJsonValue,
-        inputSchema: shapes.inputSchema as Prisma.InputJsonValue,
-        outputSchema: tdef.outputSchema as Prisma.InputJsonValue,
-        query: shapes.query as Prisma.InputJsonValue,
-        body: shapes.body as Prisma.InputJsonValue,
-        // Normalized like the shapes above, and for the same reason: the import writes straight to
-        // the DB, so a hand-edited bundle would otherwise store a list the service would refuse.
-        expectedStatuses: normalizeExpectedStatuses(tdef.expectedStatuses),
-        ackEnabled: tdef.ackEnabled,
-        ackMessage: tdef.ackMessage ?? null,
-        credentialRef: resolveCredName(tdef.credentialRef),
-        enabled: true,
-      },
+    // `createMany({ skipDuplicates })` rather than `create`, for the reason spelled out on the
+    // document-template loop below: the pre-check above can answer "free" and a concurrent writer
+    // commit before this insert, and a P2002 here does not cost one tool — the whole import runs
+    // inside ONE `runScopedOn` transaction, so it aborts that transaction and every statement after
+    // it fails with "current transaction is aborted" (issue #221).
+    const { count } = await db.toolDefinition.createMany({
+      data: [
+        {
+          tenantId,
+          name: tdef.name,
+          // label is required now; legacy exports without one fall back to the identifier.
+          label: tdef.label ?? tdef.name,
+          description: tdef.description ?? null,
+          method: tdef.method,
+          urlTemplate: (shapes.urlTemplate ?? tdef.urlTemplate) as string,
+          allowedHosts: tdef.allowedHosts,
+          headers: shapes.headers as Prisma.InputJsonValue,
+          inputSchema: shapes.inputSchema as Prisma.InputJsonValue,
+          outputSchema: tdef.outputSchema as Prisma.InputJsonValue,
+          query: shapes.query as Prisma.InputJsonValue,
+          body: shapes.body as Prisma.InputJsonValue,
+          // Normalized like the shapes above, and for the same reason: the import writes straight to
+          // the DB, so a hand-edited bundle would otherwise store a list the service would refuse.
+          expectedStatuses: normalizeExpectedStatuses(tdef.expectedStatuses),
+          ackEnabled: tdef.ackEnabled,
+          ackMessage: tdef.ackMessage ?? null,
+          credentialRef: resolveCredName(tdef.credentialRef),
+          enabled: true,
+        },
+      ],
+      skipDuplicates: true,
     });
+    if (count === 0) {
+      // Lost the race. The name is taken now, which is exactly the reuse the pre-check reports.
+      warnings.push({
+        code: "httpToolReused",
+        params: { name: tdef.name },
+        target: { kind: "tool", name: tdef.name },
+      });
+      continue;
+    }
+    // Both warnings below describe the row that was just written, so they wait for the insert to
+    // report one: the reuse path above says nothing about a body or a credential it did not store.
+    if (badBody) {
+      warnings.push({
+        code: "httpToolBodyIgnored",
+        params: { name: tdef.name },
+        target: { kind: "tool", name: tdef.name },
+      });
+    }
     if (tdef.credentialRef && !resolveCredName(tdef.credentialRef)) {
       warnings.push({
         code: "httpToolCredNotFound",
@@ -1320,17 +1339,30 @@ async function createMissingComponents(
         continue;
       }
     }
-    await db.mcpServerConnection.create({
-      data: {
-        tenantId,
-        name: m.name,
-        transport: m.transport,
-        url: m.url ?? null,
-        command: m.command ?? null,
-        credentialRef: resolveCredName(m.credentialRef),
-        enabled: true,
-      },
+    // `createMany({ skipDuplicates })` for the same reason as the loop above: a lost race on
+    // `@@unique([tenantId, name])` would abort the enclosing transaction and take the whole import
+    // with it (issue #221).
+    const { count } = await db.mcpServerConnection.createMany({
+      data: [
+        {
+          tenantId,
+          name: m.name,
+          transport: m.transport,
+          url: m.url ?? null,
+          command: m.command ?? null,
+          credentialRef: resolveCredName(m.credentialRef),
+          enabled: true,
+        },
+      ],
+      skipDuplicates: true,
     });
+    if (count === 0) {
+      warnings.push({
+        code: "mcpReused",
+        params: { name: m.name },
+        target: { kind: "mcp", name: m.name },
+      });
+    }
   }
 
   for (const i of components.integrations) {
@@ -1361,24 +1393,50 @@ async function createMissingComponents(
     const { hash } = generateRouteToken();
     // Resolve a business-hours reference carried by NAME in the config back to the local id (Google
     // Calendar's businessHoursId — the bundled schedule was recreated by createMissingBusinessHours).
+    //
+    // Collected aside rather than pushed straight through: what it reports is a reference inside the
+    // config THIS iteration built, and that config is discarded if the insert below turns out to be
+    // a reuse. The pre-check path never emitted it (it `continue`s first), and the race path is the
+    // same outcome reached later.
+    const configWarnings: ImportWarning[] = [];
     const config = await remapConfigBusinessHoursNameToId(
       db,
       i.config as Record<string, unknown>,
-      warnings,
+      configWarnings,
     );
-    await db.integrationInstance.create({
-      data: {
-        tenantId,
-        catalogType: i.catalogType,
-        name: i.name,
-        config: config as Prisma.InputJsonValue,
-        credentialRef: resolveCredName(i.credentialRef),
-        inboundAuthStrategy: "NONE",
-        inboundSecretRef: null,
-        routeTokenHash: hash,
-        enabled: true,
-      },
+    // `createMany({ skipDuplicates })` for the same reason as the loops above: a lost race on
+    // `@@unique([tenantId, catalogType, name])` would abort the enclosing transaction and take the
+    // whole import with it (issue #221). `routeTokenHash` is unique too and also covered by the
+    // ON CONFLICT, but it is 32 fresh random bytes hashed — a skip here is the name, in practice.
+    const { count } = await db.integrationInstance.createMany({
+      data: [
+        {
+          tenantId,
+          catalogType: i.catalogType,
+          name: i.name,
+          config: config as Prisma.InputJsonValue,
+          credentialRef: resolveCredName(i.credentialRef),
+          inboundAuthStrategy: "NONE",
+          inboundSecretRef: null,
+          routeTokenHash: hash,
+          enabled: true,
+        },
+      ],
+      skipDuplicates: true,
     });
+    if (count === 0) {
+      warnings.push({
+        code: "integrationReused",
+        params: { type: i.catalogType, name: i.name },
+        target: {
+          kind: "integration",
+          catalogType: i.catalogType,
+          name: i.name,
+        },
+      });
+      continue;
+    }
+    warnings.push(...configWarnings);
     // Created integrations are silent (only reused ones warn). The fresh inbound token is re-readable
     // any time on the integration page; for a clone the operator wires the external webhook from scratch.
   }

--- a/tests/modules/agent-transfer.test.ts
+++ b/tests/modules/agent-transfer.test.ts
@@ -1109,6 +1109,219 @@ describe.skipIf(!dbUp)("agent export/import with components", () => {
     });
   });
 
+  // Same race, three more call sites (issue #221). Each of the loops below pre-checks a DIFFERENT
+  // unique index, so a note on the test above would prove nothing about them: `ON CONFLICT DO
+  // NOTHING` has to be reached through each loop's own data. What a lost race costs is not the
+  // component but the IMPORT — the P2002 aborts the enclosing transaction, every statement after it
+  // fails with "current transaction is aborted", and the operator loses the agent, the grants and
+  // the knowledge bases to a collision over one name.
+  //
+  // The component is renamed to a value unique to this run rather than reusing the fixture's: the
+  // fresh-tenant import test above already created `lookup_order`, `tools-server` and `Pagamentos`
+  // on the destination and left them there, so a pre-check against those answers "taken" and the
+  // race never happens. The grant still names the fixture, which is why the import warns
+  // `httpGrantNotFound` here and the assertions do not look at that one.
+  test("survives a writer that takes the HTTP tool name between the check and the insert", async () => {
+    const exp = await exportAgent(srcCtx(), srcAgentId, appDb, {
+      includeComponents: true,
+    });
+    const tampered = structuredClone(exp);
+    const tool = tampered.components?.httpTools.find(
+      (h) => h.name === "lookup_order",
+    );
+    if (!tool) throw new Error("bundle missing the http tool");
+    tool.name = `corrida_http_${process.pid}`;
+    // A body shape this version does not execute, so the loop has something to say about it. The
+    // assertion below is that it says nothing: the warning describes a row that was never written.
+    tool.body = { contact: { email: "{{email}}" } };
+
+    let raced = false;
+    const racing = appDb.$extends({
+      query: {
+        toolDefinition: {
+          async findFirst({ args, query }) {
+            const answer = await query(args);
+            // Matched against the name under test, not just "the first miss": the import asks this
+            // table again when it resolves the HTTP grant, and a looser guard would fire there
+            // instead — after the insert it is supposed to race.
+            const asksForIt =
+              (args as { where?: { name?: unknown } }).where?.name ===
+              tool.name;
+            if (!raced && asksForIt && answer === null) {
+              raced = true;
+              await suDb.toolDefinition.create({
+                data: {
+                  tenantId: dstTenant,
+                  name: tool.name,
+                  label: "Tomado por outro",
+                  method: "GET",
+                  urlTemplate: "https://api.example.com/x",
+                  allowedHosts: ["api.example.com"],
+                },
+              });
+            }
+            return answer;
+          },
+        },
+      },
+    });
+
+    const { agent, warnings } = await importAgent(
+      dstCtx(),
+      tampered,
+      racing as unknown as typeof appDb,
+    );
+    // The rendezvous actually happened. Without this the test passes just as well when the
+    // interceptor never fired and no race was ever created.
+    expect(raced).toBe(true);
+    expect(agent.id).toBeTruthy();
+    expect(warnings.some((w) => w.code === "httpToolReused")).toBe(true);
+    // The reuse the pre-check reports says nothing about the body, and neither does the reuse the
+    // insert reports — the tool that survived is the one already there, with its own body.
+    expect(warnings.some((w) => w.code === "httpToolBodyIgnored")).toBe(false);
+    // What the issue is actually about: the statements AFTER the losing insert still ran. The grants
+    // are written at the very end of the same transaction, so a count here is the proof that it was
+    // never aborted.
+    const grants = await suDb.agentToolSelection.count({
+      where: { agentId: BigInt(agent.id) },
+    });
+    expect(grants).toBeGreaterThan(0);
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM agent_tool_selections WHERE agent_id = ${BigInt(agent.id)}`,
+    );
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM agents WHERE id = ${BigInt(agent.id)}`,
+    );
+    await suDb.toolDefinition.deleteMany({
+      where: { tenantId: dstTenant, name: tool.name },
+    });
+  });
+
+  test("survives a writer that takes the MCP connection name between the check and the insert", async () => {
+    const exp = await exportAgent(srcCtx(), srcAgentId, appDb, {
+      includeComponents: true,
+    });
+    const tampered = structuredClone(exp);
+    const conn = tampered.components?.mcpServers.find(
+      (m) => m.name === "tools-server",
+    );
+    if (!conn) throw new Error("bundle missing the mcp connection");
+    conn.name = `corrida_mcp_${process.pid}`;
+
+    let raced = false;
+    const racing = appDb.$extends({
+      query: {
+        mcpServerConnection: {
+          async findFirst({ args, query }) {
+            const answer = await query(args);
+            const asksForIt =
+              (args as { where?: { name?: unknown } }).where?.name ===
+              conn.name;
+            if (!raced && asksForIt && answer === null) {
+              raced = true;
+              await suDb.mcpServerConnection.create({
+                data: {
+                  tenantId: dstTenant,
+                  name: conn.name,
+                  transport: "streamableHttp",
+                  url: "https://outro.example.com",
+                },
+              });
+            }
+            return answer;
+          },
+        },
+      },
+    });
+
+    const { agent, warnings } = await importAgent(
+      dstCtx(),
+      tampered,
+      racing as unknown as typeof appDb,
+    );
+    expect(raced).toBe(true);
+    expect(agent.id).toBeTruthy();
+    expect(warnings.some((w) => w.code === "mcpReused")).toBe(true);
+    const grants = await suDb.agentToolSelection.count({
+      where: { agentId: BigInt(agent.id) },
+    });
+    expect(grants).toBeGreaterThan(0);
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM agent_tool_selections WHERE agent_id = ${BigInt(agent.id)}`,
+    );
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM agents WHERE id = ${BigInt(agent.id)}`,
+    );
+    await suDb.mcpServerConnection.deleteMany({
+      where: { tenantId: dstTenant, name: conn.name },
+    });
+  });
+
+  test("survives a writer that takes the integration name between the check and the insert", async () => {
+    const exp = await exportAgent(srcCtx(), srcAgentId, appDb, {
+      includeComponents: true,
+    });
+    const tampered = structuredClone(exp);
+    const integ = tampered.components?.integrations.find(
+      (i) => i.name === "Pagamentos",
+    );
+    if (!integ) throw new Error("bundle missing the integration");
+    integ.name = `Corrida ${process.pid}`;
+    // A schedule reference this destination cannot resolve, for the same reason as the body above:
+    // it belongs to the config THIS iteration built, and that config is discarded on a reuse.
+    integ.config = { businessHoursId: `Agenda ausente ${process.pid}` };
+
+    let raced = false;
+    const racing = appDb.$extends({
+      query: {
+        integrationInstance: {
+          async findFirst({ args, query }) {
+            const answer = await query(args);
+            const asksForIt =
+              (args as { where?: { name?: unknown } }).where?.name ===
+              integ.name;
+            if (!raced && asksForIt && answer === null) {
+              raced = true;
+              await suDb.integrationInstance.create({
+                data: {
+                  tenantId: dstTenant,
+                  catalogType: integ.catalogType,
+                  name: integ.name,
+                  config: {},
+                  routeTokenHash: `corrida-hash-${process.pid}`,
+                },
+              });
+            }
+            return answer;
+          },
+        },
+      },
+    });
+
+    const { agent, warnings } = await importAgent(
+      dstCtx(),
+      tampered,
+      racing as unknown as typeof appDb,
+    );
+    expect(raced).toBe(true);
+    expect(agent.id).toBeTruthy();
+    expect(warnings.some((w) => w.code === "integrationReused")).toBe(true);
+    expect(warnings.some((w) => w.code === "hoursNotFound")).toBe(false);
+    const grants = await suDb.agentToolSelection.count({
+      where: { agentId: BigInt(agent.id) },
+    });
+    expect(grants).toBeGreaterThan(0);
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM agent_tool_selections WHERE agent_id = ${BigInt(agent.id)}`,
+    );
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM agents WHERE id = ${BigInt(agent.id)}`,
+    );
+    await suDb.integrationInstance.deleteMany({
+      where: { tenantId: dstTenant, name: integ.name },
+    });
+  });
+
   // A discriminated union refuses the WHOLE array on one unknown arm, so a grant of a source a newer
   // release added would make an otherwise importable agent unimportable — and say nothing about
   // which part was the problem. Dropped with a count instead.

--- a/tests/modules/agent-transfer.test.ts
+++ b/tests/modules/agent-transfer.test.ts
@@ -1112,7 +1112,7 @@ describe.skipIf(!dbUp)("agent export/import with components", () => {
   // Same race, three more call sites (issue #221). Each of the loops below pre-checks a DIFFERENT
   // unique index, so a note on the test above would prove nothing about them: `ON CONFLICT DO
   // NOTHING` has to be reached through each loop's own data. What a lost race costs is not the
-  // component but the IMPORT — the P2002 aborts the enclosing transaction, every statement after it
+  // component but the IMPORT: the P2002 aborts the enclosing transaction, every statement after it
   // fails with "current transaction is aborted", and the operator loses the agent, the grants and
   // the knowledge bases to a collision over one name.
   //
@@ -1142,8 +1142,8 @@ describe.skipIf(!dbUp)("agent export/import with components", () => {
           async findFirst({ args, query }) {
             const answer = await query(args);
             // Matched against the name under test, not just "the first miss": the import asks this
-            // table again when it resolves the HTTP grant, and a looser guard would fire there
-            // instead — after the insert it is supposed to race.
+            // table again when it resolves the HTTP grant, and a looser guard would fire on that
+            // call instead, which happens after the insert it is supposed to race.
             const asksForIt =
               (args as { where?: { name?: unknown } }).where?.name ===
               tool.name;
@@ -1177,7 +1177,7 @@ describe.skipIf(!dbUp)("agent export/import with components", () => {
     expect(agent.id).toBeTruthy();
     expect(warnings.some((w) => w.code === "httpToolReused")).toBe(true);
     // The reuse the pre-check reports says nothing about the body, and neither does the reuse the
-    // insert reports — the tool that survived is the one already there, with its own body.
+    // insert reports: the tool that survived is the one already there, with its own body.
     expect(warnings.some((w) => w.code === "httpToolBodyIgnored")).toBe(false);
     // What the issue is actually about: the statements AFTER the losing insert still ran. The grants
     // are written at the very end of the same transaction, so a count here is the proof that it was


### PR DESCRIPTION
Fixes #221.

## What broke

`importAgent` runs the entire import inside **one** `runScopedOn` transaction, and three of its component loops pre-check a unique value and then create against it:

| loop | pre-check | unique it creates against |
| --- | --- | --- |
| HTTP tools | `toolDefinition.findFirst({ where: { name } })` | `@@unique([tenantId, name])` |
| MCP connections | `mcpServerConnection.findFirst({ where: { name } })` | `@@unique([tenantId, name])` |
| integrations | `integrationInstance.findFirst({ where: { catalogType, name } })` | `@@unique([tenantId, catalogType, name])` |

When a concurrent writer takes that value in the window between the two, the `P2002` does not cost one component. PostgreSQL aborts the transaction, every statement after it fails with `current transaction is aborted`, and the operator loses the whole import — agent, tools, connections, knowledge bases — to a race over one name.

Each of the three loops already defines the warning it wants for this outcome (`httpToolReused`, `mcpReused`, `integrationReused`), so the behaviour was fully specified. The pre-check simply does not hold under concurrency.

## Why a `catch` is not the fix

By the time the handler runs, the transaction is already dead. Catching the `P2002` swallows the one legible error and replaces it with `current transaction is aborted` on whatever statement runs next. Retrying inside the transaction fails for the same reason.

## The fix

`createMany({ skipDuplicates: true })` compiles to `ON CONFLICT DO NOTHING`, which leaves the transaction healthy and reports a count — so a count of zero **is** the signal to push the reuse warning the loop already defines. The idiom is already in the tree (`src/modules/experiments/service.ts`, `src/modules/webhooks/inbound/service.ts`), and the document-template loop right below these three has carried exactly this shape since #208. The create's return value is unused at all three call sites, which is what makes the swap available.

Two warnings move behind the insert as a consequence, and that is a behaviour change worth naming:

- **`httpToolBodyIgnored`** described a body the loop was about to store. On a lost race nothing is stored, so it would name a canonicalization that never happened, on a tool whose body is untouched.
- **the integration's business-hours reference** (`hoursNotFound`, raised while remapping the config from name to local id) describes the config *this iteration built*, which is discarded on a reuse.

Neither was ever emitted on the pre-check reuse path — that path `continue`s before reaching them — so holding them until the insert reports a row is what makes the race path land on the same outcome the pre-check path already had.

## Not in scope

The business-hours and knowledge-base loops have the same pre-check shape but **no unique index** behind them, so a lost race there duplicates a row instead of aborting the import. That is a separate and much milder problem. The remaining writes inside the transaction were swept: `Agent`, `BusinessHours` and `KnowledgeBase` carry no unique constraint, and the pending vault entries are written by `createPendingVaultEntry` in a **separate** transaction, which already handles its own `P2002`.

## Validation scope

**Proved by test** — three DB-backed tests in `tests/modules/agent-transfer.test.ts`, one per call site, built on the harness #208 introduced for the document-template loop: a Prisma `$extends` query hook intercepts the pre-check and commits the colliding row on a **second connection** (the superuser client, a different transaction) at the moment it answers `null`. The race is produced, not waited for. Each test asserts that the interceptor actually fired (`raced === true`) — without it a test that never reaches the race passes just as well — that the import completed, that the right reuse warning came back, and that the grant rows, written at the very end of the same transaction, exist. That last count is the statement about the transaction never having been aborted.

Red before the fix, for the right reason: all three fail with `PrismaClientKnownRequestError … code: "P2002"`, i.e. the import throws.

**Proved by mutation** — seven mutations, one at a time, each killing exactly one test and no test surviving:

| mutation | result |
| --- | --- |
| `skipDuplicates: false` on the HTTP tool insert | 1 fail |
| `skipDuplicates: false` on the MCP insert | 1 fail |
| `skipDuplicates: false` on the integration insert | 1 fail |
| drop the `continue` from the HTTP `count === 0` branch | 1 fail |
| push the remap's warnings straight through instead of holding them | 1 fail |
| drop the `mcpReused` warning | 1 fail |
| drop the `httpToolReused` warning | 1 fail |

**Not validated** — no live run against a real concurrent import: the race is produced deterministically by the interceptor rather than by two real clients, so what the tests prove is that `ON CONFLICT DO NOTHING` keeps the transaction alive and reports the skip, not that the window is as wide in production as it is in the test. The `routeTokenHash` unique index on `IntegrationInstance` is also covered by the same `ON CONFLICT`, so in principle a collision there would be reported as a name reuse; it is 32 fresh random bytes hashed with SHA-256, and no test exercises that branch.

`bun check` green (4558 pass, 0 fail).
