### PR TITLE
Stop a log line from being lost to a NUL, or kept with a field nobody wrote

### DIFF
--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -1,4 +1,4 @@
-import { clipText, replaceLoneSurrogates } from "@/lib/text";
+import { clipText, makeStorable } from "@/lib/text";
 
 // Non-throwing secret redaction for human-facing debug surfaces (the agent playground trace and
 // the conversation `lastError` shown to the operator). This is the REPLACE-and-continue cousin of
@@ -49,7 +49,7 @@ export function redactSecretsDeep(value: unknown, depth = 0): unknown {
   if (depth > MAX_DEPTH) return "‹…›";
   if (value == null) return null;
   if (typeof value === "string") {
-    return replaceLoneSurrogates(redactSecretsInText(truncate(value)));
+    return makeStorable(redactSecretsInText(truncate(value)));
   }
   if (typeof value === "number" || typeof value === "boolean") return value;
   if (typeof value === "bigint") return value.toString();
@@ -62,11 +62,21 @@ export function redactSecretsDeep(value: unknown, depth = 0): unknown {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
       // NOTE: The KEY gets the same repair as the values. A key is written by whoever produced the
-      // object — a model's tool-call arguments, a third party's JSON response — and one orphan half
+      // object (a model's tool-call arguments, a third party's JSON response), and one orphan half
       // anywhere in the document is enough for Postgres to refuse the whole `jsonb` write.
-      out[replaceLoneSurrogates(k)] = SECRET_KEY_RE.test(k)
-        ? REDACTED
-        : redactSecretsDeep(v, depth + 1);
+      //
+      // NOTE: `defineProperty`, not assignment: `JSON.parse` yields `__proto__` as an ordinary own
+      // property, and assigning to that key invokes the legacy prototype setter instead. The
+      // serialization that reaches the column enumerates inherited properties, so the contents of
+      // `__proto__` would be written as top-level fields of the log record.
+      Object.defineProperty(out, makeStorable(k), {
+        value: SECRET_KEY_RE.test(k)
+          ? REDACTED
+          : redactSecretsDeep(v, depth + 1),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
     return out;
   }

--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -49,7 +49,12 @@ export function redactSecretsDeep(value: unknown, depth = 0): unknown {
   if (depth > MAX_DEPTH) return "‹…›";
   if (value == null) return null;
   if (typeof value === "string") {
-    return makeStorable(redactSecretsInText(truncate(value)));
+    // NOTE: The repair runs BEFORE the scrub, and the order is the rule. A NUL inside a token breaks
+    // the pattern, so a scrub that ran first would find nothing, and the repair would then DELETE
+    // that NUL and store the token whole: `sk-<NUL>abcdefghijklmnop` came back as
+    // `sk-abcdefghijklmnop`. The cut stays first because it is the cheap bound, and `clipText`
+    // cannot manufacture an orphan half for the repair to have to catch.
+    return redactSecretsInText(makeStorable(truncate(value)));
   }
   if (typeof value === "number" || typeof value === "boolean") return value;
   if (typeof value === "bigint") return value.toString();
@@ -65,12 +70,16 @@ export function redactSecretsDeep(value: unknown, depth = 0): unknown {
       // object (a model's tool-call arguments, a third party's JSON response), and one orphan half
       // anywhere in the document is enough for Postgres to refuse the whole `jsonb` write.
       //
+      // NOTE: The credential rule reads the REPAIRED key, for the same reason the value is repaired
+      // before it is scrubbed: `pass<NUL>word` does not match, and the repair then stores it as
+      // `password` with its value intact. Testing the stored name is what closes that.
+      const key = makeStorable(k);
       // NOTE: `defineProperty`, not assignment: `JSON.parse` yields `__proto__` as an ordinary own
       // property, and assigning to that key invokes the legacy prototype setter instead. The
       // serialization that reaches the column enumerates inherited properties, so the contents of
       // `__proto__` would be written as top-level fields of the log record.
-      Object.defineProperty(out, makeStorable(k), {
-        value: SECRET_KEY_RE.test(k)
+      Object.defineProperty(out, key, {
+        value: SECRET_KEY_RE.test(key)
           ? REDACTED
           : redactSecretsDeep(v, depth + 1),
         writable: true,

--- a/src/modules/mcp/write.ts
+++ b/src/modules/mcp/write.ts
@@ -21,7 +21,7 @@ import {
   type ScopedDb,
   type TenantContext,
 } from "@/lib/tenancy";
-import { clipText, replaceLoneSurrogates } from "@/lib/text";
+import { clipText, makeStorable } from "@/lib/text";
 import {
   type BehaviorSettingsPatch,
   mergeBehaviorSettings,
@@ -113,7 +113,8 @@ const AUDIT_STR_MAX = 4000;
 // the whole write. Here the cost is worse than a lost log line — the change has already committed by
 // the time this row is written, so it lands, the tool reports a failure, and the record of who made
 // it is the only thing missing. Hence both repairs: `clipText` so the cut cannot manufacture an
-// orphan, and `replaceLoneSurrogates` for one that arrived with the value — a projection carries some
+// orphan, and `makeStorable` for one that arrived with the value (or for a NUL, which the same
+// column refuses just as flatly): a projection carries some
 // arguments as the MCP client sent them (`args.name`, `args.title`, `args.content`), and that JSON
 // can spell one out.
 //
@@ -124,7 +125,7 @@ const AUDIT_STR_MAX = 4000;
 // walker repairs come from a model's tool-call arguments and from third parties' response bodies.
 export function truncForAudit(v: unknown): unknown {
   if (typeof v === "string") {
-    return replaceLoneSurrogates(
+    return makeStorable(
       v.length > AUDIT_STR_MAX
         ? `${clipText(v, AUDIT_STR_MAX)}…[truncated]`
         : v,
@@ -133,7 +134,19 @@ export function truncForAudit(v: unknown): unknown {
   if (Array.isArray(v)) return v.map(truncForAudit);
   if (v && typeof v === "object") {
     const o: Record<string, unknown> = {};
-    for (const [k, val] of Object.entries(v)) o[k] = truncForAudit(val);
+    for (const [k, val] of Object.entries(v)) {
+      // NOTE: `defineProperty`, not assignment. `JSON.parse` yields `__proto__` as an ordinary own
+      // property, and assigning to that key invokes the legacy prototype setter instead; Prisma's
+      // serialization enumerates inherited properties, so its contents would be written as
+      // top-level fields of the audit row. Unlike the repair above, this one is not about what the
+      // column refuses: the write succeeds, carrying a field nobody wrote.
+      Object.defineProperty(o, k, {
+        value: truncForAudit(val),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
     return o;
   }
   return v;

--- a/tests/lib/redact.test.ts
+++ b/tests/lib/redact.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { redactSecretsDeep } from "@/lib/redact";
+import { unstorableProblem } from "@/lib/text";
+
+// REPAIRING A VALUE CAN RECONSTRUCT WHAT THE REDACTOR JUST FAILED TO MATCH.
+//
+// The walker does two things to every string: it scrubs secret-shaped substrings, and it repairs the
+// characters a `jsonb` column refuses. The order between them is load-bearing and was wrong: a NUL
+// inside a token breaks the pattern, so the redactor sees nothing to scrub, and the repair then
+// DELETES that NUL and stores the token whole. Measured before the fix:
+//
+//   { note: "token sk-<NUL>abcdefghijklmnop" }  ->  { note: "token sk-abcdefghijklmnop" }
+//   { "pass<NUL>word": "hunter2" }              ->  { password: "hunter2" }
+//
+// Both are the same mistake in the two places the walker makes a decision about a string, and both
+// defeat the invariant the whole module exists for. The repair is what makes the value storable, so
+// it cannot simply be dropped: it has to happen BEFORE the decision that reads the string.
+//
+// A NUL is the character that matters here, because it is the one the repair DELETES. An orphan half
+// becomes U+FFFD, which leaves `pass<U+FFFD>word` visibly broken rather than passing as `password`.
+
+const NUL = String.fromCharCode(0);
+
+describe("redactSecretsDeep repairs before it decides", () => {
+  test("a NUL inside a token does not smuggle the token past the scrubber", () => {
+    const out = redactSecretsDeep({
+      note: `token sk-${NUL}abcdefghijklmnop`,
+    }) as Record<string, string>;
+    expect(out.note).not.toContain("sk-abcdefghijklmnop");
+    expect(out.note).toContain("‹redacted›");
+  });
+
+  test("a NUL inside a credential key does not smuggle the value past the key rule", () => {
+    const out = redactSecretsDeep(
+      JSON.parse(`{"pass\\u0000word":"hunter2"}`),
+    ) as Record<string, unknown>;
+    expect(Object.values(out)).not.toContain("hunter2");
+    expect(out.password).toBe("‹redacted›");
+  });
+
+  test("still scrubs what it always scrubbed", () => {
+    const out = redactSecretsDeep({
+      token: "sk-abcdefghijklmnop",
+      api_key: "whatever",
+      note: "Authorization: Bearer abcdefghijklmnop",
+      keep: "ordinary text",
+    }) as Record<string, string>;
+    expect(out.token).not.toContain("sk-abcdefghijklmnop");
+    expect(out.api_key).toBe("‹redacted›");
+    expect(out.note).toContain("‹redacted›");
+    expect(out.keep).toBe("ordinary text");
+  });
+
+  test("whatever it returns, the column can hold it", () => {
+    const out = redactSecretsDeep({
+      [`k${NUL}1`]: `a${NUL}b`,
+      nested: [`c\ud800d`, { deep: `e${NUL}\udc00f` }],
+    });
+    const json = JSON.stringify(out) ?? "";
+    expect(unstorableProblem(json, "serialized")).toBeNull();
+  });
+});

--- a/tests/modules/flowlog-astral-detail.test.ts
+++ b/tests/modules/flowlog-astral-detail.test.ts
@@ -66,7 +66,7 @@ function loneSurrogates(s: string): number {
   return n;
 }
 
-describe.skipIf(!dbUp)("execution_logs.detail survives astral text", () => {
+describe.skipIf(!dbUp)("execution_logs.detail survives bad characters", () => {
   beforeAll(async () => {
     tenantId = (
       await suDb.tenant.create({
@@ -100,7 +100,9 @@ describe.skipIf(!dbUp)("execution_logs.detail survives astral text", () => {
 
   test("a detail string that already holds an orphan half still produces a row", async () => {
     // Exactly what an HTTP tool's response body hands `JSON.parse`.
-    const parsed = JSON.parse('{"body":"pre\\ud800post"}') as { body: string };
+    const parsed = JSON.parse('{"body":"pre\\ud800post"}') as {
+      body: string;
+    };
     expect(loneSurrogates(parsed.body)).toBe(1);
     emitFlowEvent(flow("astral-orphan"), {
       stage: "tool",
@@ -125,6 +127,53 @@ describe.skipIf(!dbUp)("execution_logs.detail survives astral text", () => {
     expect(loneSurrogates(Object.keys(detail ?? {})[0] ?? "")).toBe(0);
   });
 
+  // ── the other two things the column refuses, and the one that CORRUPTS (#241) ──
+  // Same destination, same walker, and neither is covered by the surrogate repair above.
+
+  test("a NUL in a detail value still produces a row", async () => {
+    // A JSON body spells out a NUL as readily as an orphan half, and `jsonb` refuses it just as
+    // flatly (22P05). `emitFlowEvent` swallows the refusal, so the only symptom is the missing line.
+    const NUL = String.fromCharCode(0);
+    emitFlowEvent(flow("nul-value"), {
+      stage: "tool",
+      detail: { output: `pre${NUL}post` },
+    });
+    const detail = (await rowFor("nul-value")) as { output: string } | null;
+    expect(detail).not.toBeNull();
+    expect(detail?.output).toBe("prepost");
+  });
+
+  test("a NUL in a detail KEY still produces a row", async () => {
+    const parsed = JSON.parse('{"pre\\u0000post":1}') as Record<string, number>;
+    emitFlowEvent(flow("nul-key"), { stage: "tool", detail: parsed });
+    const detail = (await rowFor("nul-key")) as Record<string, number> | null;
+    expect(detail).not.toBeNull();
+    expect(Object.keys(detail ?? {})).toEqual(["prepost"]);
+  });
+
+  test("a `__proto__` key does not put a field nobody wrote into the record", async () => {
+    // The one case that is not a loss. `JSON.parse` yields `__proto__` as an ordinary own
+    // property, and assignment on that key invokes the legacy prototype setter instead of
+    // creating a field. Prisma's serialization then enumerates INHERITED properties, so the
+    // contents were written as top-level fields: measured before the fix, this row stored
+    // {"keep":"x","leaked":1}, a field nobody wrote in a record that reads as authoritative.
+    //
+    // What is asserted is the ABSENCE of `leaked`, not the presence of `__proto__`. Keeping it an
+    // own property is what this fixes, and Prisma drops that key on the way to the column either
+    // way (measured: the column holds `{"keep": "x"}`). Trading a corrupted record for a record
+    // missing one field is the whole of the win, and asserting the key would pin behaviour that
+    // belongs to the driver rather than to us.
+    const parsed = JSON.parse('{"__proto__":{"leaked":1},"keep":"x"}');
+    emitFlowEvent(flow("proto-key"), { stage: "tool", detail: parsed });
+    const detail = (await rowFor("proto-key")) as Record<
+      string,
+      unknown
+    > | null;
+    expect(detail).not.toBeNull();
+    expect(detail).not.toHaveProperty("leaked");
+    expect(detail).toEqual({ keep: "x" });
+  });
+
   test("a whole emoji still reaches the row intact", async () => {
     // The guard against fixing this by scrubbing every surrogate: an emoji in a tool result is
     // ordinary, and it must survive.
@@ -132,7 +181,9 @@ describe.skipIf(!dbUp)("execution_logs.detail survives astral text", () => {
       stage: "tool",
       detail: { output: "tudo certo 😀🎉" },
     });
-    const detail = (await rowFor("astral-intact")) as { output: string } | null;
+    const detail = (await rowFor("astral-intact")) as {
+      output: string;
+    } | null;
     expect(detail?.output).toBe("tudo certo 😀🎉");
   });
 });

--- a/tests/modules/mcp-write.test.ts
+++ b/tests/modules/mcp-write.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import config from "@/config";
+import { unstorableProblem } from "@/lib/text";
 import { TOOL_INSTRUCTIONS_MAX } from "@/modules/agents/text-caps";
 import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
 import {
@@ -15,6 +16,7 @@ import {
   promptSet,
   resolveSecretRef,
   tenantUpdate,
+  truncForAudit,
 } from "@/modules/mcp/write";
 import { langfuseConnect } from "@/modules/mcp/write-settings";
 
@@ -41,6 +43,41 @@ describe("diffFields", () => {
   });
   test("empty when nothing changed (deep-equal via JSON)", () => {
     expect(diffFields({ x: { y: 1 } }, { x: { y: 1 } })).toEqual({});
+  });
+});
+
+// The audit projection's own walker, asserted directly: unlike the flow log, every current call
+// site projects fields that were already written to a column, so a value that would break the audit
+// write would have broken the write it audits first. The protection is a property of those call
+// sites and not of this function, and `agent.settings` is a genuinely open bag, so the rule belongs
+// here rather than in the callers.
+describe("truncForAudit", () => {
+  const NUL = String.fromCharCode(0);
+
+  test("returns a projection the jsonb column can hold", () => {
+    const out = truncForAudit({
+      name: `Agent${NUL}One`,
+      note: "half\ud800a character",
+    }) as Record<string, string>;
+    expect(unstorableProblem(out.name ?? "", "name")).toBeNull();
+    expect(unstorableProblem(out.note ?? "", "note")).toBeNull();
+    expect(out.name).toBe("AgentOne");
+  });
+
+  test("does not let a `__proto__` key become the prototype", () => {
+    // Assignment on that key invokes the legacy prototype setter, and Prisma's serialization
+    // enumerates inherited properties, so the contents would be written as top-level fields of the
+    // audit record: a field nobody wrote, in the row that says who changed what.
+    const out = truncForAudit(
+      JSON.parse('{"__proto__":{"leaked":1},"keep":"x"}'),
+    ) as Record<string, unknown>;
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    expect(JSON.parse(JSON.stringify(out))).not.toHaveProperty("leaked");
+  });
+
+  test("leaves a whole astral character alone", () => {
+    const out = truncForAudit({ name: "Suporte 😀" }) as Record<string, string>;
+    expect(out.name).toBe("Suporte 😀");
   });
 });
 


### PR DESCRIPTION
`execution_logs.detail` loses a line to a NUL, and keeps a line carrying a field nobody wrote. Both walkers that feed a `jsonb` column were written against the same hazard as #218 and predate its fix: `replaceLoneSurrogates` covers an unpaired surrogate and not a NUL, and keys are copied by assignment.

## What was measured

Through `emitFlowEvent` into the real column, on this project's own Postgres:

| `detail` | Row, before this change |
| --- | --- |
| `{ output: "a<NUL>b" }` | **no row at all** |
| `JSON.parse('{"__proto__":{"leaked":1},"keep":"x"}')` | **`{"keep":"x","leaked":1}`** |
| a value with a lone surrogate | fine (the half already covered) |

Both inputs are ordinary. `detail` carries what an HTTP tool or a provider answered and reaches the column without passing through any other one first, so nothing upstream has already rejected the character. A JSON body spells out a NUL as readily as an orphan half, and `JSON.parse` yields `__proto__` as an ordinary own property.

The second row is the one that matters, because it is not a loss. `out[k] = v` on that key invokes the legacy prototype setter instead of creating a field, and Prisma's serialization enumerates inherited properties, so the contents were written as **top-level fields of the log record**. `leaked: 1` reads as something the turn reported.

The NUL case is the silent half: `emitFlowEvent` is fire-and-forget with a catch, so the refusal never reaches the turn and the line the operator goes looking for simply does not exist.

## What the fix actually buys on the `__proto__` case

It trades a corrupted record for a record missing one field, and that is the honest description. Traced through the layers:

```
after redact, own keys:  [ "__proto__", "keep" ]
after redact, stringify: {"__proto__":{"leaked":1},"keep":"x"}
column holds:            {"keep": "x"}
```

Keeping `__proto__` an own property is ours to fix; Prisma drops that key on the way to the column either way. So the test asserts the **absence of `leaked`**, not the presence of `__proto__`: pinning the key would pin behaviour that belongs to the driver.

## The sibling, and what is not claimed about it

`truncForAudit` (`src/modules/mcp/write.ts`) has both shapes and writes `audit_logs.before` / `.after`, where the code notes the cost is higher than a lost log line: the change has already committed by the time the row is written, so what goes missing is the record of who made it.

Called directly it produces the same unstorable values and the same prototype leak, but **reachability was not demonstrated**: every current call site projects fields that were already persisted to a column, so a value that would break the audit write would have broken the write it audits first. Two reasons to fix it anyway, and they are the reasons the tests here are unit-level rather than DB-backed: the protection is a property of today's call sites rather than of the function, and `agent.settings` is a genuinely open bag (`t.Record(t.String(), t.Unknown())` on the REST controller, `z.record(z.string(), z.unknown())` in the service), so a `__proto__` key can be stored and read back.

## The order between repairing and deciding

Adopting the repair introduced two P1s of its own, both caught in review, and they are the reason this PR is not a one-line helper swap. The old repair turned the offending character into U+FFFD and reconstructed nothing; one that DELETES hands the scrubber's leftovers back whole:

```
{ note: "token sk-<NUL>abcdefghijklmnop" }  ->  { note: "token sk-abcdefghijklmnop" }
{ "pass<NUL>word": "hunter2" }              ->  { password: "hunter2" }
```

A NUL inside a token breaks the pattern, so `redactSecretsInText` finds nothing to scrub and the repair then removes the NUL and stores the token intact. The key rule had the same shape: `SECRET_KEY_RE` read the raw name while the walker stored the repaired one.

So the repair now runs before either decision. The cut stays first, because it is the cheap bound and `clipText` cannot manufacture an orphan half for the repair to have to catch. The two decisions this walker makes about a string are the value scrub and the key test, and both now read the repaired form.

Not closed by this, and stated rather than hidden: an orphan half in a key still defeats both patterns, since `pass<U+FFFD>word` matches neither the raw nor the repaired name. That predates this PR and is not closable by ordering, because the key rule was never evasion-proof: a caller that controls the key can call it `pwd`.

## The change

Both walkers adopt what `makeStorable` / `makeStorableDeep` already carry as of #218: both characters, the repair order that keeps a dropped NUL from joining two orphan halves into a character nobody wrote, and `Object.defineProperty` for keys.

`truncForAudit` still does not repair keys, and that asymmetry with `redactSecretsDeep` stays deliberate: its keys are field names we wrote or argument names from a tool's own schema. The `__proto__` hazard is about the assignment, not the repair, so it applies to both.

## Validation scope

**Proved by test** (`bun check` green: 4712 pass, 0 fail):

- DB-backed, `tests/modules/flowlog-astral-detail.test.ts` (the file that already asserts the surrogate half at the row, not at the redactor): a NUL in a value, a NUL in a key, and the `__proto__` case, each asserted on the row that comes back from Postgres. All three were red before the change.
- Unit, `tests/modules/mcp-write.test.ts`: `truncForAudit` returns a projection `unstorableProblem` accepts, does not let a `__proto__` key become the prototype, and still leaves a whole astral character alone.
- Unit, `tests/lib/redact.test.ts` (new): the two P1s above, asserting the token does not come back whole and that `hunter2` appears nowhere in the output; that everything the walker always scrubbed is still scrubbed; and that whatever it returns serializes to something `unstorableProblem` accepts.

**Mutation-tested**, one at a time. Every one breaks a test:

| Mutation | Tests failing |
| --- | --- |
| baseline | 0 |
| `redactSecretsDeep`: back to surrogate-only on values | 1 |
| `redactSecretsDeep`: back to surrogate-only on keys | 1 |
| `redactSecretsDeep`: back to assignment for keys | 1 |
| `truncForAudit`: back to surrogate-only on values | 1 |
| `truncForAudit`: back to assignment for keys | 1 |
| value: repair AFTER the scrub (the first P1) | 1 |
| key: test the RAW name (the second P1) | 1 |

**Not validated:**

- The audit half is unit-level only, for the reachability reason above. The existing DB-backed audit test (`an astral character on the audit cap does not cost the audit row`) still covers the surrogate path end to end.
- A third member of this family sits outside the PR, measured while sweeping for it: `markJobFailed` writes `clipText(error, 500)` into `scheduler_jobs.lastError`, a `text` column, and `clipText` does not remove a NUL. An error message carrying one has its write refused, so the retry bookkeeping fails exactly while recording a failure and the job is left `CLAIMED`. `sanitizeErrorMessage` does not repair either. Left for its own issue: the shape suggests a sweep test rather than another call-site fix.
- The REST/service path that lets a NUL into `agent.settings` in the first place is untouched. That is a question about refusing at the boundary rather than repairing at the log, and it is not this issue.

Fixes #241
