### PR TITLE
Give every id in a knowledge search hit a spelling JSON can carry

### DIFF
--- a/src/api/v1/knowledge.controller.ts
+++ b/src/api/v1/knowledge.controller.ts
@@ -29,6 +29,7 @@ import {
   searchKnowledge,
   updateKnowledgeBase,
 } from "@/modules/rag/service";
+import type { ChunkHit } from "@/modules/rag/sql";
 
 // Knowledge base + human-approval REST surface (same core the agent tools and MCP project over).
 // Reads need auth; mutations and approvals require TENANT_ADMIN (the approval gate is the
@@ -58,6 +59,26 @@ export function readerSafeBlock(
   block: EmbeddingBlock | null,
 ): { reason: EmbeddingBlock["reason"] } | null {
   return block ? { reason: block.reason } : null;
+}
+
+// One search hit on the wire. Written out field by field, NOT as a spread of the row: `ChunkHit`
+// carries three bigint columns and the spread published all of them, with only two given a spelling
+// JSON accepts. `documentId` rode out as a BigInt and every search that MATCHED something answered
+// 500 (issue #253) — the empty-result case serialized fine, so the endpoint looked half-alive. The
+// two other readers of `ChunkHit` (the MCP tool and the agent's search_knowledge) already project
+// explicitly; this is the one that did not. A column added to the row now reaches the client only
+// when someone gives it a spelling here.
+export function searchHitDto(h: ChunkHit) {
+  return {
+    id: String(h.id),
+    knowledgeBaseId: String(h.knowledgeBaseId),
+    knowledgeBaseName: h.knowledgeBaseName,
+    documentId: String(h.documentId),
+    documentTitle: h.documentTitle,
+    content: h.content,
+    metadata: h.metadata,
+    distance: h.distance,
+  };
 }
 
 export const knowledgeController = new Elysia({
@@ -508,14 +529,7 @@ export const knowledgeController = new Elysia({
         knowledgeBaseIds: body.knowledgeBaseIds?.map((s) => BigInt(s)),
         limit: body.limit,
       });
-      return {
-        instance: instanceIdentity,
-        hits: hits.map((h) => ({
-          ...h,
-          id: String(h.id),
-          knowledgeBaseId: String(h.knowledgeBaseId),
-        })),
-      };
+      return { instance: instanceIdentity, hits: hits.map(searchHitDto) };
     },
     {
       requireAuth: true,

--- a/tests/api/v1/knowledge-search-bigint.test.ts
+++ b/tests/api/v1/knowledge-search-bigint.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+import { authPlugin } from "@/api/lib/auth";
+import type { SearchParams } from "@/modules/rag/service";
+import type { ChunkHit } from "@/modules/rag/sql";
+import {
+  mockFindUnique,
+  mockUser,
+  setupPrismaMock,
+} from "@/tests/utils/prisma-mock";
+
+// Issue #253. `POST /v1/knowledge/search` answered 500 on every search that MATCHED something: the
+// handler spread the row and stringified two of its three bigint columns, so `documentId` reached
+// the serializer as a BigInt and `JSON.stringify` refused it. The empty-result case serialized fine,
+// which is why the endpoint looked half-alive.
+//
+// Driven through the REAL app rather than a mirrored route, because the defect is not in the
+// projection alone: it is in what the route puts on the wire. A copy of the handler here would have
+// asserted its own mapping and said nothing about the endpoint's.
+
+// happy-dom's Request DROPS the Cookie header (forbidden), so a cookie-authenticated route driven
+// through app.handle() needs Bun's native constructor. See tests/dom-setup.ts.
+const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
+setupPrismaMock();
+
+// One hit, every field a ChunkHit carries — the typed literal is what makes a bigint column added
+// later show up here as a compile error instead of as a 500 in production.
+const HIT: ChunkHit = {
+  id: 10n,
+  knowledgeBaseId: 20n,
+  knowledgeBaseName: "Support",
+  documentId: 30n,
+  documentTitle: "Refund policy",
+  content: "Refunds are issued within 5 business days.",
+  metadata: { sourceUrl: "https://example.com/refunds" },
+  distance: 0.12,
+};
+
+const ragService = await import("@/modules/rag/service");
+const searchKnowledge = mock(
+  async (_params: SearchParams): Promise<ChunkHit[]> => [HIT],
+);
+// Spread the real module: the controller imports a dozen other names from it, and replacing the
+// whole module with one function would break the route graph at import time.
+mock.module("@/modules/rag/service", () => ({
+  ...ragService,
+  searchKnowledge,
+}));
+
+const app = (await import("@/app")).default;
+
+// `mock.module` is GLOBAL to the process and outlives this file for every other test in the same
+// worker. Spreading the real module already keeps the leak inert (only `searchKnowledge` differs,
+// and no other suite calls it), but put the module back anyway so file order can never matter.
+afterAll(() => {
+  mock.module("@/modules/rag/service", () => ragService);
+});
+
+// The session the route runs under: an AGENT with a tenant, which is what `requireAuth: true` asks
+// for. Minted with the app's own signer, not hand-rolled.
+mockFindUnique.mockImplementation(() => Promise.resolve(mockUser));
+const tokenApp = new Elysia()
+  .use(authPlugin)
+  .post("/mint", async ({ setAuthCookie }) => ({
+    token: await setAuthCookie(mockUser),
+  }));
+const { token } = (await (
+  await tokenApp.handle(
+    new Request("http://localhost/mint", { method: "POST" }),
+  )
+).json()) as { token: string };
+
+async function search(): Promise<Response> {
+  return app.handle(
+    new BunRequest("http://localhost/api/v1/knowledge/search", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: `fazerai_auth_token=${token}`,
+      },
+      body: JSON.stringify({ query: "refund" }),
+    }),
+  );
+}
+
+describe("POST /v1/knowledge/search with a matching chunk", () => {
+  test("answers 200, not the BigInt serialization 500", async () => {
+    const res = await search();
+    expect(res.status).toBe(200);
+  });
+
+  test("every id reaches the client as a string, documentId included", async () => {
+    const body = (await (await search()).json()) as {
+      hits: Array<Record<string, unknown>>;
+    };
+    expect(body.hits).toHaveLength(1);
+    const hit = body.hits[0] as Record<string, unknown>;
+    expect(hit.id).toBe("10");
+    expect(hit.knowledgeBaseId).toBe("20");
+    expect(hit.documentId).toBe("30");
+  });
+
+  test("no field of the response is left as a BigInt", async () => {
+    const body = (await (await search()).json()) as {
+      hits: Array<Record<string, unknown>>;
+    };
+    // The response already came back as JSON, so nothing in it CAN be a bigint — the assertion that
+    // carries weight is on the value the handler built, which is what the status test above covers.
+    // This one pins the field set, so a bigint column added to ChunkHit cannot ride the spread out
+    // unnoticed: it would appear here and have to be given a spelling on purpose.
+    expect(Object.keys(body.hits[0] as object).sort()).toEqual(
+      Object.keys(HIT).sort(),
+    );
+  });
+
+  test("the payload the client asked for is what the service was called with", () => {
+    expect(searchKnowledge).toHaveBeenCalled();
+    expect(searchKnowledge.mock.calls[0]?.[0]?.query).toBe("refund");
+  });
+});


### PR DESCRIPTION
Fixes #253.

## What was breaking

`POST /v1/knowledge/search` answered 500 on every search that matched something. The handler spread the row and gave a JSON-safe spelling to two of its three bigint columns:

```ts
hits: hits.map((h) => ({
  ...h,
  id: String(h.id),
  knowledgeBaseId: String(h.knowledgeBaseId),
})),
```

`ChunkHit` also carries `documentId: bigint` (`src/modules/rag/sql.ts:55`). It survived the spread untouched, and serializing the response threw. Measured through the real route, before the fix:

```
BODY: {"name":"TypeError","message":"JSON.stringify cannot serialize BigInt."}
```

The empty-result case serialized fine (`hits: []`), which is why the endpoint looked half-alive rather than plainly broken. Nothing stripped or typed the stray field on the way out either: the 200 response of this route has no schema, only `response: errors(400, 401, 403)`.

The same search over MCP works because that handler projects all three ids (`src/modules/mcp/read.ts:382`), and so does the agent's `search_knowledge` tool (`src/graph/tools/rag.ts:211`). This was the one reader of `ChunkHit` that did not.

## The fix

The spread is the mechanism, not just the missing `String()`: it published every column of the row while only two had been given a spelling, so a bigint left through a door nobody had decided to open. The projection is now written out field by field, like the two readers that were already correct. The wire shape is unchanged — the same eight fields, same names, same types.

A column added to `ChunkHit` later now reaches the client only when someone gives it a spelling here.

## What of the report does not hold

Nothing. The report was right about the symptom, the surface and the mechanism, including that the index and search itself were healthy.

## Validation scope

**Proven by test** (`tests/api/v1/knowledge-search-bigint.test.ts`, driven through the real app via `app.handle`, not a mirrored route):

- the route answers 200 with a matching chunk, where it answered 500 before;
- `id`, `knowledgeBaseId` and `documentId` all reach the client as strings;
- the response field set is exactly `ChunkHit`'s, so a column added to the row cannot ride out unnoticed;
- the query the client sent is the query the service was called with.

Red before the fix (3 of 4 failing, with the `TypeError` above as the 500 body), green after.

**Mutation-tested.** Each of the three `String(...)` calls removed in turn kills 3 tests; dropping either non-bigint field (`documentTitle`, `metadata`) kills the field-set test. No surviving mutation.

**Not validated:**

- No live call against a real deployment — the search path needs an embedding credential, so `searchKnowledge` is mocked at the module boundary and the ingest/embedding half is out of scope here.
- The 500 body leaked the raw `TypeError` name and message to the client. That is visible in the evidence above and is NOT addressed by this PR; it is a separate concern about the error handler, not about this route.
- `openapi.json` is unchanged and deliberately so: this PR adds no route schema, and the endpoint's declared request/response contract is the same as before.
