### PR TITLE
Ask which bot holds the conversation before promising a countdown

### DIFF
--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -864,13 +864,24 @@ export async function getConversationDetail(
       // The strict ownership answer, which this reader is the one that needs: nothing runs after the
       // indicator to correct it, so a conversation another persona's bot is holding must not be
       // counted down (issue #214). The bot id is already in hand — the same one the header's
-      // "held by another party" line is drawn from, so the two cannot disagree on the page.
-      mirrorHolder: heldByAnotherParty(
-        { assigneeType: conv.assigneeType, assigneeId: conv.assigneeId },
-        { ourAgentBotId },
-      )
-        ? "another-party"
-        : "us",
+      // "held by another party" line is drawn from.
+      //
+      // `heldByAnotherParty` alone is not the whole answer here: it leaves an AgentBot it cannot
+      // identify UNCOUNTED, which is right for the hand-back offer it was written for (there is
+      // nobody named to hand back to) and wrong for a promise, because the unidentified bot may be
+      // the foreign one. Unverifiable is therefore not ours — the same call the live payload's own
+      // parser makes when it refuses an "AgentBot" with no numeric id.
+      mirrorHolder: (() => {
+        const holder = {
+          assigneeType: conv.assigneeType,
+          assigneeId: conv.assigneeId,
+        };
+        if (heldByAnotherParty(holder, { ourAgentBotId })) return "not-ours";
+        const unverifiableBot =
+          conv.assigneeType === "AgentBot" &&
+          (conv.assigneeId == null || ourAgentBotId == null);
+        return unverifiableBot ? "not-ours" : "ours";
+      })(),
     });
     const isRedirectWidgetConv =
       redirectCfg.enabled &&

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -861,6 +861,16 @@ export async function getConversationDetail(
       testActivatedAt: conv.testActivatedAt,
       status: conv.status,
       assigneeType: conv.assigneeType,
+      // The strict ownership answer, which this reader is the one that needs: nothing runs after the
+      // indicator to correct it, so a conversation another persona's bot is holding must not be
+      // counted down (issue #214). The bot id is already in hand — the same one the header's
+      // "held by another party" line is drawn from, so the two cannot disagree on the page.
+      mirrorHolder: heldByAnotherParty(
+        { assigneeType: conv.assigneeType, assigneeId: conv.assigneeId },
+        { ourAgentBotId },
+      )
+        ? "another-party"
+        : "us",
     });
     const isRedirectWidgetConv =
       redirectCfg.enabled &&

--- a/src/modules/followups/eligibility.ts
+++ b/src/modules/followups/eligibility.ts
@@ -16,6 +16,12 @@ import { shouldBotHandle } from "@/modules/chatwoot/normalize";
 // follow-up the handler was going to drop, telling the operator the customer would be re-engaged when
 // nobody was.
 //
+// The readers agree on the RULES and differ on the EVIDENCE, which is why `mirrorHolder` is an input
+// and not a second predicate (issue #214). The handler has a live probe behind it and says
+// "unverified" because deciding ownership from the mirror there would drop real follow-ups; the
+// indicator has nothing behind it, so it answers with the bot id in hand and gets the strict answer.
+// Same function, same rules, and each reader states what it actually knows.
+//
 // NOT included, on purpose: whether the episode is fresh, the activation fence, and the cadence.
 // Those decide WHICH step is next rather than whether the sequence is alive at all, and they differ
 // between an armed job (a later step legitimately has `lastFollowUpAt` set) and an estimate.
@@ -33,7 +39,24 @@ export interface FollowUpLiveness {
   // The bot only follows up while it still owns the conversation (pending, no human assignee).
   status: string | null;
   assigneeType: string | null;
+  // Who the mirror says is HOLDING the conversation — the ownership axis attribution alone cannot
+  // answer, because one Chatwoot account can front several Agent Bots and every one of them reads as
+  // "a bot has it". Required rather than optional: the two readers answer it from different evidence
+  // (below), and a field a reader can omit is a divergence nobody has to notice.
+  //
+  //   "us"            — nobody else is holding it: unassigned, or assigned to this inbox's own bot.
+  //   "another-party" — the mirror names a holder that is not this inbox's bot. Also the honest
+  //                     answer for a human assignee, which the status/assigneeType terms above
+  //                     already refuse on their own.
+  //   "unverified"    — this reader does not decide ownership from the mirror. It reads as LIVE, so
+  //                     it is sound ONLY for a reader that re-asks Chatwoot before it sends: the
+  //                     assignee is the field the mirror is most often stale on
+  //                     (`syncConversationState` repairs it from the live snapshot), and refusing on
+  //                     a stale value drops a follow-up the customer should have received.
+  mirrorHolder: MirrorHolder;
 }
+
+export type MirrorHolder = "us" | "another-party" | "unverified";
 
 export function isFollowUpLive(s: FollowUpLiveness): boolean {
   return (
@@ -41,6 +64,7 @@ export function isFollowUpLive(s: FollowUpLiveness): boolean {
     s.followUpEnabled &&
     !s.managedByRedirect &&
     !isTestSilenced(s.agentMode, s.testActivatedAt) &&
+    s.mirrorHolder !== "another-party" &&
     shouldBotHandle({ status: s.status, assigneeType: s.assigneeType })
   );
 }

--- a/src/modules/followups/eligibility.ts
+++ b/src/modules/followups/eligibility.ts
@@ -18,7 +18,7 @@ import { shouldBotHandle } from "@/modules/chatwoot/normalize";
 //
 // The readers agree on the RULES and differ on the EVIDENCE, which is why `mirrorHolder` is an input
 // and not a second predicate (issue #214). The handler has a live probe behind it and says
-// "unverified" because deciding ownership from the mirror there would drop real follow-ups; the
+// "not-asked" because deciding ownership from the mirror there would drop real follow-ups; the
 // indicator has nothing behind it, so it answers with the bot id in hand and gets the strict answer.
 // Same function, same rules, and each reader states what it actually knows.
 //
@@ -44,19 +44,20 @@ export interface FollowUpLiveness {
   // "a bot has it". Required rather than optional: the two readers answer it from different evidence
   // (below), and a field a reader can omit is a divergence nobody has to notice.
   //
-  //   "us"            — nobody else is holding it: unassigned, or assigned to this inbox's own bot.
-  //   "another-party" — the mirror names a holder that is not this inbox's bot. Also the honest
-  //                     answer for a human assignee, which the status/assigneeType terms above
-  //                     already refuse on their own.
-  //   "unverified"    — this reader does not decide ownership from the mirror. It reads as LIVE, so
-  //                     it is sound ONLY for a reader that re-asks Chatwoot before it sends: the
-  //                     assignee is the field the mirror is most often stale on
-  //                     (`syncConversationState` repairs it from the live snapshot), and refusing on
-  //                     a stale value drops a follow-up the customer should have received.
+  //   "ours"       — nobody else is holding it: unassigned, or verifiably this inbox's own bot.
+  //   "not-ours"   — somebody else is holding it, OR the mirror names a bot it cannot identify.
+  //                  Unverifiable is not ours: with no id to compare, a conversation owned by
+  //                  ANOTHER bot reads as ours, which is the same call `parseLiveConversation` makes
+  //                  when it refuses an "AgentBot" with no numeric id on the live payload.
+  //   "not-asked"  — this reader does not decide ownership from the mirror at all. It reads as LIVE,
+  //                  so it is sound ONLY for a reader that re-asks Chatwoot before it sends: the
+  //                  assignee is the field the mirror is most often stale on (`syncConversationState`
+  //                  repairs it from the live snapshot), and refusing on a stale value drops a
+  //                  follow-up the customer should have received.
   mirrorHolder: MirrorHolder;
 }
 
-export type MirrorHolder = "us" | "another-party" | "unverified";
+export type MirrorHolder = "ours" | "not-ours" | "not-asked";
 
 export function isFollowUpLive(s: FollowUpLiveness): boolean {
   return (
@@ -64,7 +65,7 @@ export function isFollowUpLive(s: FollowUpLiveness): boolean {
     s.followUpEnabled &&
     !s.managedByRedirect &&
     !isTestSilenced(s.agentMode, s.testActivatedAt) &&
-    s.mirrorHolder !== "another-party" &&
+    s.mirrorHolder !== "not-ours" &&
     shouldBotHandle({ status: s.status, assigneeType: s.assigneeType })
   );
 }

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -284,6 +284,11 @@ export async function followUpHandler(
         testActivatedAt: conv.testActivatedAt,
         status: conv.status,
         assigneeType: conv.assigneeType,
+        // This path never decides WHICH bot holds the conversation from the mirror: `agentNudge`
+        // runs with `requireLiveBotOwnership`, which GETs the real conversation, reconciles the
+        // stale assignee and refuses to send before any model spend. Answering from the mirror here
+        // would drop a follow-up the probe was about to allow (issue #214).
+        mirrorHolder: "unverified",
       })
     ) {
       return null;

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -288,7 +288,7 @@ export async function followUpHandler(
         // runs with `requireLiveBotOwnership`, which GETs the real conversation, reconciles the
         // stale assignee and refuses to send before any model spend. Answering from the mirror here
         // would drop a follow-up the probe was about to allow (issue #214).
-        mirrorHolder: "unverified",
+        mirrorHolder: "not-asked",
       })
     ) {
       return null;

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -55,6 +55,10 @@ let convHandedOffMidSequence = 0n;
 let convDisabledAgentArmed = 0n;
 let convFollowUpOffArmed = 0n;
 let convFinishedByResolve = 0n;
+let convForeignBotArmed = 0n;
+let convOurBotArmed = 0n;
+let convForeignBotEstimate = 0n;
+let convOurBotEstimate = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
 const REDIRECT_JOB_RUN_AT = new Date("2026-06-18T23:30:00Z");
@@ -78,6 +82,12 @@ const BH_WINDOWS = Array.from({ length: 7 }, (_, day) => ({
 }));
 const BH_LAST_EVENT_AT = new Date("2026-06-15T20:00:00Z"); // dueAt = +2min = 20:02 UTC (closed)
 const BH_EXPECTED_RUN_AT = "2026-06-16T09:00:00.000Z";
+
+// One Chatwoot account can front several Agent Bots, so "an AgentBot holds this" and "OUR bot
+// holds this" are different questions. The armed persona owns OUR_BOT_ID; FOREIGN_BOT_ID is
+// another persona's bot on the same account.
+const OUR_BOT_ID = 4001;
+const FOREIGN_BOT_ID = 4002;
 
 // A step-1 job armed two days out — the window in which the ground can shift under it.
 const ARMED_STEP1_RUN_AT = new Date("2026-06-20T23:18:45Z");
@@ -603,6 +613,60 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
       },
     });
     convFinishedByResolve = finished.id;
+
+    // ── The armed persona's own Agent Bot on this account, which is what makes "another bot is
+    //    holding this" answerable at all: without the row every AgentBot assignee looks like ours.
+    await suDb.chatwootAgentBot.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        agentId: armedAgent.id,
+        chatwootAgentBotId: OUR_BOT_ID,
+        accessToken: "enc",
+        webhookSecret: "enc",
+        webhookRouteTokenHash: `fu-estimate-${process.pid}`,
+        name: "FU Armed bot",
+      },
+    });
+    convForeignBotArmed = await seedArmedConv(324, armedInbox.id, {
+      assigneeType: "AgentBot",
+      assigneeId: FOREIGN_BOT_ID,
+    });
+    convOurBotArmed = await seedArmedConv(325, armedInbox.id, {
+      assigneeType: "AgentBot",
+      assigneeId: OUR_BOT_ID,
+    });
+    // The same two holders on the OTHER branch — no job armed yet, so the indicator estimates step 1
+    // itself. A gate placed on the armed-job branch alone leaves this one promising the countdown.
+    async function seedEstimateConv(
+      chatwootId: number,
+      conv: { assigneeType: string; assigneeId: number },
+    ): Promise<bigint> {
+      const c = await suDb.conversation.create({
+        data: {
+          tenantId: tenant,
+          chatwootInstanceId: inst,
+          chatwootConversationId: chatwootId,
+          inboxId: armedInbox.id,
+          status: "pending",
+          assigneeType: conv.assigneeType,
+          assigneeId: conv.assigneeId,
+          threadId: `${tenant}:${inst}:${chatwootId}`,
+          lastEventAt: LAST_EVENT_AT,
+          lastInboundAt: REPLY_AT,
+          lastFollowUpAt: FOLLOW_UP_AT,
+        },
+      });
+      return c.id;
+    }
+    convForeignBotEstimate = await seedEstimateConv(326, {
+      assigneeType: "AgentBot",
+      assigneeId: FOREIGN_BOT_ID,
+    });
+    convOurBotEstimate = await seedEstimateConv(327, {
+      assigneeType: "AgentBot",
+      assigneeId: OUR_BOT_ID,
+    });
   });
 
   // A live appointment is the sweep's own fence (followUp.pauseWhileAppointment, on by default): it
@@ -923,6 +987,51 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     const d = await getConversationDetail(ctx(tenant), convNewEpisode, appDb);
     expect(d.followUp?.abandoned).toBe(false);
     expect(d.followUp?.nextStep).toBe(1);
+  });
+
+  // Issue #214: with a second Agent Bot on the same Chatwoot account holding the conversation, the
+  // handler still reaches its live probe (`requireLiveBotOwnership`) and refuses to send there. The
+  // indicator has nothing after it, so a countdown here promises a re-engagement that is refused —
+  // the shape of #72, on the axis #72 left out.
+  test("another persona's bot holds it, job armed → no countdown", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convForeignBotArmed,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
+    expect(d.followUp?.abandoned).toBe(true);
+  });
+
+  test("another persona's bot holds it, no job armed → no estimate", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convForeignBotEstimate,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
+  });
+
+  // The other direction, and the reason the gate is the bot IDENTITY rather than "an AgentBot holds
+  // it": the conversation assigned to the inbox's OWN bot is the normal state of every bot-owned
+  // conversation, and suppressing the countdown there would silence the indicator for everyone.
+  test("our own bot holds it, job armed → the countdown stands", async () => {
+    const d = await getConversationDetail(ctx(tenant), convOurBotArmed, appDb);
+    expect(d.followUp?.nextStep).toBe(2);
+    expect(d.followUp?.nextRunAt).toBe(ARMED_STEP1_RUN_AT.toISOString());
+    expect(d.followUp?.abandoned).toBe(false);
+  });
+
+  test("our own bot holds it, no job armed → the estimate stands", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convOurBotEstimate,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBe(1);
+    expect(d.followUp?.nextRunAt).not.toBeNull();
   });
 
   // The distinction the flag exists for: a sequence whose last step is configured to resolve the

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -59,6 +59,8 @@ let convForeignBotArmed = 0n;
 let convOurBotArmed = 0n;
 let convForeignBotEstimate = 0n;
 let convOurBotEstimate = 0n;
+let convUnidentifiedBotArmed = 0n;
+let convNoBotRowArmed = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
 const REDIRECT_JOB_RUN_AT = new Date("2026-06-18T23:30:00Z");
@@ -614,6 +616,27 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     });
     convFinishedByResolve = finished.id;
 
+    // A persona with the same follow-up settings and NO Agent Bot row of its own.
+    const noBotAgent = await suDb.agent.create({
+      data: {
+        tenantId: tenant,
+        name: "FU No Bot",
+        systemPrompt: "x",
+        followUpArmedAt: new Date("2026-01-01T00:00:00Z"),
+        mode: "production",
+        settings: twoStepSettings,
+      },
+    });
+    const noBotInbox = await suDb.inbox.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootInboxId: 93,
+        name: "Sup sem bot",
+        agentId: noBotAgent.id,
+      },
+    });
+
     // ── The armed persona's own Agent Bot on this account, which is what makes "another bot is
     //    holding this" answerable at all: without the row every AgentBot assignee looks like ours.
     await suDb.chatwootAgentBot.create({
@@ -659,6 +682,18 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
       });
       return c.id;
     }
+    // The mirror knows A bot has it and not WHICH: `meta.assignee_type` arrives without a readable
+    // `meta.assignee.id`, and the webhook normalizer stores exactly that. Nothing here can rule out
+    // the foreign bot, and the live payload's own parser refuses this same shape.
+    convUnidentifiedBotArmed = await seedArmedConv(328, armedInbox.id, {
+      assigneeType: "AgentBot",
+    });
+    // The other way to have no id to compare with: a persona with no ChatwootAgentBot row of its own
+    // (never provisioned, or not yet synced) — every AgentBot assignee is then unidentifiable.
+    convNoBotRowArmed = await seedArmedConv(329, noBotInbox.id, {
+      assigneeType: "AgentBot",
+      assigneeId: FOREIGN_BOT_ID,
+    });
     convForeignBotEstimate = await seedEstimateConv(326, {
       assigneeType: "AgentBot",
       assigneeId: FOREIGN_BOT_ID,
@@ -1012,6 +1047,29 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     );
     expect(d.followUp?.nextStep).toBeNull();
     expect(d.followUp?.nextRunAt).toBeNull();
+  });
+
+  // Unverifiable ownership is not ours: with no id to compare, a conversation another bot owns reads
+  // as ours, and the countdown would promise a send the live probe refuses. Same call
+  // `parseLiveConversation` makes when it drops an "AgentBot" with no numeric id.
+  test("the mirror cannot say WHICH bot holds it → no countdown", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convUnidentifiedBotArmed,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.abandoned).toBe(true);
+  });
+
+  test("a persona with no Agent Bot row of its own → no countdown", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convNoBotRowArmed,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.abandoned).toBe(true);
   });
 
   // The other direction, and the reason the gate is the bot IDENTITY rather than "an AgentBot holds

--- a/tests/modules/followup-eligibility.test.ts
+++ b/tests/modules/followup-eligibility.test.ts
@@ -18,7 +18,7 @@ const LIVE: FollowUpLiveness = {
   testActivatedAt: null,
   status: "pending",
   assigneeType: null,
-  mirrorHolder: "us",
+  mirrorHolder: "ours",
 };
 
 const cases: Array<{
@@ -78,29 +78,29 @@ const cases: Array<{
   //    READER can say about the holder, which is the divergence the predicate now carries explicitly
   //    instead of leaving each reader to build its own gate.
   {
-    name: "the mirror names another party's bot",
-    patch: { assigneeType: "AgentBot", mirrorHolder: "another-party" },
+    name: "the mirror names another party's bot, or one it cannot identify",
+    patch: { assigneeType: "AgentBot", mirrorHolder: "not-ours" },
     live: false,
   },
   {
     // The handler's value: it re-asks Chatwoot before sending, so refusing on a stale assignee here
     // would drop a follow-up the probe was about to allow.
     name: "the reader does not decide ownership from the mirror",
-    patch: { assigneeType: "AgentBot", mirrorHolder: "unverified" },
+    patch: { assigneeType: "AgentBot", mirrorHolder: "not-asked" },
     live: true,
   },
   {
-    // "another-party" never RESCUES a row the other terms already refuse, and never overrides them:
+    // "not-ours" never RESCUES a row the other terms already refuse, and never overrides them:
     // every other reason to be dead stays dead whatever the holder is.
-    name: "another party's bot holds it AND the agent is disabled",
-    patch: { agentEnabled: false, mirrorHolder: "another-party" },
+    name: "somebody else holds it AND the agent is disabled",
+    patch: { agentEnabled: false, mirrorHolder: "not-ours" },
     live: false,
   },
   {
     // The human case answered on the ownership axis instead of the assignee one: still dead, and by
     // two independent terms, so neither reader depends on the other being right.
     name: "a human holds it, reported on the holder axis too",
-    patch: { assigneeType: "User", mirrorHolder: "another-party" },
+    patch: { assigneeType: "User", mirrorHolder: "not-ours" },
     live: false,
   },
 ];
@@ -113,15 +113,15 @@ describe("isFollowUpLive", () => {
   }
 });
 
-// `mirrorHolder: "unverified"` reads as live, so it is only sound for a reader that re-asks Chatwoot
+// `mirrorHolder: "not-asked"` reads as live, so it is only sound for a reader that re-asks Chatwoot
 // before it sends. The decision table above proves what the predicate DOES with each value; it cannot
-// prove that the readers pass the value they are entitled to, and picking "unverified" is what a new
+// prove that the readers pass the value they are entitled to, and picking "not-asked" is what a new
 // reader does when the strict answer is inconvenient — which is issue #214 all over again, silently.
 //
 // A file-scoped check, and deliberately no stronger: it says the abstaining file also arms the live
 // probe, not that the two are on the same branch. That is enough to make a copy-paste into a reader
 // with no probe fail here and be read about.
-describe('mirrorHolder: "unverified" — who may say it', () => {
+describe('mirrorHolder: "not-asked" — who may say it', () => {
   function sourceFiles(dir: string): string[] {
     const out: string[] = [];
     for (const entry of readdirSync(dir)) {
@@ -134,7 +134,7 @@ describe('mirrorHolder: "unverified" — who may say it', () => {
 
   test("every reader that abstains re-asks Chatwoot before sending", () => {
     const abstaining = sourceFiles("src").filter((f) =>
-      readFileSync(f, "utf8").includes('mirrorHolder: "unverified"'),
+      readFileSync(f, "utf8").includes('mirrorHolder: "not-asked"'),
     );
     // The handler is the one reader entitled to it today; zero matches would mean the check went
     // stale (the string moved or was renamed) rather than that the rule holds.

--- a/tests/modules/followup-eligibility.test.ts
+++ b/tests/modules/followup-eligibility.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 import {
   type FollowUpLiveness,
   isFollowUpLive,
@@ -16,6 +18,7 @@ const LIVE: FollowUpLiveness = {
   testActivatedAt: null,
   status: "pending",
   assigneeType: null,
+  mirrorHolder: "us",
 };
 
 const cases: Array<{
@@ -65,11 +68,40 @@ const cases: Array<{
     live: false,
   },
   {
-    // Without the instance bot id there is no way to tell OUR bot from another one; the handler
-    // and the estimate both call shouldBotHandle without it, so this stays live in both.
-    name: "a bot holds it",
+    // Attribution alone cannot tell OUR bot from another one, which is why the holder is an input:
+    // a reader that only knows "an AgentBot has it" has not answered the question.
+    name: "a bot holds it and the reader says it is ours",
     patch: { assigneeType: "AgentBot" },
     live: true,
+  },
+  // ── The ownership axis (issue #214). The same conversation is live or dead depending on what the
+  //    READER can say about the holder, which is the divergence the predicate now carries explicitly
+  //    instead of leaving each reader to build its own gate.
+  {
+    name: "the mirror names another party's bot",
+    patch: { assigneeType: "AgentBot", mirrorHolder: "another-party" },
+    live: false,
+  },
+  {
+    // The handler's value: it re-asks Chatwoot before sending, so refusing on a stale assignee here
+    // would drop a follow-up the probe was about to allow.
+    name: "the reader does not decide ownership from the mirror",
+    patch: { assigneeType: "AgentBot", mirrorHolder: "unverified" },
+    live: true,
+  },
+  {
+    // "another-party" never RESCUES a row the other terms already refuse, and never overrides them:
+    // every other reason to be dead stays dead whatever the holder is.
+    name: "another party's bot holds it AND the agent is disabled",
+    patch: { agentEnabled: false, mirrorHolder: "another-party" },
+    live: false,
+  },
+  {
+    // The human case answered on the ownership axis instead of the assignee one: still dead, and by
+    // two independent terms, so neither reader depends on the other being right.
+    name: "a human holds it, reported on the holder axis too",
+    patch: { assigneeType: "User", mirrorHolder: "another-party" },
+    live: false,
   },
 ];
 
@@ -79,4 +111,38 @@ describe("isFollowUpLive", () => {
       expect(isFollowUpLive({ ...LIVE, ...c.patch })).toBe(c.live);
     });
   }
+});
+
+// `mirrorHolder: "unverified"` reads as live, so it is only sound for a reader that re-asks Chatwoot
+// before it sends. The decision table above proves what the predicate DOES with each value; it cannot
+// prove that the readers pass the value they are entitled to, and picking "unverified" is what a new
+// reader does when the strict answer is inconvenient — which is issue #214 all over again, silently.
+//
+// A file-scoped check, and deliberately no stronger: it says the abstaining file also arms the live
+// probe, not that the two are on the same branch. That is enough to make a copy-paste into a reader
+// with no probe fail here and be read about.
+describe('mirrorHolder: "unverified" — who may say it', () => {
+  function sourceFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) out.push(...sourceFiles(full));
+      else if (full.endsWith(".ts") || full.endsWith(".tsx")) out.push(full);
+    }
+    return out;
+  }
+
+  test("every reader that abstains re-asks Chatwoot before sending", () => {
+    const abstaining = sourceFiles("src").filter((f) =>
+      readFileSync(f, "utf8").includes('mirrorHolder: "unverified"'),
+    );
+    // The handler is the one reader entitled to it today; zero matches would mean the check went
+    // stale (the string moved or was renamed) rather than that the rule holds.
+    expect(abstaining).toEqual(["src/modules/followups/handlers.ts"]);
+    for (const f of abstaining) {
+      expect(readFileSync(f, "utf8")).toContain(
+        "requireLiveBotOwnership: true",
+      );
+    }
+  });
 });

--- a/tests/modules/followup-resolved-guardrails.test.ts
+++ b/tests/modules/followup-resolved-guardrails.test.ts
@@ -136,6 +136,7 @@ async function mirroredConv(convId: number) {
     select: {
       status: true,
       assigneeType: true,
+      assigneeId: true,
       lastInboundAt: true,
       lastFollowUpAt: true,
     },
@@ -180,6 +181,9 @@ async function seedConversation(
     lastEventAt: Date;
     lastInboundAt: Date;
     lastFollowUpAt?: Date | null;
+    // O que o ESPELHO diz sobre quem detém a conversa. Default: ninguém.
+    assigneeType?: string | null;
+    assigneeId?: number | null;
   },
 ) {
   await suDb.conversation.create({
@@ -189,7 +193,8 @@ async function seedConversation(
       chatwootConversationId: convId,
       inboxId: inboxDbId,
       status: over.status ?? "pending",
-      assigneeType: null,
+      assigneeType: over.assigneeType ?? null,
+      ...(over.assigneeId != null ? { assigneeId: over.assigneeId } : {}),
       threadId: threadOf(convId),
       lastEventAt: over.lastEventAt,
       lastInboundAt: over.lastInboundAt,
@@ -673,6 +678,35 @@ describe.skipIf(!dbUp)("follow-up em conversa resolvida — guardrails", () => {
     expect(s.sent).toEqual([]);
     expect(s.notes).toEqual([]);
     expect((await mirroredConv(CONV)).assigneeType).toBe("User");
+  });
+
+  // Issue #214: o espelho dizendo que OUTRO Agent Bot detém a conversa NÃO derruba o job antes da
+  // sonda. O assignee é justamente o campo que o `syncConversationState` conserta a partir do live
+  // (uma atribuição perdida ou entregue fora de ordem deixa o espelho apontando para o bot errado),
+  // então decidir posse pelo espelho aqui trocaria um countdown errado na tela por uma mensagem que
+  // o cliente nunca recebe. Quem decide é a sonda, e ela diz que o bot da inbox continua com ela.
+  test("(2h) live gate: espelho stale em OUTRO bot + live diz que é nosso → envia", async () => {
+    const CONV = 4311;
+    await seedConversation(CONV, inboxAId, {
+      lastEventAt: new Date(Date.now() - 2 * HOUR),
+      lastInboundAt: new Date(Date.now() - 2 * HOUR),
+      assigneeType: "AgentBot",
+      assigneeId: 999,
+    });
+    const s = stubClient(() => ({
+      id: CONV,
+      status: "pending",
+      meta: {
+        assignee_type: "AgentBot",
+        assignee: { id: INBOX_A, name: "Guard" },
+      },
+    }));
+    const result = await followUpHandler(jobFor(CONV), appDb, handlerDeps(s));
+    expect(result).toEqual({ outcome: "done" });
+    expect(s.sent.length).toBe(1);
+    expect(s.notes).toEqual([]);
+    // E o espelho sai consertado, que é como o countdown volta a ser verdade na tela.
+    expect((await mirroredConv(CONV)).assigneeId).toBe(INBOX_A);
   });
 
   test("(2c) live gate pós-invoke: resolve DURANTE o turno do modelo → nada postado, espelho reconciliado", async () => {


### PR DESCRIPTION
## What broke

`isFollowUpLive` (`src/modules/followups/eligibility.ts`) exists so its two readers agree: the
handler acts on it, and the console's follow-up indicator reads it to decide whether to promise a
countdown (#72). It called `shouldBotHandle({ status, assigneeType })` with neither `assigneeId` nor
`ourAgentBotId`, so it answered the loose attribution-only question — **any** `AgentBot` assignee
reads as ours.

For the handler that is correct. It sets `requireLiveBotOwnership: true`, and `agentNudge`'s
`probeLiveOwnership` then GETs the real conversation, reconciles the mirror and re-asks the strict
question with the bot id in hand, before any model spend.

The indicator has nothing after it. With a second Agent Bot on the same Chatwoot account holding the
conversation, it rendered a countdown for a follow-up the live gate refuses — the shape #72 closed,
on the one axis #72 left out: the operator is told the customer will be re-engaged when nobody will
be. Both of the indicator's branches were affected: the armed-job countdown and the no-job estimate.

Measured on `main` before the fix, with the two new DB-backed cases:

```
(fail) another persona's bot holds it, job armed → no countdown
(fail) another persona's bot holds it, no job armed → no estimate
```

## The fix, and why not the obvious one

Adding the bot id to the predicate and tightening it **for both readers** silences real follow-ups.
`followUpHandler` evaluates the predicate and returns early *before* the live GET, so the strict
answer would be computed from the mirror — and the assignee is the field the mirror is most often
stale on (`syncConversationState` repairs `assigneeType` / `assigneeId` / `assigneeName` from the
live snapshot). That trades a wrong countdown on screen for a message the customer never receives.
Measured, by mutating the predicate to refuse every `AgentBot`:

```
(fail) (2h) live gate: espelho stale em OUTRO bot + live diz que é nosso → envia
(fail) our own bot holds it, job armed → the countdown stands
(fail) our own bot holds it, no job armed → the estimate stands
```

So ownership becomes an **input the reader has to state**, `mirrorHolder: "us" | "another-party" |
"unverified"`, required rather than optional — the readers keep one predicate and one set of rules,
and differ only in the evidence each declares:

- the **indicator** answers strictly, with `heldByAnotherParty` and the bot id `getConversationDetail`
  already loads for the header's "held by another party" line, so the two cannot disagree on the same
  page;
- the **handler** says `"unverified"`: it does not decide ownership from the mirror, because its
  probe does.

`"unverified"` reads as live, which makes it the value a future reader picks when the strict answer
is inconvenient — that is this issue happening again, silently. A call-site test pins it to readers
that re-ask Chatwoot (`requireLiveBotOwnership: true`), and fails if the string appears anywhere
else.

The three shapes the issue weighed: this is the third (a verdict richer than the boolean) in its
cheapest form. A distinct third *outcome* was not built — no reader distinguishes "dead" from
"contested" today, and the indicator treats both the same way it already treats a human handoff
(no countdown, `abandoned: true`, no "sequence complete" marker). The client renders that state
already, so there is no UI change here.

## Validation scope

**Proved by test** (all DB-backed against a real Postgres, `bun test`):

- `tests/modules/conversation-followup-estimate.test.ts` — four new cases through
  `getConversationDetail`: another persona's bot holding the conversation suppresses **both** the
  armed-job countdown and the no-job estimate and marks it `abandoned`; the inbox's **own** bot
  holding it leaves both standing (the case that guards against over-tightening).
- `tests/modules/followup-resolved-guardrails.test.ts` — `(2h)`: a mirror stale on **another** bot
  plus a live GET saying the conversation is ours still **sends**, and the mirror comes back
  repaired. This is the regression guard for the tightening described above.
- `tests/modules/followup-eligibility.test.ts` — four new decision-table rows for the ownership axis,
  plus the call-site test for who may say `"unverified"`.

**Mutation-tested**: removing the new term from the predicate, and making the indicator pass `"us"`
or `"unverified"` instead of the strict answer, each turn tests red (3, 2 and 2 failures). One
survivor, stated deliberately: the handler passing `"us"` instead of `"unverified"` changes no
behaviour — the two differ only in what the reader claims to know, which is why the call-site test
exists to cover that axis instead.

**Not validated**: nothing was exercised against a live Chatwoot with two Agent Bots on one account —
the precondition is a second `AgentBot` holding a conversation this agent also serves (same
precondition as #210), and the fixtures reproduce it from the mirror rows rather than from Chatwoot.
The mirror-staleness direction is likewise only exercised through the stubbed live GET in `(2h)`, not
against a real deployment.

Fixes #214
