### PR TITLE
Keep a character the sender wrote from costing the delivery it arrived in

### DIFF
--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -46,6 +46,9 @@ const LONE_SURROGATE_RE =
   /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/g;
 // Most strings hold no surrogate at all, and this runs on every string of every execution-log detail.
 const ANY_SURROGATE_RE = /[\ud800-\udfff]/;
+// The other character a `text` or `jsonb` column refuses. Spelled as a code unit: a literal NUL in
+// a source file is invisible in every diff and every review.
+const NUL = "\u0000";
 
 // Every unpaired surrogate replaced with U+FFFD. Cutting is only ONE of the two ways a value gets
 // one: any JSON source that spells it out (`"\ud800"`) hands `JSON.parse` an orphan directly, which
@@ -54,6 +57,50 @@ export function replaceLoneSurrogates(value: string): string {
   return ANY_SURROGATE_RE.test(value)
     ? value.replace(LONE_SURROGATE_RE, "�")
     : value;
+}
+
+// The REPAIR half of the rule `unstorableProblem` REPORTS: same two characters, opposite policy.
+// Refusing is right where the author reads the refusal and can go fix the value (an operator's
+// form). Repairing is right where the writer is a third party's webhook, which never reads a
+// refusal and whose only recourse is to retry the identical bytes until its budget runs out. There
+// a refusal costs the event, and the repair keeps it.
+//
+// The two are not repaired the same way, because they do not mean the same thing. An unpaired
+// surrogate WAS half of a real character, so U+FFFD stands where that character was. A NUL never
+// stood for anything a reader would see, and is simply dropped.
+export function makeStorable(value: string): string {
+  return replaceLoneSurrogates(
+    value.includes(NUL) ? value.replaceAll(NUL, "") : value,
+  );
+}
+
+// A deeper document than any allowlisted projection has, which is the only shape this is called on.
+const MAX_STORABLE_DEPTH = 8;
+
+// `makeStorable` over a whole JSON document, KEYS included: one orphan half anywhere in it is enough
+// for Postgres to refuse the entire `jsonb` write, so the unit that has to come back storable is the
+// document, not the field. Reaching every string structurally is also what keeps a field added to
+// the shape later from arriving unrepaired.
+//
+// Values that are not part of a JSON document (a `Date`, a class instance) are returned as they are:
+// they carry no string for the write to choke on, and rebuilding them from their entries would
+// destroy them. Below the depth cap the branch is DROPPED rather than passed through: something
+// nested that deep is not the bounded projection this is for, and losing one branch of it beats
+// losing the whole event to a refused INSERT.
+export function makeStorableDeep<T>(value: T, depth = 0): T {
+  if (typeof value === "string") return makeStorable(value) as T;
+  if (value === null || typeof value !== "object") return value;
+  if (depth >= MAX_STORABLE_DEPTH) return null as T;
+  if (Array.isArray(value)) {
+    return value.map((v) => makeStorableDeep(v, depth + 1)) as T;
+  }
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== null && proto !== Object.prototype) return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) {
+    out[makeStorable(k)] = makeStorableDeep(v, depth + 1);
+  }
+  return out as T;
 }
 
 // What PostgreSQL refuses to STORE, which is a different question from what anything can draw.

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -103,7 +103,16 @@ export function makeStorableDeep<T>(value: T, depth = 0): T {
   if (proto !== null && proto !== Object.prototype) return value;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value)) {
-    out[makeStorable(k)] = makeStorableDeep(v, depth + 1);
+    // `defineProperty`, not assignment: `JSON.parse` gives `__proto__` as an ORDINARY own property
+    // (a key a third party's body can carry, and one a malformed key can repair INTO), while
+    // assignment on that same key invokes the legacy prototype setter instead. The field would
+    // vanish from what gets persisted and the copy would come back with a different prototype.
+    Object.defineProperty(out, makeStorable(k), {
+      value: makeStorableDeep(v, depth + 1),
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
   }
   return out as T;
 }

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -68,10 +68,15 @@ export function replaceLoneSurrogates(value: string): string {
 // The two are not repaired the same way, because they do not mean the same thing. An unpaired
 // surrogate WAS half of a real character, so U+FFFD stands where that character was. A NUL never
 // stood for anything a reader would see, and is simply dropped.
+//
+// The ORDER carries a rule of its own: surrogates are repaired while the NULs are still in place.
+// Dropping the NUL out of `\ud800 \udc00` first would leave the two orphan halves adjacent, and
+// they would then read as the well-formed pair U+10000 and survive untouched, inventing a character
+// nobody wrote out of three defects. Repairing first keeps each defect represented by its own
+// U+FFFD.
 export function makeStorable(value: string): string {
-  return replaceLoneSurrogates(
-    value.includes(NUL) ? value.replaceAll(NUL, "") : value,
-  );
+  const repaired = replaceLoneSurrogates(value);
+  return repaired.includes(NUL) ? repaired.replaceAll(NUL, "") : repaired;
 }
 
 // A deeper document than any allowlisted projection has, which is the only shape this is called on.
@@ -119,18 +124,22 @@ export function makeStorableDeep<T>(value: T, depth = 0): T {
 // be perfectly storable and impossible to print (an emoji in a tool description a model reads and
 // nobody draws). A caller that only needs the value to survive its column asks this one.
 export function unstorableProblem(value: string, what: string): string | null {
-  const bad: string[] = [];
+  // A Set, not a scan of a growing array: the distinct offenders number 2049 (a NUL and every
+  // surrogate code unit), so `includes` on the accumulator turns a long malformed value into
+  // quadratic work on a caller's behalf. Insertion order is preserved either way, and the message
+  // names them in the order they appear.
+  const bad = new Set<string>();
   for (const ch of value) {
     const code = ch.codePointAt(0) ?? 0;
     // `for...of` yields a well-formed pair as ONE two-unit string, so a single-unit string in the
     // surrogate range never had its other half.
     const lone = ch.length === 1 && code >= 0xd800 && code <= 0xdfff;
-    if ((code === 0 || lone) && !bad.includes(ch)) bad.push(ch);
+    if (code === 0 || lone) bad.add(ch);
   }
-  if (bad.length === 0) return null;
+  if (bad.size === 0) return null;
   // Named by code point, never pasted: quoting the character itself would put a NUL into a log line
   // and an API response, and half a character into a JSON body.
-  const named = bad.map(
+  const named = [...bad].map(
     (ch) =>
       `U+${(ch.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, "0")}`,
   );

--- a/src/modules/webhooks/inbound/service.ts
+++ b/src/modules/webhooks/inbound/service.ts
@@ -6,7 +6,7 @@ import { type AgentNudge, runAgentNudge } from "@/graph/nudge";
 import type { RuntimeDeps } from "@/graph/runtime";
 import { AppError, UnauthorizedError } from "@/lib/errors";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
-import { makeStorableDeep } from "@/lib/text";
+import { makeStorableDeep, unstorableProblem } from "@/lib/text";
 import { getMapper } from "@/modules/integrations/mappers";
 import {
   type ResolvedInboundRoute,
@@ -199,6 +199,37 @@ export async function receiveInbound(
     };
   }
 
+  // An identity field carrying a character the column refuses is NOT repaired: repairing is lossy,
+  // and lossy on an identity is how a payment lands in the wrong conversation. `ref\u0000` repaired
+  // to `ref` MATCHES the ref an unrelated conversation registered, and `dispatchConversion` would
+  // credit the conversion there and nudge that customer, the one outcome this module says it never
+  // produces. Two distinct provider ids that differ only by such a character would likewise collapse
+  // into one `dedupeKey` and silently drop a real delivery. So a malformed identity takes the
+  // fail-closed path that already exists for a payload we cannot process: a durable FAILED record
+  // and a 2xx, which is what stops the sender's retry loop. The payload itself is display and
+  // diagnostics, and IS repaired (below).
+  const badIdentity =
+    unstorableProblem(result.event.dedupeKey, "dedupeKey") ??
+    unstorableProblem(result.event.externalId, "externalId");
+  if (badIdentity) {
+    logger.warn(
+      "inbound: %s identity field is unstorable (instance %s): %s",
+      route.catalogType,
+      String(route.id),
+      badIdentity,
+    );
+    const failedId = await persistFailed(base, route, params.rawBody, {
+      reason: "unstorable-identity",
+      issues: badIdentity,
+    });
+    return {
+      ack: true,
+      deliveryId: failedId,
+      tenantId: route.tenantId,
+      outcome: "invalid",
+    };
+  }
+
   const { id, duplicate } = await persistInbound(base, route, result.event);
   return {
     ack: true,
@@ -251,20 +282,19 @@ async function persistFailed(
 // so the existence re-read must run in a fresh one). Handles concurrent identical deliveries.
 //
 // The mapper is pure and knows nothing about columns; this is where its output becomes a row, so it
-// is where a third party's characters have to survive the write. Measured against Postgres, BOTH
-// destinations of the event refuse the same two characters: the `jsonb` payload (`invalid input
-// syntax for type json`, and 22P05 for a NUL) and the `text` correlation columns (22021), and
-// `dedupeKey` is built from the provider's own id. That is why the repair takes the WHOLE event
-// rather than the payload, and why the re-read below looks for the REPAIRED key. A refusal here
-// escapes `receiveInbound`, which nothing above catches: a 500 with no delivery row and no FAILED
-// record either, and a sender retrying a body that can never succeed.
+// is where a third party's characters have to survive the write. Measured against Postgres, the
+// `jsonb` payload refuses a lone surrogate (`invalid input syntax for type json`) and a NUL (22P05),
+// and the refusal escapes `receiveInbound`, which nothing above catches: a 500 with no delivery row
+// and no FAILED record either, and a sender retrying a body that can never succeed. The payload is
+// display and diagnostics, so it is REPAIRED. The identity fields, which the `text` columns refuse
+// just as flatly (22021), are not repairable without changing what they identify, and the caller has
+// already turned those away.
 async function persistInbound(
   base: PrismaClient,
   route: ResolvedInboundRoute,
-  mapped: NormalizedInboundEvent,
+  n: NormalizedInboundEvent,
 ): Promise<{ id: bigint; duplicate: boolean }> {
-  const n = makeStorableDeep(mapped);
-  const payload = toStoredPayload(n);
+  const payload = makeStorableDeep(toStoredPayload(n));
   try {
     const row = await runScopedOn(base, sysCtx(route.tenantId), (db) =>
       db.inboundDelivery.create({

--- a/src/modules/webhooks/inbound/service.ts
+++ b/src/modules/webhooks/inbound/service.ts
@@ -6,6 +6,7 @@ import { type AgentNudge, runAgentNudge } from "@/graph/nudge";
 import type { RuntimeDeps } from "@/graph/runtime";
 import { AppError, UnauthorizedError } from "@/lib/errors";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { makeStorableDeep } from "@/lib/text";
 import { getMapper } from "@/modules/integrations/mappers";
 import {
   type ResolvedInboundRoute,
@@ -248,11 +249,21 @@ async function persistFailed(
 
 // create-then-catch across two transactions (a unique violation aborts its own transaction,
 // so the existence re-read must run in a fresh one). Handles concurrent identical deliveries.
+//
+// The mapper is pure and knows nothing about columns; this is where its output becomes a row, so it
+// is where a third party's characters have to survive the write. Measured against Postgres, BOTH
+// destinations of the event refuse the same two characters: the `jsonb` payload (`invalid input
+// syntax for type json`, and 22P05 for a NUL) and the `text` correlation columns (22021), and
+// `dedupeKey` is built from the provider's own id. That is why the repair takes the WHOLE event
+// rather than the payload, and why the re-read below looks for the REPAIRED key. A refusal here
+// escapes `receiveInbound`, which nothing above catches: a 500 with no delivery row and no FAILED
+// record either, and a sender retrying a body that can never succeed.
 async function persistInbound(
   base: PrismaClient,
   route: ResolvedInboundRoute,
-  n: NormalizedInboundEvent,
+  mapped: NormalizedInboundEvent,
 ): Promise<{ id: bigint; duplicate: boolean }> {
+  const n = makeStorableDeep(mapped);
   const payload = toStoredPayload(n);
   try {
     const row = await runScopedOn(base, sysCtx(route.tenantId), (db) =>

--- a/src/modules/webhooks/inbound/service.ts
+++ b/src/modules/webhooks/inbound/service.ts
@@ -34,6 +34,25 @@ import {
 const PROCESSING_STALE_MS = 5 * 60_000;
 const MAX_PROCESS_ATTEMPTS = 5;
 
+// What an identity field is allowed to be, and it is a REFUSAL rather than a truncation: cutting an
+// identity is the same lossy-identity defect as repairing one. Measured against this database, a
+// `dedupeKey` that does not compress fails its own unique index at ~2704 bytes ("index row size
+// 6432 exceeds btree version 4 maximum 2704"), which is the same 500-with-no-record as an
+// unstorable character, reached by a different road. 512 characters is far above any provider id
+// (Asaas sends ~20, and the mapper already caps `externalReference` at 128) and far below the index
+// limit even if every character were 4 bytes.
+const MAX_IDENTITY_CHARS = 512;
+
+// The two things an identity field must be for the row to exist: storable, and short enough for the
+// index that enforces idempotency on it. Same verdict shape as `unstorableProblem`, whose message
+// this passes through, because the caller does the same thing with either answer.
+function identityProblem(value: string, what: string): string | null {
+  if (value.length > MAX_IDENTITY_CHARS) {
+    return `${what} is ${value.length} characters, over the ${MAX_IDENTITY_CHARS} an identity field may hold.`;
+  }
+  return unstorableProblem(value, what);
+}
+
 function sysCtx(tenantId: bigint): TenantContext {
   return { tenantId, userId: null, role: "TENANT_ADMIN" };
 }
@@ -199,7 +218,7 @@ export async function receiveInbound(
     };
   }
 
-  // An identity field carrying a character the column refuses is NOT repaired: repairing is lossy,
+  // An identity field the row cannot carry is NOT repaired or cut: both are lossy,
   // and lossy on an identity is how a payment lands in the wrong conversation. `ref\u0000` repaired
   // to `ref` MATCHES the ref an unrelated conversation registered, and `dispatchConversion` would
   // credit the conversion there and nudge that customer, the one outcome this module says it never
@@ -209,11 +228,11 @@ export async function receiveInbound(
   // and a 2xx, which is what stops the sender's retry loop. The payload itself is display and
   // diagnostics, and IS repaired (below).
   const badIdentity =
-    unstorableProblem(result.event.dedupeKey, "dedupeKey") ??
-    unstorableProblem(result.event.externalId, "externalId");
+    identityProblem(result.event.dedupeKey, "dedupeKey") ??
+    identityProblem(result.event.externalId, "externalId");
   if (badIdentity) {
     logger.warn(
-      "inbound: %s identity field is unstorable (instance %s): %s",
+      "inbound: %s identity field cannot be stored (instance %s): %s",
       route.catalogType,
       String(route.id),
       badIdentity,

--- a/tests/lib/text.test.ts
+++ b/tests/lib/text.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   clipText,
   clipTextEnd,
+  makeStorable,
+  makeStorableDeep,
   replaceLoneSurrogates,
   unstorableProblem,
 } from "@/lib/text";
@@ -145,5 +147,86 @@ describe("unstorableProblem", () => {
     for (const value of ["Ana", "😀", "a\tb", "a\nb", "Orçamento", ""]) {
       expect(unstorableProblem(value, "x")).toBeNull();
     }
+  });
+});
+
+// The REPAIR half of the same rule `unstorableProblem` reports: same predicate, opposite policy.
+// Refusing is right where the author reads the refusal and can fix the value (an operator's form);
+// repairing is right where the writer is a third party's webhook that will never read the refusal
+// and whose only recourse is to retry the identical body forever.
+describe("makeStorable", () => {
+  // Written as a code unit rather than pasted: a literal NUL in a source file is invisible in every
+  // diff and every review.
+  const NUL = String.fromCharCode(0);
+
+  test("drops a NUL and replaces half a character, in every position", () => {
+    expect(makeStorable(`a${NUL}b`)).toBe("ab");
+    expect(makeStorable(`${NUL}ab`)).toBe("ab");
+    expect(makeStorable(`ab${NUL}`)).toBe("ab");
+    expect(makeStorable("a\ud800b")).toBe("a�b");
+    expect(makeStorable("a\udc00b")).toBe("a�b");
+    // Both defects in one value, which is what a truncating upstream actually produces.
+    expect(makeStorable(`a${NUL}b\ud800c`)).toBe("ab�c");
+  });
+
+  test("leaves everything a column can hold exactly as it was", () => {
+    for (const value of ["Ana", "\u{1f600}", "a\tb", "a\nb", "Orcamento", ""]) {
+      expect(makeStorable(value)).toBe(value);
+    }
+  });
+
+  test("its output is what unstorableProblem accepts, which is the whole point", () => {
+    for (const value of [`a${NUL}b`, "a\ud800b", "a\udc00b", `${NUL}\ud800`]) {
+      expect(unstorableProblem(value, "x")).not.toBeNull();
+      expect(unstorableProblem(makeStorable(value), "x")).toBeNull();
+    }
+  });
+
+  test("is idempotent", () => {
+    const once = makeStorable(`a${NUL}b\ud800c`);
+    expect(makeStorable(once)).toBe(once);
+  });
+});
+
+// One orphan half ANYWHERE in a document is enough for Postgres to refuse the whole `jsonb` write,
+// so the unit that has to come back storable is the document, not the field.
+describe("makeStorableDeep", () => {
+  const NUL = String.fromCharCode(0);
+  // The predicate the whole function exists for: nothing a column refuses survives anywhere in the
+  // result. Asserted on the SERIALIZED document, so a value the test forgot to name still counts.
+  function residue(value: unknown): number {
+    const json = JSON.stringify(value) ?? "";
+    return (json.match(/\\u0000/g)?.length ?? 0) + loneSurrogates(json);
+  }
+
+  test("repairs values, keys, and everything nested inside either", () => {
+    const out = makeStorableDeep({
+      [`k${NUL}1`]: "clean",
+      k2: `v\ud800`,
+      nested: { [`k\ud800`]: [`a${NUL}b`, { deep: `c\udc00` }] },
+    }) as Record<string, unknown>;
+    expect(Object.keys(out)).toEqual(["k1", "k2", "nested"]);
+    expect(out.k2).toBe("v�");
+    expect(out.nested).toEqual({ "k�": ["ab", { deep: "c�" }] });
+    expect(residue(out)).toBe(0);
+  });
+
+  test("leaves a clean document, its non-strings, and its Dates alone", () => {
+    const date = new Date("2026-08-24T00:00:00.000Z");
+    const input = { s: "Ana", n: 1, b: true, nul: null, date, list: [1, "x"] };
+    const out = makeStorableDeep(input);
+    expect(out).toEqual(input);
+    // The Date is the reason a non-plain object is returned as it is: rebuilding it from its
+    // entries (there are none) would silently turn a timestamp into `{}`.
+    expect(out.date).toBe(date);
+  });
+
+  test("drops the branch below the depth cap rather than passing it through unrepaired", () => {
+    // 12 levels: deeper than any allowlisted projection, and deep enough to be past the cap.
+    let deep: unknown = `bottom\ud800`;
+    for (let i = 0; i < 12; i++) deep = { down: deep };
+    const out = makeStorableDeep(deep);
+    expect(residue(out)).toBe(0);
+    expect(JSON.stringify(out)).toContain("null");
   });
 });

--- a/tests/lib/text.test.ts
+++ b/tests/lib/text.test.ts
@@ -219,6 +219,24 @@ describe("makeStorableDeep", () => {
     expect(residue(out)).toBe(0);
   });
 
+  test("keeps a `__proto__` key as a field instead of feeding it to the prototype setter", () => {
+    // `JSON.parse` produces `__proto__` as an ordinary own property, so a third party's body can
+    // carry one, and a malformed key can repair INTO one. Plain assignment would invoke the legacy
+    // setter: the field disappears from what gets persisted and the copy's prototype changes.
+    const raw = JSON.parse(`{"__pro${"\\u0000"}to__": {"a": 1}, "keep": "x"}`);
+    const out = makeStorableDeep(raw) as Record<string, unknown>;
+    expect(Object.getOwnPropertyNames(out).sort()).toEqual([
+      "__proto__",
+      "keep",
+    ]);
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    // What actually reaches the column is the serialization, which is where the loss shows up.
+    expect(JSON.parse(JSON.stringify(out))).toEqual({
+      __proto__: { a: 1 },
+      keep: "x",
+    });
+  });
+
   test("leaves a clean document, its non-strings, and its Dates alone", () => {
     const date = new Date("2026-08-24T00:00:00.000Z");
     const input = { s: "Ana", n: 1, b: true, nul: null, date, list: [1, "x"] };

--- a/tests/lib/text.test.ts
+++ b/tests/lib/text.test.ts
@@ -169,6 +169,14 @@ describe("makeStorable", () => {
     expect(makeStorable(`a${NUL}b\ud800c`)).toBe("ab�c");
   });
 
+  test("does not let a dropped NUL join two orphan halves into a character", () => {
+    // Three defects, and dropping the NUL FIRST would leave `\ud800\udc00` adjacent, which is the
+    // well-formed pair U+10000: a character nobody wrote, surviving the repair intact.
+    const out = makeStorable(`\ud800${NUL}\udc00`);
+    expect(out).toBe("��");
+    expect([...out].map((c) => c.codePointAt(0))).toEqual([0xfffd, 0xfffd]);
+  });
+
   test("leaves everything a column can hold exactly as it was", () => {
     for (const value of ["Ana", "\u{1f600}", "a\tb", "a\nb", "Orcamento", ""]) {
       expect(makeStorable(value)).toBe(value);

--- a/tests/modules/inbound-receptor.test.ts
+++ b/tests/modules/inbound-receptor.test.ts
@@ -816,6 +816,50 @@ describe.skipIf(!dbUp)("inbound receptor", () => {
     });
   }
 
+  test("records a durable FAILED delivery when the identity is too long for its own index", async () => {
+    const { routeToken } = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "ASAAS",
+        name: "asaas-identity-long",
+        inboundAuthStrategy: "NONE",
+        config: { notifyOnPayment: false },
+      },
+      appDb,
+    );
+    // Incompressible on purpose: a run of one character compresses inside the index and slips past
+    // the limit, so a probe built from `repeat("x", n)` would prove nothing. Measured on this
+    // database, an incompressible dedupe key fails its unique index at ~2704 bytes with "index row
+    // size 6432 exceeds btree version 4 maximum 2704", which is the same 500-with-no-record this
+    // PR exists to remove. The mapper puts `payment.id` straight into the key and its schema caps
+    // neither that nor `event`.
+    const longId = Array.from({ length: 3000 }, (_, i) =>
+      String.fromCharCode(97 + ((i * 7 + (i % 13)) % 26)),
+    ).join("");
+    const r = await receiveInbound({
+      routeToken: routeToken as string,
+      rawBody: JSON.stringify({
+        event: "PAYMENT_RECEIVED",
+        payment: {
+          id: longId,
+          value: 10,
+          status: "RECEIVED",
+          externalReference: "r-long",
+        },
+      }),
+      getHeader: () => null,
+      base: appDb,
+    });
+    expect(r.ack).toBe(true);
+    expect(r.outcome).toBe("invalid");
+
+    const delivery = await suDb.inboundDelivery.findUniqueOrThrow({
+      where: { id: r.deliveryId as bigint },
+    });
+    expect(delivery.status).toBe("FAILED");
+    expect(delivery.payload).toMatchObject({ reason: "unstorable-identity" });
+  });
+
   test("a malformed reference never correlates onto the conversation the clean one owns", async () => {
     const { id: instanceId, routeToken } = await createIntegrationInstance(
       tenantId,

--- a/tests/modules/inbound-receptor.test.ts
+++ b/tests/modules/inbound-receptor.test.ts
@@ -692,83 +692,48 @@ describe.skipIf(!dbUp)("inbound receptor", () => {
   // ── characters Postgres refuses to store (issue #218) ──
   // A body that is valid JSON, passes the mapper's schema, and that the column then refuses. The
   // two characters and BOTH destinations of the normalized event, measured against this database:
-  //   jsonb payload + lone surrogate → invalid input syntax for type json
-  //   jsonb payload + NUL            → 22P05 unsupported Unicode escape sequence
-  //   text  column  + lone surrogate → 22021 invalid byte sequence for encoding "UTF8": 0xef 0xbf
-  //   text  column  + NUL            → 22021 invalid byte sequence for encoding "UTF8": 0x00
+  //   jsonb payload + lone surrogate -> invalid input syntax for type json
+  //   jsonb payload + NUL            -> 22P05 unsupported Unicode escape sequence
+  //   text  column  + lone surrogate -> 22021 invalid byte sequence for encoding "UTF8": 0xef 0xbf
+  //   text  column  + NUL            -> 22021 invalid byte sequence for encoding "UTF8": 0x00
   // Each one used to throw out of `receiveInbound`, which nothing above catches: a 500 with no
   // delivery row and no FAILED record either, and a sender retrying a body that can never succeed.
-  // The text columns are the half worth pinning: `dedupeKey` is built from the provider's own id,
-  // the field most likely to carry whatever the provider was handed.
+  // The two halves get OPPOSITE treatment, which is what the second group below pins.
   const NUL = String.fromCharCode(0);
-  const unstorable: Array<{
+
+  // The payload is display and diagnostics: repaired, and the delivery is kept.
+  const repaired: Array<{
     name: string;
     payment: Record<string, unknown>;
-    expect: { externalId: string; dedupeKey: string; payload: unknown };
+    status: string;
+    metadata?: unknown;
   }> = [
     {
       name: "a lone surrogate in metadata (jsonb)",
       payment: { id: "u1", externalReference: "r1", paymentLink: "l\ud800k" },
-      expect: {
-        externalId: "r1",
-        dedupeKey: "PAYMENT_RECEIVED:u1",
-        payload: { paymentLink: "l�k" },
-      },
+      status: "RECEIVED",
+      metadata: { paymentLink: "l�k" },
     },
     {
       name: "a NUL in metadata (jsonb)",
       payment: { id: "u2", externalReference: "r2", paymentLink: `l${NUL}k` },
-      expect: {
-        externalId: "r2",
-        dedupeKey: "PAYMENT_RECEIVED:u2",
-        payload: { paymentLink: "lk" },
-      },
+      status: "RECEIVED",
+      metadata: { paymentLink: "lk" },
     },
     {
       name: "a lone surrogate in the provider's status (jsonb)",
       payment: { id: "u3", externalReference: "r3", status: "RECEIVED\ud800" },
-      expect: {
-        externalId: "r3",
-        dedupeKey: "PAYMENT_RECEIVED:u3",
-        payload: undefined,
-      },
-    },
-    {
-      name: "a lone surrogate in the provider's id (text dedupe_key)",
-      payment: { id: "u4\ud800", externalReference: "r4" },
-      expect: {
-        externalId: "r4",
-        dedupeKey: "PAYMENT_RECEIVED:u4�",
-        payload: undefined,
-      },
-    },
-    {
-      name: "a NUL in the provider's id (text dedupe_key)",
-      payment: { id: `u5${NUL}x`, externalReference: "r5" },
-      expect: {
-        externalId: "r5",
-        dedupeKey: "PAYMENT_RECEIVED:u5x",
-        payload: undefined,
-      },
-    },
-    {
-      name: "a lone surrogate in the correlation reference (text external_id)",
-      payment: { id: "u6", externalReference: "r6\ud800" },
-      expect: {
-        externalId: "r6�",
-        dedupeKey: "PAYMENT_RECEIVED:u6",
-        payload: undefined,
-      },
+      status: "RECEIVED�",
     },
   ];
 
-  for (const [i, c] of unstorable.entries()) {
-    test(`records the delivery when the body carries ${c.name}`, async () => {
+  for (const [i, c] of repaired.entries()) {
+    test(`repairs and keeps the delivery when the body carries ${c.name}`, async () => {
       const { routeToken } = await createIntegrationInstance(
         tenantId,
         {
           catalogType: "ASAAS",
-          name: `asaas-unstorable-${i}`,
+          name: `asaas-repaired-${i}`,
           inboundAuthStrategy: "NONE",
           config: { notifyOnPayment: false },
         },
@@ -788,31 +753,131 @@ describe.skipIf(!dbUp)("inbound receptor", () => {
       const delivery = await suDb.inboundDelivery.findUniqueOrThrow({
         where: { id: r.deliveryId as bigint },
       });
-      expect(delivery.externalId).toBe(c.expect.externalId);
-      expect(delivery.dedupeKey).toBe(c.expect.dedupeKey);
+      expect(delivery.status).toBe("PENDING");
       const payload = delivery.payload as Record<string, unknown>;
-      expect(payload.status).toBe(
-        (c.payment.status as string | undefined) === "RECEIVED\ud800"
-          ? "RECEIVED�"
-          : "RECEIVED",
-      );
-      if (c.expect.payload) expect(payload.metadata).toEqual(c.expect.payload);
+      expect(payload.status).toBe(c.status);
+      if (c.metadata) expect(payload.metadata).toEqual(c.metadata);
     });
   }
 
-  test("a repaired delivery still converts end to end (the payment is not lost)", async () => {
+  // An identity field is NOT repaired. Repairing is lossy, and lossy on an identity is how a
+  // payment lands in someone else's conversation (`ref<NUL>` becomes `ref`, which is a reference
+  // another conversation registered) or how two distinct provider ids collapse into one dedupe key.
+  // The delivery takes the fail-closed path instead: a durable FAILED row and a 2xx, which is what
+  // stops the retry loop without inventing an identity.
+  const refused: Array<{ name: string; payment: Record<string, unknown> }> = [
+    {
+      name: "a lone surrogate in the provider's id (text dedupe_key)",
+      payment: { id: "u4\ud800", externalReference: "r4" },
+    },
+    {
+      name: "a NUL in the provider's id (text dedupe_key)",
+      payment: { id: `u5${NUL}x`, externalReference: "r5" },
+    },
+    {
+      name: "a lone surrogate in the correlation reference (text external_id)",
+      payment: { id: "u6", externalReference: "r6\ud800" },
+    },
+  ];
+
+  for (const [i, c] of refused.entries()) {
+    test(`records a durable FAILED delivery when the body carries ${c.name}`, async () => {
+      const { routeToken } = await createIntegrationInstance(
+        tenantId,
+        {
+          catalogType: "ASAAS",
+          name: `asaas-refused-${i}`,
+          inboundAuthStrategy: "NONE",
+          config: { notifyOnPayment: false },
+        },
+        appDb,
+      );
+      const r = await receiveInbound({
+        routeToken: routeToken as string,
+        rawBody: JSON.stringify({
+          event: "PAYMENT_RECEIVED",
+          payment: { value: 10, status: "RECEIVED", ...c.payment },
+        }),
+        getHeader: () => null,
+        base: appDb,
+      });
+      // The sender still gets its 2xx: the point of the fail-closed path is that the retry loop
+      // ends, not that the caller learns anything it could act on.
+      expect(r.ack).toBe(true);
+      expect(r.outcome).toBe("invalid");
+
+      const delivery = await suDb.inboundDelivery.findUniqueOrThrow({
+        where: { id: r.deliveryId as bigint },
+      });
+      expect(delivery.status).toBe("FAILED");
+      expect(delivery.externalId).toBeNull();
+      expect(delivery.dedupeKey).toMatch(/^raw:[0-9a-f]{64}$/);
+      expect(delivery.payload).toMatchObject({ reason: "unstorable-identity" });
+    });
+  }
+
+  test("a malformed reference never correlates onto the conversation the clean one owns", async () => {
     const { id: instanceId, routeToken } = await createIntegrationInstance(
       tenantId,
       {
         catalogType: "ASAAS",
-        name: "asaas-unstorable-e2e",
+        name: "asaas-identity-bleed",
+        inboundAuthStrategy: "NONE",
+        // notifyOnPayment stays ON: the wrong-thread nudge is half of what this guards against.
+        config: {},
+      },
+      appDb,
+    );
+    // A real conversation owns the reference `corr_bleed`.
+    await suDb.integrationExternalRef.create({
+      data: {
+        tenantId,
+        integrationInstanceId: instanceId,
+        externalId: "corr_bleed",
+        threadId: "1:1:777",
+        kind: "asaas_payment",
+      },
+    });
+    // A different payment arrives carrying that same reference with a NUL glued to it. Repairing
+    // it would produce `corr_bleed` exactly, and credit this payment to thread 1:1:777.
+    const r = await receiveInbound({
+      routeToken: routeToken as string,
+      rawBody: JSON.stringify({
+        event: "PAYMENT_RECEIVED",
+        payment: {
+          id: "pay_bleed",
+          value: 999,
+          status: "RECEIVED",
+          externalReference: `corr_bleed${NUL}`,
+        },
+      }),
+      getHeader: () => null,
+      base: appDb,
+    });
+    expect(r.outcome).toBe("invalid");
+    if (r.outcome !== "invalid") return;
+    await processInboundDelivery({
+      deliveryId: r.deliveryId as bigint,
+      tenantId,
+      base: appDb,
+    });
+    const conv = await suDb.conversionEvent.findFirst({
+      where: { tenantId, threadId: "1:1:777", source: "ASAAS" },
+    });
+    expect(conv).toBeNull();
+  });
+
+  test("a repaired payload still converts end to end (the payment is not lost)", async () => {
+    const { id: instanceId, routeToken } = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "ASAAS",
+        name: "asaas-repaired-e2e",
         inboundAuthStrategy: "NONE",
         config: { notifyOnPayment: false },
       },
       appDb,
     );
-    // The correlation reference is clean: the repair must not move a payment that was always
-    // correlatable into the uncorrelated pile just because another field was malformed.
     await suDb.integrationExternalRef.create({
       data: {
         tenantId,

--- a/tests/modules/inbound-receptor.test.ts
+++ b/tests/modules/inbound-receptor.test.ts
@@ -689,6 +689,168 @@ describe.skipIf(!dbUp)("inbound receptor", () => {
     expect(conv?.value?.toString()).toBe("500");
   });
 
+  // ── characters Postgres refuses to store (issue #218) ──
+  // A body that is valid JSON, passes the mapper's schema, and that the column then refuses. The
+  // two characters and BOTH destinations of the normalized event, measured against this database:
+  //   jsonb payload + lone surrogate → invalid input syntax for type json
+  //   jsonb payload + NUL            → 22P05 unsupported Unicode escape sequence
+  //   text  column  + lone surrogate → 22021 invalid byte sequence for encoding "UTF8": 0xef 0xbf
+  //   text  column  + NUL            → 22021 invalid byte sequence for encoding "UTF8": 0x00
+  // Each one used to throw out of `receiveInbound`, which nothing above catches: a 500 with no
+  // delivery row and no FAILED record either, and a sender retrying a body that can never succeed.
+  // The text columns are the half worth pinning: `dedupeKey` is built from the provider's own id,
+  // the field most likely to carry whatever the provider was handed.
+  const NUL = String.fromCharCode(0);
+  const unstorable: Array<{
+    name: string;
+    payment: Record<string, unknown>;
+    expect: { externalId: string; dedupeKey: string; payload: unknown };
+  }> = [
+    {
+      name: "a lone surrogate in metadata (jsonb)",
+      payment: { id: "u1", externalReference: "r1", paymentLink: "l\ud800k" },
+      expect: {
+        externalId: "r1",
+        dedupeKey: "PAYMENT_RECEIVED:u1",
+        payload: { paymentLink: "l�k" },
+      },
+    },
+    {
+      name: "a NUL in metadata (jsonb)",
+      payment: { id: "u2", externalReference: "r2", paymentLink: `l${NUL}k` },
+      expect: {
+        externalId: "r2",
+        dedupeKey: "PAYMENT_RECEIVED:u2",
+        payload: { paymentLink: "lk" },
+      },
+    },
+    {
+      name: "a lone surrogate in the provider's status (jsonb)",
+      payment: { id: "u3", externalReference: "r3", status: "RECEIVED\ud800" },
+      expect: {
+        externalId: "r3",
+        dedupeKey: "PAYMENT_RECEIVED:u3",
+        payload: undefined,
+      },
+    },
+    {
+      name: "a lone surrogate in the provider's id (text dedupe_key)",
+      payment: { id: "u4\ud800", externalReference: "r4" },
+      expect: {
+        externalId: "r4",
+        dedupeKey: "PAYMENT_RECEIVED:u4�",
+        payload: undefined,
+      },
+    },
+    {
+      name: "a NUL in the provider's id (text dedupe_key)",
+      payment: { id: `u5${NUL}x`, externalReference: "r5" },
+      expect: {
+        externalId: "r5",
+        dedupeKey: "PAYMENT_RECEIVED:u5x",
+        payload: undefined,
+      },
+    },
+    {
+      name: "a lone surrogate in the correlation reference (text external_id)",
+      payment: { id: "u6", externalReference: "r6\ud800" },
+      expect: {
+        externalId: "r6�",
+        dedupeKey: "PAYMENT_RECEIVED:u6",
+        payload: undefined,
+      },
+    },
+  ];
+
+  for (const [i, c] of unstorable.entries()) {
+    test(`records the delivery when the body carries ${c.name}`, async () => {
+      const { routeToken } = await createIntegrationInstance(
+        tenantId,
+        {
+          catalogType: "ASAAS",
+          name: `asaas-unstorable-${i}`,
+          inboundAuthStrategy: "NONE",
+          config: { notifyOnPayment: false },
+        },
+        appDb,
+      );
+      const r = await receiveInbound({
+        routeToken: routeToken as string,
+        rawBody: JSON.stringify({
+          event: "PAYMENT_RECEIVED",
+          payment: { value: 10, status: "RECEIVED", ...c.payment },
+        }),
+        getHeader: () => null,
+        base: appDb,
+      });
+      expect(r.outcome).toBe("queued");
+
+      const delivery = await suDb.inboundDelivery.findUniqueOrThrow({
+        where: { id: r.deliveryId as bigint },
+      });
+      expect(delivery.externalId).toBe(c.expect.externalId);
+      expect(delivery.dedupeKey).toBe(c.expect.dedupeKey);
+      const payload = delivery.payload as Record<string, unknown>;
+      expect(payload.status).toBe(
+        (c.payment.status as string | undefined) === "RECEIVED\ud800"
+          ? "RECEIVED�"
+          : "RECEIVED",
+      );
+      if (c.expect.payload) expect(payload.metadata).toEqual(c.expect.payload);
+    });
+  }
+
+  test("a repaired delivery still converts end to end (the payment is not lost)", async () => {
+    const { id: instanceId, routeToken } = await createIntegrationInstance(
+      tenantId,
+      {
+        catalogType: "ASAAS",
+        name: "asaas-unstorable-e2e",
+        inboundAuthStrategy: "NONE",
+        config: { notifyOnPayment: false },
+      },
+      appDb,
+    );
+    // The correlation reference is clean: the repair must not move a payment that was always
+    // correlatable into the uncorrelated pile just because another field was malformed.
+    await suDb.integrationExternalRef.create({
+      data: {
+        tenantId,
+        integrationInstanceId: instanceId,
+        externalId: "corr_repaired",
+        threadId: "1:1:218",
+        kind: "asaas_payment",
+      },
+    });
+    const r = await receiveInbound({
+      routeToken: routeToken as string,
+      rawBody: JSON.stringify({
+        event: "PAYMENT_RECEIVED",
+        payment: {
+          id: "pay_repaired",
+          value: 42,
+          status: "RECEIVED",
+          externalReference: "corr_repaired",
+          paymentLink: `link${NUL}\ud800abc`,
+        },
+      }),
+      getHeader: () => null,
+      base: appDb,
+    });
+    expect(r.outcome).toBe("queued");
+
+    const proc = await processInboundDelivery({
+      deliveryId: r.deliveryId as bigint,
+      tenantId,
+      base: appDb,
+    });
+    expect(proc).toBe("processed");
+    const conv = await suDb.conversionEvent.findFirst({
+      where: { tenantId, threadId: "1:1:218", source: "ASAAS" },
+    });
+    expect(conv?.value?.toString()).toBe("42");
+  });
+
   test("records an unparseable payload as invalid (durable FAILED delivery)", async () => {
     const { routeToken } = await createIntegrationInstance(
       tenantId,


### PR DESCRIPTION
A body that is valid JSON, authenticates, and passes the mapper's schema can still be refused by the column it is written to. `receiveInbound` has no catch above it, so the refusal became a 500: no delivery row, no `FAILED` record either, and a sender retrying a body that can never succeed.

## What was measured

Against this project's own Postgres, through the real receptor and the Asaas mapper. Six probes, all six refused before this change:

| Field in the body | Character | Destination | Postgres |
| --- | --- | --- | --- |
| `payment.paymentLink` | lone surrogate | `payload` (jsonb) | `invalid input syntax for type json` |
| `payment.status` | lone surrogate | `payload` (jsonb) | `invalid input syntax for type json` |
| `payment.paymentLink` | NUL | `payload` (jsonb) | `22P05 unsupported Unicode escape sequence` |
| `payment.id` | lone surrogate | `dedupe_key` (**text**) | `22021 invalid byte sequence for encoding "UTF8": 0xef 0xbf` |
| `payment.id` | NUL | `dedupe_key` (**text**) | `22021 invalid byte sequence for encoding "UTF8": 0x00` |
| `payment.externalReference` | lone surrogate | `external_id` (**text**) | `22021 invalid byte sequence for encoding "UTF8": 0xef 0xbf` |

A seventh case reaches the same end through a different road, found while reviewing the fix. `dedupeKey` is `` `${event}:${payment.id}` `` and carries a unique index, which a btree refuses above 2704 bytes, and the Asaas schema caps neither field:

```
ERROR:  index row size 6432 exceeds btree version 4 maximum 2704 for index "t3_a_b_k_idx"
```

The probe has to be incompressible to show it: `repeat('x', 5000)` compresses inside the index and inserts fine.

## What the issue got right, and the two things it did not

The mechanism and the consequence are exactly as #218 describes: the escape is well-formed JSON, so it survives `JSON.parse` and the zod schema, and Postgres is the first thing to object, after authentication and after mapping, with the work already done and thrown away.

Two corrections, both of which widen the fix.

**The text columns are not safe.** The issue reads "`externalId` and `dedupeKey` are separate `String` columns and never enter the `jsonb`", which is true and not sufficient: a `text` column refuses the same characters (22021), and `dedupeKey` is built from the provider's own id, the field most likely to carry through whatever the provider was handed.

**A NUL is the same defect in the same place.** `replaceLoneSurrogates` does not cover it, and `jsonb` refuses it too (22P05), as does `text` (22021). The issue's own reasoning applies unchanged: nothing has to truncate anything, a sender simply writes `"\u0000"`.

Confirmed safe and left alone: `persistFailed` (its `dedupeKey` is a sha256 hex digest, and the mapper's `detail` carries zod issue **paths** only, never values, by contract).

## The change

The two halves of the normalized event get **opposite** treatment, and that split is the design.

**The payload is repaired.** It is display and diagnostics, so a character it cannot hold is replaced rather than fatal. `makeStorable` (`src/lib/text.ts`) is the repair half of the rule `unstorableProblem` already reports in the same file: same two characters, opposite policy. Refusing is right where the author reads the refusal and can go fix the value (an operator's form, which is where `unstorableProblem` is used). Repairing is right where the writer is a third party's webhook: it never reads a refusal, and its only recourse is to retry the identical bytes.

The two are repaired differently because they do not mean the same thing. An unpaired surrogate **was** half of a real character, so U+FFFD stands where that character was; a NUL never stood for anything a reader would see, and is dropped. The order carries a rule too: surrogates are repaired while the NULs are still in place, because dropping the NUL out of `\ud800<NUL>\udc00` first leaves the two orphan halves adjacent, where they read as the well-formed pair U+10000 and survive untouched, inventing a character nobody wrote out of three defects.

`makeStorableDeep` applies it to a whole document, keys included, because one orphan half anywhere in it is enough for Postgres to refuse the entire write. The unit that has to come back storable is the document, not the field. Keys are copied with `Object.defineProperty` rather than assignment: `JSON.parse` yields `__proto__` as an ordinary own property, and assignment on that key invokes the legacy prototype setter instead, so the field would vanish from what gets persisted and the copy would come back with a different prototype.

**The identity is refused, never repaired and never cut.** Both are lossy, and lossy on an identity is how a payment lands in someone else's conversation: `dispatchConversion` correlates on `externalId`, so `ref<NUL>` repaired to `ref` matches the reference an unrelated conversation registered, credits the conversion to that thread and nudges that customer, which is the one outcome the module says it never produces. Two provider ids differing only by such a character would likewise collapse into one `dedupeKey` and silently drop a real delivery. Encoding the identity instead of refusing it was considered and dropped: an escape is only injective against values that never contain the escape sequence itself, which trades one collision for a subtler one.

So a malformed **or over-long** identity takes the fail-closed path that already exists for a payload we cannot process: `persistFailed` with `reason: "unstorable-identity"`, a durable FAILED row and a 2xx. The sender's retry loop still ends, which is the point of the PR, and no identity is invented. The cap is 512 characters: far above any provider id (Asaas sends ~20, and the mapper already caps `externalReference` at 128) and far below the index limit even if every character were 4 bytes.

`unstorableProblem` also accumulates its offenders in a `Set` now. The distinct offenders are bounded at 2049, so scanning a growing array made a long malformed value cost quadratic work, and the function has three other callers in the documents module where values are genuinely long.

## Validation scope

**Proved by test** (`bun check` green: 4578 pass, 0 fail):

- Unit, `tests/lib/text.test.ts`: NUL dropped and lone surrogate replaced in every position and in combination; the repair order pinned by asserting the code points come back as `[0xFFFD, 0xFFFD]` (a string assertion would also pass if both halves vanished); clean values, including a well-formed astral character and non-NUL controls, returned untouched; idempotent; and the round-trip property tying the two halves together, namely that every value `unstorableProblem` refuses is accepted after `makeStorable`. For the deep pass: nested values, **keys**, arrays, a `Date` returned by identity, a `__proto__` key surviving as an own property with the prototype intact, and the branch below the depth cap dropped rather than passed through unrepaired.
- DB-backed e2e, `tests/modules/inbound-receptor.test.ts`, each case through the real receptor against the real Postgres: three payload cases repaired and kept (`outcome: "queued"`, asserting what the row stored); three identity cases refused (`ack: true`, `outcome: "invalid"`, a FAILED row keyed on the raw-body digest); the over-long identity refused, with an incompressible 3000-character id; a repaired delivery still processing end to end and recording its `ConversionEvent`; and the wrong-thread case, which registers `corr_bleed` on thread `1:1:777` and asserts that a payment carrying `corr_bleed<NUL>`, with `notifyOnPayment` ON, lands no conversion there.
- Every case was red before its fix, and the character cases were red with the Postgres error rather than an assertion failure.

**Mutation-tested**, one mutation at a time against the final code. Every one breaks at least one test:

| Mutation | Tests failing |
| --- | --- |
| baseline | 0 |
| identity gate off (identity repaired lossily) | 5 |
| gate: stop checking `externalId` | 2 |
| gate: stop checking `dedupeKey` | 3 |
| gate: drop the length cap | 1 |
| payload: stop repairing it | 4 |
| `makeStorable`: drop NUL before repairing surrogates | 1 |
| `makeStorable`: stop dropping NUL | 7 |
| `makeStorable`: stop repairing lone surrogates | 7 |
| `makeStorableDeep`: assign keys instead of defining them | 1 |
| `makeStorableDeep`: stop repairing keys | 2 |
| `makeStorableDeep`: stop descending into arrays | 1 |
| `makeStorableDeep`: stop sparing `Date` | 1 |
| `makeStorableDeep`: pass the too-deep branch through | 1 |

**Not validated:**

- No live Asaas call. As #218 says, with today's only mapper no customer-authored text reaches these fields at all, so this is not reproducible against the real provider. The probes drive the real receptor and the real mapper with a body Asaas would have to be broken to send.
- The controller still has no `try`/`catch` around `receiveInbound`, deliberately. A write that fails for any other reason (the database being down) must stay a non-2xx so the sender retries, because that is the case retrying actually fixes. This change removes the reasons the write failed, rather than hiding a failure behind a false ack.
- The `Set` in `unstorableProblem` is a cost change, not a rule, so no test pins it; with the identity cap in place the quadratic path is no longer reachable from the webhook at all, and the remaining beneficiaries are the documents callers.
- `redactSecretsDeep` (`src/lib/redact.ts`) repairs lone surrogates but not NUL on its way into `execution_logs.detail`, which is the same gap in a different place. Left out on purpose: the effect there is a log line that silently never lands, not a lost delivery, and it belongs to its own issue.

Fixes #218
