### PR TITLE
Stop a pool blip from losing an event Chatwoot will not send again

### DIFF
--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -331,7 +331,7 @@ export async function recordAndProcessChatwootDelivery(
   params: RecordAndProcessChatwootParams,
 ): Promise<"processed" | "skipped"> {
   const base = params.base ?? basePrisma;
-  const { rowId } = await recordDelivery(
+  const { rowId } = await claimDelivery(
     base,
     { tenantId: params.tenantId, instanceId: params.instanceId },
     params.deliveryId,
@@ -346,6 +346,47 @@ export async function recordAndProcessChatwootDelivery(
     base,
     deps: params.deps,
   });
+}
+
+// THE 200 IS ALREADY OUT WHEN THIS RUNS, so a throw here is not a delivery that gets retried: it is
+// a message that never existed. Chatwoot was told we have the event, and the upstream retry ladder
+// that would otherwise redeliver it is spent. That makes the ledger claim the one step on this path
+// with nothing behind it, and the failure it actually meets is the one this whole design is about, a
+// pool momentarily full (`maxWait` is 2s). Retrying turns a blip into a delay instead of a lost turn.
+//
+// What this does NOT cover is the process dying between the ack and the claim, which takes the
+// in-memory payload with it. That is the durability the fast ack trades away, and closing it needs
+// the payload stored before the 200, not a longer retry here.
+const LEDGER_CLAIM_ATTEMPTS = 4;
+const LEDGER_CLAIM_BACKOFF_MS = 300;
+
+async function claimDelivery(
+  base: PrismaClient,
+  scope: { tenantId: bigint; instanceId: bigint },
+  deliveryId: string,
+  event: string,
+): Promise<{ rowId: bigint; duplicate: boolean }> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= LEDGER_CLAIM_ATTEMPTS; attempt++) {
+    try {
+      return await recordDelivery(base, scope, deliveryId, event);
+    } catch (err) {
+      lastErr = err;
+      logger.warn(
+        "chatwoot ledger claim attempt %d/%d failed (delivery %s): %s",
+        attempt,
+        LEDGER_CLAIM_ATTEMPTS,
+        deliveryId,
+        errMsg(err),
+      );
+      if (attempt < LEDGER_CLAIM_ATTEMPTS) {
+        await new Promise((r) =>
+          setTimeout(r, LEDGER_CLAIM_BACKOFF_MS * 2 ** (attempt - 1)),
+        );
+      }
+    }
+  }
+  throw lastErr;
 }
 
 // Idempotency ledger insert: create-then-catch across two transactions (a unique violation

--- a/tests/modules/chatwoot-receiver.test.ts
+++ b/tests/modules/chatwoot-receiver.test.ts
@@ -466,6 +466,71 @@ describe.skipIf(!dbUp)("chatwoot webhook receiver", () => {
     expect(r.normalized?.conversationId).toBe(47);
   });
 
+  // The ack is already out when the detached half runs, so a throw in the ledger claim is not a
+  // delivery Chatwoot retries: the upstream ladder is spent and the event simply never existed. The
+  // failure it meets is the one this path is built around, a pool momentarily full, and that has to
+  // cost latency rather than the turn.
+  test("a pool blip on the ledger claim delays the delivery instead of losing it", async () => {
+    const body = JSON.stringify({
+      event: "conversation_updated",
+      id: 52,
+      inbox_id: 7,
+      status: "pending",
+      meta: { assignee_type: "AgentBot", assignee: { id: 9 } },
+    });
+    const r = await receiveChatwootWebhook({
+      routeToken,
+      rawBody: body,
+      getHeader: signedHeaders(body, NOW, "uuid-blip"),
+      nowSeconds: NOW,
+      base: appDb,
+    });
+
+    // Two transactions fail the way an exhausted pool fails, then the pool recovers.
+    let blips = 2;
+    const wrap = (client: unknown): unknown =>
+      new Proxy(client as object, {
+        get(target, prop, recv) {
+          if (prop === "$transaction") {
+            const orig = Reflect.get(target, prop, recv) as (
+              ...a: unknown[]
+            ) => Promise<unknown>;
+            return async (...args: unknown[]) => {
+              if (blips-- > 0) {
+                throw new Error(
+                  "Timed out fetching a new connection from the connection pool",
+                );
+              }
+              return orig.apply(target, args);
+            };
+          }
+          if (prop === "$extends") {
+            const orig = Reflect.get(target, prop, recv) as (
+              ...a: unknown[]
+            ) => unknown;
+            return (...args: unknown[]) => wrap(orig.apply(target, args));
+          }
+          return Reflect.get(target, prop, recv);
+        },
+      });
+
+    expect(
+      await recordAndProcessChatwootDelivery({
+        tenantId,
+        instanceId: r.instanceId as bigint,
+        deliveryId: r.deliveryId as string,
+        agentBotId: r.agentBotId ?? null,
+        normalized: r.normalized as NonNullable<typeof r.normalized>,
+        base: wrap(appDb) as PrismaClient,
+      }),
+    ).toBe("processed");
+
+    const row = await suDb.chatwootWebhookDelivery.findFirstOrThrow({
+      where: { chatwootInstanceId: instanceId, deliveryId: "uuid-blip" },
+    });
+    expect(row.status).toBe("PROCESSED");
+  });
+
   test("a delivery stranded on PENDING is recovered by the redelivery", async () => {
     const body = JSON.stringify({
       event: "conversation_updated",


### PR DESCRIPTION
Fixes #235

## What broke

The receiver acks before it writes the idempotency ledger row, which is what keeps a slow Postgres from costing the conversation its bot. It also leaves the ledger claim as the one step on this path with nothing behind it: Chatwoot has its 200, its retry ladder is spent, and a throw there is not a delivery that comes back. There is no `PENDING` row, no processing, and no redelivery. The customer's message produced nothing, and the only trace was a log line.

The failure that step actually meets is the one the ack redesign is about. `runScopedOn` opens an interactive transaction (RLS needs `set_config`) and Prisma's default `maxWait` is 2s, so under the pool pressure that made the ack slow in the first place the claim is exactly as likely to time out as the lookup that was moved off it, and the next attempt would usually have worked.

## What changed

The claim runs with a bounded retry (4 attempts, 300ms doubling). On a path where latency is free, a pool blip costs about a second instead of a turn.

## What this deliberately does not fix

A process that dies between the ack and the claim takes the in-memory payload with it. That is the durability the fast ack trades away, and closing it means storing the payload before the 200, not retrying longer after it. This change does not pretend otherwise, and the comment on `claimDelivery` says so.

## Validation scope

**Proven by test.** A DB-backed test drives the delivery through a client whose first two transactions fail the way an exhausted pool fails, then recovers; the row still reaches `PROCESSED`. The test is red with `LEDGER_CLAIM_ATTEMPTS = 1` (46 pass / 1 fail), which is the pre-change behaviour. Full suite 4561 pass / 0 fail.

**Not validated.** The retry is not exercised against a real exhausted pool, only against an injected client that throws the same error. The backoff constants are not tuned against a measurement of how long real pool pressure lasts; they are chosen to outlast a `maxWait` of 2s a few times over. And nothing here tests the process-death case, which this change does not address.
