### PR TITLE
Stop a job from losing the write that says it failed

### DIFF
--- a/src/lib/redact.ts
+++ b/src/lib/redact.ts
@@ -93,8 +93,24 @@ export function redactSecretsDeep(value: unknown, depth = 0): unknown {
 }
 
 // A short, safe one-line string for an error surfaced to the operator (conversation lastError):
-// the message only, secret-scrubbed and length-bounded — never a stack trace or raw provider body.
+// the message only, secret-scrubbed and length-bounded, never a stack trace or raw provider body.
+//
+// Also the ONE place the storability rule is applied to error text, because every column that holds
+// an error message is written through here. A `text` column refuses a NUL outright, and a lone
+// surrogate costs a character off the tail before it either lands corrupted or refuses. What the
+// refusal costs is not the string: `failJob`'s write IS the transition that schedules the retry or
+// dead-letters the job, so refused, the row stops moving. tests/lib/storable-write-sweep.test.ts is
+// the ledger of these columns, and carries how a third party's bytes reach one (issue #243).
+//
+// `makeStorable` runs BEFORE the scrub, never after. It DELETES the NUL rather than replacing it,
+// so a token the pattern missed only because a NUL sat inside it (`sk-<NUL>abcd…`) would be handed
+// back whole by a repair that ran second (issue #241 review). The cut stays last: it cannot
+// manufacture an orphan half for the repair to have to catch, and repairing first is what makes
+// the length it measures the length that gets stored.
 export function sanitizeErrorMessage(err: unknown, max = 500): string {
   const raw = err instanceof Error ? err.message : String(err);
-  return truncate(redactSecretsInText(raw.replace(/\s+/g, " ").trim()), max);
+  return truncate(
+    redactSecretsInText(makeStorable(raw.replace(/\s+/g, " ").trim())),
+    max,
+  );
 }

--- a/src/modules/flowlog/alert-worker.ts
+++ b/src/modules/flowlog/alert-worker.ts
@@ -3,6 +3,7 @@ import { decryptJson } from "@/api/lib/crypto";
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import config from "@/config";
+import { sanitizeErrorMessage } from "@/lib/redact";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { clipText } from "@/lib/text";
@@ -69,9 +70,11 @@ function sysCtx(tenantId: bigint): TenantContext {
   return { tenantId, userId: null, role: "TENANT_ADMIN" };
 }
 
+// `sanitizeErrorMessage` rather than a bare cut: this string is stored in `last_error`, and the
+// exceptions a delivery produces wrap what the remote endpoint answered. See issue #243 and the
+// function's own header for why a NUL or an orphan surrogate costs the whole write.
 function errMsg(err: unknown): string {
-  const m = err instanceof Error ? err.message : String(err);
-  return m.length > MAX_ERROR_LEN ? `${clipText(m, MAX_ERROR_LEN)}…` : m;
+  return sanitizeErrorMessage(err, MAX_ERROR_LEN);
 }
 
 async function mapWithConcurrency<T, R>(

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -3,8 +3,8 @@ import { broadcastDocumentEvent } from "@/api/features/realtime/realtime.service
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
+import { sanitizeErrorMessage } from "@/lib/redact";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
-import { clipText } from "@/lib/text";
 import { cancelPendingJob, enqueueJob } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import { readEmbeddingSettings } from "@/modules/tenant-settings/service";
@@ -617,13 +617,15 @@ async function runIngestJobForTenant(
     return { outcome: "done" };
   } catch (err) {
     // Store the i18n key (a stable token) when the failure is a known AppError, so the UI can localize
-    // the reason (e.g. embedding credential missing); otherwise the raw message (diagnostic).
+    // the reason (e.g. embedding credential missing); otherwise the message itself (diagnostic).
+    //
+    // `sanitizeErrorMessage` rather than a cut: the diagnostic branch carries what the embedding
+    // provider answered, and `error` is a `text` column that refuses a NUL outright. It also bounds
+    // the non-Error branch, which `String(err)` left unbounded (issue #243).
     const message =
       err instanceof AppError && err.translationKey
         ? err.translationKey
-        : err instanceof Error
-          ? clipText(err.message, 500)
-          : String(err);
+        : sanitizeErrorMessage(err, 500);
     logger.error({ err, documentId: String(documentId) }, "RAG ingest failed");
     // NOTE: the same release, and for the same reason. A failure belongs to the content this run
     // read, so stamping it on a document that has since been edited both reports the wrong thing

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -1,13 +1,13 @@
 import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
+import { sanitizeErrorMessage } from "@/lib/redact";
 import {
   asSuperAdminOn,
   runScopedOn,
   type ScopedDb,
   type TenantContext,
 } from "@/lib/tenancy";
-import { clipText } from "@/lib/text";
 import {
   JOB_DELETE_ON_DONE,
   kindsInLane,
@@ -637,6 +637,13 @@ export async function rescheduleJob(
 }
 
 // Failure: attempts++; retry with backoff until the cap, then DEAD.
+//
+// `sanitizeErrorMessage`, not a bare cut: `error` is whatever a job handler threw, and THIS write is
+// the transition itself. A character Postgres refuses (a NUL, an orphan surrogate) takes the whole
+// statement with it, and then the row keeps its CLAIMED status and its old `attempts`: nothing
+// reclaims it and nothing reports it. What used to guard this column was every handler's own habit
+// of not quoting a third party, never anything stated here (issue #243). The same call is what keeps
+// a credential-shaped substring out of the column.
 // Returns whether this call is the one that DEAD-LETTERED the job — the attempt count alone does not
 // say so. The CAS is on `status = 'CLAIMED'` AND on the claim's own token, so a job re-armed mid-run
 // (`armDebounce` upserts the claimed row back to PENDING) fails to match on either count: the row
@@ -658,12 +665,16 @@ export async function failJob(
     db.schedulerJob.updateMany({
       where: { id, status: "CLAIMED", claimSeq },
       data: dead
-        ? { status: "DEAD", attempts: next, lastError: clipText(error, 500) }
+        ? {
+            status: "DEAD",
+            attempts: next,
+            lastError: sanitizeErrorMessage(error),
+          }
         : {
             status: "PENDING",
             attempts: next,
             runAt: new Date(now.getTime() + backoffMs(next)),
-            lastError: clipText(error, 500),
+            lastError: sanitizeErrorMessage(error),
           },
     }),
   );

--- a/src/modules/webhooks/outbound/worker.ts
+++ b/src/modules/webhooks/outbound/worker.ts
@@ -2,9 +2,9 @@ import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import config from "@/config";
+import { sanitizeErrorMessage } from "@/lib/redact";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
-import { clipText } from "@/lib/text";
 import { tryResolveVaultSecret } from "@/modules/vault/service";
 import { nextBackoffMs } from "./service";
 import { outboundHeaders } from "./signing";
@@ -70,9 +70,11 @@ function sysCtx(tenantId: bigint): TenantContext {
   return { tenantId, userId: null, role: "TENANT_ADMIN" };
 }
 
+// `sanitizeErrorMessage` rather than a bare cut: this string is stored in `last_error`, and the
+// exceptions a delivery produces wrap what the remote endpoint answered. See issue #243 and the
+// function's own header for why a NUL or an orphan surrogate costs the whole write.
 function errMsg(err: unknown): string {
-  const m = err instanceof Error ? err.message : String(err);
-  return m.length > MAX_ERROR_LEN ? `${clipText(m, MAX_ERROR_LEN)}…` : m;
+  return sanitizeErrorMessage(err, MAX_ERROR_LEN);
 }
 
 async function mapWithConcurrency<T, R>(

--- a/tests/graph/tool-flowlog.test.ts
+++ b/tests/graph/tool-flowlog.test.ts
@@ -160,6 +160,41 @@ describe.skipIf(!dbUp)("ToolFlowLogger — failure-aware tool lines", () => {
     expect(rows[0]?.errorMessage).toBeNull();
   });
 
+  // Issue #243, and the concrete way a third party's characters reach `execution_logs.error_message`.
+  // An HTTP tool passes the remote's response body through verbatim so the model can read it, and
+  // `toolFailure` makes that body the failure's cause. With `logToolValues` on, the operator asked to
+  // SEE that body, so `failureCause` hands the whole thing here instead of the first line.
+  //
+  // `error_message` is a `text` column and Postgres refuses a NUL in one (22021), while emitFlowEvent
+  // is fire-and-forget with a catch: the refusal never reaches the turn and the line is simply not
+  // there. Turning detailed logging ON is what used to make the log line disappear.
+  test("a response body carrying a NUL still lands the tool line", async () => {
+    const flow = flowCtx();
+    const logger = new ToolFlowLogger(flow, { logValues: true });
+    logger.handleToolStart(
+      {} as never,
+      "{}",
+      "run-nul",
+      undefined,
+      undefined,
+      undefined,
+      "probe",
+    );
+    logger.handleToolEnd(
+      new ToolMessage({
+        status: "error",
+        content: `HTTP 400\n{"detail":"bad${String.fromCharCode(0)}request"}`,
+        tool_call_id: "c1",
+        name: "probe",
+      }),
+      "run-nul",
+    );
+    const rows = await pollToolRows(flow.turnId, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe("error");
+    expect(rows[0]?.errorMessage).toContain("HTTP 400");
+  });
+
   test("a ToolMessage with status error logs ONE warn/error line carrying the message", async () => {
     const flow = flowCtx();
     const logger = new ToolFlowLogger(flow);

--- a/tests/lib/redact.test.ts
+++ b/tests/lib/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { redactSecretsDeep } from "@/lib/redact";
+import { redactSecretsDeep, sanitizeErrorMessage } from "@/lib/redact";
 import { unstorableProblem } from "@/lib/text";
 
 // REPAIRING A VALUE CAN RECONSTRUCT WHAT THE REDACTOR JUST FAILED TO MATCH.
@@ -58,5 +58,35 @@ describe("redactSecretsDeep repairs before it decides", () => {
     });
     const json = JSON.stringify(out) ?? "";
     expect(unstorableProblem(json, "serialized")).toBeNull();
+  });
+});
+
+// The same ordering, in the other function that repairs and then decides. This one guards every
+// column that holds an error message (issue #243), and an exception message is exactly where a
+// provider's own answer, key included, ends up quoted verbatim.
+describe("sanitizeErrorMessage repairs before it decides", () => {
+  test("a NUL inside a token does not smuggle the token past the scrubber", () => {
+    const out = sanitizeErrorMessage(
+      new Error(`upstream rejected token sk-${NUL}abcdefghijklmnop`),
+    );
+    expect(out).not.toContain("sk-abcdefghijklmnop");
+    expect(out).toContain("\u2039redacted\u203a");
+  });
+
+  test("whatever it returns, the column can hold it", () => {
+    for (const raw of [
+      `boom${NUL}tail`,
+      "boom\ud800tail",
+      "boom\ud800",
+      `\ud800${NUL}\udc00`,
+    ]) {
+      expect(unstorableProblem(sanitizeErrorMessage(raw), "out")).toBeNull();
+    }
+  });
+
+  test("still bounds what it always bounded", () => {
+    const out = sanitizeErrorMessage("x".repeat(600));
+    expect(out.length).toBeLessThanOrEqual(500 + "\u2026[truncated]".length);
+    expect(out).toContain("[truncated]");
   });
 });

--- a/tests/lib/storable-write-sweep.test.ts
+++ b/tests/lib/storable-write-sweep.test.ts
@@ -1,0 +1,394 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { sanitizeErrorMessage } from "@/lib/redact";
+import { unstorableProblem } from "@/lib/text";
+import { claimDueJobs, enqueueJob, failJob } from "@/modules/scheduler/service";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// THE GUARD AGAINST THE NEXT COLUMN THAT LOSES AN ERROR MESSAGE.
+//
+// Third instance of one shape, and the reason it is a sweep rather than a fourth call-site fix. The
+// inbound receptor lost a delivery to a character in a third party's body (#218), both `jsonb`
+// walkers behind the flow log and the audit log lost a row to the same thing (#241), and this file
+// is the answer to the same question asked of every column that holds an ERROR message:
+//
+//   does this value reach a column, and has anything applied the rule the column enforces?
+//
+// The rule, measured against this project's own Postgres. A NUL is refused outright by `text` and by
+// `jsonb` alike (22021 / 22P05). An unpaired surrogate is WORSE than refused in a `text` parameter:
+// the driver spends one byte of the tail encoding its replacement, so `boom\ud800tail` lands as
+// `boom<U+FFFD>tai` (one character eaten, silently) and only refuses at all when the orphan sits at
+// the very end and the truncated `EF BF` becomes the last bytes.
+//
+// Error text is where this bites, and the demonstrated way a third party's bytes get in is an HTTP
+// tool: it passes the remote endpoint's response body through verbatim so the model can read it,
+// `toolFailure` makes that body the failure's cause, and with `observability.logToolValues` on the
+// whole body reaches `execution_logs.error_message` (tests/graph/tool-flowlog.test.ts). Asking for
+// detailed logging is what used to make the line disappear.
+//
+// The write it breaks is also the bookkeeping ABOUT a failure: `failJob` is the transition that
+// either schedules the retry or dead-letters the job, so a refused write leaves the row CLAIMED
+// with its old `attempts`, and nothing reclaims it, nothing reports it (issue #243).
+//
+// So `sanitizeErrorMessage` (src/lib/redact.ts) is the ONE place the rule is applied to error text,
+// and this file is the check, in two halves:
+//
+//   1. its output survives every column that holds an error message, asserted at the ROW;
+//   2. the source ledgers below account for every line that puts text in one of those columns, so a
+//      new writer that reaches for a bare cut is a failure here rather than a job that stops moving.
+//
+// The second half exists because a table like the first proves the FUNCTION and nothing about
+// whether the call sites call it (#205). What the ledgers pin is exactly that.
+//
+// NOT in scope, and stated so the ledgers are not read as a clean bill of health for the tree: this
+// is the error family only. The wider question, every write of externally-sourced text into a
+// column, reaches other places with other right answers (a model's own output, the text extracted
+// from an uploaded file, the Chatwoot mirror, an OAuth client's own registration). Each needs its
+// own reading of who can act on a refusal, which is exactly why they are not folded in here under
+// one blanket policy.
+
+const NUL = String.fromCharCode(0);
+
+// Each is a message a provider, an HTTP tool or a third party can produce, and each is refused or
+// corrupted by a `text` column as it stands. The last one is the ordering trap: dropping the NUL
+// first would join the two orphan halves into U+10000, a character nobody wrote.
+const BAD: [string, string][] = [
+  ["NUL in the middle", `boom${NUL}tail`],
+  ["NUL at the end", `boom${NUL}`],
+  ["lone high surrogate, then text", "boom\ud800tail"],
+  ["lone high surrogate at the end", "boom\ud800"],
+  ["lone low surrogate, then text", "boom\udc00tail"],
+  ["a NUL between two orphan halves", `\ud800${NUL}\udc00`],
+];
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let channelId = 0n;
+let subscriptionId = 0n;
+let knowledgeBaseId = 0n;
+
+// Every column that holds an error message, with a write that puts the guard's OUTPUT in it and
+// reads the stored value back. The claim is about the column, so the value is asserted where it
+// landed rather than where it was produced.
+const SINKS: { name: string; write: (v: string) => Promise<string | null> }[] =
+  [
+    {
+      name: "execution_logs.error_message",
+      write: async (v) => {
+        const row = await suDb.executionLog.create({
+          data: {
+            tenantId,
+            turnId: "sweep",
+            stage: "generate",
+            errorMessage: v,
+          },
+          select: { errorMessage: true },
+        });
+        return row.errorMessage;
+      },
+    },
+    {
+      name: "scheduler_jobs.last_error",
+      write: async (v) => {
+        const row = await suDb.schedulerJob.create({
+          data: {
+            tenantId,
+            kind: "WEBHOOK_RETRY",
+            dedupeKey: `sweep-${Math.random()}`,
+            runAt: new Date(),
+            lastError: v,
+          },
+          select: { lastError: true },
+        });
+        return row.lastError;
+      },
+    },
+    {
+      name: "alert_deliveries.summary",
+      write: async (v) => {
+        const row = await suDb.alertDelivery.create({
+          data: { tenantId, channelId, level: "error", summary: v },
+          select: { summary: true },
+        });
+        return row.summary;
+      },
+    },
+    {
+      name: "alert_deliveries.last_error",
+      write: async (v) => {
+        const row = await suDb.alertDelivery.create({
+          data: {
+            tenantId,
+            channelId,
+            level: "error",
+            summary: "s",
+            lastError: v,
+          },
+          select: { lastError: true },
+        });
+        return row.lastError;
+      },
+    },
+    {
+      name: "outbound_webhook_deliveries.last_error",
+      write: async (v) => {
+        const row = await suDb.outboundWebhookDelivery.create({
+          data: { tenantId, subscriptionId, event: "sweep", lastError: v },
+          select: { lastError: true },
+        });
+        return row.lastError;
+      },
+    },
+    {
+      name: "knowledge_documents.error",
+      write: async (v) => {
+        const row = await suDb.knowledgeDocument.create({
+          data: {
+            tenantId,
+            knowledgeBaseId,
+            title: "sweep",
+            sourceType: "text",
+            content: "c",
+            status: "FAILED",
+            error: v,
+          },
+          select: { error: true },
+        });
+        return row.error;
+      },
+    },
+    {
+      name: "conversations.last_error",
+      write: async (v) => {
+        const row = await suDb.conversation.update({
+          where: { id: conversationRowId },
+          data: { lastError: v },
+          select: { lastError: true },
+        });
+        return row.lastError;
+      },
+    },
+  ];
+
+let conversationRowId = 0n;
+
+describe.skipIf(!dbUp)("error text reaches every column that holds it", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "SWEEP243", slug: `sweep243-${process.pid}` },
+    });
+    tenantId = t.id;
+    const ch = await suDb.alertChannel.create({
+      data: { tenantId, name: "c", type: "discord", url: "enc" },
+      select: { id: true },
+    });
+    channelId = ch.id;
+    const sub = await suDb.webhookSubscription.create({
+      data: { tenantId, url: "https://example.test/hook", events: ["a"] },
+      select: { id: true },
+    });
+    subscriptionId = sub.id;
+    const kb = await suDb.knowledgeBase.create({
+      data: { tenantId, name: "kb" },
+      select: { id: true },
+    });
+    knowledgeBaseId = kb.id;
+    const inst = await seedChatwootInstance(suDb, { tenantId, accountId: 1 });
+    const conv = await suDb.conversation.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: inst.id,
+        chatwootConversationId: 1,
+        status: "open",
+        threadId: `${tenantId}:${inst.id}:1`,
+      },
+      select: { id: true },
+    });
+    conversationRowId = conv.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  for (const sink of SINKS) {
+    for (const [label, raw] of BAD) {
+      test(`${sink.name} <- ${label}`, async () => {
+        const guarded = sanitizeErrorMessage(raw);
+        expect(unstorableProblem(guarded, "guarded")).toBeNull();
+        const stored = await sink.write(guarded);
+        expect(stored).toBe(guarded);
+      });
+    }
+  }
+
+  test("a failing job with a NUL still schedules its retry", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "WEBHOOK_RETRY",
+      dedupeKey: "sweep-failjob",
+      runAt: new Date(Date.now() - 60_000),
+      base: appDb,
+    });
+    const claimed = (await claimDueJobs(10, appDb, new Date(), tenantId)).find(
+      (j) => j.id === id,
+    );
+    expect(claimed).toBeDefined();
+    const r = await failJob(
+      tenantId,
+      id,
+      claimed?.claimSeq ?? 0,
+      claimed?.attempts ?? 0,
+      `provider said ${NUL} nothing`,
+      appDb,
+    );
+    expect(r.applied).toBe(true);
+    const row = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id },
+      select: { status: true, attempts: true, lastError: true },
+    });
+    // The row moved: the retry is scheduled and the attempt was counted. Before the repair the
+    // write was refused, the row stayed CLAIMED with attempts 0, and nothing reclaimed it.
+    expect(row.status).toBe("PENDING");
+    expect(row.attempts).toBe(1);
+    expect(row.lastError).toContain("provider said");
+  });
+
+  test("a NUL in the message still dead-letters the last attempt", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "WEBHOOK_RETRY",
+      dedupeKey: "sweep-failjob-dead",
+      runAt: new Date(Date.now() - 60_000),
+      base: appDb,
+    });
+    const claimed = (await claimDueJobs(10, appDb, new Date(), tenantId)).find(
+      (j) => j.id === id,
+    );
+    expect(claimed).toBeDefined();
+    // One below MAX_ATTEMPTS, so this call is the one that gives up. It is the half that costs more
+    // when the write is refused: a job that cannot reach DEAD is not merely un-retried, it is
+    // absent from every list of what died.
+    const r = await failJob(
+      tenantId,
+      id,
+      claimed?.claimSeq ?? 0,
+      4,
+      `provider said ${NUL} nothing`,
+      appDb,
+    );
+    expect(r.deadLettered).toBe(true);
+    const row = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id },
+      select: { status: true, lastError: true },
+    });
+    expect(row.status).toBe("DEAD");
+    expect(row.lastError).toContain("provider said");
+  });
+});
+
+// Every line in `src/` that names one of the two error columns whose key is unambiguous enough to
+// scan for (`lastError`, `errorMessage`), with what it does there. The count per file is what makes
+// a NEW line in an already-listed file trip this too, rather than only a new file.
+//
+//   flow-event  handed to emitFlowEvent as FlowEvent.errorMessage. Sanitized at the chokepoint in
+//               flowlog/service.ts, so these are the one shape that legitimately passes a raw
+//               exception message along: the guard sits between them and the column.
+//   guarded     sanitizeErrorMessage applied right here, at the write
+//   cleared     writes null (a row leaving the state the error described)
+//   read        reads the column back out: a select, a filter, a DTO field
+type ErrorSite = "flow-event" | "guarded" | "cleared" | "read";
+
+const ERROR_COLUMN_LINES: Record<string, [number, ErrorSite | string]> = {
+  "src/graph/nudge.ts": [1, "flow-event"],
+  "src/graph/prepare.ts": [2, "flow-event"],
+  "src/graph/runtime.ts": [4, "flow-event"],
+  "src/graph/tool-flowlog.ts": [2, "flow-event"],
+  "src/modules/chatwoot/webhook.ts": [1, "cleared"],
+  "src/modules/contact-auth/service.ts": [1, "flow-event"],
+  "src/modules/conversations/error.ts": [3, "guarded + cleared"],
+  "src/modules/conversations/service.ts": [12, "read"],
+  "src/modules/debounce/service.ts": [1, "cleared"],
+  "src/modules/flowlog/alert-worker.ts": [4, "guarded + cleared"],
+  "src/modules/flowlog/read.ts": [4, "read"],
+  "src/modules/flowlog/service.ts": [2, "guarded"],
+  "src/modules/guardrails/gate.ts": [2, "flow-event"],
+  "src/modules/guardrails/health.ts": [4, "read"],
+  "src/modules/memory/compact.ts": [1, "flow-event"],
+  "src/modules/scheduler/service.ts": [4, "guarded + cleared"],
+  "src/modules/stt/service.ts": [2, "flow-event"],
+  "src/modules/vision/service.ts": [2, "flow-event"],
+  "src/modules/webhooks/outbound/worker.ts": [4, "guarded + cleared"],
+};
+
+// The other half of the same ledger, and the half that covers the two columns the scan above cannot
+// see: `knowledge_documents.error` and `alert_deliveries.summary` are named by keys (`error`,
+// `summary`) far too common to grep for. Pinning where the guard is CALLED reaches them, and catches
+// the removal of a call that the ledger above would read as an ordinary `read`.
+const GUARD_CALLS: Record<string, number> = {
+  "src/graph/tool-flowlog.ts": 2,
+  "src/lib/redact.ts": 1,
+  "src/modules/conversations/error.ts": 1,
+  "src/modules/conversations/failure-note.ts": 1,
+  "src/modules/flowlog/alert-worker.ts": 1,
+  "src/modules/flowlog/alerts.ts": 1,
+  "src/modules/flowlog/service.ts": 2,
+  "src/modules/rag/documents.ts": 1,
+  "src/modules/scheduler/service.ts": 2,
+  "src/modules/webhooks/outbound/worker.ts": 1,
+};
+
+async function countInSrc(re: RegExp): Promise<Record<string, number>> {
+  const { Glob } = await import("bun");
+  const found: Record<string, number> = {};
+  for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
+    const src = await Bun.file(`src/${rel}`).text();
+    const n = (src.match(re) ?? []).length;
+    if (n > 0) found[`src/${rel}`] = n;
+  }
+  return found;
+}
+
+describe("every line that names an error column is accounted for", () => {
+  test("the file list and the per-file counts still match", async () => {
+    const found = await countInSrc(/\b(?:lastError|errorMessage)\s*:/g);
+    const expected = Object.fromEntries(
+      Object.entries(ERROR_COLUMN_LINES).map(([f, [n]]) => [f, n]),
+    );
+    expect(found).toEqual(expected);
+  });
+
+  test("the guard is still called everywhere it was", async () => {
+    const found = await countInSrc(/sanitizeErrorMessage\(/g);
+    expect(found).toEqual(GUARD_CALLS);
+  });
+});

--- a/tests/modules/flowlog-worker.test.ts
+++ b/tests/modules/flowlog-worker.test.ts
@@ -213,6 +213,32 @@ describe.skipIf(!dbUp)("alert worker", () => {
     expect(row?.nextAttemptAt?.getTime()).toBeGreaterThan(t);
   });
 
+  // Issue #243. The transport error's own message is what lands in `last_error`, a `text` column
+  // that refuses a NUL outright, and the refusal takes the whole retry write with it: the row keeps
+  // its SENDING claim and its attempt count, so nothing re-drives it and nothing dead-letters it.
+  test("retries a transport failure whose message carries a NUL", async () => {
+    const ch = await createAlertChannel(
+      ctx(tenantId),
+      { name: "nul", type: "webhook", url: outboundUrl("/nul") },
+      appDb,
+    );
+    const id = await makeDelivery(BigInt(ch.id));
+    const fetchImpl = (async () => {
+      throw new Error(`socket hang up ${String.fromCharCode(0)} (ECONNRESET)`);
+    }) as unknown as typeof fetch;
+    await processAlertBatch({
+      base: appDb,
+      tenantId,
+      coalesceWindowMs: 0,
+      fetchImpl,
+      assertSafe: async (u: string) => new URL(u),
+    });
+    const row = await suDb.alertDelivery.findUnique({ where: { id } });
+    expect(row?.status).toBe("PENDING");
+    expect(row?.attempts).toBe(1);
+    expect(row?.lastError).toContain("socket hang up");
+  });
+
   test("a blocked (SSRF) URL goes straight to DEAD", async () => {
     const ch = await createAlertChannel(
       ctx(tenantId),

--- a/tests/modules/webhooks-outbound-worker.test.ts
+++ b/tests/modules/webhooks-outbound-worker.test.ts
@@ -233,6 +233,26 @@ describe.skipIf(!dbUp)("outbound delivery worker", () => {
     expect(row.lastError).toContain("500");
   });
 
+  // Issue #243. The remote endpoint's own error message is what lands in `last_error`, and a `text`
+  // column refuses a NUL outright. Refused, the whole retry write is refused with it: the row keeps
+  // its SENDING claim and its attempt count, so nothing re-drives it and nothing dead-letters it.
+  test("retries a transport failure whose message carries a NUL", async () => {
+    const id = await seedDelivery({ subscriptionId: unsignedSubId });
+    const fetchImpl = (async () => {
+      throw new Error(`socket hang up ${String.fromCharCode(0)} (ECONNRESET)`);
+    }) as unknown as typeof fetch;
+    await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl,
+      assertSafe: passthroughSafe,
+    });
+    const row = await readDelivery(id);
+    expect(row.status).toBe("PENDING");
+    expect(row.attempts).toBe(1);
+    expect(row.lastError).toContain("socket hang up");
+  });
+
   test("gives up after the maximum attempts (DEAD)", async () => {
     // attempts at MAX-1 (7); one more failure crosses the threshold.
     const id = await seedDelivery({


### PR DESCRIPTION
`sanitizeErrorMessage` is the one guard standing between an exception message and the column that stores it, and it did not apply the rule those columns enforce. Four of the seven sinks did not call it at all.

## What was measured

Against this project's own Postgres, on the real columns:

| input | `text` column |
| --- | --- |
| `boom<NUL>tail` | **refused**, `22021 invalid byte sequence for encoding "UTF8": 0x00` |
| `boom\ud800tail` | **stored as `boom<U+FFFD>tai`**, one character eaten off the tail |
| `boom\ud800` | **refused**, `22021 ... 0xef 0xbf` |

The middle row is the half #218 did not find. A lone surrogate in a `text` parameter is not cleanly refused: the driver spends one byte of the tail encoding its replacement, so the row lands one character short, silently. It only refuses at all when the truncated `EF BF` ends up as the last bytes.

What a refusal costs is not the string. `failJob` is the transition that either schedules the retry or dead-letters the job, so its write being refused means neither happens:

```
failJob(..., "provider said <NUL> nothing")
  -> throws 22021
row after: { status: "CLAIMED", attempts: 0, lastError: null }
```

The row keeps the claim it was already holding. Nothing reclaims it, nothing reports it, and the bookkeeping fails precisely while recording a failure.

## How a third party's bytes get in

An HTTP tool passes the remote endpoint's response body through verbatim, because the model has to be able to read it, and `toolFailure` makes that body the failure's cause. With `observability.logToolValues` on, `failureCause` hands the whole thing to `sanitizeErrorMessage` instead of just the first line, and it lands in `execution_logs.error_message`.

`emitFlowEvent` is fire-and-forget with a catch, so the refusal never reaches the turn: **asking for detailed logging is what made the log line disappear.** That is the same ending as #241, one column over.

## What does not hold, from the issue

The issue said the NUL arrives by the ordinary path, "an exception message wraps what a provider, an HTTP tool or a third party's API answered". Traced, that is not true of this tree for provider errors. `lib/provider-failure.ts` replaces a provider's message with a closed vocabulary (`timeout`, `HTTP <nnn>`) before it travels, and its own header names three of these columns as the reason. The same discipline holds in `ChatwootApiError` (body excluded except an allowlisted auth reason), in `SttError` / `VisionError` (status only), and in the toolpacks, which swallow a `JSON.parse` failure rather than quote it. Postgres' own errors do not carry the value back either: Prisma drops the `DETAIL` line.

So the character is kept out today by a dozen call sites each having independently chosen well, for a different reason (PII), and by nothing that says they must. The path above is the one that does not go through any of them.

## The change

`sanitizeErrorMessage` repairs, and the four sinks that were cutting by hand call it:

| Column | Was | Now |
| --- | --- | --- |
| `execution_logs.error_message` | `sanitizeErrorMessage` | guard repairs |
| `alert_deliveries.summary` | `sanitizeErrorMessage` | guard repairs |
| `conversations.last_error` | `sanitizeErrorMessage` | guard repairs |
| `scheduler_jobs.last_error` | `clipText(error, 500)` | routed through the guard |
| `outbound_webhook_deliveries.last_error` | `clipText` + ellipsis | routed |
| `alert_deliveries.last_error` | `clipText` + ellipsis | routed |
| `knowledge_documents.error` | `clipText`, or `String(err)` unbounded | routed |

The repair runs BEFORE the scrub, never after, which is the P1 #241's review found in the sibling walker: `makeStorable` DELETES a NUL, so a token the pattern missed only because a NUL sat inside it (`sk-<NUL>abcd…`) is handed back whole by a repair that runs second. The cut stays last, because it cannot manufacture an orphan half and repairing first is what makes the length it measures the length that gets stored.

The three routed workers also gain the secret scrub and the whitespace collapse they did not have.

## The sweep

`tests/lib/storable-write-sweep.test.ts`, built like `tests/lib/astral-cap-sweep.test.ts` and for the same reason: a rule written next to one call site is invisible from the next one.

- **The table**, DB-backed: the guard's output written into each of the seven columns and read back, for six inputs including the ordering trap (`\ud800<NUL>\udc00`, which a repair that dropped the NUL first would fuse into U+10000).
- **Two source ledgers**, because a table proves the FUNCTION and says nothing about whether the call sites call it (#205). One accounts for every line in `src/` naming `lastError` or `errorMessage`, classified (`flow-event` / `guarded` / `cleared` / `read`) with a per-file count; the other pins where the guard is called, which is what reaches the two columns whose key names (`error`, `summary`) are too common to scan for.

## Validation scope

**Proved by test** (`bun check`: 4799 pass, 0 fail):

- DB-backed, the sweep file: all seven columns x six inputs, asserted on the row; and `failJob` driven end to end on both branches, the retry (`PENDING`, `attempts` 1) and the dead-letter (`DEAD`), with a NUL in the message. Red before the change with `22021`.
- DB-backed, `tests/graph/tool-flowlog.test.ts`: the reachable path above, asserted as the row's existence.
- DB-backed, `tests/modules/webhooks-outbound-worker.test.ts` and `tests/modules/flowlog-worker.test.ts`: a transport failure whose message carries a NUL still retries, asserted at the delivery row.
- Unit, `tests/lib/redact.test.ts`: the ordering (a NUL inside a token does not come back whole), the output being storable, and the bound still applied.

**Mutation-tested**, one at a time. Every one breaks a test:

| Mutation | Tests failing |
| --- | --- |
| baseline | 0 |
| `sanitizeErrorMessage`: drop the repair | 49 |
| `sanitizeErrorMessage`: repair AFTER the scrub | 1 |
| `failJob`, retry branch: back to a bare value | 2 |
| `failJob`, dead branch: back to a bare value | 2 |
| outbound worker `errMsg`: back to a bare cut | 2 |
| alert worker `errMsg`: back to a bare cut | 2 |
| rag ingest: back to a bare cut | 1 |

**Not validated:**

- `knowledge_documents.error` is guarded but its reachability is closed upstream: every embedding failure passes through `throughProvider`, so what reaches the column is already `HTTP <nnn>`. A test asserting otherwise was written, measured, and dropped rather than kept green against a path that does not exist. The `String(err)` branch it replaces was genuinely unbounded, which is a small defect of its own.
- The wider question the issue opens, every write of externally-sourced text into a column, is deliberately not answered here. It reaches places with different right answers, and one is measured and reachable in the same way: `extractText` decodes an uploaded `.txt` with `TextDecoder("utf-8")`, so a file holding a `0x00` byte puts a NUL straight into `KnowledgeDocument.content`. The uploader is an operator who can act on a refusal, so that one wants `unstorableProblem`, not a repair, and it belongs to its own issue rather than to a blanket policy applied here.

Fixes #243
