### PR TITLE
Name the field a refusal is about, instead of spending it on prose

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -247,6 +247,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -266,6 +269,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -284,6 +290,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -385,6 +394,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -403,6 +415,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -504,6 +519,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -522,6 +540,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -644,6 +665,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -662,6 +686,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -721,6 +748,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -739,6 +769,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -861,6 +894,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -880,6 +916,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -898,6 +937,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1013,6 +1055,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1032,6 +1077,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1050,6 +1098,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1202,6 +1253,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1246,6 +1300,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1264,6 +1321,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1331,6 +1391,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1349,6 +1412,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1421,6 +1487,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1439,6 +1508,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1549,6 +1621,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1567,6 +1642,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1587,6 +1665,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1605,6 +1686,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1709,6 +1793,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1727,6 +1814,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1747,6 +1837,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1765,6 +1858,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1886,6 +1982,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1904,6 +2003,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -1924,6 +2026,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1942,6 +2047,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2007,6 +2115,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2025,6 +2136,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2079,6 +2193,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2097,6 +2214,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2117,6 +2237,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2135,6 +2258,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2166,6 +2292,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2472,6 +2601,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2491,6 +2623,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2509,6 +2644,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2581,6 +2719,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2599,6 +2740,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2719,6 +2863,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2738,6 +2885,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2756,6 +2906,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2823,6 +2976,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2842,6 +2998,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2860,6 +3019,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2891,6 +3053,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -2935,6 +3100,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3070,6 +3238,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3088,6 +3259,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3108,6 +3282,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3126,6 +3303,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3193,6 +3373,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3212,6 +3395,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3230,6 +3416,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3326,6 +3515,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3344,6 +3536,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3364,6 +3559,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3382,6 +3580,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3499,6 +3700,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3517,6 +3721,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3537,6 +3744,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3555,6 +3765,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3636,6 +3849,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3654,6 +3870,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3708,6 +3927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3727,6 +3949,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3745,6 +3970,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3808,6 +4036,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3827,6 +4058,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3845,6 +4079,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -3908,6 +4145,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3927,6 +4167,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3945,6 +4188,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4064,6 +4310,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4083,6 +4332,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4101,6 +4353,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4223,6 +4478,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4242,6 +4500,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4260,6 +4521,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4314,6 +4578,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4333,6 +4600,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4351,6 +4621,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4405,6 +4678,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4424,6 +4700,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4442,6 +4721,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4555,6 +4837,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4574,6 +4859,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4592,6 +4880,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4658,6 +4949,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4676,6 +4970,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4729,6 +5026,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4804,6 +5104,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4822,6 +5125,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -4875,6 +5181,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5007,6 +5316,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5026,6 +5338,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5044,6 +5359,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5292,6 +5610,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5311,6 +5632,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5329,6 +5653,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5396,6 +5723,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5414,6 +5744,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5434,6 +5767,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5452,6 +5788,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5725,6 +6064,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5743,6 +6085,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5763,6 +6108,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5782,6 +6130,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5800,6 +6151,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5917,6 +6271,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5935,6 +6292,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -5955,6 +6315,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5973,6 +6336,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6027,6 +6393,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6045,6 +6414,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6065,6 +6437,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6083,6 +6458,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6137,6 +6515,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6156,6 +6537,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6174,6 +6558,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6269,6 +6656,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6287,6 +6677,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6307,6 +6700,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6325,6 +6721,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6397,6 +6796,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6415,6 +6817,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6435,6 +6840,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6453,6 +6861,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6529,6 +6940,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6548,6 +6962,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6566,6 +6983,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6633,6 +7053,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6651,6 +7074,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -6671,6 +7097,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6689,6 +7118,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7028,6 +7460,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7046,6 +7481,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7066,6 +7504,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7085,6 +7526,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7103,6 +7547,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7387,6 +7834,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7405,6 +7855,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7425,6 +7878,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7443,6 +7899,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7497,6 +7956,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7515,6 +7977,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7535,6 +8000,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7553,6 +8021,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7813,6 +8284,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7831,6 +8305,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -7851,6 +8328,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7869,6 +8349,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -8141,6 +8624,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8159,6 +8645,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -8179,6 +8668,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8197,6 +8689,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -8517,6 +9012,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8535,6 +9033,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -8555,6 +9056,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8573,6 +9077,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -8845,6 +9352,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8863,6 +9373,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -8883,6 +9396,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8901,6 +9417,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9233,6 +9752,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9251,6 +9773,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9271,6 +9796,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9289,6 +9817,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9352,6 +9883,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9370,6 +9904,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9390,6 +9927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9408,6 +9948,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9462,6 +10005,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9480,6 +10026,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9500,6 +10049,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9518,6 +10070,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9581,6 +10136,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9599,6 +10157,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9619,6 +10180,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9637,6 +10201,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9698,6 +10265,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9716,6 +10286,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9736,6 +10309,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9754,6 +10330,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -9884,6 +10463,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9903,6 +10485,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9921,6 +10506,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -10064,6 +10652,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10083,6 +10674,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10101,6 +10695,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -10146,6 +10743,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10164,6 +10764,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -10596,6 +11199,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10614,6 +11220,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -10634,6 +11243,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10652,6 +11264,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -10719,6 +11334,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10737,6 +11355,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -10757,6 +11378,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10775,6 +11399,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11216,6 +11843,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11234,6 +11864,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11254,6 +11887,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11273,6 +11909,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11291,6 +11930,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11343,6 +11985,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11361,6 +12006,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11381,6 +12029,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11399,6 +12050,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11453,6 +12107,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11471,6 +12128,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11491,6 +12151,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11509,6 +12172,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11541,6 +12207,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11559,6 +12228,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11775,6 +12447,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11794,6 +12469,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11812,6 +12490,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -11879,6 +12560,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11898,6 +12582,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11916,6 +12603,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12141,6 +12831,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12159,6 +12852,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12179,6 +12875,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12197,6 +12896,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12249,6 +12951,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12267,6 +12972,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12287,6 +12995,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12305,6 +13016,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12359,6 +13073,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12377,6 +13094,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12397,6 +13117,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12415,6 +13138,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12469,6 +13195,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12487,6 +13216,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12507,6 +13239,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12525,6 +13260,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12557,6 +13295,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12575,6 +13316,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -12938,6 +13682,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12957,6 +13704,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12975,6 +13725,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13042,6 +13795,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13060,6 +13816,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13080,6 +13839,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13098,6 +13860,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13470,6 +14235,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13488,6 +14256,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13508,6 +14279,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13526,6 +14300,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13578,6 +14355,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13596,6 +14376,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13616,6 +14399,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13634,6 +14420,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13666,6 +14455,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13684,6 +14476,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -13906,6 +14701,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13925,6 +14723,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13943,6 +14744,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14010,6 +14814,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14028,6 +14835,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14048,6 +14858,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14066,6 +14879,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14285,6 +15101,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14303,6 +15122,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14323,6 +15145,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14341,6 +15166,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14393,6 +15221,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14411,6 +15242,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14431,6 +15265,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14449,6 +15286,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14503,6 +15343,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14521,6 +15364,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14541,6 +15387,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14559,6 +15408,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14591,6 +15443,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14609,6 +15464,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14810,6 +15668,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14828,6 +15689,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -14848,6 +15712,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14866,6 +15733,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15068,6 +15938,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15086,6 +15959,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15106,6 +15982,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15125,6 +16004,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15143,6 +16025,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15196,6 +16081,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15215,6 +16103,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15233,6 +16124,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15288,6 +16182,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15307,6 +16204,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15325,6 +16225,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15488,6 +16391,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15507,6 +16413,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15525,6 +16434,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15652,6 +16564,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15670,6 +16585,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15690,6 +16608,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15708,6 +16629,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15822,6 +16746,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15840,6 +16767,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15860,6 +16790,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15878,6 +16811,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15933,6 +16869,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15951,6 +16890,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -15971,6 +16913,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15989,6 +16934,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16044,6 +16992,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16062,6 +17013,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16082,6 +17036,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16100,6 +17057,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16254,6 +17214,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16272,6 +17235,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16292,6 +17258,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16311,6 +17280,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16329,6 +17301,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16384,6 +17359,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16402,6 +17380,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16422,6 +17403,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16440,6 +17424,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16495,6 +17482,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16513,6 +17503,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16533,6 +17526,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16551,6 +17547,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16664,6 +17663,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16682,6 +17684,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -16858,6 +17863,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16877,6 +17885,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16895,6 +17906,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17035,6 +18049,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17054,6 +18071,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17072,6 +18092,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17218,6 +18241,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17237,6 +18263,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17255,6 +18284,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17416,6 +18448,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17435,6 +18470,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17453,6 +18491,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17551,6 +18592,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17570,6 +18614,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17588,6 +18635,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17631,6 +18681,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17649,6 +18702,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17692,6 +18748,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17711,6 +18770,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17729,6 +18791,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17774,6 +18839,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17792,6 +18860,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -17837,6 +18908,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17855,6 +18929,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18029,6 +19106,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18048,6 +19128,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18066,6 +19149,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18252,6 +19338,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18270,6 +19359,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18290,6 +19382,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18308,6 +19403,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18360,6 +19458,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18378,6 +19479,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18398,6 +19502,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18416,6 +19523,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18470,6 +19580,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18488,6 +19601,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18508,6 +19624,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18526,6 +19645,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18558,6 +19680,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18576,6 +19701,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18672,6 +19800,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18691,6 +19822,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18709,6 +19843,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18776,6 +19913,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18794,6 +19934,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18814,6 +19957,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18832,6 +19978,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -18895,6 +20044,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18914,6 +20066,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18932,6 +20087,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -19076,6 +20234,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19095,6 +20256,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19113,6 +20277,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -19257,6 +20424,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19276,6 +20446,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19294,6 +20467,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -19326,6 +20502,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19344,6 +20523,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -19389,6 +20571,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19407,6 +20592,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -19641,6 +20829,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19660,6 +20851,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19678,6 +20872,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -19921,6 +21118,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19939,6 +21139,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -19959,6 +21162,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19977,6 +21183,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20029,6 +21238,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20047,6 +21259,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20067,6 +21282,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20085,6 +21303,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20163,6 +21384,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20181,6 +21405,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20224,6 +21451,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20242,6 +21472,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20309,6 +21542,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20327,6 +21563,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20347,6 +21586,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20365,6 +21607,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20419,6 +21664,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20437,6 +21685,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20457,6 +21708,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20475,6 +21729,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20507,6 +21764,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20525,6 +21785,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20759,6 +22022,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20778,6 +22044,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20796,6 +22065,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20863,6 +22135,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20881,6 +22156,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -20901,6 +22179,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20919,6 +22200,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21138,6 +22422,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21156,6 +22443,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21176,6 +22466,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21194,6 +22487,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21246,6 +22542,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21264,6 +22563,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21284,6 +22586,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21302,6 +22607,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21356,6 +22664,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21374,6 +22685,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21394,6 +22708,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21412,6 +22729,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21444,6 +22764,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21462,6 +22785,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21579,6 +22905,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21598,6 +22927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21616,6 +22948,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21683,6 +23018,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21701,6 +23039,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21721,6 +23062,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21739,6 +23083,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -21973,6 +23320,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21991,6 +23341,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22011,6 +23364,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22029,6 +23385,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22081,6 +23440,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22099,6 +23461,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22119,6 +23484,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22137,6 +23505,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22169,6 +23540,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22187,6 +23561,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22254,6 +23631,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22272,6 +23652,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22292,6 +23675,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22310,6 +23696,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22430,6 +23819,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22448,6 +23840,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22468,6 +23863,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22486,6 +23884,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22605,6 +24006,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22623,6 +24027,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22643,6 +24050,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22661,6 +24071,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22681,6 +24094,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22700,6 +24116,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22718,6 +24137,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22772,6 +24194,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22790,6 +24215,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22810,6 +24238,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22828,6 +24259,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22936,6 +24370,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22954,6 +24391,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -22974,6 +24414,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22992,6 +24435,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23044,6 +24490,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23062,6 +24511,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23082,6 +24534,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23100,6 +24555,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23154,6 +24612,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23172,6 +24633,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23192,6 +24656,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23211,6 +24678,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23229,6 +24699,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23292,6 +24765,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23310,6 +24786,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23330,6 +24809,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23348,6 +24830,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23505,6 +24990,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23524,6 +25012,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23542,6 +25033,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23676,6 +25170,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23694,6 +25191,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23714,6 +25214,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23732,6 +25235,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23777,6 +25283,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23795,6 +25304,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -23924,6 +25436,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23943,6 +25458,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23961,6 +25479,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24015,6 +25536,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24034,6 +25558,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24052,6 +25579,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24106,6 +25636,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24125,6 +25658,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24143,6 +25679,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24197,6 +25736,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24215,6 +25757,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24235,6 +25780,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24253,6 +25801,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24285,6 +25836,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24303,6 +25857,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24588,6 +26145,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24606,6 +26166,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24626,6 +26189,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24644,6 +26210,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24711,6 +26280,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24729,6 +26301,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -24973,6 +26548,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24991,6 +26569,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25011,6 +26592,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25030,6 +26614,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25048,6 +26635,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25116,6 +26706,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25134,6 +26727,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25154,6 +26750,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25172,6 +26771,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25467,6 +27069,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25485,6 +27090,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25505,6 +27113,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25524,6 +27135,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25542,6 +27156,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25595,6 +27212,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25613,6 +27233,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25633,6 +27256,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25651,6 +27277,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25706,6 +27335,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25725,6 +27357,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25743,6 +27378,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -25817,6 +27455,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25836,6 +27477,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25854,6 +27498,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26009,6 +27656,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26027,6 +27677,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26047,6 +27700,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26066,6 +27722,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26084,6 +27743,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26152,6 +27814,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26170,6 +27835,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26190,6 +27858,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26208,6 +27879,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26263,6 +27937,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26281,6 +27958,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26301,6 +27981,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26319,6 +28002,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26651,6 +28337,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26669,6 +28358,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26724,6 +28416,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26742,6 +28437,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -26869,6 +28567,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26888,6 +28589,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26906,6 +28610,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27100,6 +28807,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27130,6 +28840,10 @@
                   "properties": {
                     "error": {
                       "description": "Human-readable error message.",
+                      "type": "string"
+                    },
+                    "field": {
+                      "description": "The value the refusal is about, by the server's name for it (a column, a patch key, or a dotted path into a settings bag). Absent when the refusal is not about one input. Never localized.",
                       "type": "string"
                     }
                   },
@@ -27170,6 +28884,10 @@
                     "error": {
                       "description": "Human-readable error message.",
                       "type": "string"
+                    },
+                    "field": {
+                      "description": "The value the refusal is about, by the server's name for it (a column, a patch key, or a dotted path into a settings bag). Absent when the refusal is not about one input. Never localized.",
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27209,6 +28927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27227,6 +28948,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27295,6 +29019,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27313,6 +29040,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27345,6 +29075,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27363,6 +29096,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27408,6 +29144,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27426,6 +29165,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27471,6 +29213,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27489,6 +29234,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27645,6 +29393,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27664,6 +29415,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27682,6 +29436,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27838,6 +29595,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27856,6 +29616,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27876,6 +29639,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27894,6 +29660,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -27946,6 +29715,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27965,6 +29737,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -27983,6 +29758,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28037,6 +29815,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28055,6 +29836,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28109,6 +29893,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28128,6 +29915,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28146,6 +29936,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28178,6 +29971,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28196,6 +29992,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28264,6 +30063,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28283,6 +30085,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28301,6 +30106,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28371,6 +30179,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28389,6 +30200,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28432,6 +30246,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28450,6 +30267,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28558,6 +30378,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28576,6 +30399,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28596,6 +30422,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28615,6 +30444,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28633,6 +30465,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28726,6 +30561,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28744,6 +30582,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28764,6 +30605,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28783,6 +30627,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28801,6 +30648,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28909,6 +30759,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28927,6 +30780,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -28947,6 +30803,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -28965,6 +30824,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29010,6 +30872,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29028,6 +30893,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29048,6 +30916,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29067,6 +30938,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29085,6 +30959,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29211,6 +31088,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29229,6 +31109,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29249,6 +31132,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29268,6 +31154,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29286,6 +31175,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29353,6 +31245,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29371,6 +31266,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29391,6 +31289,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29409,6 +31310,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29463,6 +31367,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29481,6 +31388,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29501,6 +31411,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29519,6 +31432,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29638,6 +31554,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29656,6 +31575,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29676,6 +31598,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29694,6 +31619,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29748,6 +31676,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29766,6 +31697,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29786,6 +31720,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29804,6 +31741,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29836,6 +31776,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29854,6 +31797,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -29899,6 +31845,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29918,6 +31867,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29936,6 +31888,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30003,6 +31958,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30022,6 +31980,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30040,6 +32001,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30094,6 +32058,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30113,6 +32080,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30131,6 +32101,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30185,6 +32158,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30204,6 +32180,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30222,6 +32201,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30276,6 +32258,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30295,6 +32280,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30313,6 +32301,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30367,6 +32358,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30386,6 +32380,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30404,6 +32401,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30526,6 +32526,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30544,6 +32547,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30564,6 +32570,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30583,6 +32592,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30601,6 +32613,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30655,6 +32670,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30673,6 +32691,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30693,6 +32714,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30711,6 +32735,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },
@@ -30731,6 +32758,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30749,6 +32779,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   },

--- a/src/api/lib/openapi.ts
+++ b/src/api/lib/openapi.ts
@@ -10,9 +10,18 @@ import { type DocumentDecoration, type TSchema, t } from "elysia";
 // does not run through response validation either — so these annotations are documentation-only and
 // carry no runtime-validation risk.
 
-// The canonical error body every endpoint returns on failure: `{ error: "<message>" }`.
+// The canonical error body every endpoint returns on failure: `{ error: "<message>" }`, plus the
+// name of the value the refusal is about when it is about one (see src/api/lib/refusal.ts).
 export const ErrorResponse = t.Object(
-  { error: t.String({ description: "Human-readable error message." }) },
+  {
+    error: t.String({ description: "Human-readable error message." }),
+    field: t.Optional(
+      t.String({
+        description:
+          "The value the refusal is about, by the server's name for it (a column, a patch key, or a dotted path into a settings bag). Absent when the refusal is not about one input. Never localized.",
+      }),
+    ),
+  },
   { description: "Error response." },
 );
 
@@ -43,7 +52,7 @@ const STATUS_DESCRIPTION: Record<number, string> = {
 // builders can never drift apart in the published spec.
 function errorSchema(status: number): typeof ErrorResponse {
   return t.Object(
-    { error: t.String() },
+    { error: t.String(), field: t.Optional(t.String()) },
     { description: STATUS_DESCRIPTION[status] ?? "Error." },
   );
 }

--- a/src/api/lib/refusal.ts
+++ b/src/api/lib/refusal.ts
@@ -16,6 +16,18 @@ import type { AppError } from "@/lib/errors";
 // the FIRST oversized change (`const [first] = collectOversizedTextChanges(…)`) and every other site
 // that knows a field knows exactly one. A list would be a shape nothing fills.
 //
+// WHICH refusals name one: the ones where the operator can go and fix exactly one input, and the
+// server already knows which. That is a judgement about the refusal, not about the variable that
+// holds the name, so `requireDbId` does not qualify even though it interpolates a `label`: the label
+// is a noun phrase ("template id") and what it refuses is a URL segment, not an input on a form.
+// tests/api/lib/refusal-callsites.test.ts holds the sweep, and that exclusion, in writing.
+//
+// ONE transport, also deliberate. An MCP write refusal is `err(e.message)` (src/modules/mcp/write.ts)
+// rendered by `writeContent` as a text block with `isError: true`: there is no structured error
+// channel to carry a key in, and what reads that text is a model, which has no input to attach a
+// refusal to. What it can use is the sentence, and every refusal named here already spells the value
+// out in it. The same surface does not localize either, and for the same reason.
+//
 // ABSENT rather than null when nothing was named: most refusals are not about one input (a 403, a
 // 404, a conflict), and they must keep answering exactly the body they answer today. A `field: null`
 // would be a wire change for all of them and a second spelling of "nothing here" for every client.

--- a/src/api/lib/refusal.ts
+++ b/src/api/lib/refusal.ts
@@ -1,0 +1,43 @@
+import { getLocaleFromHeader, translateWithLocale } from "@/api/lib/i18n";
+import type { AppError } from "@/lib/errors";
+
+// What a refusal ANSWERS. One place, because the two halves of it are decided by different things
+// and get confused for each other otherwise: the sentence is written for whoever is reading, in the
+// language they asked for, and the field is a key the client matches on, identical in every language.
+//
+// The field exists because the server already knew it and spent it on prose. `SettingsTextTooLongError`
+// takes `(field, length, max)` and interpolates the field into a localized sentence; a console that
+// wants to put the message next to the input it is about would have to parse that sentence back
+// apart, per locale. Measured before the change: the same refusal reads "The text in
+// guardrails.output.templateMessage is too long…" in English and "O texto em … é longo demais…" in
+// pt-BR, with the path embedded in both and named by neither.
+//
+// ONE field, not a list, because one is what the app produces: `assertSettingsTextSizes` refuses on
+// the FIRST oversized change (`const [first] = collectOversizedTextChanges(…)`) and every other site
+// that knows a field knows exactly one. A list would be a shape nothing fills.
+//
+// ABSENT rather than null when nothing was named: most refusals are not about one input (a 403, a
+// 404, a conflict), and they must keep answering exactly the body they answer today. A `field: null`
+// would be a wire change for all of them and a second spelling of "nothing here" for every client.
+export interface RefusalBody {
+  error: string;
+  field?: string;
+}
+
+export function refusalBody(
+  error: AppError,
+  acceptLanguage: string | null,
+): RefusalBody {
+  const message = error.translationKey
+    ? translateWithLocale(
+        getLocaleFromHeader(acceptLanguage),
+        error.translationKey,
+        error.message,
+        error.translationParams,
+      )
+    : error.message;
+  // A blank name is not a name: it would put the key on the wire for a client to match against
+  // nothing, which is worse than the honest silence of not naming a field at all.
+  const field = error.field?.trim();
+  return field ? { error: message, field } : { error: message };
+}

--- a/src/api/lib/refusal.ts
+++ b/src/api/lib/refusal.ts
@@ -48,7 +48,7 @@ export function refusalBody(
         error.translationParams,
       )
     : error.message;
-  // A blank name is not a name: it would put the key on the wire for a client to match against
+  // NOTE: a blank name is not a name: it would put the key on the wire for a client to match against
   // nothing, which is worse than the honest silence of not naming a field at all.
   const field = error.field?.trim();
   return field ? { error: message, field } : { error: message };

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,9 +4,9 @@ import Elysia from "elysia";
 import { helmet } from "elysia-helmet";
 import api from "@/api";
 import { cspDirectives } from "@/api/lib/csp";
-import { getLocaleFromHeader, translateWithLocale } from "@/api/lib/i18n";
 import logger from "@/api/lib/logger";
 import { parseOrigins } from "@/api/lib/origin";
+import { refusalBody } from "@/api/lib/refusal";
 import { localeMiddleware } from "@/api/middlewares/locale";
 import {
   credentialRateLimitMiddleware,
@@ -107,18 +107,11 @@ const app = new Elysia({
   .onError(({ path, error, request, set }) => {
     if (!(error instanceof AppError)) return;
     logger.warn("%s %s", path, error.message);
-    const message = error.translationKey
-      ? translateWithLocale(
-          getLocaleFromHeader(request.headers.get("accept-language")),
-          error.translationKey,
-          error.message,
-          error.translationParams,
-        )
-      : error.message;
+    const body = refusalBody(error, request.headers.get("accept-language"));
     // NOTE: keep set.status in sync, because the access log in onAfterResponse reads it and a raw
     // Response alone would make a 4xx show up there as a 500.
     set.status = error.statusCode;
-    return Response.json({ error: message }, { status: error.statusCode });
+    return Response.json(body, { status: error.statusCode });
   })
   .use(rateLimitMiddleware())
   .use(mcpTransportRateLimitMiddleware())

--- a/src/client/lib/types.ts
+++ b/src/client/lib/types.ts
@@ -1,3 +1,8 @@
 export interface ApiErrorPayload {
   error?: string;
+  // The value the server refused, by ITS name for it: a column (`systemPrompt`), a key of a patch
+  // (`document`), or a dotted path into a settings bag (`guardrails.output.templateMessage`): the
+  // same strings TEXT_CAP_TARGETS already routes on. Absent whenever the refusal is not about one
+  // input, which is most of them. See src/api/lib/refusal.ts.
+  field?: string;
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -57,8 +57,8 @@ export class ProEditionError extends AppError {
 
 // NOTE: a uniqueness/state conflict surfaced to the user (e.g. a duplicate tenant slug).
 export class ConflictError extends AppError {
-  constructor(message = "Conflict", translationKey?: string) {
-    super(message, 409, translationKey);
+  constructor(message = "Conflict", translationKey?: string, field?: string) {
+    super(message, 409, translationKey, undefined, field);
   }
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -11,17 +11,31 @@ export class AppError extends Error {
   // NOTE: interpolation values for translationKey ({{placeholders}} in the locale entry).
   // `message` must arrive pre-interpolated: it is the log line and the untranslated fallback.
   readonly translationParams?: Record<string, string | number>;
+  // NOTE: optional. The value this refusal is ABOUT, by the name the SERVER uses for it: a column
+  // (`systemPrompt`), a key of a patch (`document`), or a dotted path into a bag the server owns
+  // (`guardrails.output.templateMessage`). Never a form path and never localized: it is a key the
+  // client keys on, and it must read the same in every language the sentence is written in.
+  //
+  // It is the server's vocabulary and not the caller's on purpose. The same service function is
+  // reached by REST and by MCP, which spell the same write differently, so a name taken from the
+  // request shape would be a different string depending on who called, and the console already
+  // maps these exact paths (TEXT_CAP_TARGETS, src/client/lib/configHealth.ts), which is the map a
+  // refusal wants to reuse. Absent whenever the refusal is not about one input: see
+  // src/api/lib/refusal.ts for what the wire then carries. Issue #231.
+  readonly field?: string;
   constructor(
     message: string,
     statusCode: number,
     translationKey?: string,
     translationParams?: Record<string, string | number>,
+    field?: string,
   ) {
     super(message);
     this.name = new.target.name;
     this.statusCode = statusCode;
     this.translationKey = translationKey;
     this.translationParams = translationParams;
+    this.field = field;
   }
 }
 

--- a/src/modules/agents/service.ts
+++ b/src/modules/agents/service.ts
@@ -235,6 +235,7 @@ export class PromptTooLongError extends AppError {
       400,
       "errors.promptTooLong",
       { len: length, max },
+      "systemPrompt",
     );
   }
 }
@@ -261,6 +262,9 @@ export class SettingsTextTooLongError extends AppError {
       400,
       "errors.settingsTextTooLong",
       { field, len: length, max },
+      // The dotted path collectOversizedTextChanges reports, which is the same string the console's
+      // own text-cap warning already routes on (TEXT_CAP_TARGETS).
+      field,
     );
   }
 }
@@ -804,7 +808,13 @@ interface NormalizedGrant {
 // both; see lib/db-id.ts.
 function bigOrThrow(v: string | null | undefined, field: string): bigint {
   if (v == null) {
-    throw new AppError(`${field} is required`, 400, "errors.invalidToolGrant");
+    throw new AppError(
+      `${field} is required`,
+      400,
+      "errors.invalidToolGrant",
+      undefined,
+      field,
+    );
   }
   const id = parseDbId(v);
   if (id === null) {
@@ -812,6 +822,8 @@ function bigOrThrow(v: string | null | undefined, field: string): bigint {
       `${field} must be a numeric id`,
       400,
       "errors.invalidToolGrant",
+      undefined,
+      field,
     );
   }
   return id;

--- a/src/modules/agents/service.ts
+++ b/src/modules/agents/service.ts
@@ -262,7 +262,7 @@ export class SettingsTextTooLongError extends AppError {
       400,
       "errors.settingsTextTooLong",
       { field, len: length, max },
-      // The dotted path collectOversizedTextChanges reports, which is the same string the console's
+      // NOTE: the dotted path collectOversizedTextChanges reports, which is the same string the console's
       // own text-cap warning already routes on (TEXT_CAP_TARGETS).
       field,
     );

--- a/src/modules/documents/templates.ts
+++ b/src/modules/documents/templates.ts
@@ -133,10 +133,15 @@ function nameAlreadyUsed(name: string): Refusal {
   };
 }
 
+// `slugExplicit` is what decides WHICH input the refusal is about, and it is not cosmetic: a caller
+// who typed the slug cannot clear a slug clash by renaming, so a refusal that points at the name
+// sends them to change something that will not help. A DERIVED slug is the opposite case: the caller
+// never saw a slug, and the name is the only thing they can change.
 function nameTaken(
   existingName: string,
   name: string | undefined,
   slug: string,
+  slugExplicit: boolean,
 ): Refusal {
   const tool = documentToolName(slug);
   if (name === undefined) {
@@ -149,14 +154,16 @@ function nameTaken(
   }
   // Same name, or merely the same normalisation ("Orçamento" vs "Orcamento"). The second is the one
   // that would otherwise read as a false refusal, so its message names both templates.
-  return existingName === name
-    ? nameAlreadyUsed(name)
-    : {
-        message: `"${name}" collides with the template "${existingName}": both produce the tool name ${tool}`,
-        key: "errors.documentTemplateNameCollides",
-        params: { name, existing: existingName, tool },
-        field: "name",
-      };
+  if (existingName === name) return nameAlreadyUsed(name);
+  return {
+    // The SENTENCE stays the tool-name explanation in both cases, because the tool name is what is
+    // actually in the way and #208 chose that wording for an authoring client on purpose. Only the
+    // input it is attached to depends on who chose the slug.
+    message: `"${name}" collides with the template "${existingName}": both produce the tool name ${tool}`,
+    key: "errors.documentTemplateNameCollides",
+    params: { name, existing: existingName, tool },
+    field: slugExplicit ? "slug" : "name",
+  };
 }
 
 // The same constraint arriving from the database instead of the pre-check, which is the concurrent
@@ -174,7 +181,11 @@ function conflictTarget(e: unknown): "name" | "slug" {
 
 // The unique indexes deciding what the pre-check could not: the concurrent case, and every write
 // that does not pass through the console (MCP, an imported bundle).
-function writeConflict(slug: string, name?: string): (e: unknown) => never {
+function writeConflict(
+  slug: string,
+  name: string | undefined,
+  slugExplicit: boolean,
+): (e: unknown) => never {
   return (e: unknown) => {
     if (e instanceof Error && (e as { code?: string }).code === "P2002") {
       if (name !== undefined && conflictTarget(e) === "name") {
@@ -198,7 +209,7 @@ function writeConflict(slug: string, name?: string): (e: unknown) => never {
         409,
         "errors.documentTemplateNameCollidesUnknown",
         { tool: documentToolName(slug) },
-        "name",
+        slugExplicit ? "slug" : "name",
       );
     }
     throw e;
@@ -286,7 +297,7 @@ export async function documentTemplateWriteProblem(
   // never returns `byName` without one.
   if (clash.byName && name !== undefined) return nameAlreadyUsed(name).message;
   return clash.bySlug && slug !== undefined
-    ? nameTaken(clash.bySlug.name, name, slug).message
+    ? nameTaken(clash.bySlug.name, name, slug, input.slug !== undefined).message
     : null;
 }
 
@@ -590,13 +601,13 @@ export async function createDocumentTemplate(
   const clash = await existingClash(ctx, base, slug, name);
   const holder = clash.byName ?? clash.bySlug;
   if (holder) {
-    const refusal = nameTaken(holder.name, name, slug);
+    const refusal = nameTaken(holder.name, name, slug, !derived);
     refuse(refusal, 409);
   }
   const row = await runScopedOn(base, ctx, (db) =>
     db.documentTemplate
       .create({ data: { ...data, slug }, select: SELECT })
-      .catch(writeConflict(slug, name)),
+      .catch(writeConflict(slug, name, !derived)),
   );
   return toDto(row);
 }
@@ -873,17 +884,14 @@ async function patched(
       select: { name: true },
     });
     if (taken) {
-      const refusal = nameTaken(
-        taken.name,
-        data.name,
-        patch.slug ?? current.slug,
-      );
-      throw new AppError(
-        refusal.message,
+      refuse(
+        nameTaken(
+          taken.name,
+          data.name,
+          patch.slug ?? current.slug,
+          patch.slug !== undefined,
+        ),
         409,
-        refusal.key,
-        refusal.params,
-        refusal.field,
       );
     }
   }
@@ -896,6 +904,7 @@ async function patched(
         writeConflict(
           patch.slug ?? current.slug,
           typeof data.name === "string" ? data.name : undefined,
+          patch.slug !== undefined,
         ),
       )
   );

--- a/src/modules/documents/templates.ts
+++ b/src/modules/documents/templates.ts
@@ -156,7 +156,7 @@ function nameTaken(
   // that would otherwise read as a false refusal, so its message names both templates.
   if (existingName === name) return nameAlreadyUsed(name);
   return {
-    // The SENTENCE stays the tool-name explanation in both cases, because the tool name is what is
+    // NOTE: the SENTENCE stays the tool-name explanation in both cases, because the tool name is what is
     // actually in the way and #208 chose that wording for an authoring client on purpose. Only the
     // input it is attached to depends on who chose the slug.
     message: `"${name}" collides with the template "${existingName}": both produce the tool name ${tool}`,
@@ -816,7 +816,7 @@ async function patched(
   if (patch.slug !== undefined) {
     const problem = slugProblem(patch.slug);
     if (problem) {
-      // A patch always writes the slug EXPLICITLY, so this is the producer's explicit branch. Calling
+      // NOTE: a patch always writes the slug EXPLICITLY, so this is the producer's explicit branch. Calling
       // it rather than restating it is what keeps POST and PATCH answering the same refusal.
       refuse(slugRefusal(problem, undefined, true, patch.slug), 400);
     }

--- a/src/modules/documents/templates.ts
+++ b/src/modules/documents/templates.ts
@@ -106,6 +106,21 @@ async function existingClash(
   return { byName: byName ?? undefined, bySlug: bySlug ?? undefined };
 }
 
+// The one way a Refusal becomes a thrown error. It exists because the field was the FOURTH thing a
+// throw site had to remember to carry, and the round that added it found a hand-written copy of
+// `slugRefusal`'s explicit branch on the patch path (same message, same key, no field), which had
+// made the wire contract depend on the HTTP method. One converter, and the producer is the only
+// place that decides.
+function refuse(refusal: Refusal, statusCode: number): never {
+  throw new AppError(
+    refusal.message,
+    statusCode,
+    refusal.key,
+    refusal.params,
+    refusal.field,
+  );
+}
+
 // `nameTaken`'s same-name branch, lifted out so it can be produced without a slug to interpolate.
 // The one clash reachable with no slug in play is this one: `existingClash` matches the name
 // exactly, so the row it finds is always holding precisely this name.
@@ -566,13 +581,7 @@ export async function createDocumentTemplate(
   const problem = slugProblem(slug);
   if (problem) {
     const refusal = slugRefusal(problem, name, !derived, slug);
-    throw new AppError(
-      refusal.message,
-      400,
-      refusal.key,
-      refusal.params,
-      refusal.field,
-    );
+    refuse(refusal, 400);
   }
   // Asked BEFORE the insert, so the refusal can name the template that is in the way. The unique
   // index is still the authority — it is what catches two creates racing — but all it can say is
@@ -582,13 +591,7 @@ export async function createDocumentTemplate(
   const holder = clash.byName ?? clash.bySlug;
   if (holder) {
     const refusal = nameTaken(holder.name, name, slug);
-    throw new AppError(
-      refusal.message,
-      409,
-      refusal.key,
-      refusal.params,
-      refusal.field,
-    );
+    refuse(refusal, 409);
   }
   const row = await runScopedOn(base, ctx, (db) =>
     db.documentTemplate
@@ -802,11 +805,9 @@ async function patched(
   if (patch.slug !== undefined) {
     const problem = slugProblem(patch.slug);
     if (problem) {
-      throw new AppError(
-        `slug: ${problem}.`,
-        400,
-        "errors.invalidDocumentSlug",
-      );
+      // A patch always writes the slug EXPLICITLY, so this is the producer's explicit branch. Calling
+      // it rather than restating it is what keeps POST and PATCH answering the same refusal.
+      refuse(slugRefusal(problem, undefined, true, patch.slug), 400);
     }
     data.slug = patch.slug;
   }

--- a/src/modules/documents/templates.ts
+++ b/src/modules/documents/templates.ts
@@ -66,6 +66,11 @@ interface Refusal {
   message: string;
   key: string;
   params: Record<string, string>;
+  // Which of the two inputs the operator has to go and change. This module already decided it before
+  // the wire could carry it: `conflictTarget` reads which index fired, and `slugRefusal` re-points a
+  // derived-slug problem at the NAME because that is the only field the caller ever saw. Required so
+  // a refusal added later has to answer the same question. See src/api/lib/refusal.ts.
+  field: "name" | "slug";
 }
 
 // The two unique constraints this table carries, asked as one question. Separate rows can hold them
@@ -109,6 +114,7 @@ function nameAlreadyUsed(name: string): Refusal {
     message: `you already have a document template called "${name}"`,
     key: "errors.documentTemplateNameTaken",
     params: { name },
+    field: "name",
   };
 }
 
@@ -123,6 +129,7 @@ function nameTaken(
       message: `the slug "${slug}" is already taken by the template "${existingName}"`,
       key: "errors.documentTemplateSlugTaken",
       params: {},
+      field: "slug",
     };
   }
   // Same name, or merely the same normalisation ("Orçamento" vs "Orcamento"). The second is the one
@@ -133,6 +140,7 @@ function nameTaken(
         message: `"${name}" collides with the template "${existingName}": both produce the tool name ${tool}`,
         key: "errors.documentTemplateNameCollides",
         params: { name, existing: existingName, tool },
+        field: "name",
       };
 }
 
@@ -160,12 +168,14 @@ function writeConflict(slug: string, name?: string): (e: unknown) => never {
           409,
           "errors.documentTemplateNameTaken",
           { name },
+          "name",
         );
       }
       if (name === undefined) {
         throw new ConflictError(
           `a document template with the slug "${slug}" already exists`,
           "errors.documentTemplateSlugTaken",
+          "slug",
         );
       }
       throw new AppError(
@@ -173,6 +183,7 @@ function writeConflict(slug: string, name?: string): (e: unknown) => never {
         409,
         "errors.documentTemplateNameCollidesUnknown",
         { tool: documentToolName(slug) },
+        "name",
       );
     }
     throw e;
@@ -194,6 +205,7 @@ function slugRefusal(
       message: `slug: ${problem}.`,
       key: "errors.invalidDocumentSlug",
       params: {},
+      field: "slug",
     };
   }
   // The only rule a DERIVED slug can still break: the derivation guarantees the shape and the
@@ -203,6 +215,7 @@ function slugRefusal(
     message: `"${name}" would produce the tool ${documentToolName(slug)}, which is already a built-in. Pick another name.`,
     key: "errors.documentNameIsBuiltinTool",
     params: { name, tool: documentToolName(slug) },
+    field: "name",
   };
 }
 
@@ -553,7 +566,13 @@ export async function createDocumentTemplate(
   const problem = slugProblem(slug);
   if (problem) {
     const refusal = slugRefusal(problem, name, !derived, slug);
-    throw new AppError(refusal.message, 400, refusal.key, refusal.params);
+    throw new AppError(
+      refusal.message,
+      400,
+      refusal.key,
+      refusal.params,
+      refusal.field,
+    );
   }
   // Asked BEFORE the insert, so the refusal can name the template that is in the way. The unique
   // index is still the authority — it is what catches two creates racing — but all it can say is
@@ -563,7 +582,13 @@ export async function createDocumentTemplate(
   const holder = clash.byName ?? clash.bySlug;
   if (holder) {
     const refusal = nameTaken(holder.name, name, slug);
-    throw new AppError(refusal.message, 409, refusal.key, refusal.params);
+    throw new AppError(
+      refusal.message,
+      409,
+      refusal.key,
+      refusal.params,
+      refusal.field,
+    );
   }
   const row = await runScopedOn(base, ctx, (db) =>
     db.documentTemplate
@@ -852,7 +877,13 @@ async function patched(
         data.name,
         patch.slug ?? current.slug,
       );
-      throw new AppError(refusal.message, 409, refusal.key, refusal.params);
+      throw new AppError(
+        refusal.message,
+        409,
+        refusal.key,
+        refusal.params,
+        refusal.field,
+      );
     }
   }
   return (

--- a/src/modules/tenant-settings/service.ts
+++ b/src/modules/tenant-settings/service.ts
@@ -312,7 +312,7 @@ export async function updateCompanySettings(
         400,
         "errors.invalidCompanyField",
         { reason: problem },
-        // The key of the patch, which is the name the console's company form uses for the input.
+        // NOTE: the key of the patch, which is the name the console's company form uses for the input.
         field,
       );
   }

--- a/src/modules/tenant-settings/service.ts
+++ b/src/modules/tenant-settings/service.ts
@@ -307,9 +307,14 @@ export async function updateCompanySettings(
     if (typeof value !== "string") continue;
     const problem = unprintableProblem(value, field);
     if (problem)
-      throw new AppError(problem, 400, "errors.invalidCompanyField", {
-        reason: problem,
-      });
+      throw new AppError(
+        problem,
+        400,
+        "errors.invalidCompanyField",
+        { reason: problem },
+        // The key of the patch, which is the name the console's company form uses for the input.
+        field,
+      );
   }
   return patchBlock(ctx, base, "company", (raw) =>
     companySettingsSchema.parse({ ...parseCompanySettings(raw), ...patch }),

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -376,6 +376,11 @@ function validateVaultValue(kind: string, value: unknown): void {
           `value.${key} must be a non-empty string`,
           400,
           "errors.invalidVaultValue",
+          undefined,
+          // The credential form renders one input per declared field and keys it by exactly this
+          // (`fieldValues[f.key]`, src/client/components/CredentialForm.tsx), so the key IS the
+          // console's name for the input that was refused.
+          key,
         );
       }
     }

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -377,7 +377,7 @@ function validateVaultValue(kind: string, value: unknown): void {
           400,
           "errors.invalidVaultValue",
           undefined,
-          // The credential form renders one input per declared field and keys it by exactly this
+          // NOTE: the credential form renders one input per declared field and keys it by exactly this
           // (`fieldValues[f.key]`, src/client/components/CredentialForm.tsx), so the key IS the
           // console's name for the input that was refused.
           key,

--- a/tests/api/lib/refusal-callsites.test.ts
+++ b/tests/api/lib/refusal-callsites.test.ts
@@ -1,0 +1,239 @@
+/**
+ * biome-ignore-all lint/suspicious/noTemplateCurlyInString: the strings below are SOURCE CODE fed to
+ * the rule under test, and the template hole is the shape the rule reads.
+ */
+import { describe, expect, test } from "bun:test";
+
+// THE GUARD AGAINST THE NEXT REFUSAL THAT KNOWS A FIELD AND DOES NOT SAY SO.
+//
+// The defect #231 fixed was never that the server did not know which value it refused: it knew, as a
+// typed argument, and then spent that argument on prose. `SettingsTextTooLongError` took `(field,
+// length, max)` and interpolated the field into a sentence; `bigOrThrow` wrote `${field} is
+// required`. Both are the same shape, and the shape is the thing that comes back: a refusal is
+// written next to the code that raises it, and the wire format is somewhere else entirely.
+//
+// So the rule is checked where it can fail: a refusal whose message or interpolation params mention
+// a `field` in scope must also hand that field to the wire. What this catches is the sentence that
+// spells out a name the body does not carry. What it CANNOT catch is a refusal that never names the
+// field in either place (`updateCompanySettings` builds its prose in a helper), so the sweep is a
+// floor, not a proof.
+
+const REFUSAL_ROOT = "AppError";
+
+// Every class that IS a refusal, resolved from the source rather than listed here: a subclass added
+// tomorrow is covered on the day it is written, which is the only day this check is worth anything.
+function refusalClasses(sources: Map<string, string>): Set<string> {
+  const parents = new Map<string, string>();
+  for (const src of sources.values()) {
+    for (const m of src.matchAll(/class\s+(\w+)\s+extends\s+(\w+)/g)) {
+      parents.set(m[1] as string, m[2] as string);
+    }
+  }
+  const names = new Set<string>([REFUSAL_ROOT]);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const [child, parent] of parents) {
+      if (names.has(parent) && !names.has(child)) {
+        names.add(child);
+        grew = true;
+      }
+    }
+  }
+  return names;
+}
+
+// The text between one call's parentheses, split at the commas that belong to IT, never the ones
+// inside a nested call, an object literal or a template hole.
+export function topLevelArgs(argText: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let current = "";
+  for (let i = 0; i < argText.length; i++) {
+    const c = argText[i] as string;
+    if (quote) {
+      if (c === "\\") {
+        current += c + (argText[i + 1] ?? "");
+        i++;
+        continue;
+      }
+      if (c === quote) quote = null;
+      current += c;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      current += c;
+      continue;
+    }
+    if (c === "(" || c === "[" || c === "{") depth++;
+    if (c === ")" || c === "]" || c === "}") depth--;
+    if (c === "," && depth === 0) {
+      args.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += c;
+  }
+  if (current.trim()) args.push(current.trim());
+  return args;
+}
+
+function callArgsAt(src: string, openParen: number): string | null {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = openParen; i < src.length; i++) {
+    const c = src[i] as string;
+    if (quote) {
+      if (c === "\\") {
+        i++;
+        continue;
+      }
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      continue;
+    }
+    if (c === "(") depth++;
+    if (c === ")") {
+      depth--;
+      if (depth === 0) return src.slice(openParen + 1, i);
+    }
+  }
+  return null;
+}
+
+// Only the CODE of an argument, never the prose: a sentence can contain the word "field" (a tool
+// error says "via a fixed field") without any field being in scope, and a template hole is code
+// even though it lives inside a string.
+export function codeOnly(text: string): string {
+  let out = "";
+  let quote: string | null = null;
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i] as string;
+    if (quote) {
+      if (c === "\\") {
+        i++;
+        continue;
+      }
+      if (quote === "`" && c === "$" && text[i + 1] === "{") {
+        depth = 1;
+        i++;
+        for (let j = i + 1; j < text.length && depth > 0; j++) {
+          const h = text[j] as string;
+          if (h === "{") depth++;
+          if (h === "}") depth--;
+          if (depth > 0) out += h;
+          i = j;
+        }
+        out += " ";
+        continue;
+      }
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+const NAMES_A_FIELD = /(?<![.\w])field(?![\w:])/;
+
+// A refusal that spells a field into its sentence must pass that field as the wire argument.
+export function fieldOffenders(src: string, classNames: Set<string>): string[] {
+  const declaresRefusal = [...classNames].some((n) =>
+    new RegExp(`extends\\s+${n}\\b`).test(src),
+  );
+  const callHeads = [...classNames].map((n) => `new ${n}(`);
+  if (declaresRefusal) callHeads.push("super(");
+  const out: string[] = [];
+  for (const head of callHeads) {
+    let at = src.indexOf(head);
+    while (at !== -1) {
+      const args = callArgsAt(src, at + head.length - 1);
+      at = src.indexOf(head, at + head.length);
+      if (args === null) continue;
+      const parts = topLevelArgs(args);
+      const names =
+        NAMES_A_FIELD.test(codeOnly(parts[0] ?? "")) ||
+        NAMES_A_FIELD.test(codeOnly(parts[3] ?? ""));
+      if (!names) continue;
+      if ((parts[4] ?? "") === "") {
+        out.push(`${head}…) names a field in its message but sends none`);
+      }
+    }
+  }
+  return out;
+}
+
+async function sources(): Promise<Map<string, string>> {
+  const { Glob } = await import("bun");
+  const files = new Map<string, string>();
+  for await (const file of new Glob("src/**/*.{ts,tsx}").scan(".")) {
+    files.set(file, await Bun.file(file).text());
+  }
+  return files;
+}
+
+describe("a refusal that knows a field says so on the wire", () => {
+  test("no call site spends a field name on prose alone", async () => {
+    const files = await sources();
+    const classNames = refusalClasses(files);
+    // The set resolves through the tree, not from a literal list.
+    expect(classNames.has("SettingsTextTooLongError")).toBe(true);
+    expect(classNames.has("NotFoundError")).toBe(true);
+    const offenders: string[] = [];
+    for (const [path, src] of files) {
+      for (const problem of fieldOffenders(src, classNames)) {
+        offenders.push(`${path}: ${problem}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // The predicate against a known positive and a known negative: a sweep that matches nothing
+  // reports a clean tree forever.
+  test("the rule recognises the shape it was written for, and leaves bystanders alone", () => {
+    const names = new Set(["AppError"]);
+    expect(
+      fieldOffenders(
+        "throw new AppError(`${field} is required`, 400, 'errors.x');",
+        names,
+      ),
+    ).toHaveLength(1);
+    expect(
+      fieldOffenders(
+        "throw new AppError(`${field} is required`, 400, 'errors.x', undefined, field);",
+        names,
+      ),
+    ).toHaveLength(0);
+    // Not a field name: a property read and an object KEY are both about something else.
+    expect(
+      fieldOffenders("throw new AppError(`${o.field} bad`, 400);", names),
+    ).toHaveLength(0);
+    expect(
+      fieldOffenders("throw new AppError('x', 400, 'k', { field: 1 });", names),
+    ).toHaveLength(0);
+    // The English word, inside a sentence, with nothing in scope by that name.
+    expect(
+      fieldOffenders(
+        "throw new AppError(`tool ${n}: needs {{secret}} (via a fixed field)`, 400);",
+        names,
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("the splitter keeps a call's own commas apart from everything nested", () => {
+    expect(
+      topLevelArgs('`a, b`, 400, "k", { field, len: 1, max: 2 }, field'),
+    ).toEqual(["`a, b`", "400", '"k"', "{ field, len: 1, max: 2 }", "field"]);
+  });
+});

--- a/tests/api/lib/refusal-callsites.test.ts
+++ b/tests/api/lib/refusal-callsites.test.ts
@@ -145,7 +145,22 @@ export function codeOnly(text: string): string {
   return out;
 }
 
-const NAMES_A_FIELD = /(?<![.\w])field(?![\w:])/;
+// The identifiers this codebase reaches for when the thing being interpolated is a value's NAME.
+// Measured across src/: `field`, `key`, `label` and `name` are the whole set. Keying on `field`
+// alone was a naming coincidence rather than the rule, and it missed `value.${key} must be a
+// non-empty string` in the vault, which is the same defect under another variable name.
+const INPUT_NAME_IDENTIFIERS = ["field", "key", "label", "name"];
+const NAMES_A_FIELD = new RegExp(
+  `(?<![.\\w])(${INPUT_NAME_IDENTIFIERS.join("|")})(?![\\w:])`,
+);
+
+// A refusal that interpolates one of those names without being ABOUT an input anyone can go and fix.
+// Listed with the reason rather than quietly excluded, and asserted in both directions: an entry
+// that stops matching is describing code that no longer exists.
+const NOT_ABOUT_AN_INPUT: Record<string, string> = {
+  "src/lib/db-id.ts":
+    'requireDbId\'s `label` is a human noun phrase ("template id"), and what it refuses is a URL path segment, not an input on a form.',
+};
 
 // A refusal that spells a field into its sentence must pass that field as the wire argument.
 export function fieldOffenders(src: string, classNames: Set<string>): string[] {
@@ -191,12 +206,17 @@ describe("a refusal that knows a field says so on the wire", () => {
     expect(classNames.has("SettingsTextTooLongError")).toBe(true);
     expect(classNames.has("NotFoundError")).toBe(true);
     const offenders: string[] = [];
+    const exemptWithNothingToExempt: string[] = [];
     for (const [path, src] of files) {
-      for (const problem of fieldOffenders(src, classNames)) {
-        offenders.push(`${path}: ${problem}`);
+      const problems = fieldOffenders(src, classNames);
+      if (path in NOT_ABOUT_AN_INPUT) {
+        if (problems.length === 0) exemptWithNothingToExempt.push(path);
+        continue;
       }
+      for (const problem of problems) offenders.push(`${path}: ${problem}`);
     }
     expect(offenders).toEqual([]);
+    expect(exemptWithNothingToExempt).toEqual([]);
   });
 
   // The predicate against a known positive and a known negative: a sweep that matches nothing
@@ -212,6 +232,19 @@ describe("a refusal that knows a field says so on the wire", () => {
     expect(
       fieldOffenders(
         "throw new AppError(`${field} is required`, 400, 'errors.x', undefined, field);",
+        names,
+      ),
+    ).toHaveLength(0);
+    // The vocabulary is live, not just `field`: this is the vault's shape, under another name.
+    expect(
+      fieldOffenders(
+        "throw new AppError(`value.${key} must be a non-empty string`, 400, 'errors.x');",
+        names,
+      ),
+    ).toHaveLength(1);
+    expect(
+      fieldOffenders(
+        "throw new AppError(`value.${key} must be a non-empty string`, 400, 'errors.x', undefined, key);",
         names,
       ),
     ).toHaveLength(0);

--- a/tests/api/lib/refusal.test.ts
+++ b/tests/api/lib/refusal.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { refusalBody } from "@/api/lib/refusal";
+import { AppError } from "@/lib/errors";
+import { SettingsTextTooLongError } from "@/modules/agents/service";
+
+// What a refusal ANSWERS, as a table: the message the operator reads, and the name of the value that
+// was refused. The two are decided by different things: the message by the request's locale, the
+// name by the server's own vocabulary. The table exists to keep them from being confused for
+// each other. Issue #231.
+
+interface Row {
+  name: string;
+  error: AppError;
+  acceptLanguage: string | null;
+  body: { error: string; field?: string };
+}
+
+const ROWS: Row[] = [
+  {
+    name: "the field rides ALONGSIDE the localized sentence, not inside it",
+    error: new SettingsTextTooLongError(
+      "guardrails.output.templateMessage",
+      5000,
+      2000,
+    ),
+    acceptLanguage: "en",
+    body: {
+      error:
+        "The text in guardrails.output.templateMessage is too long: 5000 characters (limit 2000).",
+      field: "guardrails.output.templateMessage",
+    },
+  },
+  {
+    name: "another locale changes the sentence and NOT the field: it is a key, never copy",
+    error: new SettingsTextTooLongError(
+      "guardrails.output.templateMessage",
+      5000,
+      2000,
+    ),
+    acceptLanguage: "pt-BR",
+    body: {
+      error:
+        "O texto em guardrails.output.templateMessage é longo demais: 5000 caracteres (limite 2000).",
+      field: "guardrails.output.templateMessage",
+    },
+  },
+  {
+    name: "no translation key: the raw message is the sentence, and the field still rides",
+    error: new AppError(
+      "agentId is required",
+      400,
+      undefined,
+      undefined,
+      "agentId",
+    ),
+    acceptLanguage: "pt-BR",
+    body: { error: "agentId is required", field: "agentId" },
+  },
+  {
+    name: "a refusal that names no field answers EXACTLY the body it answers today",
+    error: new AppError("Forbidden", 403),
+    acceptLanguage: "en",
+    body: { error: "Forbidden" },
+  },
+  {
+    name: "a blank name is not a name: omitted rather than sent empty",
+    error: new AppError("nope", 400, undefined, undefined, "   "),
+    acceptLanguage: "en",
+    body: { error: "nope" },
+  },
+  {
+    name: "no Accept-Language falls back to en, the same as every other translated answer",
+    error: new SettingsTextTooLongError("vision.extractionPrompt", 9, 8),
+    acceptLanguage: null,
+    body: {
+      error:
+        "The text in vision.extractionPrompt is too long: 9 characters (limit 8).",
+      field: "vision.extractionPrompt",
+    },
+  },
+];
+
+describe("refusalBody", () => {
+  for (const row of ROWS) {
+    test(row.name, () => {
+      expect(refusalBody(row.error, row.acceptLanguage)).toEqual(row.body);
+    });
+  }
+
+  test("the key is ABSENT, not null, when nothing was named", () => {
+    // A `field: null` would be a wire change for every refusal in the app, and every client that
+    // reads the body would have to learn a second spelling of "nothing here".
+    expect("field" in refusalBody(new AppError("Forbidden", 403), "en")).toBe(
+      false,
+    );
+  });
+});

--- a/tests/api/lib/refusal.test.ts
+++ b/tests/api/lib/refusal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { refusalBody } from "@/api/lib/refusal";
-import { AppError } from "@/lib/errors";
+import { AppError, ConflictError } from "@/lib/errors";
 import { SettingsTextTooLongError } from "@/modules/agents/service";
 
 // What a refusal ANSWERS, as a table: the message the operator reads, and the name of the value that
@@ -61,6 +61,19 @@ const ROWS: Row[] = [
     error: new AppError("Forbidden", 403),
     acceptLanguage: "en",
     body: { error: "Forbidden" },
+  },
+  {
+    name: "a 409 names its input too: the status is not what decides this",
+    error: new ConflictError(
+      'a document template with the slug "orcamento" already exists',
+      "errors.documentTemplateSlugTaken",
+      "slug",
+    ),
+    acceptLanguage: "en",
+    body: {
+      error: "A document template with this identifier already exists",
+      field: "slug",
+    },
   },
   {
     name: "a blank name is not a name: omitted rather than sent empty",

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { errors } from "@/api/lib/openapi";
+import { AppError } from "@/lib/errors";
+import { SettingsTextTooLongError } from "@/modules/agents/service";
+import { setupPrismaMock } from "@/tests/utils/prisma-mock";
+
+// The refusal as the CLIENT receives it, through the app the process actually serves.
+//
+// It goes through the REAL app rather than a rebuilt one because the branch under test is the
+// `onError` registered in src/app.ts, and an app built here would pin this file's own ordering
+// instead of the app's. The declared-response route is the second half: Elysia's `normalize` strips
+// what a schema does not declare, and an error body is only exempt because the handler answers with
+// a raw `Response`. That exemption is asserted, not assumed. Issue #231.
+setupPrismaMock();
+const app = (await import("@/app")).default;
+
+app.get("/__refusal/named", () => {
+  throw new SettingsTextTooLongError(
+    "guardrails.output.templateMessage",
+    5000,
+    2000,
+  );
+});
+app.get(
+  "/__refusal/declared",
+  () => {
+    throw new SettingsTextTooLongError("kanban.instructions", 5000, 2000);
+  },
+  { response: errors(400) },
+);
+app.get("/__refusal/unnamed", () => {
+  throw new AppError("Forbidden", 403);
+});
+
+const refusal = async (
+  path: string,
+  lang: string,
+): Promise<{ status: number; body: Record<string, unknown> }> => {
+  const res = await app.handle(
+    new Request(`http://localhost${path}`, {
+      headers: { "accept-language": lang },
+    }),
+  );
+  return {
+    status: res.status,
+    body: (await res.json()) as Record<string, unknown>,
+  };
+};
+
+describe("a refusal over the wire", () => {
+  test("carries the field the server refused, next to the sentence it localized", async () => {
+    const { status, body } = await refusal("/__refusal/named", "en");
+    expect(status).toBe(400);
+    expect(body.field).toBe("guardrails.output.templateMessage");
+    expect(body.error).toBe(
+      "The text in guardrails.output.templateMessage is too long: 5000 characters (limit 2000).",
+    );
+  });
+
+  test("the sentence follows Accept-Language and the field does not", async () => {
+    const en = await refusal("/__refusal/named", "en");
+    const pt = await refusal("/__refusal/named", "pt-BR");
+    expect(pt.body.error).not.toBe(en.body.error);
+    expect(pt.body.error).toContain("longo demais");
+    // Named, not merely equal: two absent fields are also equal, and that is the state this test
+    // exists to fail on.
+    expect(en.body.field).toBe("guardrails.output.templateMessage");
+    expect(pt.body.field).toBe("guardrails.output.templateMessage");
+  });
+
+  test("survives a route that DECLARES its error responses (normalize does not strip it)", async () => {
+    const { status, body } = await refusal("/__refusal/declared", "en");
+    expect(status).toBe(400);
+    expect(body.field).toBe("kanban.instructions");
+  });
+
+  test("a refusal that names no field answers the same body it answers today", async () => {
+    const { status, body } = await refusal("/__refusal/unnamed", "en");
+    expect(status).toBe(403);
+    expect(body).toEqual({ error: "Forbidden" });
+  });
+});

--- a/tests/modules/documents.test.ts
+++ b/tests/modules/documents.test.ts
@@ -1058,6 +1058,53 @@ describe.skipIf(!dbUp)("document templates + issuance", () => {
     expect(pdfHeader(bytes)).toBe("%PDF-");
   });
 
+  // Which INPUT a refusal is about cannot depend on the HTTP method that carried the write. The
+  // patch path had a hand-written copy of the create path's refusal (same sentence, same key) that
+  // named no field, so the console would have had somewhere to put the message on create and nowhere
+  // on rename. Issue #231.
+  test("a bad slug names the same input whether it was created or renamed", async () => {
+    const starter = documentStarter("receipt", "pt-BR");
+    if (!starter) throw new Error("no starter");
+    const bad = "2026_orcamento";
+    const created = await createDocumentTemplate(
+      ctx(tenantA),
+      {
+        name: "Recibo com slug ruim",
+        slug: "recibo_slug_ruim",
+        blocks: starter.blocks,
+        fields: starter.fields,
+        style: starter.style,
+      },
+      appDb,
+    );
+    const onCreate = await createDocumentTemplate(
+      ctx(tenantA),
+      {
+        name: "Outro",
+        slug: bad,
+        blocks: starter.blocks,
+        fields: starter.fields,
+        style: starter.style,
+      },
+      appDb,
+    ).then(
+      () => null,
+      (e: unknown) => e as AppError,
+    );
+    const onRename = await updateDocumentTemplate(
+      ctx(tenantA),
+      BigInt(created.id),
+      { slug: bad },
+      appDb,
+    ).then(
+      () => null,
+      (e: unknown) => e as AppError,
+    );
+    expect(onCreate?.field).toBe("slug");
+    expect(onRename?.field).toBe("slug");
+    expect(onRename?.translationKey).toBe(onCreate?.translationKey);
+  });
+
   // Creation already answers a taken slug with a conflict; an update raising the same constraint has
   // to answer the same way, or the console shows an internal error for a name the operator can fix.
   test("answers a slug already taken on update with a conflict", async () => {

--- a/tests/modules/documents.test.ts
+++ b/tests/modules/documents.test.ts
@@ -739,6 +739,22 @@ describe.skipIf(!dbUp)("document templates + issuance", () => {
     ).rejects.toThrow();
   });
 
+  // The company profile is a form of several inputs, and the refusal knows which one it read: the
+  // loop that finds the unprintable character is iterating the patch by key. Without the key on the
+  // wire the operator is told a character cannot be printed and left to find where they typed it.
+  test("an unprintable company field names the input it was read from", async () => {
+    const refused = await updateCompanySettings(
+      ctx(tenantA),
+      { document: "12.345.678/0001-90 \u2603" },
+      appDb,
+    ).then(
+      () => null,
+      (e: unknown) => e as AppError,
+    );
+    expect(refused?.field).toBe("document");
+    expect(refused?.statusCode).toBe(400);
+  });
+
   // The letterhead is read at issue time and frozen into the snapshot, so a profile edited later
   // does not rewrite documents already sent.
   test("freezes the company profile into the issued document", async () => {

--- a/tests/modules/documents.test.ts
+++ b/tests/modules/documents.test.ts
@@ -1058,6 +1058,51 @@ describe.skipIf(!dbUp)("document templates + issuance", () => {
     expect(pdfHeader(bytes)).toBe("%PDF-");
   });
 
+  // WHO CHOSE THE SLUG decides which input the refusal is about, and getting it wrong sends the
+  // operator to change something that cannot clear the clash: a slug they typed themselves stays
+  // exactly where it is no matter what they rename the template to. Issue #231.
+  test("a taken slug names the slug when it was typed, and the name when it was derived", async () => {
+    const starter = documentStarter("receipt", "pt-BR");
+    if (!starter) throw new Error("no starter");
+    const body = {
+      blocks: starter.blocks,
+      fields: starter.fields,
+      style: starter.style,
+    };
+    await createDocumentTemplate(
+      ctx(tenantA),
+      { name: "Contrato de servico", slug: "contrato_de_servico", ...body },
+      appDb,
+    );
+    const typed = await createDocumentTemplate(
+      ctx(tenantA),
+      {
+        name: "Nome completamente outro",
+        slug: "contrato_de_servico",
+        ...body,
+      },
+      appDb,
+    ).then(
+      () => null,
+      (e: unknown) => e as AppError,
+    );
+    // No slug in the write at all: the name is the only thing this caller ever chose, and it is what
+    // the derivation turned into the clashing slug.
+    const derived = await createDocumentTemplate(
+      ctx(tenantA),
+      { name: "Contrato de serviço", ...body },
+      appDb,
+    ).then(
+      () => null,
+      (e: unknown) => e as AppError,
+    );
+    expect(typed?.field).toBe("slug");
+    expect(derived?.field).toBe("name");
+    // The sentence is the same one in both, and it is the one that was already there.
+    expect(typed?.translationKey).toBe("errors.documentTemplateNameCollides");
+    expect(derived?.translationKey).toBe("errors.documentTemplateNameCollides");
+  });
+
   // Which INPUT a refusal is about cannot depend on the HTTP method that carried the write. The
   // patch path had a hand-written copy of the create path's refusal (same sentence, same key) that
   // named no field, so the console would have had somewhere to put the message on create and nowhere

--- a/tests/modules/vault/google-oauth.test.ts
+++ b/tests/modules/vault/google-oauth.test.ts
@@ -3,6 +3,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { decryptJson, encryptJson } from "@/api/lib/crypto";
 import { buildHttpTool, type HttpToolDef } from "@/graph/tools/http";
+import type { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
 import {
   buildAuthorizeUrl,
@@ -331,20 +332,25 @@ describe.skipIf(!dbUp)("google-oauth: DB-backed", () => {
   });
 
   test("createVaultEntry validates google_oauth fields (clientId + clientSecret)", async () => {
-    // Missing clientSecret → rejected.
-    await expect(
-      createVaultEntry(
-        ctx(),
-        {
-          name: "g-bad",
-          value: { clientId: "c" } as Record<string, string>,
-          kind: "google_oauth",
-        },
-        undefined,
-        undefined,
-        appDb,
-      ),
-    ).rejects.toThrow();
+    // Missing clientSecret → rejected, NAMING the field: the credential form renders one input per
+    // declared field and keys it by exactly this string, so a refusal that only says it in prose
+    // leaves the console with nowhere to put the message (issue #231).
+    const refused = await createVaultEntry(
+      ctx(),
+      {
+        name: "g-bad",
+        value: { clientId: "c" } as Record<string, string>,
+        kind: "google_oauth",
+      },
+      undefined,
+      undefined,
+      appDb,
+    ).then(
+      () => null,
+      (e: unknown) => e as AppError,
+    );
+    expect(refused).not.toBeNull();
+    expect(refused?.field).toBe("clientSecret");
 
     // Both fields present → accepted.
     const { id } = await createVaultEntry(


### PR DESCRIPTION
When the API refuses a write it answers `{ error }` and nothing else. The value the refusal is *about*
exists on the server as a typed argument, gets flattened into a localized sentence, and the wire has
nowhere to carry it. Measured on `main`, through the real app, with the same refusal in two locales:

```
GET /__probe/settings-cap  en     400  {"error":"The text in guardrails.output.templateMessage is too long: 5000 characters (limit 2000)."}
GET /__probe/settings-cap  pt-BR  400  {"error":"O texto em guardrails.output.templateMessage é longo demais: 5000 caracteres (limite 2000)."}
GET /__probe/required      en     400  {"error":"agentId is required"}
```

The path is in there twice, in two different sentences, and named by neither. A console that wanted to
put that message next to the input it is about would have to parse the sentence back apart, once per
locale, and re-do it whenever the copy changes.

Now the refusal names it:

```
400  {"error":"The text in guardrails.output.templateMessage is too long: 5000 characters (limit 2000).","field":"guardrails.output.templateMessage"}
400  {"error":"O texto em guardrails.output.templateMessage é longo demais: 5000 caracteres (limite 2000).","field":"guardrails.output.templateMessage"}
```

The sentence still follows `Accept-Language`. The field does not: it is a key, and it reads the same
in every language.

## The two questions the issue left open

**Whose name is it?** The server's. The same service function is reached by REST and by MCP, which
spell the same write differently, so a name taken from the request shape would be a different string
depending on who called. The console, meanwhile, already routes on exactly these strings:
`TEXT_CAP_TARGETS` (`src/client/lib/configHealth.ts`) maps `guardrails.output.templateMessage`,
`toolGuidance.assign_label`, `followUp.steps[…]` to a tab and a section, for the text-cap warning it
computes itself. A refusal that speaks the same vocabulary reuses that map instead of needing a
second one.

**One field or several?** One, because one is what the app produces: `assertSettingsTextSizes` refuses
on the FIRST oversized change (`const [first] = collectOversizedTextChanges(…)`), and every other site
that knows a field knows exactly one. A list would be a shape nothing fills.

## What is on the wire

`{ error, field? }`, with `field` **absent** — not null — whenever the refusal is not about one input.
Most refusals are not (a 403, a 404, a conflict), and they keep answering byte-identical bodies; a
`field: null` would have been a wire change for all of them and a second spelling of "nothing here"
for every client that reads one.

Populated where the operator can go and fix exactly one input and the server already knows which: the
settings text caps (the dotted path), the system-prompt cap (`systemPrompt`), the two tool-grant id
checks, the company-profile character check (the key of the patch), the vault's per-field check
(`key`, which is exactly how `CredentialForm` keys its inputs), and every document-template name/slug
conflict. That last module already DECIDED which of the two inputs a refusal is about, and had
nowhere to put the answer: `conflictTarget` reads which unique index fired, and `slugRefusal`
re-points a derived-slug problem at the NAME because the slug is not something the caller ever saw.
Its own `Refusal` type now carries `field: "name" | "slug"`, required, so a refusal added later has to
answer the same question.

`requireDbId` is the one that interpolates a name and does NOT qualify: its `label` is a noun phrase
("template id") and what it refuses is a URL segment, not an input on a form. That exclusion is
listed with its reason in the sweep and asserted in both directions.

Nothing consumes the key yet: the form mechanism is the next sub-issue of #224.

## The guard

`tests/api/lib/refusal-callsites.test.ts` reads the source and fails on a refusal that spells a name
into its sentence without sending it. It matches the identifiers this codebase actually uses for that
(`field`, `key`, `label`, `name`, measured across `src/` as the whole set): keying on `field` alone
was a naming coincidence, and it is what missed the vault. The class set is resolved from `extends AppError` through the
tree rather than listed, so a subclass written tomorrow is covered the day it is written. It is a
floor, not a proof: it cannot see a refusal that names the field in neither the message nor the
params (`updateCompanySettings` builds its prose in a helper), which is why that site was found by
reading and not by the sweep.

## What review changed

Round 2 found the population rule was keyed on the identifier `field`, which is a naming coincidence
rather than a rule: the vault refuses `value.${key}` under another variable name. The sweep now
matches the identifiers this codebase actually uses, and the vault and document-template refusals are
named.

Round 3 found the same refusal answered differently depending on the HTTP method: the patch path held
a hand-written copy of the create path's refusal (same sentence, same key, no field). The fix is
structural rather than a fifth argument — the module has one converter (`refuse`) and the patch path
calls the producer instead of restating it, so the divergence is no longer expressible.

Round 4 found the field could point at an input that cannot clear the refusal: a slug the caller
TYPED is not freed by renaming the template, and the create path was answering `name` for it. Who
chose the slug now decides, in the pre-check, the dry run and the P2002 fallback alike. The sentence
is byte-identical to `main` in every branch — an existing test pins the tool-name wording, chosen
deliberately in #208 for an authoring client, and the first attempt at this fix changed it. Only the
input it attaches to moved.

Two sweeps were measured for the round-3 class and neither is honest, which is why there is none: matching
on the same message LITERAL would not have caught it (the create site passes `refusal.message`, a
variable), and matching on the same translation KEY would fire on `errors.invalidToolGrant`, which
twelve different grant problems share. What holds it instead is the type: `Refusal.field` is
required, and a DB-backed test asserts that creating and renaming with the same bad slug name the
same input.

## Validation scope

Proven by test:

- the body over the wire, through the app `src/app.ts` builds, in both locales, and on a route that
  DECLARES its error responses — Elysia's `normalize` strips what a schema does not declare, and the
  error body is only exempt because the handler answers with a raw `Response`; that exemption is
  asserted rather than assumed;
- the decision table for `refusalBody` (translated / raw / named / unnamed / blank / no header);
- the call-site sweep, and the sweep's own predicate against a known positive and a known negative;
- create and rename answering with the same field for the same bad slug, DB-backed, at the service
  boundary;
- a taken slug naming `slug` when it was typed and `name` when it was derived from the name, with the
  same translation key in both, DB-backed;
- the NAME that arrives, not only that an argument was passed: the vault refusal answers
  `clientSecret` and the company-profile one answers `document`, both DB-backed. The sweep alone
  could not have caught a call site handing over the wrong name, and a mutation sending `"value"`
  instead of the key survives it;
- eleven mutations, all killed: always-include the field, drop the `trim`, drop the field at one call
  site, derive it from `translationParams` instead of from the error, drop the vault's field, drop a
  document-template field, make the `requireDbId` exclusion stale, restore the patch path's
  hand-copied refusal, collapse the typed/derived slug distinction, drop the company-profile field,
  and hand the vault refusal the wrong name.

Not validated:

- **no client reads it yet.** That is #232 by design, and until it lands the operator sees exactly
  what they see today;
- MCP surfaces an `AppError` as tool-error text, on a path this change does not touch;
- nothing Chatwoot-facing is involved, so there is no live leg to run.

Measured and deliberately NOT fixed here (each one is its own issue):

- **A schema refusal answers a different body entirely.** Elysia's `VALIDATION` code falls through to
  the default branch, so a bad body comes back 422 as `{type,on,property,message,expected,found,errors}`
  with **no `error` key at all** — `apiErrorMessage` returns `null` for every one of them, which is
  the generic-sentence path #224 is about. It also echoes the whole submitted payload back under
  `found`, and the published spec says 4xx is `{ error }`. Same question as this issue, different
  producer, and its own vocabulary problem (`property` is a JSON pointer into the request body, not a
  domain path) — mixing the two into one key would have made `field` mean two things.
- **`errors.invalidToolGrant` names a locale entry that does not exist** in either `src/api/locales`
  file, so both tool-grant refusals fall back to their untranslated English message. Measured above:
  `pt-BR` returns `agentId is required`.

## Declined in review

**"Thread the field through the MCP write result too."** The MCP error channel is
`{ ok: false, error: string }` (`src/modules/mcp/write.ts`), rendered by `writeContent` as
`{ content: [{ type: "text", text }], isError: true }`. There is no structured error channel to put a
key in, and the consumer of that text is a model, which has no input to attach a refusal to. What it
does have is the sentence, and every refusal this PR names already spells the value out in it.
Measured, printing exactly the `e.message` that `err(e.message)` sends:

```
field=guardrails.output.templateMessage  |  text: settings text is too long: guardrails.output.templateMessage has 5000 characters (limit 2000)
field=toolDefinitionId                   |  text: toolDefinitionId is required
field=document                           |  text: document contains characters this document cannot print (…)
field=systemPrompt                       |  text: system prompt is too long: 120000 characters (limit 100000)
```

Adding the key would mean widening `WriteResult` and every `err(…)` call site to serve no reader. The
two surfaces already differ on purpose in the same place: an MCP refusal is not localized either, it
carries the raw English `e.message`, because it is written for a model rather than for whoever is
looking at a form.

`openapi.json` moves by ~2000 lines because `errorSchema` inlines the body at every declared error
status rather than `$ref`-ing a component. Generated, mechanical, and unchanged in shape.

Fixes #231
