### PR TITLE
Refuse a knowledge text the column cannot hold, by name

### DIFF
--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -91,7 +91,7 @@
     "unknownFlowStage": "Unknown flow stage",
     "unknownProvider": "Unknown model provider.",
     "unknownWebhookEvent": "Unknown webhook event",
-    "unstorableText": "This text cannot be stored: {{reason}}",
+    "unstorableText": "{{field}} contains characters that cannot be stored ({{codePoints}})",
     "unsupportedAudioType": "Unsupported audio type",
     "unsupportedFileType": "Unsupported file type",
     "unsupportedImageType": "Unsupported image type",

--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -91,6 +91,7 @@
     "unknownFlowStage": "Unknown flow stage",
     "unknownProvider": "Unknown model provider.",
     "unknownWebhookEvent": "Unknown webhook event",
+    "unstorableText": "This text cannot be stored: {{reason}}",
     "unsupportedAudioType": "Unsupported audio type",
     "unsupportedFileType": "Unsupported file type",
     "unsupportedImageType": "Unsupported image type",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -91,7 +91,7 @@
     "unknownFlowStage": "Etapa de fluxo desconhecida",
     "unknownProvider": "Provedor de modelo desconhecido.",
     "unknownWebhookEvent": "Evento de webhook desconhecido",
-    "unstorableText": "Este texto não pode ser armazenado: {{reason}}",
+    "unstorableText": "{{field}} contém caracteres que não podem ser armazenados ({{codePoints}})",
     "unsupportedAudioType": "Tipo de áudio não suportado",
     "unsupportedFileType": "Tipo de arquivo não suportado",
     "unsupportedImageType": "Tipo de imagem não suportado",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -91,6 +91,7 @@
     "unknownFlowStage": "Etapa de fluxo desconhecida",
     "unknownProvider": "Provedor de modelo desconhecido.",
     "unknownWebhookEvent": "Evento de webhook desconhecido",
+    "unstorableText": "Este texto não pode ser armazenado: {{reason}}",
     "unsupportedAudioType": "Tipo de áudio não suportado",
     "unsupportedFileType": "Tipo de arquivo não suportado",
     "unsupportedImageType": "Tipo de imagem não suportado",

--- a/src/api/v1/knowledge.controller.ts
+++ b/src/api/v1/knowledge.controller.ts
@@ -41,7 +41,7 @@ import {
 // translate('errors.noExtractableText', 'No extractable text found in this file')
 // translate('errors.unsupportedFileType', 'Unsupported file type')
 // translate('errors.documentTooLarge', 'Document is too large to process')
-// translate('errors.unstorableText', 'This text cannot be stored: {{reason}}')
+// translate('errors.unstorableText', '{{field}} contains characters that cannot be stored ({{codePoints}})')
 
 function tenantId(ctx: TenantContext | null): bigint {
   if (!ctx) throw new ForbiddenError();

--- a/src/api/v1/knowledge.controller.ts
+++ b/src/api/v1/knowledge.controller.ts
@@ -41,6 +41,7 @@ import {
 // translate('errors.noExtractableText', 'No extractable text found in this file')
 // translate('errors.unsupportedFileType', 'Unsupported file type')
 // translate('errors.documentTooLarge', 'Document is too large to process')
+// translate('errors.unstorableText', 'This text cannot be stored: {{reason}}')
 
 function tenantId(ctx: TenantContext | null): bigint {
   if (!ctx) throw new ForbiddenError();

--- a/src/client/pages/resources/useKnowledgeManager.tsx
+++ b/src/client/pages/resources/useKnowledgeManager.tsx
@@ -34,6 +34,7 @@ import {
 import { Tooltip } from "@/client/components/Tooltip";
 import { useTenantEvents } from "@/client/hooks/useTenantEvents";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { mergeDocumentEvent } from "@/client/lib/knowledgeDocs";
 import { cn } from "@/client/lib/utils";
 
@@ -75,6 +76,7 @@ interface PickedFile {
   status: UploadStatus;
   // HTTP status of the failed upload (set when status === "error"); 0 for a thrown/network error.
   errorStatus?: number;
+  errorMessage?: string;
 }
 
 // Run `worker` over `items` with at most `limit` in flight (bounded concurrency for batch uploads,
@@ -503,15 +505,27 @@ export function useKnowledgeManager(opts: {
       addContentModal.close();
       if (docsModal.payload) await reloadDocs(docsModal.payload.id);
       void onChanged();
-    } catch {
-      showToast(t("knowledge.addError", "Could not add document."), "error");
+    } catch (e) {
+      // The server's own message when it sent one: a refusal that names the field and the character
+      // is the whole answer, and collapsing it into "Could not add document" throws away the only
+      // part the operator can act on (issue #247).
+      showToast(
+        apiErrorMessage(e) ??
+          t("knowledge.addError", "Could not add document."),
+        "error",
+      );
     } finally {
       setBusy(false);
     }
   }
 
-  // Localized failure reason for a per-file upload error (static keys: extractor-friendly).
-  function uploadErrorMessage(status: number | undefined): string {
+  // Localized failure reason for a per-file upload error (static keys: extractor-friendly). The
+  // server's own message wins when it sent one: the statuses below are the ones we can phrase better
+  // than the API can, and everything else the API already phrased for this operator's language.
+  function uploadErrorMessage(
+    status: number | undefined,
+    message: string | undefined,
+  ): string {
     if (status === 422) {
       return t(
         "knowledge.fileNotExtractable",
@@ -524,7 +538,7 @@ export function useKnowledgeManager(opts: {
     if (status === 413) {
       return t("knowledge.fileTooLarge", "The file exceeds the size limit.");
     }
-    return t("knowledge.addError", "Could not add document.");
+    return message ?? t("knowledge.addError", "Could not add document.");
   }
 
   // Upload one staged file, returning the failing HTTP status (undefined on success, 0 on a thrown
@@ -534,7 +548,7 @@ export function useKnowledgeManager(opts: {
     baseId: string,
     pf: PickedFile,
     useTitle: boolean,
-  ): Promise<number | undefined> {
+  ): Promise<{ status: number; message?: string } | undefined> {
     try {
       // NOTE: the treaty serializes a File body as multipart AND injects the
       // X-Tenant-Id header (SUPER_ADMIN target tenant); a raw fetch here 500s
@@ -545,9 +559,11 @@ export function useKnowledgeManager(opts: {
           file: pf.file,
           ...(useTitle && docTitle.trim() ? { title: docTitle.trim() } : {}),
         });
-      return err ? err.status : undefined;
+      return err
+        ? { status: err.status, message: apiErrorMessage(err) ?? undefined }
+        : undefined;
     } catch {
-      return 0;
+      return { status: 0 };
     }
   }
 
@@ -567,17 +583,21 @@ export function useKnowledgeManager(opts: {
           : { ...p, status: "uploading", errorKey: undefined },
       ),
     );
-    const results = new Map<string, number | undefined>();
+    const results = new Map<
+      string,
+      { status: number; message?: string } | undefined
+    >();
     await runPool(toUpload, 3, async (pf) => {
-      const errorStatus = await uploadOne(payload.id, pf, useTitle);
-      results.set(pf.id, errorStatus);
+      const failure = await uploadOne(payload.id, pf, useTitle);
+      results.set(pf.id, failure);
       setPicked((prev) =>
         prev.map((p) =>
           p.id === pf.id
             ? {
                 ...p,
-                status: errorStatus === undefined ? "done" : "error",
-                errorStatus,
+                status: failure === undefined ? "done" : "error",
+                errorStatus: failure?.status,
+                errorMessage: failure?.message,
               }
             : p,
         ),
@@ -1252,7 +1272,10 @@ export function useKnowledgeManager(opts: {
                       )}
                       {p.status === "error" && (
                         <Tooltip
-                          content={uploadErrorMessage(p.errorStatus)}
+                          content={uploadErrorMessage(
+                            p.errorStatus,
+                            p.errorMessage,
+                          )}
                           side="top"
                         >
                           <span className="shrink-0 cursor-help rounded-full bg-error/10 px-2 py-0.5 text-error text-xs">

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -154,3 +154,21 @@ export function unstorableProblem(value: string, what: string): string | null {
   );
   return `${what} contains characters the database cannot store (${named.join(" ")}) — a NUL or half of a character, which PostgreSQL refuses in text and JSON columns alike.`;
 }
+
+// The same question asked of a whole WRITE rather than one value: a row is refused as a unit, so
+// checking one field and not its neighbours only moves which value produces the 500. Returns the
+// first offender's message, or null. Undefined and null are skipped, so an optional column can be
+// listed unconditionally and a field added to the shape later joins by being listed here.
+//
+// Pure on purpose. The caller throws, because what STATUS a refusal carries is the caller's
+// question: the same unstorable value is a 400 at a REST boundary and a tool failure to a model.
+export function firstUnstorableProblem(
+  fields: readonly (readonly [string, string | null | undefined])[],
+): string | null {
+  for (const [what, value] of fields) {
+    if (typeof value !== "string") continue;
+    const problem = unstorableProblem(value, what);
+    if (problem) return problem;
+  }
+  return null;
+}

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -132,11 +132,16 @@ export function makeStorableDeep<T>(value: T, depth = 0): T {
 // SEPARATE from the documents module's `unprintableProblem`, and deliberately narrower: a string can
 // be perfectly storable and impossible to print (an emoji in a tool description a model reads and
 // nobody draws). A caller that only needs the value to survive its column asks this one.
-export function unstorableProblem(value: string, what: string): string | null {
+// The offenders themselves, named by code point, or null when the value is storable. Separate from
+// the message because a REFUSAL that crosses a localized boundary needs the values, not a sentence:
+// interpolating an English sentence into a translated template answers a pt-BR caller in two
+// languages at once. The field name stays English on purpose, in both forms: it names the request
+// field the caller has to change, the way a schema path does.
+export function unstorableCodePoints(value: string): string[] | null {
   // A Set, not a scan of a growing array: the distinct offenders number 2049 (a NUL and every
   // surrogate code unit), so `includes` on the accumulator turns a long malformed value into
-  // quadratic work on a caller's behalf. Insertion order is preserved either way, and the message
-  // names them in the order they appear.
+  // quadratic work on a caller's behalf. Insertion order is preserved either way, so they are named
+  // in the order they appear.
   const bad = new Set<string>();
   for (const ch of value) {
     const code = ch.codePointAt(0) ?? 0;
@@ -148,27 +153,49 @@ export function unstorableProblem(value: string, what: string): string | null {
   if (bad.size === 0) return null;
   // Named by code point, never pasted: quoting the character itself would put a NUL into a log line
   // and an API response, and half a character into a JSON body.
-  const named = [...bad].map(
+  return [...bad].map(
     (ch) =>
       `U+${(ch.codePointAt(0) ?? 0).toString(16).toUpperCase().padStart(4, "0")}`,
   );
+}
+
+export function unstorableProblem(value: string, what: string): string | null {
+  const named = unstorableCodePoints(value);
+  if (named === null) return null;
   return `${what} contains characters the database cannot store (${named.join(" ")}) — a NUL or half of a character, which PostgreSQL refuses in text and JSON columns alike.`;
+}
+
+export interface UnstorableField {
+  // The request field the caller has to change. English, like a schema path.
+  what: string;
+  // The offenders, e.g. ["U+0000"].
+  codePoints: string[];
+  // The same thing as one English sentence, for a caller with nowhere to put the parts: a log line,
+  // an MCP error, the untranslated fallback of a localized refusal.
+  message: string;
 }
 
 // The same question asked of a whole WRITE rather than one value: a row is refused as a unit, so
 // checking one field and not its neighbours only moves which value produces the 500. Returns the
-// first offender's message, or null. Undefined and null are skipped, so an optional column can be
-// listed unconditionally and a field added to the shape later joins by being listed here.
+// first offender, or null. Undefined and null are skipped, so an optional column can be listed
+// unconditionally and a field added to the shape later joins by being listed here.
 //
-// Pure on purpose. The caller throws, because what STATUS a refusal carries is the caller's
-// question: the same unstorable value is a 400 at a REST boundary and a tool failure to a model.
-export function firstUnstorableProblem(
+// Pure on purpose, and it returns the PARTS rather than only the sentence, because what a refusal
+// looks like is the caller's question. The same unstorable value is a 400 whose text a REST caller
+// reads in their own language, and an MCP tool failure a client reads in English.
+export function firstUnstorableField(
   fields: readonly (readonly [string, string | null | undefined])[],
-): string | null {
+): UnstorableField | null {
   for (const [what, value] of fields) {
     if (typeof value !== "string") continue;
-    const problem = unstorableProblem(value, what);
-    if (problem) return problem;
+    const codePoints = unstorableCodePoints(value);
+    if (codePoints) {
+      return {
+        what,
+        codePoints,
+        message: unstorableProblem(value, what) as string,
+      };
+    }
   }
   return null;
 }

--- a/src/modules/mcp/write-knowledge.ts
+++ b/src/modules/mcp/write-knowledge.ts
@@ -1,6 +1,6 @@
 import basePrisma from "@/api/lib/prisma";
 import { AppError } from "@/lib/errors";
-import { firstUnstorableProblem } from "@/lib/text";
+import { firstUnstorableField } from "@/lib/text";
 import {
   createDocument,
   deleteDocument,
@@ -45,8 +45,10 @@ import {
 function unstorable(
   fields: readonly (readonly [string, string | null | undefined])[],
 ): WriteResult | null {
-  const problem = firstUnstorableProblem(fields);
-  return problem ? err(problem) : null;
+  const bad = firstUnstorableField(fields);
+  // The sentence, not the parts: an MCP error is a single string an English-speaking client reads,
+  // with no place to interpolate and no language to negotiate.
+  return bad ? err(bad.message) : null;
 }
 
 function failOf(e: unknown): WriteResult {

--- a/src/modules/mcp/write-knowledge.ts
+++ b/src/modules/mcp/write-knowledge.ts
@@ -1,5 +1,6 @@
 import basePrisma from "@/api/lib/prisma";
 import { AppError } from "@/lib/errors";
+import { firstUnstorableProblem } from "@/lib/text";
 import {
   createDocument,
   deleteDocument,
@@ -36,6 +37,18 @@ import {
 // stays UI-only), and the suggestion-approval queue. Spine: gate (mcp:write + tenant) → dry-run
 // preview by default → apply + audit. No secrets here, so no credential resolution.
 
+// The storability rule, asked HERE and not left to the core, because a dry run never reaches the
+// core: it answers "this would work" off the arguments alone. A text the column cannot hold would
+// preview clean and then fail on apply, which is the one thing a dry run exists to prevent. The
+// pure form is used rather than the core's throwing wrapper, because what a refusal looks like is
+// the transport's question and here it is a WriteResult, not an exception (issue #247).
+function unstorable(
+  fields: readonly (readonly [string, string | null | undefined])[],
+): WriteResult | null {
+  const problem = firstUnstorableProblem(fields);
+  return problem ? err(problem) : null;
+}
+
 function failOf(e: unknown): WriteResult {
   if (e instanceof AppError) return err(e.message);
   throw e;
@@ -70,6 +83,12 @@ export async function knowledgeCreate(
   const ctx = gate(principal);
   if ("ok" in ctx) return ctx;
   const tenantId = ctx.tenantId as bigint;
+  const bad = unstorable([
+    ["name", args.name],
+    ["description", args.description],
+    ["embedding_model", args.embedding_model],
+  ]);
+  if (bad) return bad;
   try {
     if (args.dry_run !== false) {
       return ok({
@@ -138,6 +157,11 @@ export async function knowledgeUpdate(
       "no updatable fields provided (name, description, chunk_size, chunk_overlap)",
     );
   }
+  const bad = unstorable([
+    ["name", args.name],
+    ["description", args.description],
+  ]);
+  if (bad) return bad;
   try {
     const current = await getKnowledgeBase({ tenantId, id, base });
     const target = `knowledge_base:${id}`;
@@ -234,6 +258,11 @@ export async function knowledgeDocumentCreate(
   const tenantId = ctx.tenantId as bigint;
   const kbId = parseMcpId(args.knowledge_base_id, "knowledge_base_id");
   if (typeof kbId !== "bigint") return kbId;
+  const bad = unstorable([
+    ["title", args.title],
+    ["text", args.text],
+  ]);
+  if (bad) return bad;
   try {
     if (args.dry_run !== false) {
       return ok({
@@ -542,6 +571,12 @@ export async function knowledgeEdit(
   ) {
     return err("no updatable fields provided (title, content, rationale)");
   }
+  const bad = unstorable([
+    ["title", args.title],
+    ["content", args.content],
+    ["rationale", args.rationale],
+  ]);
+  if (bad) return bad;
   const target = `approval:${id}`;
   try {
     if (args.dry_run !== false) {

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -5,6 +5,7 @@ import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
 import { sanitizeErrorMessage } from "@/lib/redact";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { firstUnstorableProblem } from "@/lib/text";
 import { cancelPendingJob, enqueueJob } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import { readEmbeddingSettings } from "@/modules/tenant-settings/service";
@@ -118,6 +119,21 @@ export function validateChunkParams(
   }
 }
 
+// The refusal, in the core rather than at a transport, because three roads reach these writes: the
+// REST endpoints, the MCP write tool, and the agent's own suggestion being published. `unstorable`
+// carries the field and the offending code point, which is the whole difference between an answer a
+// caller can act on and the 500 this replaces.
+export function refuseUnstorable(
+  fields: readonly (readonly [string, string | null | undefined])[],
+): void {
+  const problem = firstUnstorableProblem(fields);
+  if (problem) {
+    throw new AppError(problem, 400, "errors.unstorableText", {
+      reason: problem,
+    });
+  }
+}
+
 export interface CreateDocumentParams {
   tenantId: bigint;
   knowledgeBaseId: bigint;
@@ -129,11 +145,28 @@ export interface CreateDocumentParams {
   base?: PrismaClient;
 }
 
+// The whole write is held to what the columns can store, before anything is read or enqueued. It is
+// not a hypothetical shape: `extractText` decodes an uploaded .txt with `TextDecoder("utf-8")`, so a
+// file carrying a 0x00 byte hands a NUL straight to `content`, and Postgres refuses one in a `text`
+// column (22021). Nothing caught it between the write and the transport, so an operator uploading a
+// file got a 500 naming neither the file nor the reason (issue #247).
+//
+// REFUSED, not repaired, which is the opposite of what #218 and #243 do with the same characters.
+// The rule is who can act on the answer: there the writer is a third party's webhook or an exception
+// message and nobody reads a rejection, so repairing keeps the event. Here it is a person who chose
+// this file, or a client calling an API that answers them, and silently deleting bytes out of a
+// document an agent is about to answer from is worse than saying it cannot be stored.
 export async function createDocument(
   params: CreateDocumentParams,
 ): Promise<{ id: bigint; status: string }> {
   const base = params.base ?? basePrisma;
   const { tenantId, knowledgeBaseId } = params;
+  refuseUnstorable([
+    ["title", params.title],
+    ["text", params.text],
+    ["fileName", params.fileName],
+    ["mimeType", params.mimeType],
+  ]);
 
   const doc = await runScopedOn(base, sysCtx(tenantId), async (db) => {
     const kb = await db.knowledgeBase.findUnique({
@@ -277,6 +310,12 @@ export async function updateDocument(
   const hasTitle = params.title !== undefined;
   const hasText = params.text !== undefined;
   if (!hasTitle && !hasText) throw new AppError("nothing to update", 400);
+  // Same rule as the create, and asked here too because an edit is a write of its own: the create's
+  // check says nothing about the text an update carries.
+  refuseUnstorable([
+    ["title", params.title],
+    ["text", params.text],
+  ]);
 
   const { doc, reingest } = await runScopedOn(
     base,

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -5,7 +5,7 @@ import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
 import { sanitizeErrorMessage } from "@/lib/redact";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
-import { firstUnstorableProblem } from "@/lib/text";
+import { firstUnstorableField } from "@/lib/text";
 import { cancelPendingJob, enqueueJob } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import { readEmbeddingSettings } from "@/modules/tenant-settings/service";
@@ -126,10 +126,15 @@ export function validateChunkParams(
 export function refuseUnstorable(
   fields: readonly (readonly [string, string | null | undefined])[],
 ): void {
-  const problem = firstUnstorableProblem(fields);
-  if (problem) {
-    throw new AppError(problem, 400, "errors.unstorableText", {
-      reason: problem,
+  const bad = firstUnstorableField(fields);
+  if (bad) {
+    // The PARTS, not the sentence. `translationKey` is translated per the request's Accept-Language
+    // and `message` is only the untranslated fallback, so interpolating an English sentence into a
+    // pt-BR template would answer in two languages at once. What stays English either way is the
+    // field name, which names the request field to change the way a schema path does.
+    throw new AppError(bad.message, 400, "errors.unstorableText", {
+      field: bad.what,
+      codePoints: bad.codePoints.join(" "),
     });
   }
 }

--- a/src/modules/rag/service.ts
+++ b/src/modules/rag/service.ts
@@ -165,9 +165,13 @@ export async function createSuggestion(
   params: SuggestParams,
 ): Promise<{ id: bigint }> {
   const base = params.base ?? basePrisma;
+  // Labelled by the names the CALLER sends, not by the columns they land in: both roads here (the
+  // REST body and the agent's suggestion tool) spell these `title` / `content` / `rationale`, so a
+  // refusal naming `proposedContent` would tell a caller to fix a field they never sent (review
+  // round 3).
   refuseUnstorable([
-    ["proposedTitle", params.proposedTitle],
-    ["proposedContent", params.proposedContent],
+    ["title", params.proposedTitle],
+    ["content", params.proposedContent],
     ["rationale", params.rationale],
   ]);
   return runScopedOn(base, sysCtx(params.tenantId), async (db) => {
@@ -348,9 +352,10 @@ export async function editApprovalItem(
   params: EditApprovalParams,
 ): Promise<"updated" | "not-pending"> {
   const base = params.base ?? basePrisma;
+  // The caller's names, as in createSuggestion above.
   refuseUnstorable([
-    ["proposedTitle", params.proposedTitle],
-    ["proposedContent", params.proposedContent],
+    ["title", params.proposedTitle],
+    ["content", params.proposedContent],
     ["rationale", params.rationale],
   ]);
   const data: Record<string, unknown> = { status: "EDITED" };

--- a/src/modules/rag/service.ts
+++ b/src/modules/rag/service.ts
@@ -7,6 +7,7 @@ import {
   cancelPendingJob,
   createDocument,
   sysCtx as docsSysCtx,
+  refuseUnstorable,
   resolveEmbeddingConfig,
   validateChunkParams,
 } from "./documents";
@@ -107,6 +108,10 @@ export async function listKnowledgeBases(
   });
 }
 
+// Every text this module stores is held to what its column can hold, at the core rather than at a
+// transport, because three roads reach these writes: REST, the MCP write tools, and the agent's own
+// suggestion tool. Refused rather than repaired: the writer here reads the answer and can send the
+// value again without the character. See rag/documents.ts for the full reasoning (issue #247).
 export async function createKnowledgeBase(params: {
   tenantId: bigint;
   name: string;
@@ -115,6 +120,11 @@ export async function createKnowledgeBase(params: {
   base?: PrismaClient;
 }): Promise<{ id: bigint }> {
   const base = params.base ?? basePrisma;
+  refuseUnstorable([
+    ["name", params.name],
+    ["description", params.description],
+    ["embeddingModel", params.embeddingModel],
+  ]);
   return runScopedOn(base, sysCtx(params.tenantId), async (db) => {
     // New bases inherit the tenant's default embedding model (so the tenant's one embedding config
     // applies uniformly) unless the caller pins one explicitly.
@@ -147,10 +157,19 @@ export interface SuggestParams {
   base?: PrismaClient;
 }
 
+// The same rule the document write applies (issue #247), asked one table earlier and of a different
+// writer: `proposedContent` and its siblings are `text` columns, and the agent's own suggestion tool
+// is what fills them, so the characters are a model's rather than a person's. A model reads a tool
+// failure and can write the fact again without them, so the answer is still a refusal.
 export async function createSuggestion(
   params: SuggestParams,
 ): Promise<{ id: bigint }> {
   const base = params.base ?? basePrisma;
+  refuseUnstorable([
+    ["proposedTitle", params.proposedTitle],
+    ["proposedContent", params.proposedContent],
+    ["rationale", params.rationale],
+  ]);
   return runScopedOn(base, sysCtx(params.tenantId), async (db) => {
     const kb = await db.knowledgeBase.findUnique({
       where: { id: params.knowledgeBaseId },
@@ -329,6 +348,11 @@ export async function editApprovalItem(
   params: EditApprovalParams,
 ): Promise<"updated" | "not-pending"> {
   const base = params.base ?? basePrisma;
+  refuseUnstorable([
+    ["proposedTitle", params.proposedTitle],
+    ["proposedContent", params.proposedContent],
+    ["rationale", params.rationale],
+  ]);
   const data: Record<string, unknown> = { status: "EDITED" };
   if (params.proposedTitle !== undefined)
     data.proposedTitle = params.proposedTitle;
@@ -530,6 +554,10 @@ export async function updateKnowledgeBase(params: {
   base?: PrismaClient;
 }): Promise<void> {
   const base = params.base ?? basePrisma;
+  refuseUnstorable([
+    ["name", params.name],
+    ["description", params.description],
+  ]);
 
   if (params.chunkSize !== undefined && params.chunkOverlap !== undefined) {
     validateChunkParams(params.chunkSize, params.chunkOverlap);

--- a/tests/client/pages/KnowledgeDocsBlock.test.tsx
+++ b/tests/client/pages/KnowledgeDocsBlock.test.tsx
@@ -657,6 +657,16 @@ describe("knowledge: a refusal the server phrased reaches the operator", () => {
     cleanup();
   });
 
+  // This describe reinstalls the stub in its own beforeEach, AFTER the describe above already
+  // handed `fetch` back in its afterAll. Without this, the last case leaves both the stub and a 415
+  // `addDocResponse` installed for whatever else shares this Bun worker, and a POST whose URL
+  // happens to contain `/documents` is answered by a test that already finished. The failure would
+  // land in another file and depend on execution order (review round 4).
+  afterAll(() => {
+    globalThis.fetch = realFetch;
+    addDocResponse = null;
+  });
+
   async function addText(body: unknown, status: number) {
     addDocResponse = { status, body };
     await openModal();

--- a/tests/client/pages/KnowledgeDocsBlock.test.tsx
+++ b/tests/client/pages/KnowledgeDocsBlock.test.tsx
@@ -37,6 +37,8 @@ interface DocsPayload {
 let docsQueue: DocsPayload[] = [];
 let docsCalls = 0;
 let reindexResponse: Record<string, unknown> = {};
+// What the add-a-text-document POST answers. Null means it is not being exercised.
+let addDocResponse: { status: number; body: unknown } | null = null;
 let onKnowledgeDocument:
   | ((e: {
       knowledgeBaseId: string;
@@ -120,6 +122,12 @@ function installFetchStub() {
     }
     if (url.includes("/documents") && method === "GET") {
       return json(await nextDocs());
+    }
+    if (url.includes("/documents") && method === "POST" && addDocResponse) {
+      return new Response(JSON.stringify(addDocResponse.body), {
+        status: addDocResponse.status,
+        headers: { "content-type": "application/json" },
+      });
     }
     return realFetch(input as RequestInfo | URL, init);
   }) as typeof fetch;
@@ -235,6 +243,7 @@ describe("knowledge documents modal — the embedding block is never stale", () 
     gateOnCall = null;
     gatedDocsCalls = [];
     docsReleasers.clear();
+    addDocResponse = null;
     installFetchStub();
   });
 
@@ -621,5 +630,95 @@ describe("knowledge documents modal — the embedding block is never stale", () 
     });
     await waitFor(() => expect(shows("Doc")).toBe(true));
     expect(blockCalls).toBe(0);
+  });
+});
+
+// Issue #247. The API refusal names the field and the offending code point, which is the whole
+// difference between an answer an operator can act on and a 500. The console used to collapse every
+// 4xx into "Could not add document", so the reported scenario (someone uploads a file, gets nothing
+// they can act on) survived the API being fixed. What is asserted here is the SERVER's sentence on
+// screen, not a status the client re-phrased.
+describe("knowledge: a refusal the server phrased reaches the operator", () => {
+  beforeEach(() => {
+    docsCalls = 0;
+    docsQueue = [{ documents: [doc()], embeddingBlock: null }];
+    blockCalls = 0;
+    blockQueue = [];
+    blockThrows = false;
+    addDocResponse = null;
+    onKnowledgeDocument = null;
+    gateOnCall = null;
+    gatedDocsCalls = [];
+    docsReleasers.clear();
+    installFetchStub();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  async function addText(body: unknown, status: number) {
+    addDocResponse = { status, body };
+    await openModal();
+    fireEvent.click(screen.getByRole("button", { name: /adicionar/i }));
+    fireEvent.change(await screen.findByRole("textbox", { name: /text/i }), {
+      target: { value: "some text" },
+    });
+    const buttons = screen.getAllByRole("button", { name: /adicionar/i });
+    fireEvent.click(buttons[buttons.length - 1] as HTMLElement);
+  }
+
+  test("the refusal's own words are what the toast shows", async () => {
+    await addText(
+      { error: "text contains characters that cannot be stored (U+0000)" },
+      400,
+    );
+    await waitFor(() => expect(shows(/U\+0000/)).toBe(true));
+    expect(shows(/Could not add document/i)).toBe(false);
+  });
+
+  test("a refusal with no body of its own still says something", async () => {
+    await addText({}, 500);
+    await waitFor(() => expect(shows(/Could not add document/i)).toBe(true));
+  });
+
+  // The other road to the same column, and the one the issue actually reported: a file, refused
+  // per-row rather than by a toast. The three statuses this screen phrases better than the API can
+  // (unsupported type, too large, nothing extractable) still win; everything else the API already
+  // phrased in this operator's language.
+  async function uploadFile(body: unknown, status: number) {
+    addDocResponse = { status, body };
+    await openModal();
+    fireEvent.click(screen.getByRole("button", { name: /adicionar/i }));
+    fireEvent.click(screen.getByRole("tab", { name: /arquivo/i }));
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(["policy"], "policy.txt", { type: "text/plain" });
+    Object.defineProperty(input, "files", { value: [file], writable: false });
+    fireEvent.change(input);
+    const buttons = screen.getAllByRole("button", { name: /adicionar/i });
+    fireEvent.click(buttons[buttons.length - 1] as HTMLElement);
+  }
+
+  test("an upload row carries the refusal's own words", async () => {
+    await uploadFile(
+      { error: "text contains characters that cannot be stored (U+0000)" },
+      400,
+    );
+    // Exact "Failed": the toast beside it says "1 failed.", so a loose match picks the wrong node.
+    const chip = await screen.findByText("Failed");
+    fireEvent.pointerEnter(chip);
+    fireEvent.focus(chip);
+    await waitFor(() => expect(shows(/U\+0000/)).toBe(true));
+  });
+
+  test("a status this screen phrases better still wins", async () => {
+    await uploadFile({ error: "whatever the API said" }, 415);
+    const chip = await screen.findByText("Failed");
+    fireEvent.pointerEnter(chip);
+    fireEvent.focus(chip);
+    await waitFor(() => expect(shows(/Unsupported file type/i)).toBe(true));
+    expect(shows(/whatever the API said/)).toBe(false);
   });
 });

--- a/tests/lib/storable-write-sweep.test.ts
+++ b/tests/lib/storable-write-sweep.test.ts
@@ -326,13 +326,19 @@ describe.skipIf(!dbUp)("error text reaches every column that holds it", () => {
 //   guarded     sanitizeErrorMessage applied right here, at the write
 //   cleared     writes null (a row leaving the state the error described)
 //   read        reads the column back out: a select, a filter, a DTO field
-type ErrorSite = "flow-event" | "guarded" | "cleared" | "read";
+//   unrelated   the name, and none of the meaning: a field of a client-side shape that happens to
+//               be called this. The scan cannot tell them apart, which is the honest limit of
+//               keying on a name rather than on a write, and is why they are listed rather than
+//               filtered out by a path rule that would also hide a real one.
+type ErrorSite = "flow-event" | "guarded" | "cleared" | "read" | "unrelated";
 
 const ERROR_COLUMN_LINES: Record<string, [number, ErrorSite | string]> = {
   "src/graph/nudge.ts": [1, "flow-event"],
   "src/graph/prepare.ts": [2, "flow-event"],
   "src/graph/runtime.ts": [4, "flow-event"],
   "src/graph/tool-flowlog.ts": [2, "flow-event"],
+  // An upload row's own failure in the console, which never reaches a column.
+  "src/client/pages/resources/useKnowledgeManager.tsx": [1, "unrelated"],
   "src/modules/chatwoot/webhook.ts": [1, "cleared"],
   "src/modules/contact-auth/service.ts": [1, "flow-event"],
   "src/modules/conversations/error.ts": [3, "guarded + cleared"],

--- a/tests/modules/rag-document-storable.test.ts
+++ b/tests/modules/rag-document-storable.test.ts
@@ -1,0 +1,323 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { AppError } from "@/lib/errors";
+import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
+import {
+  knowledgeCreate,
+  knowledgeDocumentCreate,
+  knowledgeEdit,
+  knowledgeUpdate,
+} from "@/modules/mcp/write-knowledge";
+import { createDocument, updateDocument } from "@/modules/rag/documents";
+import { extractText } from "@/modules/rag/loaders";
+import {
+  createKnowledgeBase,
+  createSuggestion,
+  editApprovalItem,
+  updateKnowledgeBase,
+} from "@/modules/rag/service";
+
+// A DOCUMENT THE COLUMN CANNOT HOLD IS REFUSED BY NAME, NOT BY A 500.
+//
+// `extractText` decodes an uploaded .txt/.md/.csv with `TextDecoder("utf-8")`, and its `normalize`
+// only folds CRLF and trims. A file carrying a `0x00` byte therefore produces a string holding
+// U+0000, which `createDocument` wrote straight into `KnowledgeDocument.content`. That column is
+// `text`, Postgres refuses a NUL in one (22021), and nothing caught it between the write and the
+// transport: an operator uploading the file got a 500 naming neither the file nor the reason
+// (issue #247). A `0x00` in a text export is ordinary: a fixed-width dump, a CSV from a tool that
+// pads, a file truncated mid-write.
+//
+// REFUSED, which is the opposite of what #218 and #243 do with the same two characters, and the
+// rule that decides is who can act on the answer. There the writer is a third party's webhook or an
+// exception message: nobody reads a rejection and a refusal costs the event, so the value is
+// repaired. Here it is a person who chose this file, a client calling an API that answers them, or a
+// model reading a tool failure it can act on. Deleting bytes out of a document an agent is about to
+// answer from would be worse than saying it cannot be stored.
+//
+// Asked of every text this module stores, not just the one that was reported: the column refuses the
+// ROW, so checking `content` and not `title` only moves which value produces the 500. The knowledge
+// bases, the documents and the approval queue are all covered below.
+//
+// The last block is the MCP half and needs no database, which is the point: `dry_run` defaults to
+// true and answers off the arguments alone, so a value the column cannot hold used to preview clean
+// and fail on apply. A dry run that cannot predict its own apply is worse than no dry run.
+
+const NUL = String.fromCharCode(0);
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let kbId = 0n;
+
+// What the caller gets back, reduced to the two things that decide whether they can act on it: the
+// HTTP status, and whether the text names the field and the character.
+async function refusal(run: () => Promise<unknown>): Promise<{
+  status: number | null;
+  message: string;
+}> {
+  try {
+    await run();
+    return { status: null, message: "" };
+  } catch (e) {
+    return {
+      status: e instanceof AppError ? e.statusCode : null,
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+describe.skipIf(!dbUp)("a knowledge document the column cannot hold", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "DOCSTOR", slug: `docstor-${process.pid}` },
+    });
+    tenantId = t.id;
+    const kb = await suDb.knowledgeBase.create({
+      data: { tenantId, name: "KB" },
+    });
+    kbId = kb.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  // The reachability the issue rests on: nothing exotic reaches `content`, an ordinary .txt does.
+  test("a .txt holding a 0x00 byte decodes to a NUL in the text", async () => {
+    const { text } = await extractText({
+      name: "policy.txt",
+      type: "text/plain",
+      bytes: new TextEncoder().encode(`policy${NUL}text`),
+    });
+    expect(text).toContain(NUL);
+  });
+
+  test("createDocument refuses the text, naming the field and the code point", async () => {
+    const r = await refusal(() =>
+      createDocument({
+        tenantId,
+        knowledgeBaseId: kbId,
+        title: "policy",
+        text: `policy${NUL}text`,
+        sourceType: "file",
+        fileName: "policy.txt",
+        base: appDb,
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+0000");
+    expect(r.message).toContain("text");
+  });
+
+  test("createDocument refuses half a character in the title", async () => {
+    const r = await refusal(() =>
+      createDocument({
+        tenantId,
+        knowledgeBaseId: kbId,
+        title: "policy\ud800",
+        text: "fine",
+        sourceType: "text",
+        base: appDb,
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+D800");
+  });
+
+  test("createDocument refuses a file name the column cannot hold", async () => {
+    const r = await refusal(() =>
+      createDocument({
+        tenantId,
+        knowledgeBaseId: kbId,
+        title: "policy",
+        text: "fine",
+        sourceType: "file",
+        fileName: `policy${NUL}.txt`,
+        base: appDb,
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+0000");
+  });
+
+  test("a refused create leaves no row behind", async () => {
+    const before = await suDb.knowledgeDocument.count({ where: { tenantId } });
+    await refusal(() =>
+      createDocument({
+        tenantId,
+        knowledgeBaseId: kbId,
+        title: "policy",
+        text: `a${NUL}b`,
+        sourceType: "text",
+        base: appDb,
+      }),
+    );
+    expect(await suDb.knowledgeDocument.count({ where: { tenantId } })).toBe(
+      before,
+    );
+  });
+
+  test("updateDocument refuses an edit the column cannot hold", async () => {
+    const doc = await createDocument({
+      tenantId,
+      knowledgeBaseId: kbId,
+      title: "editable",
+      text: "ORIGINAL",
+      sourceType: "text",
+      base: appDb,
+    });
+    const r = await refusal(() =>
+      updateDocument(tenantId, doc.id, { text: `EDITED${NUL}` }, appDb),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+0000");
+    // The document keeps the text it had: a refused edit is not a half-applied one.
+    const row = await suDb.knowledgeDocument.findUniqueOrThrow({
+      where: { id: doc.id },
+      select: { content: true, status: true },
+    });
+    expect(row.content).toBe("ORIGINAL");
+  });
+
+  test("createKnowledgeBase refuses a name the column cannot hold", async () => {
+    const r = await refusal(() =>
+      createKnowledgeBase({
+        tenantId,
+        name: `kb${NUL}`,
+        base: appDb,
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+0000");
+  });
+
+  test("updateKnowledgeBase refuses a description the column cannot hold", async () => {
+    const r = await refusal(() =>
+      updateKnowledgeBase({
+        tenantId,
+        id: kbId,
+        description: "half\ud800",
+        base: appDb,
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+D800");
+  });
+
+  test("editApprovalItem refuses an edit the column cannot hold", async () => {
+    const r = await refusal(() =>
+      editApprovalItem({
+        tenantId,
+        id: 1n,
+        proposedContent: `edited${NUL}`,
+        base: appDb,
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+0000");
+  });
+
+  // The same question one table upstream, where the writer is the AGENT's own tool (graph/tools/rag)
+  // rather than a person: `proposedContent` is a `text` column too, and a model can emit half a
+  // character. A refusal reaches the model as a tool failure it can act on, so the answer is the
+  // same one, not a repair.
+  test("createSuggestion refuses content the column cannot hold", async () => {
+    const r = await refusal(() =>
+      createSuggestion({
+        tenantId,
+        knowledgeBaseId: kbId,
+        proposedContent: `learned${NUL}fact`,
+        proposedTitle: "fact",
+        rationale: "the customer said so",
+        threadId: `${tenantId}:1:1`,
+        interruptKey: "k1",
+        base: appDb,
+      }),
+    );
+    expect(r.status).toBe(400);
+    expect(r.message).toContain("U+0000");
+  });
+});
+
+// The MCP half, which needs no database: the gate is DB-free and so is the dry run, which is
+// exactly the problem. `dry_run` defaults to true and answers off the arguments alone, so before
+// this check a text the column cannot hold previewed clean and failed on APPLY. A dry run that
+// cannot predict its own apply is worse than no dry run.
+function principal(over: Partial<VerifiedToken> = {}): VerifiedToken {
+  return {
+    userId: 1n,
+    tenantId: 1n,
+    role: "TENANT_ADMIN",
+    scopes: ["mcp:read", "mcp:write"],
+    clientId: "c",
+    jti: "j",
+    ...over,
+  };
+}
+
+describe("the MCP dry run refuses what the apply would refuse", () => {
+  test("knowledge_document_create", async () => {
+    const r = await knowledgeDocumentCreate(principal(), {
+      knowledge_base_id: "1",
+      title: "policy",
+      text: `policy${NUL}text`,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("U+0000");
+  });
+
+  test("knowledge_create", async () => {
+    const r = await knowledgeCreate(principal(), {
+      name: "kb\ud800",
+      description: "d",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("U+D800");
+  });
+
+  test("knowledge_update", async () => {
+    const r = await knowledgeUpdate(principal(), {
+      knowledge_base_id: "1",
+      description: `d${NUL}`,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("U+0000");
+  });
+
+  test("knowledge_edit", async () => {
+    const r = await knowledgeEdit(principal(), {
+      approval_id: "1",
+      content: `edited${NUL}`,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("U+0000");
+  });
+});

--- a/tests/modules/rag-document-storable.test.ts
+++ b/tests/modules/rag-document-storable.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
+import { translateWithLocale } from "@/api/lib/i18n";
 import { AppError } from "@/lib/errors";
 import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
 import {
@@ -264,6 +265,57 @@ describe.skipIf(!dbUp)("a knowledge document the column cannot hold", () => {
     );
     expect(r.status).toBe(400);
     expect(r.message).toContain("U+0000");
+  });
+});
+
+// What the refusal actually reads like, at the layer that renders it. `translationKey` is translated
+// per the request's Accept-Language while `message` is only the untranslated fallback, so a refusal
+// that interpolates an ENGLISH SENTENCE answers a pt-BR caller in two languages at once (review
+// round 2). Passing the parts instead is what closes it; the field name stays English in both, the
+// way a schema path does.
+describe("the refusal answers in the caller's language", () => {
+  async function render(locale: "en" | "pt-BR"): Promise<string> {
+    let caught: unknown = null;
+    try {
+      await createDocument({
+        tenantId: 0n,
+        knowledgeBaseId: 0n,
+        title: "t",
+        text: `a${NUL}b`,
+        sourceType: "text",
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    const err = caught as AppError;
+    return translateWithLocale(
+      locale,
+      err.translationKey as string,
+      err.message,
+      err.translationParams,
+    );
+  }
+
+  test("pt-BR carries no English prose", async () => {
+    const out = await render("pt-BR");
+    expect(out).toContain("não podem ser armazenados");
+    expect(out).toContain("U+0000");
+    // The sentence the old shape interpolated, in the language it was stuck in.
+    expect(out).not.toContain("the database cannot store");
+    expect(out).not.toContain("PostgreSQL");
+  });
+
+  test("en says the same thing", async () => {
+    const out = await render("en");
+    expect(out).toContain("cannot be stored");
+    expect(out).toContain("U+0000");
+  });
+
+  test("the field is named, so the caller knows which one to fix", async () => {
+    for (const locale of ["en", "pt-BR"] as const) {
+      expect(await render(locale)).toContain("text");
+    }
   });
 });
 

--- a/tests/modules/rag-document-storable.test.ts
+++ b/tests/modules/rag-document-storable.test.ts
@@ -265,6 +265,11 @@ describe.skipIf(!dbUp)("a knowledge document the column cannot hold", () => {
     );
     expect(r.status).toBe(400);
     expect(r.message).toContain("U+0000");
+    // Named by what the CALLER sent, not by the column it lands in. The REST body and the agent's
+    // suggestion tool both spell this `content`; `proposedContent` is a field nobody can change
+    // because nobody sent it (review round 3).
+    expect(r.message).toContain("content ");
+    expect(r.message).not.toContain("proposedContent");
   });
 });
 


### PR DESCRIPTION
Uploading a `.txt` that happens to hold a `0x00` byte answers 500, naming neither the file nor the reason.

## What was measured

`extractText` (`src/modules/rag/loaders.ts`) decodes an uploaded `.txt`/`.md`/`.csv` with `new TextDecoder("utf-8")`, and its `normalize` only folds CRLF and trims. So a byte the file happens to carry becomes a character the string carries:

```
extractText keeps the NUL:  true
unstorableProblem(content): content contains characters the database cannot store (U+0000)
```

`createDocument` writes that straight into `KnowledgeDocument.content`. That column is `text`, Postgres refuses a NUL in one (`22021`), and nothing sat between the write and the transport, so what a caller got back was an `AppError`-less throw:

```
statusCode of what was thrown: undefined   (i.e. a 500)
```

A `0x00` in a text export is ordinary: a fixed-width dump, a CSV written by a tool that pads, a file truncated mid-write.

## Why refuse rather than repair

This is the opposite answer from #218 and #243, on the same two characters, and the rule that decides is **who can act on the answer**.

There the writer is a third party's webhook or an exception message. Nobody reads a rejection, a refusal costs the event, so the value is repaired (`makeStorable`). Here the writer is a person who chose this file, a client calling an API that answers them, or a model reading a tool failure it can act on. Silently deleting bytes out of a document an agent is about to answer from is worse than saying it cannot be stored.

`unstorableProblem` already exists for exactly this and is already used this way by the documents module, which answers 400 naming the field and the code point.

## Asked of the row, not of the field

A column refuses the ROW, so checking `content` and not `title` only moves which value produces the 500. Every text this module stores is now held to the same rule, at the **core** rather than at a transport, because three roads reach these writes: REST, the MCP write tools, and the agent's own suggestion tool.

| Column | Guarded in |
| --- | --- |
| `knowledge_documents.title / .content / .file_name / .mime_type` | `createDocument`, `updateDocument` |
| `knowledge_bases.name / .description / .embedding_model` | `createKnowledgeBase`, `updateKnowledgeBase` |
| `approval_queue_items.proposed_title / .proposed_content / .rationale` | `createSuggestion`, `editApprovalItem` |

`knowledge_chunks.content` is not in the list on purpose: it is derived from a `content` that has already passed this check.

## The MCP dry run previewed clean and failed on apply

Found while sweeping for the writers above, and it is the second defect here. `dry_run` defaults to true and answers off the arguments alone, never reaching the core:

```ts
if (args.dry_run !== false) {
  return ok({ dryRun: true, action: "create", preview: { ..., textChars: args.text.length } });
}
```

So a text the column could not hold previewed as fine and then failed on apply, which is the one thing a dry run exists to prevent. The check now runs before that branch in all four write tools that carry text (`knowledge_create`, `knowledge_update`, `knowledge_document_create`, `knowledge_edit`).

## What the review rounds changed, because none of it was cosmetic

**The console still said nothing** (round 3). Fixing the API is not fixing the reported scenario: `uploadOne` kept only `err.status` and the text-add `catch` collapsed every 4xx into `Could not add document.`, so the operator read a generic sentence while the API was answering with the field and the code point. Both paths now go through `apiErrorMessage`; the three statuses this screen phrases better than the API can (415, 413, 422) still win.

**The refusal named a field nobody sent** (round 3). `createSuggestion` and `editApprovalItem` labelled by the COLUMN (`proposedTitle` / `proposedContent`) while both roads that reach them spell these `title` / `content`. Labels are the caller's names now, which was the property this PR claimed in the first place.

**Two languages in one sentence** (round 2). `translationKey` is translated per Accept-Language while `message` is only the untranslated fallback, so interpolating an English sentence answered a pt-BR caller in both. The helper returns the parts instead:

```
en     text contains characters that cannot be stored (U+0000)
pt-BR  text contém caracteres que não podem ser armazenados (U+0000)
```

That is why the helper is **pure**: what a refusal looks like belongs to the caller. REST wants an `AppError(400)` whose text gets translated; MCP wants a `WriteResult` carrying one English string, with no place to interpolate and no language to negotiate.

```ts
export function firstUnstorableField(
  fields: readonly (readonly [string, string | null | undefined])[],
): UnstorableField | null;   // { what, codePoints, message }
```

**A global taken in a `beforeEach` and never handed back** (round 4). The new client describe reinstalled the `fetch` stub after the describe above had already restored it, with no teardown of its own, leaving both the stub and a 415 response armed for whatever shared the Bun worker.

## Validation scope

**Proved by test** (`bun check`: 4835 pass, 0 fail):

- DB-backed, `tests/modules/rag-document-storable.test.ts`: the reachability itself (a `.txt` holding `0x00` decodes to a NUL), then a named 400 out of `createDocument` (text, title, file name), `updateDocument`, `createKnowledgeBase`, `updateKnowledgeBase`, `createSuggestion` and `editApprovalItem`. Each asserts the status AND that the message names the code point, because a 400 that says nothing is only a prettier 500.
- DB-backed: a refused create leaves no row, and a refused edit leaves the document with the text it had.
- No DB needed, which is the point: the four MCP dry runs refuse instead of previewing clean.
- The rendered refusal, through the real `translateWithLocale`: the pt-BR output contains neither `PostgreSQL` nor `the database cannot store`.
- Client, `tests/client/pages/KnowledgeDocsBlock.test.tsx`, driving the real modal against a stubbed 400: the toast path, the per-file upload row, the no-body fallback, and a status-specific message still beating the server's.

Twelve of the original fourteen service tests were red before the change, throwing a non-`AppError` (status `undefined`). The other two pin facts that hold on both sides and are marked as such rather than counted as proof: the reachability probe, and "a refused create leaves no row", which Postgres already guaranteed by refusing the INSERT and which now holds for the better reason that nothing is attempted.

**Mutation-tested**, one at a time. All 19 break a test:

| Mutation | Tests failing |
| --- | --- |
| baseline | 0 |
| `firstUnstorableField`: never reports | 15 |
| `firstUnstorableField`: only the first field | 12 |
| the refusal interpolates the English sentence again | 1 |
| `createDocument`: drop the guard | 6 |
| `createDocument`: check only the text | 2 |
| `updateDocument`: drop the guard | 1 |
| `createSuggestion`: drop the guard | 1 |
| `editApprovalItem`: drop the guard | 1 |
| `createSuggestion`: label by the column again | 1 |
| console: drop the server message on the toast | 1 |
| console: drop the server message on the upload row | 1 |
| `createKnowledgeBase`: drop the guard | 1 |
| `updateKnowledgeBase`: drop the guard | 1 |
| MCP `knowledge_document_create`: guard after the dry run | 1 |
| MCP `knowledge_create`: guard after the dry run | 1 |
| MCP `knowledge_update`: guard after the dry run | 1 |
| MCP `knowledge_edit`: guard after the dry run | 1 |
| the refusal carries 500 instead of 400 | 8 |

The upload-row entry is there because it once survived: the first client test covered only the toast, and the test that appeared to cover the row matched the toast's own `1 failed.` instead of the row's chip, so it opened a tooltip that was not there and passed.

**Not validated:**

- The REST transports are covered at the core they call and at the console that reads the answer, but not through a live HTTP request. The untested link is `AppError(400)` becoming an HTTP 400 body, which is the shared `onError` handler every endpoint already goes through.
- The `fetch`-teardown fix (round 4) is reasoned from the state left behind, not from an observed failure: running this file beside `document-refresh-error` and `document-preview-session` is green either way, because those install stubs of their own.
- Only the `text` sources are held to this. A `.pdf` or `.docx` whose extractor emits an unstorable character is refused by the same check, but no fixture proves an extractor can produce one.
- The wider sweep of externally-sourced text into columns stays open beyond this module. #243's `tests/lib/storable-write-sweep.test.ts` carries the error family; a model's own output outside the approval queue, and the Chatwoot mirror, still have nobody asking the question.
- The base moved twice during the loop (#239/#240, then #120/#123/#220). Rebased onto `428cb91` and re-measured rather than assumed; the #244 ledger tripped on the console's new `errorMessage` field and now carries it as `unrelated`, which is the honest limit of a scan that keys on a name.

Fixes #247
