### PR TITLE
Let the ladder stand down without standing the episode down

### DIFF
--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -302,23 +302,26 @@ async function resolveWhatsAppSibling(
 
 export type WhatsAppFollowUpOutcome =
   | "retired"
-  // The agent stopped being live while this stage did its own I/O. Distinct from "retired" because
-  // the CALLER answers them differently: a retired ladder is gone, a stood-down one must not be
-  // advanced to a closing that a re-enabled agent would then deliver (issue #246).
+  // The agent stopped being live while this stage did its own I/O. Distinct from "retired"
+  // because the CALLER answers them differently: a retired ladder is gone, a stood-down one must not
+  // be advanced to a closing that a re-enabled agent would then deliver (issue #246).
   | "stood-down"
   | "sent"
   | "no-sibling"
   | "misconfigured";
 
+// Whether a stage that is about to say something to the customer may still say it. ONE ask covering
+// BOTH reasons it may not — the ladder was retired (/reset, a new inbound), or the agent stopped
+// being live — because each ask is a round trip, and a second one placed after the first puts I/O
+// between that first answer and the write it guards. THE RULE the file states for the retirement
+// question ("one ask per stretch of I/O that precedes a write, and never any I/O between an ask and
+// the write it guards") is only satisfiable for both questions if they are one ask.
+export type LadderVerdict = "go" | "retired" | "stood-down";
+
 export interface SendWhatsAppFollowUpParams {
   // Asked immediately before the send, after the sibling lookup and the token mint — both of which
-  // are round trips a /reset can land inside. Absent, the answer is yes.
-  stillWanted?: () => Promise<boolean>;
-  // The same question for the agent's own switch, asked in the same place and answered separately
-  // (issue #246). Its own callback rather than a term inside `stillWanted`: the caller reads a false
-  // `stillWanted` as "retired" and still advances the ladder, which is wrong for this one. Absent,
-  // the answer is yes.
-  stillLive?: () => Promise<boolean>;
+  // are round trips a /reset or an operator's switch can land inside. Absent, the answer is "go".
+  fence?: () => Promise<LadderVerdict>;
   tenantId: bigint;
   instanceId: bigint;
   agentId: bigint;
@@ -369,8 +372,8 @@ export async function sendWhatsAppFollowUp(
   });
   // NOTE: The link mint above is an HTTP round trip to Chatwoot, so the answer the caller had is older than
   // this line. Nothing has left yet, which makes this the last free place to stop.
-  if (p.stillWanted && !(await p.stillWanted())) return "retired";
-  if (p.stillLive && !(await p.stillLive())) return "stood-down";
+  const verdict = p.fence ? await p.fence() : "go";
+  if (verdict !== "go") return verdict;
   const sw = readServiceWindowConfig(p.settings);
   const mode = proactiveSendMode(sw, sibling.lastInboundAt, p.now, {
     channelType: sibling.channelType,
@@ -458,50 +461,59 @@ export async function redirectFollowUpHandler(
   ) {
     return { outcome: "done" };
   }
-  // The same question, re-asked from inside the stages, because the answer above is taken before a
-  // sibling lookup, a link mint (an HTTP round trip) and a client build — and an operator reaching
-  // for the switch is likeliest to do it WHILE the agent is chasing somebody (issue #246).
+  // Both questions, re-asked from inside the stages in ONE round trip, because the answer at
+  // the top of this handler is taken before a sibling lookup, a link mint (an HTTP round trip) and a
+  // client build — and an operator reaching for the switch is likeliest to do it WHILE the agent is
+  // chasing somebody (issue #246). Asking them separately would put one round trip between the other
+  // answer and the write it guards, which is THE RULE this file states for the retirement half.
   //
-  // Fail OPEN on a read that fails, which is the same call `jobRetired` makes and for the same
-  // reason: an unknown answer must not silently drop work that was legitimately armed. A DELETED
-  // agent is an answer, and it is no.
-  const stillLive = async (): Promise<boolean> => {
-    const now = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+  // Fail OPEN on a read that fails, the same call `jobRetired` makes and for the same reason: an
+  // unknown answer must not silently drop work that was legitimately armed. A DELETED agent is an
+  // answer, and it is no.
+  //
+  // The activation stamp is read only for a test agent, so the common path is a single row read after
+  // the job row and nothing straddles it. For a test agent the two reads share the transaction but not
+  // a snapshot (`runScopedOn` uses the default isolation), which leaves a gap of one statement with no
+  // network in it — narrower than the window this whole fence exists to close.
+  const fence = async (): Promise<LadderVerdict> => {
+    const answer = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+      if (await jobRetired(job, base, db)) return "retired" as const;
       const a = await db.agent.findUnique({
         where: { id: agentId },
         select: { enabled: true, mode: true },
       });
-      if (!a) return { deleted: true as const };
-      const c = await db.conversation.findUnique({
-        where: {
-          tenantId_chatwootInstanceId_chatwootConversationId: {
-            tenantId,
-            chatwootInstanceId: parsed.instanceId,
-            chatwootConversationId: parsed.conversationId,
-          },
-        },
-        select: { testActivatedAt: true },
-      });
-      return {
-        deleted: false as const,
-        a,
-        testActivatedAt: c?.testActivatedAt ?? null,
-      };
+      if (!a) return "stood-down" as const;
+      const testActivatedAt =
+        a.mode === "test"
+          ? ((
+              await db.conversation.findUnique({
+                where: {
+                  tenantId_chatwootInstanceId_chatwootConversationId: {
+                    tenantId,
+                    chatwootInstanceId: parsed.instanceId,
+                    chatwootConversationId: parsed.conversationId,
+                  },
+                },
+                select: { testActivatedAt: true },
+              })
+            )?.testActivatedAt ?? null)
+          : null;
+      return isRedirectFollowUpLive({
+        agentEnabled: a.enabled,
+        agentMode: a.mode,
+        testActivatedAt,
+      })
+        ? ("go" as const)
+        : ("stood-down" as const);
     }).catch((err: unknown) => {
       logger.warn(
-        "channel-redirect: could not re-read the agent's liveness (widget thread=%s): %s",
+        "channel-redirect: could not re-read the ladder's fence (widget thread=%s): %s",
         payload.widgetThreadId,
         err instanceof Error ? err.message : String(err),
       );
-      return null;
+      return "go" as const;
     });
-    if (now === null) return true;
-    if (now.deleted) return false;
-    return isRedirectFollowUpLive({
-      agentEnabled: now.a.enabled,
-      agentMode: now.a.mode,
-      testActivatedAt: now.testActivatedAt,
-    });
+    return answer;
   };
   const entryInboxId = cfg.entryInboxId ?? payload.entryInboxId;
 
@@ -565,8 +577,7 @@ export async function redirectFollowUpHandler(
     if (await retired()) return { outcome: "done" };
     if (cfg.waFollowupEnabled && entryInboxId !== null) {
       const outcome = await sendWhatsAppFollowUp({
-        stillWanted: async () => !(await retired()),
-        stillLive,
+        fence,
         tenantId,
         instanceId: parsed.instanceId,
         agentId,
@@ -605,7 +616,7 @@ export async function redirectFollowUpHandler(
   if (cfg.closingEnabled && entryInboxId !== null) {
     await deliverRedirectClosing({
       stillWanted: async () => !(await retired()),
-      stillLive,
+      fence,
       tenantId,
       instanceId: parsed.instanceId,
       widgetConversationId: parsed.conversationId,
@@ -670,11 +681,11 @@ export interface DeliverRedirectClosingParams {
   // at-most-once anchor) and again before the sends, after the reads and the client build. Absent,
   // the answer is yes — the resolve-transition caller has no job to retire.
   stillWanted?: () => Promise<boolean>;
-  // Whether the AGENT is still live, asked at the same two points and for the same reason: this
-  // function reads, builds a client and looks up a sibling before it says anything, and the caller's
-  // answer is older than all of it (issue #246). Separate from `stillWanted` because a false there
-  // means "retired", which its callers act on differently. Absent, the answer is yes.
-  stillLive?: () => Promise<boolean>;
+  // The post-claim asks, covering retirement AND the agent's switch in one round trip (issue #246).
+  // `stillWanted` stays for the pre-claim ask because its PRESENCE is also a signal — it means the
+  // caller holds a job token, which the /reset rule below reads — and the resolve-transition caller
+  // has no job while still needing the liveness half. Absent, the answer is "go".
+  fence?: () => Promise<LadderVerdict>;
   tenantId: bigint;
   instanceId: bigint;
   // The WIDGET conversation's chatwootConversationId. The closing watermark lives on this row; the agent
@@ -748,12 +759,25 @@ export async function deliverRedirectClosing(
   });
   const sw = readServiceWindowConfig(cx.settings);
 
+  // ONE ask per fence site, and the fence is the composite one when the caller has it: asking
+  // the two questions separately would put a round trip between the first answer and the write it
+  // guards, which is the rule stated below. A caller that passes only `stillWanted` — no agent to ask
+  // about, or a direct call — keeps every fence it always had, answered by the retirement half alone.
+  const ask = async (): Promise<LadderVerdict> => {
+    if (p.fence) return p.fence();
+    if (p.stillWanted && !(await p.stillWanted())) return "retired";
+    return "go";
+  };
+
   // NOTE: The retirement fence and the CLAIM sit together, here rather than at the top, and the ordering is
   // the point: everything above is a read, and claiming before them meant a ladder retired mid-read
   // burned the at-most-once anchor on a closing it then refused to deliver — leaving a funnel that
   // could never close again. Claiming last costs a loser of the race a few reads it will discard,
   // which is the cheaper side of the trade.
-  if (p.stillWanted && !(await p.stillWanted())) return "already-closed";
+  const beforeClaim = await ask();
+  if (beforeClaim !== "go") {
+    return beforeClaim === "retired" ? "already-closed" : "stood-down";
+  }
 
   // What the resolve trigger has instead of a job to ask about — and the reason it needs anything at
   // all. `redirectClosedAt: null` cannot tell "never closed" from "was closed and /reset just cleared
@@ -828,13 +852,10 @@ export async function deliverRedirectClosing(
       );
     });
   };
-  if (p.stillWanted && !(await p.stillWanted())) {
+  const afterClaim = await ask();
+  if (afterClaim !== "go") {
     await releaseClaim();
-    return "already-closed";
-  }
-  if (p.stillLive && !(await p.stillLive())) {
-    await releaseClaim();
-    return "stood-down";
+    return afterClaim === "retired" ? "already-closed" : "stood-down";
   }
 
   // And the fence for the caller that has no job to ask about. The resolve trigger reaches here
@@ -883,13 +904,10 @@ export async function deliverRedirectClosing(
   // which the claim CAS already makes rare and which costs a duplicate goodbye. What closes is the
   // reset, which is what this whole change is about and which costs the operator a conversation they
   // were told was clean.
-  if (p.stillWanted && !(await p.stillWanted())) {
+  const beforeSends = await ask();
+  if (beforeSends !== "go") {
     await releaseClaim();
-    return "already-closed";
-  }
-  if (p.stillLive && !(await p.stillLive())) {
-    await releaseClaim();
-    return "stood-down";
+    return beforeSends === "retired" ? "already-closed" : "stood-down";
   }
 
   // Chat (website widget): post the goodbye + resolve. Skipped on the resolve-path, where the chat is
@@ -935,7 +953,18 @@ export async function deliverRedirectClosing(
   // WhatsApp side still open — and report `delivered` for it. A reset that lands mid-delivery cannot
   // un-send the first half, so the honest completion of a started delivery is both halves; the ask
   // is what stops one that has not started.
-  if (sibling && (p.closeChat || (await stillDelivering()))) {
+  // NOTE: The fence covers the same stretch, which the watermark check does not: on the resolve path
+  // nothing has been delivered when the ask above runs, and the sibling lookup is a round trip in
+  // front of the only send that path makes (issue #246). Skipped once the chat has been messaged, for
+  // the reason stated right above: a started delivery is finished, not half-left.
+  //
+  // The fence goes FIRST and the watermark LAST, so the question this file has always asked
+  // immediately before this send keeps that position, and what sits behind the fence's answer is one
+  // database round trip rather than the lookup it was taken before.
+  if (
+    sibling &&
+    (p.closeChat || ((await ask()) === "go" && (await stillDelivering())))
+  ) {
     const waMode = proactiveSendMode(sw, sibling.lastInboundAt, now, {
       channelType: sibling.channelType,
       provider: sibling.provider,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -597,6 +597,11 @@ export async function redirectFollowUpHandler(
         // it and the post comes after that — so a switch flipped mid-turn would otherwise reach the
         // customer from an agent that is already off.
         //
+        // A stand-down here suppresses the send and leaves the generated turn in the thread's
+        // history, because the graph has already checkpointed it by the time any post-invoke gate
+        // answers. That is `runAgentNudge`'s shared behaviour — the ownership re-probe and a /reset
+        // land the same way — and it is #251, not this fence's to change.
+        //
         // The verdict is not carried out to the advance below, deliberately. `rescheduleTo` asks the
         // fence again, so an agent still off there ends the ladder anyway; what is left uncovered is
         // an operator switching OFF during the turn and back ON inside the milliseconds before that

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -961,10 +961,17 @@ export async function deliverRedirectClosing(
   // The fence goes FIRST and the watermark LAST, so the question this file has always asked
   // immediately before this send keeps that position, and what sits behind the fence's answer is one
   // database round trip rather than the lookup it was taken before.
-  if (
-    sibling &&
-    (p.closeChat || ((await ask()) === "go" && (await stillDelivering())))
-  ) {
+  if (sibling && !p.closeChat) {
+    const beforeSibling = await ask();
+    if (beforeSibling !== "go") {
+      // NOTE: Released, unlike the watermark check below. A claim lost to another run is not ours to
+      // give back — that is why nothing is released there — but a stand-down leaves this run holding
+      // an anchor over a goodbye nobody delivered, which is a funnel that can never close again.
+      await releaseClaim();
+      return beforeSibling === "retired" ? "already-closed" : "stood-down";
+    }
+  }
+  if (sibling && (p.closeChat || (await stillDelivering()))) {
     const waMode = proactiveSendMode(sw, sibling.lastInboundAt, now, {
       channelType: sibling.channelType,
       provider: sibling.provider,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -477,7 +477,12 @@ export async function redirectFollowUpHandler(
   // network in it — narrower than the window this whole fence exists to close.
   const fence = async (): Promise<LadderVerdict> => {
     const answer = await runScopedOn(base, sysCtx(tenantId), async (db) => {
-      if (await jobRetired(job, base, db)) return "retired" as const;
+      // NOTE: The retirement read goes LAST, and that ordering is the whole of what the transaction
+      // can offer: the two statements share a connection but not a snapshot (default READ COMMITTED),
+      // so whichever is asked last is the one observed closest to the send. Retirement gets it,
+      // because that is the position it held before this fence existed — a /reset must not be
+      // overtaken by a question added on top of it — and the liveness answer carries the residual,
+      // which is one statement wide rather than the round trip this fence exists to close.
       const a = await db.agent.findUnique({
         where: { id: agentId },
         select: { enabled: true, mode: true },
@@ -498,13 +503,13 @@ export async function redirectFollowUpHandler(
               })
             )?.testActivatedAt ?? null)
           : null;
-      return isRedirectFollowUpLive({
+      const live = isRedirectFollowUpLive({
         agentEnabled: a.enabled,
         agentMode: a.mode,
         testActivatedAt,
-      })
-        ? ("go" as const)
-        : ("stood-down" as const);
+      });
+      if (await jobRetired(job, base, db)) return "retired" as const;
+      return live ? ("go" as const) : ("stood-down" as const);
     }).catch((err: unknown) => {
       logger.warn(
         "channel-redirect: could not re-read the ladder's fence (widget thread=%s): %s",
@@ -528,7 +533,7 @@ export async function redirectFollowUpHandler(
     value: number,
     unit: RedirectDelayUnit,
   ): Promise<JobResult> =>
-    (await retired())
+    (await fence()) !== "go"
       ? { outcome: "done" }
       : {
           outcome: "reschedule",
@@ -961,12 +966,17 @@ export async function deliverRedirectClosing(
   // The fence goes FIRST and the watermark LAST, so the question this file has always asked
   // immediately before this send keeps that position, and what sits behind the fence's answer is one
   // database round trip rather than the lookup it was taken before.
-  if (sibling && !p.closeChat) {
+  if (sibling && !p.closeChat && (await stillDelivering())) {
+    // NOTE: Asked AFTER the watermark, so the fence is the last thing before the send rather than one
+    // round trip behind it. Which of the two takes that spot is a real choice: a stale watermark
+    // costs a duplicate goodbye in a race the CAS already makes rare, while a stale fence costs a
+    // message from an agent the operator switched off — the thing this fence exists to prevent.
+    //
+    // Released, unlike the watermark check itself. A claim lost to another run is not ours to give
+    // back, which is why nothing is released there; a stand-down leaves this run holding an anchor
+    // over a goodbye nobody delivered, and that is a funnel that can never close again.
     const beforeSibling = await ask();
     if (beforeSibling !== "go") {
-      // NOTE: Released, unlike the watermark check below. A claim lost to another run is not ours to
-      // give back — that is why nothing is released there — but a stand-down leaves this run holding
-      // an anchor over a goodbye nobody delivered, which is a funnel that can never close again.
       await releaseClaim();
       return beforeSibling === "retired" ? "already-closed" : "stood-down";
     }

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -302,6 +302,10 @@ async function resolveWhatsAppSibling(
 
 export type WhatsAppFollowUpOutcome =
   | "retired"
+  // The agent stopped being live while this stage did its own I/O. Distinct from "retired" because
+  // the CALLER answers them differently: a retired ladder is gone, a stood-down one must not be
+  // advanced to a closing that a re-enabled agent would then deliver (issue #246).
+  | "stood-down"
   | "sent"
   | "no-sibling"
   | "misconfigured";
@@ -310,6 +314,11 @@ export interface SendWhatsAppFollowUpParams {
   // Asked immediately before the send, after the sibling lookup and the token mint — both of which
   // are round trips a /reset can land inside. Absent, the answer is yes.
   stillWanted?: () => Promise<boolean>;
+  // The same question for the agent's own switch, asked in the same place and answered separately
+  // (issue #246). Its own callback rather than a term inside `stillWanted`: the caller reads a false
+  // `stillWanted` as "retired" and still advances the ladder, which is wrong for this one. Absent,
+  // the answer is yes.
+  stillLive?: () => Promise<boolean>;
   tenantId: bigint;
   instanceId: bigint;
   agentId: bigint;
@@ -361,6 +370,7 @@ export async function sendWhatsAppFollowUp(
   // NOTE: The link mint above is an HTTP round trip to Chatwoot, so the answer the caller had is older than
   // this line. Nothing has left yet, which makes this the last free place to stop.
   if (p.stillWanted && !(await p.stillWanted())) return "retired";
+  if (p.stillLive && !(await p.stillLive())) return "stood-down";
   const sw = readServiceWindowConfig(p.settings);
   const mode = proactiveSendMode(sw, sibling.lastInboundAt, p.now, {
     channelType: sibling.channelType,
@@ -448,6 +458,51 @@ export async function redirectFollowUpHandler(
   ) {
     return { outcome: "done" };
   }
+  // The same question, re-asked from inside the stages, because the answer above is taken before a
+  // sibling lookup, a link mint (an HTTP round trip) and a client build — and an operator reaching
+  // for the switch is likeliest to do it WHILE the agent is chasing somebody (issue #246).
+  //
+  // Fail OPEN on a read that fails, which is the same call `jobRetired` makes and for the same
+  // reason: an unknown answer must not silently drop work that was legitimately armed. A DELETED
+  // agent is an answer, and it is no.
+  const stillLive = async (): Promise<boolean> => {
+    const now = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+      const a = await db.agent.findUnique({
+        where: { id: agentId },
+        select: { enabled: true, mode: true },
+      });
+      if (!a) return { deleted: true as const };
+      const c = await db.conversation.findUnique({
+        where: {
+          tenantId_chatwootInstanceId_chatwootConversationId: {
+            tenantId,
+            chatwootInstanceId: parsed.instanceId,
+            chatwootConversationId: parsed.conversationId,
+          },
+        },
+        select: { testActivatedAt: true },
+      });
+      return {
+        deleted: false as const,
+        a,
+        testActivatedAt: c?.testActivatedAt ?? null,
+      };
+    }).catch((err: unknown) => {
+      logger.warn(
+        "channel-redirect: could not re-read the agent's liveness (widget thread=%s): %s",
+        payload.widgetThreadId,
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    });
+    if (now === null) return true;
+    if (now.deleted) return false;
+    return isRedirectFollowUpLive({
+      agentEnabled: now.a.enabled,
+      agentMode: now.a.mode,
+      testActivatedAt: now.testActivatedAt,
+    });
+  };
   const entryInboxId = cfg.entryInboxId ?? payload.entryInboxId;
 
   // Reschedule this same job to the next stage after its configured delay. The payload is authoritative
@@ -511,6 +566,7 @@ export async function redirectFollowUpHandler(
     if (cfg.waFollowupEnabled && entryInboxId !== null) {
       const outcome = await sendWhatsAppFollowUp({
         stillWanted: async () => !(await retired()),
+        stillLive,
         tenantId,
         instanceId: parsed.instanceId,
         agentId,
@@ -528,6 +584,11 @@ export async function redirectFollowUpHandler(
           payload.widgetThreadId,
         );
       }
+      // The ladder ENDS on a stand-down instead of advancing. Arming the closing here would leave it
+      // pointed at an episode nobody is chasing any more: re-enable the agent before that delay
+      // expires and the closing messages and resolves BOTH conversations, with no fresh inbound
+      // behind it. A customer message re-arms the ladder from stage "chat" the normal way.
+      if (outcome === "stood-down") return { outcome: "done" };
     }
     if (cfg.closingEnabled) {
       return await rescheduleTo(
@@ -544,6 +605,7 @@ export async function redirectFollowUpHandler(
   if (cfg.closingEnabled && entryInboxId !== null) {
     await deliverRedirectClosing({
       stillWanted: async () => !(await retired()),
+      stillLive,
       tenantId,
       instanceId: parsed.instanceId,
       widgetConversationId: parsed.conversationId,
@@ -608,6 +670,11 @@ export interface DeliverRedirectClosingParams {
   // at-most-once anchor) and again before the sends, after the reads and the client build. Absent,
   // the answer is yes — the resolve-transition caller has no job to retire.
   stillWanted?: () => Promise<boolean>;
+  // Whether the AGENT is still live, asked at the same two points and for the same reason: this
+  // function reads, builds a client and looks up a sibling before it says anything, and the caller's
+  // answer is older than all of it (issue #246). Separate from `stillWanted` because a false there
+  // means "retired", which its callers act on differently. Absent, the answer is yes.
+  stillLive?: () => Promise<boolean>;
   tenantId: bigint;
   instanceId: bigint;
   // The WIDGET conversation's chatwootConversationId. The closing watermark lives on this row; the agent
@@ -625,7 +692,12 @@ export interface DeliverRedirectClosingParams {
   deps?: RuntimeDeps;
 }
 
-export type DeliverRedirectClosingOutcome = "delivered" | "already-closed";
+export type DeliverRedirectClosingOutcome =
+  | "delivered"
+  | "already-closed"
+  // The agent stopped being live while this run did its reads. Told apart from "already-closed" so
+  // the log line names the switch rather than a race that did not happen (issue #246).
+  | "stood-down";
 
 // The single closing entry point, shared by the ladder's terminal "closing" stage and the webhook's
 // widget-resolve detection. The closing is a FIXED message posted on BOTH channels — the website chat and
@@ -760,6 +832,10 @@ export async function deliverRedirectClosing(
     await releaseClaim();
     return "already-closed";
   }
+  if (p.stillLive && !(await p.stillLive())) {
+    await releaseClaim();
+    return "stood-down";
+  }
 
   // And the fence for the caller that has no job to ask about. The resolve trigger reaches here
   // straight from a webhook, so `stillWanted` is undefined for it and every check above is one this
@@ -810,6 +886,10 @@ export async function deliverRedirectClosing(
   if (p.stillWanted && !(await p.stillWanted())) {
     await releaseClaim();
     return "already-closed";
+  }
+  if (p.stillLive && !(await p.stillLive())) {
+    await releaseClaim();
+    return "stood-down";
   }
 
   // Chat (website widget): post the goodbye + resolve. Skipped on the resolve-path, where the chat is

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -596,6 +596,11 @@ export async function redirectFollowUpHandler(
         // in the ladder — the config load is fail-closed on `enabled`, but the model turn runs after
         // it and the post comes after that — so a switch flipped mid-turn would otherwise reach the
         // customer from an agent that is already off.
+        //
+        // The verdict is not carried out to the advance below, deliberately. `rescheduleTo` asks the
+        // fence again, so an agent still off there ends the ladder anyway; what is left uncovered is
+        // an operator switching OFF during the turn and back ON inside the milliseconds before that
+        // ask, and an agent that is live again by then has a defensible claim to the next stage.
         stillWanted: async (scoped) => (await fence(scoped)) === "go",
         deps,
       });

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -966,22 +966,28 @@ export async function deliverRedirectClosing(
   // The fence goes FIRST and the watermark LAST, so the question this file has always asked
   // immediately before this send keeps that position, and what sits behind the fence's answer is one
   // database round trip rather than the lookup it was taken before.
+  // NOTE: ONE watermark read and ONE fence, in that order, and nothing between the fence and the
+  // send. Asking the watermark again after the fence — which is what a second `stillDelivering()`
+  // here would be — puts a round trip behind the fence's answer and hands the last word back to the
+  // question that was not supposed to have it.
+  //
+  // Which of the two gets that word is a real choice: a stale watermark costs a duplicate goodbye in
+  // a race the claim CAS already makes rare, while a stale fence costs a message from an agent the
+  // operator switched off, which is what this fence exists to prevent.
+  //
+  // The stand-down releases the claim; the watermark refusal does not, and that asymmetry is the
+  // point — a claim lost to another run is not ours to give back, while a stand-down leaves this run
+  // holding one over a goodbye nobody delivered.
+  let deliverToSibling = Boolean(sibling) && p.closeChat;
   if (sibling && !p.closeChat && (await stillDelivering())) {
-    // NOTE: Asked AFTER the watermark, so the fence is the last thing before the send rather than one
-    // round trip behind it. Which of the two takes that spot is a real choice: a stale watermark
-    // costs a duplicate goodbye in a race the CAS already makes rare, while a stale fence costs a
-    // message from an agent the operator switched off — the thing this fence exists to prevent.
-    //
-    // Released, unlike the watermark check itself. A claim lost to another run is not ours to give
-    // back, which is why nothing is released there; a stand-down leaves this run holding an anchor
-    // over a goodbye nobody delivered, and that is a funnel that can never close again.
     const beforeSibling = await ask();
     if (beforeSibling !== "go") {
       await releaseClaim();
       return beforeSibling === "retired" ? "already-closed" : "stood-down";
     }
+    deliverToSibling = true;
   }
-  if (sibling && (p.closeChat || (await stillDelivering()))) {
+  if (sibling && deliverToSibling) {
     const waMode = proactiveSendMode(sw, sibling.lastInboundAt, now, {
       channelType: sibling.channelType,
       provider: sibling.provider,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -496,38 +496,45 @@ export async function redirectFollowUpHandler(
       // and the catch around this whole read turns a failure into "go" — which is right for an answer
       // nobody could read, and wrong for one already in hand.
       if (!a.enabled) return "stood-down" as const;
-      // NOTE: The stamp lookup fails open ON ITS OWN, not through the catch around the whole read:
-      // that one would answer "go" without ever asking about retirement, so a blip on a test agent's
-      // activation would carry a /reset past the tombstone that exists to stop it. Unknown liveness
-      // is live; unknown retirement is a different question and is still asked below.
-      let live = true;
-      if (a.mode === "test") {
-        try {
-          const c = await db.conversation.findUnique({
-            where: {
-              tenantId_chatwootInstanceId_chatwootConversationId: {
-                tenantId,
-                chatwootInstanceId: parsed.instanceId,
-                chatwootConversationId: parsed.conversationId,
-              },
-            },
-            select: { testActivatedAt: true },
-          });
-          live = isRedirectFollowUpLive({
-            agentEnabled: a.enabled,
-            agentMode: a.mode,
-            testActivatedAt: c?.testActivatedAt ?? null,
-          });
-        } catch (err) {
-          logger.warn(
-            "channel-redirect: could not read the activation stamp (widget thread=%s): %s",
-            payload.widgetThreadId,
-            err instanceof Error ? err.message : String(err),
-          );
-        }
-      }
+      // NOTE: Retirement is answered BEFORE the fallible read, not after it, and that ordering is
+      // what a `catch` alone cannot buy: a query PostgreSQL rejects leaves the transaction aborted,
+      // so every later statement in it fails too — the retirement read included, and the outer catch
+      // would then answer "go" on a ladder a /reset had already retired. Taken first, that answer is
+      // already in hand when the stamp read can go wrong.
+      //
+      // The cost is that for a TEST agent the retirement answer is one statement older than the send
+      // instead of the last thing read. For every other agent nothing moves: the stamp is not read at
+      // all, so retirement stays last.
       if (await jobRetired(job, base, db)) return "retired" as const;
-      return live ? ("go" as const) : ("stood-down" as const);
+      if (a.mode !== "test") return "go" as const;
+      // NOTE: The stamp lookup fails open ON ITS OWN: unknown liveness is live, and the answer that
+      // matters more — retirement — is already decided above.
+      try {
+        const c = await db.conversation.findUnique({
+          where: {
+            tenantId_chatwootInstanceId_chatwootConversationId: {
+              tenantId,
+              chatwootInstanceId: parsed.instanceId,
+              chatwootConversationId: parsed.conversationId,
+            },
+          },
+          select: { testActivatedAt: true },
+        });
+        return isRedirectFollowUpLive({
+          agentEnabled: a.enabled,
+          agentMode: a.mode,
+          testActivatedAt: c?.testActivatedAt ?? null,
+        })
+          ? ("go" as const)
+          : ("stood-down" as const);
+      } catch (err) {
+        logger.warn(
+          "channel-redirect: could not read the activation stamp (widget thread=%s): %s",
+          payload.widgetThreadId,
+          err instanceof Error ? err.message : String(err),
+        );
+        return "go" as const;
+      }
     };
     const answer = await (scoped
       ? read(scoped)

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -492,6 +492,10 @@ export async function redirectFollowUpHandler(
         select: { enabled: true, mode: true },
       });
       if (!a) return "stood-down" as const;
+      // NOTE: A conclusive answer, taken before the fallible one. The stamp lookup below can throw,
+      // and the catch around this whole read turns a failure into "go" — which is right for an answer
+      // nobody could read, and wrong for one already in hand.
+      if (!a.enabled) return "stood-down" as const;
       const testActivatedAt =
         a.mode === "test"
           ? ((

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -1001,19 +1001,15 @@ export async function deliverRedirectClosing(
     p.entryInboxId,
     base,
   );
-  // The second ask, and it is skipped once the chat has ALREADY been messaged and resolved. Standing
-  // down here would leave the episode half-closed — the widget said goodbye and is resolved, the
-  // WhatsApp side still open — and report `delivered` for it. A reset that lands mid-delivery cannot
-  // un-send the first half, so the honest completion of a started delivery is both halves; the ask
-  // is what stops one that has not started.
-  // NOTE: The fence covers the same stretch, which the watermark check does not: on the resolve path
-  // nothing has been delivered when the ask above runs, and the sibling lookup is a round trip in
-  // front of the only send that path makes (issue #246). Skipped once the chat has been messaged, for
-  // the reason stated right above: a started delivery is finished, not half-left.
   // NOTE: ONE watermark read and ONE fence, in that order, and nothing between the fence and the
   // send. Asking the watermark again after the fence — which is what a second `stillDelivering()`
   // here would be — puts a round trip behind the fence's answer and hands the last word back to the
   // question that was not supposed to have it.
+  //
+  // Both asks are skipped once the chat has ALREADY been messaged and resolved. Standing down there
+  // would leave the episode half-closed — the widget said goodbye and is resolved, the WhatsApp side
+  // still open — and report `delivered` for it. Nothing can un-send the first half, so the honest
+  // completion of a started delivery is both halves; the asks are what stop one that has not started.
   //
   // Which of the two gets that word is a real choice: a stale watermark costs a duplicate goodbye in
   // a race the claim CAS already makes rare, while a stale fence costs a message from an agent the

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -995,10 +995,6 @@ export async function deliverRedirectClosing(
   // nothing has been delivered when the ask above runs, and the sibling lookup is a round trip in
   // front of the only send that path makes (issue #246). Skipped once the chat has been messaged, for
   // the reason stated right above: a started delivery is finished, not half-left.
-  //
-  // The fence goes FIRST and the watermark LAST, so the question this file has always asked
-  // immediately before this send keeps that position, and what sits behind the fence's answer is one
-  // database round trip rather than the lookup it was taken before.
   // NOTE: ONE watermark read and ONE fence, in that order, and nothing between the fence and the
   // send. Asking the watermark again after the fence — which is what a second `stillDelivering()`
   // here would be — puts a round trip behind the fence's answer and hands the last word back to the

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -475,8 +475,12 @@ export async function redirectFollowUpHandler(
   // the job row and nothing straddles it. For a test agent the two reads share the transaction but not
   // a snapshot (`runScopedOn` uses the default isolation), which leaves a gap of one statement with no
   // network in it — narrower than the window this whole fence exists to close.
-  const fence = async (): Promise<LadderVerdict> => {
-    const answer = await runScopedOn(base, sysCtx(tenantId), async (db) => {
+  //
+  // Takes the caller's connection when there is one — the same rule `jobRetired` states and for the
+  // same reason: asked from inside the nudge's thread claim, a second connection would stall on an
+  // exhausted pool while the advisory lock is held, and `DB_POOL_MAX=1` is a supported setting.
+  const fence = async (scoped?: ScopedDb): Promise<LadderVerdict> => {
+    const read = async (db: ScopedDb) => {
       // NOTE: The retirement read goes LAST, and that ordering is the whole of what the transaction
       // can offer: the two statements share a connection but not a snapshot (default READ COMMITTED),
       // so whichever is asked last is the one observed closest to the send. Retirement gets it,
@@ -510,7 +514,11 @@ export async function redirectFollowUpHandler(
       });
       if (await jobRetired(job, base, db)) return "retired" as const;
       return live ? ("go" as const) : ("stood-down" as const);
-    }).catch((err: unknown) => {
+    };
+    const answer = await (scoped
+      ? read(scoped)
+      : runScopedOn(base, sysCtx(tenantId), read)
+    ).catch((err: unknown) => {
       logger.warn(
         "channel-redirect: could not re-read the ladder's fence (widget thread=%s): %s",
         payload.widgetThreadId,
@@ -553,7 +561,11 @@ export async function redirectFollowUpHandler(
         threadId: payload.widgetThreadId,
         nudge: chatFollowupNudge(cfg.chatFollowupInstructions),
         base,
-        stillWanted: async (scoped) => !(await retired(scoped)),
+        // NOTE: The composite fence, on the nudge's own connection. This stage's window is the widest
+        // in the ladder — the config load is fail-closed on `enabled`, but the model turn runs after
+        // it and the post comes after that — so a switch flipped mid-turn would otherwise reach the
+        // customer from an agent that is already off.
+        stillWanted: async (scoped) => (await fence(scoped)) === "go",
         deps,
       });
     }

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -539,13 +539,23 @@ export async function redirectFollowUpHandler(
     const answer = await (scoped
       ? read(scoped)
       : runScopedOn(base, sysCtx(tenantId), read)
-    ).catch((err: unknown) => {
+    ).catch(async (err: unknown) => {
       logger.warn(
         "channel-redirect: could not re-read the ladder's fence (widget thread=%s): %s",
         payload.widgetThreadId,
         err instanceof Error ? err.message : String(err),
       );
-      return "go" as const;
+      // NOTE: The liveness half is unknown here, and unknown is live. Retirement is not allowed to be
+      // unknown by association: a statement the server rejects leaves the transaction aborted, so it
+      // cannot be asked in THAT one — it gets a fresh one. A /reset is the strongest fence in this
+      // file and it must not be overtaken by a question that was added on top of it.
+      //
+      // Not when the caller handed us its connection: opening a second one inside the nudge's
+      // advisory lock is the pool inversion `jobRetired` warns about, and that path keeps its own
+      // retirement fences either side of this one.
+      if (scoped) return "go" as const;
+      const stillRetired = await jobRetired(job, base).catch(() => false);
+      return stillRetired ? ("retired" as const) : ("go" as const);
     });
     return answer;
   };

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -496,26 +496,36 @@ export async function redirectFollowUpHandler(
       // and the catch around this whole read turns a failure into "go" — which is right for an answer
       // nobody could read, and wrong for one already in hand.
       if (!a.enabled) return "stood-down" as const;
-      const testActivatedAt =
-        a.mode === "test"
-          ? ((
-              await db.conversation.findUnique({
-                where: {
-                  tenantId_chatwootInstanceId_chatwootConversationId: {
-                    tenantId,
-                    chatwootInstanceId: parsed.instanceId,
-                    chatwootConversationId: parsed.conversationId,
-                  },
-                },
-                select: { testActivatedAt: true },
-              })
-            )?.testActivatedAt ?? null)
-          : null;
-      const live = isRedirectFollowUpLive({
-        agentEnabled: a.enabled,
-        agentMode: a.mode,
-        testActivatedAt,
-      });
+      // NOTE: The stamp lookup fails open ON ITS OWN, not through the catch around the whole read:
+      // that one would answer "go" without ever asking about retirement, so a blip on a test agent's
+      // activation would carry a /reset past the tombstone that exists to stop it. Unknown liveness
+      // is live; unknown retirement is a different question and is still asked below.
+      let live = true;
+      if (a.mode === "test") {
+        try {
+          const c = await db.conversation.findUnique({
+            where: {
+              tenantId_chatwootInstanceId_chatwootConversationId: {
+                tenantId,
+                chatwootInstanceId: parsed.instanceId,
+                chatwootConversationId: parsed.conversationId,
+              },
+            },
+            select: { testActivatedAt: true },
+          });
+          live = isRedirectFollowUpLive({
+            agentEnabled: a.enabled,
+            agentMode: a.mode,
+            testActivatedAt: c?.testActivatedAt ?? null,
+          });
+        } catch (err) {
+          logger.warn(
+            "channel-redirect: could not read the activation stamp (widget thread=%s): %s",
+            payload.widgetThreadId,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
       if (await jobRetired(job, base, db)) return "retired" as const;
       return live ? ("go" as const) : ("stood-down" as const);
     };

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2588,28 +2588,36 @@ export async function processChatwootDelivery(
               // function's own reads, and this path has no job to ask about — so the switch is
               // re-asked from inside, at the same points (issue #246). Fail OPEN on a read that
               // fails: a conversation resolves once, so a transient error must not cost the closing.
-              stillLive: async () => {
+              // The gate above is older than the sibling lookup, the client build and this
+              // function's own reads, and this path has no job to ask about — so the switch is
+              // re-asked from inside, at the same points the ladder asks (issue #246). One read, and
+              // it fails OPEN: a conversation resolves once, so a transient error must not cost the
+              // closing. A production agent needs no stamp lookup at all.
+              fence: async () => {
                 const rt = await inboxAgentRuntime(
                   params.tenantId,
                   params.instanceId,
                   closingInboxId,
                   base,
                 ).catch(() => undefined);
-                if (rt === undefined) return true;
-                if (rt === null) return false;
+                if (rt === undefined) return "go" as const;
+                if (rt === null) return "stood-down" as const;
+                const testActivatedAt =
+                  rt.mode === "test"
+                    ? await widgetTestActivatedAt(
+                        params.tenantId,
+                        params.instanceId,
+                        conversationId,
+                        base,
+                      ).catch(() => new Date())
+                    : null;
                 return isRedirectFollowUpLive({
                   agentEnabled: rt.enabled,
                   agentMode: rt.mode,
-                  testActivatedAt:
-                    rt.mode === "test"
-                      ? await widgetTestActivatedAt(
-                          params.tenantId,
-                          params.instanceId,
-                          conversationId,
-                          base,
-                        ).catch(() => new Date())
-                      : null,
-                });
+                  testActivatedAt,
+                })
+                  ? ("go" as const)
+                  : ("stood-down" as const);
               },
               tenantId: params.tenantId,
               instanceId: params.instanceId,

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2602,15 +2602,22 @@ export async function processChatwootDelivery(
                 ).catch(() => undefined);
                 if (rt === undefined) return "go" as const;
                 if (rt === null) return "stood-down" as const;
-                const testActivatedAt =
-                  rt.mode === "test"
-                    ? await widgetTestActivatedAt(
-                        params.tenantId,
-                        params.instanceId,
-                        conversationId,
-                        base,
-                      ).catch(() => new Date())
-                    : null;
+                // The switch is conclusive on its own, and it is read here — before the stamp, which
+                // is fallible and which only a test agent needs at all.
+                if (!rt.enabled) return "stood-down" as const;
+                if (rt.mode !== "test") return "go" as const;
+                // A test agent's answer takes a second read, and the two do not share a snapshot: the
+                // switch could flip inside it. Left as a residual rather than closed, because closing
+                // it needs the agent and the stamp in ONE statement and `Inbox` has no `agent`
+                // relation to select through — so it would take raw SQL or a schema change, for a
+                // window one query wide on a test agent, on the path where the operator has just
+                // resolved the conversation by hand.
+                const testActivatedAt = await widgetTestActivatedAt(
+                  params.tenantId,
+                  params.instanceId,
+                  conversationId,
+                  base,
+                ).catch(() => new Date());
                 return isRedirectFollowUpLive({
                   agentEnabled: rt.enabled,
                   agentMode: rt.mode,

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2584,6 +2584,33 @@ export async function processChatwootDelivery(
             });
           if (closingLive && redirectCfg.entryInboxId !== null) {
             const outcome = await deliverRedirectClosing({
+              // The answer above is older than the sibling lookup, the client build and this
+              // function's own reads, and this path has no job to ask about — so the switch is
+              // re-asked from inside, at the same points (issue #246). Fail OPEN on a read that
+              // fails: a conversation resolves once, so a transient error must not cost the closing.
+              stillLive: async () => {
+                const rt = await inboxAgentRuntime(
+                  params.tenantId,
+                  params.instanceId,
+                  closingInboxId,
+                  base,
+                ).catch(() => undefined);
+                if (rt === undefined) return true;
+                if (rt === null) return false;
+                return isRedirectFollowUpLive({
+                  agentEnabled: rt.enabled,
+                  agentMode: rt.mode,
+                  testActivatedAt:
+                    rt.mode === "test"
+                      ? await widgetTestActivatedAt(
+                          params.tenantId,
+                          params.instanceId,
+                          conversationId,
+                          base,
+                        ).catch(() => new Date())
+                      : null,
+                });
+              },
               tenantId: params.tenantId,
               instanceId: params.instanceId,
               widgetConversationId: conversationId,

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2602,12 +2602,13 @@ export async function processChatwootDelivery(
                 ).catch(() => undefined);
                 if (rt === undefined) return "go" as const;
                 if (rt === null) return "stood-down" as const;
-                // The switch is conclusive on its own, and it is read here — before the stamp, which
-                // is fallible and which only a test agent needs at all.
+                // NOTE: The switch is conclusive on its own, and it is read here — before the
+                // stamp, which is fallible and which only a test agent needs at all.
                 if (!rt.enabled) return "stood-down" as const;
                 if (rt.mode !== "test") return "go" as const;
-                // A test agent's answer takes a second read, and the two do not share a snapshot: the
-                // switch could flip inside it. Left as a residual rather than closed, because closing
+                // NOTE: A test agent's answer takes a second read, and the two do not share a
+                // snapshot: the switch could flip inside it. Left as a residual rather than closed,
+                // because closing
                 // it needs the agent and the stamp in ONE statement and `Inbox` has no `agent`
                 // relation to select through — so it would take raw SQL or a schema change, for a
                 // window one query wide on a test agent, on the path where the operator has just

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -505,6 +505,13 @@ describe.skipIf(!dbUp)(
         // The lookup really ran, so this is the window and not a path that stopped earlier.
         expect(flipped).toBe(true);
         expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+        // And the anchor is handed back. A stand-down that keeps it burns the at-most-once mark on a
+        // goodbye nobody delivered, which is a funnel that can never close.
+        const widget = await suDb.conversation.findFirstOrThrow({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          select: { redirectClosedAt: true },
+        });
+        expect(widget.redirectClosedAt).toBeNull();
       } finally {
         await suDb.agent.update({
           where: { id: agent },

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -473,6 +473,46 @@ describe.skipIf(!dbUp)(
       }
     });
 
+    // The stretch the gate at the top cannot cover on this path: with `closeChat: false` nothing has
+    // been said when the fence answers, and the sibling lookup is a round trip in front of the only
+    // send the resolve trigger makes.
+    test("switched off during the sibling lookup posts nothing", async () => {
+      await suDb.agent.update({
+        where: { id: agent },
+        data: { enabled: true },
+      });
+      await rearm();
+      let flipped = false;
+      const flipping = appDb.$extends({
+        query: {
+          conversation: {
+            async findFirst({ args, query }) {
+              const res = await query(args);
+              if (!flipped) {
+                flipped = true;
+                await suDb.agent.update({
+                  where: { id: agent },
+                  data: { enabled: false },
+                });
+              }
+              return res;
+            },
+          },
+        },
+      }) as unknown as PrismaClient;
+      try {
+        await resolveWidget(flipping);
+        // The lookup really ran, so this is the window and not a path that stopped earlier.
+        expect(flipped).toBe(true);
+        expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+      } finally {
+        await suDb.agent.update({
+          where: { id: agent },
+          data: { enabled: true },
+        });
+      }
+    });
+
     // The control: the same resolve, agent on, does reach the customer — otherwise the assertion above
     // would pass on a path that never delivers anything.
     test("the same resolve with the agent on does post it", async () => {

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -333,7 +333,7 @@ describe.skipIf(!dbUp)(
     });
 
     // The widget conversation transitions pending -> resolved, which is the trigger the receiver reads.
-    const resolveWidget = async () => {
+    const resolveWidget = async (db: PrismaClient = appDb) => {
       seq += 1;
       const n = normalizeChatwootEvent({
         event: "conversation_resolved",
@@ -366,7 +366,7 @@ describe.skipIf(!dbUp)(
           deliveryRowId: delivery.id,
           agentBotId: 12,
           normalized: n,
-          base: appDb,
+          base: db,
         });
       } finally {
         globalThis.fetch = originalFetch;
@@ -421,6 +421,54 @@ describe.skipIf(!dbUp)(
         await suDb.agent.update({
           where: { id: agent },
           data: { mode: "production" },
+        });
+      }
+    });
+
+    // Issue #246: the runtime is read, and then compaction arming, the ladder cancel and the closing's
+    // own reads all run before anything is posted. The switch is re-asked from inside for that window.
+    test("switched off while the closing reads posts nothing", async () => {
+      await suDb.agent.update({
+        where: { id: agent },
+        data: { enabled: true },
+      });
+      await rearm();
+      // The rendezvous is the receiver's OWN agent read — the one that answers the gate. The switch
+      // flips the instant after it returns, so the gate sees a live agent and everything the closing
+      // does afterwards (the sibling lookup, the client build, its own reads) happens under an answer
+      // that is already false.
+      let reads = 0;
+      const flipping = appDb.$extends({
+        query: {
+          agent: {
+            async findUnique({ args, query }) {
+              const res = await query(args);
+              reads += 1;
+              if (reads === 1) {
+                await suDb.agent.update({
+                  where: { id: agent },
+                  data: { enabled: false },
+                });
+              }
+              return res;
+            },
+          },
+        },
+      }) as unknown as PrismaClient;
+      try {
+        await resolveWidget(flipping);
+        expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+        const widget = await suDb.conversation.findFirstOrThrow({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          select: { redirectClosedAt: true },
+        });
+        // Released rather than burned: the anchor is what makes the closing at-most-once, and a
+        // stand-down is not a delivery.
+        expect(widget.redirectClosedAt).toBeNull();
+      } finally {
+        await suDb.agent.update({
+          where: { id: agent },
+          data: { enabled: true },
         });
       }
     });

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -520,6 +520,59 @@ describe.skipIf(!dbUp)(
       }
     });
 
+    // Which of the two questions is asked LAST is a decision, and this is the case that shows it: the
+    // switch flips from inside the watermark count itself, so a fence asked before it would answer
+    // "go" and the goodbye would go out. A stale watermark costs a duplicate goodbye in a race the
+    // CAS already makes rare; a stale fence costs a message from an agent the operator switched off.
+    test("switched off from inside the watermark check posts nothing", async () => {
+      await suDb.agent.update({
+        where: { id: agent },
+        data: { enabled: true },
+      });
+      await rearm();
+      let claimReads = 0;
+      const flipping = appDb.$extends({
+        query: {
+          conversation: {
+            async count({ args, query }) {
+              const where =
+                (args as { where?: Record<string, unknown> }).where ?? {};
+              const res = await query(args);
+              // The SECOND claim read: this function checks the watermark once before its sends and
+              // again inside the sibling branch, and only the second one is the round trip the fence
+              // is being ordered against. Flipping on the first would be caught by the fence that
+              // follows it, and the ordering would go untested.
+              if (where.redirectClosedAt instanceof Date) {
+                claimReads += 1;
+              }
+              if (claimReads === 2) {
+                await suDb.agent.update({
+                  where: { id: agent },
+                  data: { enabled: false },
+                });
+              }
+              return res;
+            },
+          },
+        },
+      }) as unknown as PrismaClient;
+      try {
+        await resolveWidget(flipping);
+        expect(claimReads).toBeGreaterThanOrEqual(2);
+        expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+        const widget = await suDb.conversation.findFirstOrThrow({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          select: { redirectClosedAt: true },
+        });
+        expect(widget.redirectClosedAt).toBeNull();
+      } finally {
+        await suDb.agent.update({
+          where: { id: agent },
+          data: { enabled: true },
+        });
+      }
+    });
+
     // The control: the same resolve, agent on, does reach the customer — otherwise the assertion above
     // would pass on a path that never delivers anything.
     test("the same resolve with the agent on does post it", async () => {

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1238,6 +1238,139 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     });
   });
 
+  // ── Issue #246: the gate answers at handler entry and the stages send later, across I/O of their
+  //    own. These pin what the ladder does when the switch flips INSIDE that window, which is the
+  //    moment an operator watching a lead being chased is likeliest to reach for it.
+  test("switched off during the link mint sends nothing AND does not advance", async () => {
+    const job = await claimed("whatsapp");
+    const s = stubClient();
+    wire.length = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      wire.push(url);
+      if (url.includes("/redirect_tokens")) {
+        await suDb.agent.update({
+          where: { id: agentId },
+          data: { enabled: false },
+        });
+      }
+      const body = url.includes("/redirect_tokens")
+        ? { token: "tok-246", website_url: "https://loja.example" }
+        : url.includes("/inboxes")
+          ? { id: 111, website_url: "https://loja.example" }
+          : { id: 1, payload: {} };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    let result: Awaited<ReturnType<typeof redirectFollowUpHandler>>;
+    try {
+      result = await redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { enabled: true },
+      });
+    }
+    // The mint happened, so this is the window and not a stage that stopped earlier.
+    expect(wire.some((u) => u.includes("/redirect_tokens"))).toBe(true);
+    expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+    // And the ladder ENDS. Rescheduling would arm the closing on a stood-down episode: re-enable the
+    // agent before that delay expires and it messages and resolves both conversations, with no fresh
+    // inbound behind it.
+    expect(result).toEqual({ outcome: "done" });
+  });
+
+  test("switched off while the closing reads sends nothing and frees the anchor", async () => {
+    const job = await claimed("closing");
+    const s = stubClient();
+    // The rendezvous is the closing's own first read: everything after it — the bot, the client, the
+    // sibling — is I/O this run does while holding an answer it took before.
+    let reads = 0;
+    const flipping = appDb.$extends({
+      query: {
+        conversation: {
+          async findUnique({ args, query }) {
+            const res = await query(args);
+            reads += 1;
+            if (reads === 1) {
+              await suDb.agent.update({
+                where: { id: agentId },
+                data: { enabled: false },
+              });
+            }
+            return res;
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    try {
+      await redirectFollowUpHandler(job, flipping, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { enabled: true },
+      });
+    }
+    expect(s.sent).toEqual([]);
+    expect(s.resolved).toEqual([]);
+    // Released, not burned: the at-most-once anchor left set on a closing nobody delivered is a
+    // funnel that can never close.
+    const widget = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: WIDGET_CONV },
+      select: { redirectClosedAt: true },
+    });
+    expect(widget.redirectClosedAt).toBeNull();
+  });
+
+  // The other half of the rule, and the one a fence gets wrong silently: an answer that could not be
+  // READ is not a refusal. `jobRetired` makes the same call for the same reason — an unknown answer
+  // must not drop work that was legitimately armed — so a database blip during the mint costs a
+  // follow-up the customer should have received.
+  test("a liveness read that fails does not stand the ladder down", async () => {
+    const job = await claimed("whatsapp");
+    const s = stubClient();
+    wire.length = 0;
+    globalThis.fetch = httpDouble;
+    // Only the liveness re-read fails: it asks for `enabled` + `mode` alone, while the handler's own
+    // load at the top takes `settings` with them. A blanket failure would prove nothing, since every
+    // read on the path would be down — including the one that decides whether to run at all.
+    const failing = appDb.$extends({
+      query: {
+        agent: {
+          async findUnique({ args, query }) {
+            const sel = args.select as Record<string, unknown> | undefined;
+            if (
+              sel?.enabled === true &&
+              sel?.mode === true &&
+              sel?.settings === undefined
+            ) {
+              throw new Error("liveness read is down");
+            }
+            return query(args);
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    try {
+      await redirectFollowUpHandler(job, failing, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    expect(wire.some((u) => u.includes("/messages"))).toBe(true);
+  });
+
   test("a retire mid-stage stops the closing, and the resolve with it", async () => {
     const job = await claimed("closing");
     const s = stubClient();

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1371,6 +1371,46 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     expect(wire.some((u) => u.includes("/messages"))).toBe(true);
   });
 
+  // The widest window in the ladder: the nudge's config load is fail-closed on `enabled`, but the
+  // model turn runs after it and the post comes after that. A switch flipped mid-turn has to reach
+  // the send, or the chat follow-up goes out from an agent that is already off — and with no later
+  // stage enabled, nothing downstream would ever notice.
+  test("switched off during the model turn posts no chat follow-up", async () => {
+    const job = await claimed("chat");
+    const s = stubClient();
+    // The rendezvous is the nudge's own config load: it is the read that selects the prompt, and the
+    // model turn is what happens next.
+    const flipping = appDb.$extends({
+      query: {
+        agent: {
+          async findUnique({ args, query }) {
+            const res = await query(args);
+            const sel = args.select as Record<string, unknown> | undefined;
+            if (sel?.systemPrompt === true) {
+              await suDb.agent.update({
+                where: { id: agentId },
+                data: { enabled: false },
+              });
+            }
+            return res;
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    try {
+      await redirectFollowUpHandler(job, flipping, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { enabled: true },
+      });
+    }
+    expect(s.sent).toEqual([]);
+  });
+
   // Advancing is a decision too. A stage can end without ever reaching its own fence — the sibling
   // lookup finds nobody, the link cannot be minted, or the chat stage simply finishes — and arming
   // the next stage there points a closing at an episode the agent is no longer allowed to touch:

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1371,6 +1371,56 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     expect(wire.some((u) => u.includes("/messages"))).toBe(true);
   });
 
+  // Advancing is a decision too. A stage can end without ever reaching its own fence — the sibling
+  // lookup finds nobody, the link cannot be minted, or the chat stage simply finishes — and arming
+  // the next stage there points a closing at an episode the agent is no longer allowed to touch:
+  // re-enable it before that delay expires and it messages and resolves BOTH conversations.
+  test("switched off mid-stage does not arm the next stage", async () => {
+    const job = await claimed("chat");
+    // The rendezvous is the chat stage's own send: the follow-up goes out, and the operator switches
+    // the agent off right after reading it. Everything the ladder does from there — arming the next
+    // stage included — happens under an answer that is already false.
+    const flipOnSend = () => {
+      const sent: Array<[number, string]> = [];
+      const client = {
+        getConversation: async (c: number) => ({
+          id: c,
+          status: "pending",
+          meta: {},
+        }),
+        sendMessage: async (c: number, t: string) => {
+          sent.push([c, t]);
+          await suDb.agent.update({
+            where: { id: agentId },
+            data: { enabled: false },
+          });
+          return {};
+        },
+        sendPrivateNote: async () => ({}),
+        getConversationLabels: async () => [],
+        setConversationLabels: async () => ({}),
+        toggleStatus: async () => ({}),
+      } as unknown as ChatwootClient;
+      return { sent, makeClient: async () => client };
+    };
+    const s2 = flipOnSend();
+    let result: Awaited<ReturnType<typeof redirectFollowUpHandler>>;
+    try {
+      result = await redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s2.makeClient,
+      });
+    } finally {
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { enabled: true },
+      });
+    }
+    // The stage really ran, so this is the advance being fenced and not a handler that stopped early.
+    expect(s2.sent).toHaveLength(1);
+    expect(result).toEqual({ outcome: "done" });
+  });
+
   test("a retire mid-stage stops the closing, and the resolve with it", async () => {
     const job = await claimed("closing");
     const s = stubClient();

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1542,6 +1542,52 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     expect(s.resolved).toEqual([]);
   });
 
+  // The fence's own read can fail, and when it does the liveness half is unknown — which is live. The
+  // retirement half is not allowed to be unknown with it: an aborted transaction cannot answer it, so
+  // it is asked again on a fresh one. A /reset that landed mid-run must not be overtaken by a
+  // question added on top of it.
+  test("a failed fence read still sees a retired ladder", async () => {
+    const job = await claimed("whatsapp");
+    const s = stubClient();
+    wire.length = 0;
+    globalThis.fetch = httpDouble;
+    // The fence's agent read is the one that fails — it asks for `enabled` + `mode` alone, while the
+    // handler's own load at the top takes `settings` with them — and the /reset lands just before it.
+    let retiredMidRun = false;
+    const failingFence = appDb.$extends({
+      query: {
+        agent: {
+          async findUnique({ args, query }) {
+            const sel = args.select as Record<string, unknown> | undefined;
+            if (
+              sel?.enabled === true &&
+              sel?.mode === true &&
+              sel?.settings === undefined
+            ) {
+              if (!retiredMidRun) {
+                retiredMidRun = true;
+                await retireRedirectFollowUp(tenantId, widgetThread, appDb);
+              }
+              throw new Error("fence read is down");
+            }
+            return query(args);
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    try {
+      await redirectFollowUpHandler(job, failingFence, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    expect(retiredMidRun).toBe(true);
+    expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+    expect(s.sent).toEqual([]);
+  });
+
   // Advancing is a decision too. A stage can end without ever reaching its own fence — the sibling
   // lookup finds nobody, the link cannot be minted, or the chat stage simply finishes — and arming
   // the next stage there points a closing at an episode the agent is no longer allowed to touch:

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1527,9 +1527,17 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
         data: { testActivatedAt: null },
       });
     }
-    // Both rendezvous really happened, so this is the window and not a run that stopped earlier.
+    // The reset really landed mid-run, so this is the window and not a run that stopped earlier.
+    // `stampReads` stays at 1: the fence answers "retired" before it ever reaches the fallible read,
+    // which is the ordering this pins. Move the retirement read back after the stamp read and the
+    // double's throw reaches the outer catch, the fence answers "go", and the closing goes out.
+    //
+    // What the double CANNOT reproduce is a query PostgreSQL rejects: it throws in JS before any SQL
+    // runs, so the transaction is never left aborted. That case is why the ordering exists rather
+    // than a catch — with a real abort, every later statement in the transaction fails too — and it
+    // is argued in the code, not covered here.
     expect(retiredMidRun).toBe(true);
-    expect(stampReads).toBeGreaterThan(1);
+    expect(stampReads).toBe(1);
     expect(s.sent).toEqual([]);
     expect(s.resolved).toEqual([]);
   });

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1472,6 +1472,68 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     expect(s.sent).toEqual([]);
   });
 
+  // The two questions fail differently on purpose. A stamp read nobody could complete means unknown
+  // LIVENESS, which is live — but it must not swallow the retirement question with it. The closing is
+  // where that matters: its stage-level check runs once at the top, and every fence after it is the
+  // composite one, so if a failed stamp read answered "go" a /reset landing mid-run would be carried
+  // straight past the tombstone.
+  test("a failed stamp read does not carry a retired closing past the tombstone", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: { enabled: true, mode: "test" },
+    });
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: WIDGET_CONV },
+      data: { testActivatedAt: new Date(), redirectClosedAt: null },
+    });
+    const job = await claimed("closing");
+    const s = stubClient();
+    // The /reset lands on the closing's OWN first read — past the stage's retirement check, so the
+    // fence is the only thing left that can see it — and the fence's stamp read is the one that fails.
+    let stampReads = 0;
+    let retiredMidRun = false;
+    const retiringThenFailing = appDb.$extends({
+      query: {
+        conversation: {
+          async findUnique({ args, query }) {
+            const sel = args.select as Record<string, unknown> | undefined;
+            if (sel?.testActivatedAt === true) {
+              stampReads += 1;
+              if (stampReads > 1) throw new Error("activation lookup is down");
+              return query(args);
+            }
+            const res = await query(args);
+            if (sel?.lastInboundAt === true && !retiredMidRun) {
+              retiredMidRun = true;
+              await retireRedirectFollowUp(tenantId, widgetThread, appDb);
+            }
+            return res;
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    try {
+      await redirectFollowUpHandler(job, retiringThenFailing, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { mode: "production" },
+      });
+      await suDb.conversation.updateMany({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        data: { testActivatedAt: null },
+      });
+    }
+    // Both rendezvous really happened, so this is the window and not a run that stopped earlier.
+    expect(retiredMidRun).toBe(true);
+    expect(stampReads).toBeGreaterThan(1);
+    expect(s.sent).toEqual([]);
+    expect(s.resolved).toEqual([]);
+  });
+
   // Advancing is a decision too. A stage can end without ever reaching its own fence — the sibling
   // lookup finds nobody, the link cannot be minted, or the chat stage simply finishes — and arming
   // the next stage there points a closing at an episode the agent is no longer allowed to touch:

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1411,6 +1411,67 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     expect(s.sent).toEqual([]);
   });
 
+  // Fail-open covers an answer nobody could READ, never one already in hand. A disabled agent is
+  // conclusive before the activation lookup runs, and that lookup is the fallible part: let the fence
+  // reach it and a failed read turns a switched-off agent back into a send.
+  test("a disabled test agent stands down even if the stamp read fails", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: { enabled: true, mode: "test" },
+    });
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: WIDGET_CONV },
+      data: { testActivatedAt: new Date() },
+    });
+    const job = await claimed("whatsapp");
+    const s = stubClient();
+    wire.length = 0;
+    globalThis.fetch = httpDouble;
+    // Both rendezvous on the same column. The handler's own load reads it first — the switch flips
+    // right after, so the run gets past the entry gate — and the FENCE's read is the one that fails.
+    let stampReads = 0;
+    const failingStamp = appDb.$extends({
+      query: {
+        conversation: {
+          async findUnique({ args, query }) {
+            const sel = args.select as Record<string, unknown> | undefined;
+            if (sel?.testActivatedAt !== true) return query(args);
+            stampReads += 1;
+            if (stampReads > 1) throw new Error("activation lookup is down");
+            const res = await query(args);
+            await suDb.agent.update({
+              where: { id: agentId },
+              data: { enabled: false },
+            });
+            return res;
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    try {
+      await redirectFollowUpHandler(job, failingStamp, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { enabled: true, mode: "production" },
+      });
+      await suDb.conversation.updateMany({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        data: { testActivatedAt: null },
+      });
+    }
+    // One read, the handler's own: the fence answered from `enabled` and never reached the fallible
+    // one. Drop the short-circuit and this becomes two — the read throws, the catch answers "go", and
+    // the link goes out from an agent that is already off.
+    expect(stampReads).toBe(1);
+    expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+    expect(s.sent).toEqual([]);
+  });
+
   // Advancing is a decision too. A stage can end without ever reaching its own fence — the sibling
   // lookup finds nobody, the link cannot be minted, or the chat stage simply finishes — and arming
   // the next stage there points a closing at an episode the agent is no longer allowed to touch:


### PR DESCRIPTION
## What broke

#220 gave the redirect ladder a liveness gate, evaluated once at handler entry. The stages send
later — across a sibling lookup, a link mint (an HTTP round trip to Chatwoot), a config load and a
model turn — so the answer they act on is older than everything in between. The file already says
that window matters, for a different question:

> The link mint above is an HTTP round trip to Chatwoot, so the answer the caller had is older than
> this line. Nothing has left yet, which makes this the last free place to stop.

That guards the *retirement* question. The liveness question had the same window and no guard, so an
operator who switches the agent off while it is chasing a lead could still get the link re-sent, or
the closing posted and both conversations resolved. The same applied to the resolve-triggered
closing in `webhook.ts`, which reads the agent's runtime and then runs compaction arming, the ladder
cancel and `deliverRedirectClosing`'s own reads before anything reaches the wire.

## Why it is not a term inside `stillWanted`

This was tried in #220 and reverted there, with the two failure modes measured. Composing the
liveness question into the existing fence inherits **what the caller does with a false** and **how
that fence treats a read that fails**, and both differ:

- `sendWhatsAppFollowUp` reported a false `stillWanted` as `"retired"`, and the handler still
  rescheduled the closing on it. Under a retirement that is right. Under a liveness refusal it arms
  a closing on an episode nobody is chasing: re-enable the agent before that delay expires and it
  messages and resolves **both** conversations, with no fresh inbound behind it.
- `jobRetired` swallows a failed read deliberately. A liveness read composed into the same callback
  did not, so a read that threw after `deliverRedirectClosing` had claimed the at-most-once watermark
  skipped the release branch and lost the goodbye permanently.

So the two questions keep separate answers. One composite `fence` is asked at every send boundary
and returns a three-way `LadderVerdict`:

| verdict | means | the ladder |
| --- | --- | --- |
| `go` | live, not retired | proceeds |
| `retired` | a /reset landed | ends (unchanged behaviour) |
| `stood-down` | the agent is off, deleted, or test-silenced | **ends** rather than advancing |

A customer message re-arms the ladder from stage `chat` the normal way, which is the same shape the
`!cfg.enabled` arm has always had.

Three properties of that fence are load-bearing, and each is pinned by a test:

- **It fails open on a read it could not make** — the call `jobRetired` already makes, for the reason
  it states: an answer that could not be read is not a refusal, and a database blip must not cost a
  follow-up the customer should have received. A **deleted** agent is an answer, and it is no.
- **Retirement is answered before the fallible read.** A statement PostgreSQL rejects leaves the
  transaction aborted, so every later statement in it fails too. Asked after, the outer `catch` would
  answer `go` on a ladder a /reset had already retired. The cost is that for a test agent the
  retirement answer is one statement older than the send; for every other agent nothing moves,
  because the activation stamp is not read at all.
- **It takes the caller's connection when there is one.** Opening a second connection inside the
  nudge's advisory lock is the pool inversion `jobRetired` warns about, and `DB_POOL_MAX=1` is a
  supported setting.

The `chat` stage is fenced through `stillWanted` rather than skipped. `runAgentNudge` reloads the
config, which is fail-closed on `enabled`, but the model turn runs after that load and the post comes
after the turn, so that stage has the widest window in the ladder.

## Validation scope

**Proved by test** (DB-backed, against a real Postgres):

- `tests/modules/channel-redirect-followup.test.ts` — the switch flipped **during the link mint**
  (the HTTP double is the rendezvous): nothing is posted, and the handler returns `done` instead of
  arming the closing. Flipped during the **model turn** and during the **config load**: the nudge is
  generated but never posted. Flipped during the **closing's own reads**: nothing sent, nothing
  resolved, and the at-most-once anchor released rather than burned. And a **liveness read that
  throws** still sends — the fence's other half, and the one a guard gets wrong silently.
- `tests/modules/channel-redirect-closing-origin.test.ts` — the same for the resolve-triggered path,
  with the receiver's own agent read as the rendezvous.

Each was measured red against a mutation that removes what it pins: dropping the fence from the
resolve path, letting the ladder advance past a stand-down, reordering the retirement read after the
fallible one, and turning the fail-open into a fail-closed.

Full suite: 4819 pass, 0 fail.

**Not validated**: nothing was exercised against a live Chatwoot. The windows are reproduced by
flipping the row mid-flight from a Prisma extension and from the HTTP double, which is the same
rendezvous style the file's existing `/reset` race tests use — it proves the fences are asked where
the code says, not that a real deployment's timings hit that window at any particular rate.

**Deliberately out of scope**, both raised in review and left as their own work:

- A stand-down at the `chat` stage suppresses the send and leaves the generated turn in the thread's
  history: the graph has checkpointed it before any post-invoke gate answers. That is
  `runAgentNudge`'s shared behaviour — the ownership re-probe and a /reset land the same way — and it
  predates this fence. Filed as #251.
- An operator switching the agent **off during the turn and back on** inside the milliseconds before
  `rescheduleTo` re-asks the fence still advances the ladder. Remembering the earlier stand-down
  would cost mutable state across a callback boundary, and an agent that is live again by then has a
  defensible claim to the next stage.

Fixes #246
