### PR TITLE
Hold the agent's own credentials to the vault-ref rule the columns already follow

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -5417,14 +5417,14 @@
                     "type": "boolean"
                   },
                   "modelConfig": {
-                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
                     }
                   },
                   "settings": {
-                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -5488,14 +5488,14 @@
                     "type": "boolean"
                   },
                   "modelConfig": {
-                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
                     }
                   },
                   "settings": {
-                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -5559,14 +5559,14 @@
                     "type": "boolean"
                   },
                   "modelConfig": {
-                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
                     }
                   },
                   "settings": {
-                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -5865,14 +5865,14 @@
                     "type": "boolean"
                   },
                   "modelConfig": {
-                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
                     }
                   },
                   "settings": {
-                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -5937,14 +5937,14 @@
                     "type": "boolean"
                   },
                   "modelConfig": {
-                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
                     }
                   },
                   "settings": {
-                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -6009,14 +6009,14 @@
                     "type": "boolean"
                   },
                   "modelConfig": {
-                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+                    "description": "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
                     }
                   },
                   "settings": {
-                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+                    "description": "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
                     "type": "object",
                     "patternProperties": {
                       "^(.*)$": {}
@@ -17742,7 +17742,7 @@
                     "type": "string"
                   },
                   "credentialRef": {
-                    "description": "Vault entry reference for the provider key (null clears it).",
+                    "description": "Vault reference (`vault:<id>`, from GET /v1/vault) for the provider key. Never the secret itself, and never an entry name; null clears it.",
                     "anyOf": [
                       {
                         "type": "string"
@@ -17784,7 +17784,7 @@
                     "type": "string"
                   },
                   "credentialRef": {
-                    "description": "Vault entry reference for the provider key (null clears it).",
+                    "description": "Vault reference (`vault:<id>`, from GET /v1/vault) for the provider key. Never the secret itself, and never an entry name; null clears it.",
                     "anyOf": [
                       {
                         "type": "string"
@@ -17826,7 +17826,7 @@
                     "type": "string"
                   },
                   "credentialRef": {
-                    "description": "Vault entry reference for the provider key (null clears it).",
+                    "description": "Vault reference (`vault:<id>`, from GET /v1/vault) for the provider key. Never the secret itself, and never an entry name; null clears it.",
                     "anyOf": [
                       {
                         "type": "string"
@@ -17957,7 +17957,7 @@
                   "credentialRef": {
                     "anyOf": [
                       {
-                        "description": "Vault entry reference for the Langfuse credential (null clears it).",
+                        "description": "Vault reference (`vault:<id>`, from GET /v1/vault) for the Langfuse credential. Never the secret itself, and never an entry name; null clears it.",
                         "type": "string"
                       },
                       {
@@ -17987,7 +17987,7 @@
                   "credentialRef": {
                     "anyOf": [
                       {
-                        "description": "Vault entry reference for the Langfuse credential (null clears it).",
+                        "description": "Vault reference (`vault:<id>`, from GET /v1/vault) for the Langfuse credential. Never the secret itself, and never an entry name; null clears it.",
                         "type": "string"
                       },
                       {
@@ -18017,7 +18017,7 @@
                   "credentialRef": {
                     "anyOf": [
                       {
-                        "description": "Vault entry reference for the Langfuse credential (null clears it).",
+                        "description": "Vault reference (`vault:<id>`, from GET /v1/vault) for the Langfuse credential. Never the secret itself, and never an entry name; null clears it.",
                         "type": "string"
                       },
                       {

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -411,13 +411,13 @@ export const agentsController = new Elysia({
         modelConfig: t.Optional(
           t.Record(t.String(), t.Unknown(), {
             description:
-              "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+              "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
           }),
         ),
         settings: t.Optional(
           t.Record(t.String(), t.Unknown(), {
             description:
-              "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+              "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
           }),
         ),
         businessHoursId: t.Optional(
@@ -497,13 +497,13 @@ export const agentsController = new Elysia({
         modelConfig: t.Optional(
           t.Record(t.String(), t.Unknown(), {
             description:
-              "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.); secrets are referenced, never inlined.",
+              "Model settings (provider, model, credentialRef, temperature, reasoningEffort, etc.). `credentialRef` is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
           }),
         ),
         settings: t.Optional(
           t.Record(t.String(), t.Unknown(), {
             description:
-              "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar).",
+              "Behavior settings bag (debounce, stt, tts, split, serviceWindow, and similar). Every `credentialRef` in it is a vault reference (`vault:<id>`, from GET /v1/vault): never the secret itself, and never an entry name.",
           }),
         ),
         businessHoursId: t.Optional(

--- a/src/api/v1/tenant-settings.controller.ts
+++ b/src/api/v1/tenant-settings.controller.ts
@@ -94,7 +94,7 @@ export const tenantSettingsController = new Elysia({
         credentialRef: t.Optional(
           t.Union([t.String(), t.Null()], {
             description:
-              "Vault entry reference for the provider key (null clears it).",
+              "Vault reference (`vault:<id>`, from GET /v1/vault) for the provider key. Never the secret itself, and never an entry name; null clears it.",
           }),
         ),
         baseURL: t.Optional(
@@ -135,7 +135,7 @@ export const tenantSettingsController = new Elysia({
           t.Nullable(
             t.String({
               description:
-                "Vault entry reference for the Langfuse credential (null clears it).",
+                "Vault reference (`vault:<id>`, from GET /v1/vault) for the Langfuse credential. Never the secret itself, and never an entry name; null clears it.",
             }),
           ),
         ),

--- a/src/graph/model-config.ts
+++ b/src/graph/model-config.ts
@@ -77,7 +77,9 @@ export const modelConfigSchema = z
     // openai-compatible: single-model servers (llama.cpp) ignore the requested name, so forcing a
     // pick there is pure friction. Every other provider requires an explicit model.
     model: z.string().default(""),
-    // Vault entry name holding the API key (resolved by the runtime, never stored here).
+    // Vault reference (`vault:<id>`) for the API key, never the key and never an entry name:
+    // `vaultRefWhere` turns anything else into a filter that matches nothing, so the runtime
+    // finds no credential and the agent produces nothing. Refused at the write boundary (#254).
     credentialRef: z.string().min(1).optional(),
     baseURL: z.string().url().optional(),
     temperature: z.number().min(0).max(2).optional(),

--- a/src/modules/agents/credential-paths.ts
+++ b/src/modules/agents/credential-paths.ts
@@ -111,3 +111,81 @@ export function remapCredRefAt(
 export type CredentialFieldTab =
   | "general"
   | (typeof SETTINGS_CREDENTIAL_PATHS)[number]["tab"];
+
+export interface CredentialRefWrite {
+  // Dotted path from the agent row, so a refusal names the field the editor shows rather than the
+  // bag it lives in: `modelConfig.credentialRef`, `settings.tts.normalizeCredentialRef`.
+  path: string;
+  ref: string;
+  // Writes the canonical spelling back where the ref was found. In place, for the same reason
+  // clampOversizedTextInPlace is: the caller owns a freshly parsed payload whose bags hold keys this
+  // module knows nothing about, and rebuilding them from the paths listed here would drop the rest.
+  replace: (canonical: string) => void;
+}
+
+function bagOf(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+// Every credential ref a write INTRODUCES or CHANGES, over the eight fields an agent keeps one in
+// (modelConfig plus the seven settings paths above). A bag the write does not send is a bag it does
+// not touch, and a ref equal to the stored one is not a write at all.
+//
+// Only what changes, and that is the whole design. These eight fields sit on three editor tabs and
+// several of them are only rendered with their section switched on, so a check over the whole bag
+// could answer 400 naming a field the operator has no way to open — and one deleted vault entry
+// would then freeze every agent that named it, down to the switch that turns the agent off. What a
+// write leaves alone is REPORTED rather than refused: configHealth already raises it as
+// `unresolved` on the field itself. Same rule, same reason as collectOversizedTextChanges.
+export function collectCredentialRefWrites(
+  next: { modelConfig?: unknown; settings?: unknown },
+  stored: { modelConfig?: unknown; settings?: unknown },
+): CredentialRefWrite[] {
+  const out: CredentialRefWrite[] = [];
+  const add = (
+    path: string,
+    holder: Record<string, unknown>,
+    key: string,
+    storedRef: unknown,
+  ): void => {
+    const ref = holder[key];
+    if (typeof ref !== "string" || !ref || ref === storedRef) return;
+    out.push({
+      path,
+      ref,
+      replace: (canonical) => {
+        holder[key] = canonical;
+      },
+    });
+  };
+
+  const nextModel =
+    next.modelConfig === undefined ? null : bagOf(next.modelConfig);
+  if (nextModel) {
+    add(
+      "modelConfig.credentialRef",
+      nextModel,
+      "credentialRef",
+      bagOf(stored.modelConfig)?.credentialRef,
+    );
+  }
+  const nextSettings =
+    next.settings === undefined ? null : bagOf(next.settings);
+  if (nextSettings) {
+    const storedSettings = bagOf(stored.settings);
+    for (const { path } of SETTINGS_CREDENTIAL_PATHS) {
+      const slot = credRefSlot(nextSettings, path);
+      if (!slot) continue;
+      const storedSlot = credRefSlot(storedSettings, path);
+      add(
+        `settings.${path.join(".")}`,
+        slot.holder,
+        slot.key,
+        storedSlot ? storedSlot.holder[storedSlot.key] : undefined,
+      );
+    }
+  }
+  return out;
+}

--- a/src/modules/agents/service.ts
+++ b/src/modules/agents/service.ts
@@ -12,6 +12,7 @@ import {
   TenantTargetRequiredError,
 } from "@/lib/errors";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import { collectCredentialRefWrites } from "@/modules/agents/credential-paths";
 import { collectOversizedTextChanges } from "@/modules/agents/text-caps";
 import { isOutOfHoursNow, parseSchedule } from "@/modules/business-hours/hours";
 import { renameAgentBots } from "@/modules/chatwoot/provisioning";
@@ -25,6 +26,7 @@ import {
   getToolpackToolNames,
   getToolpackToolViews,
 } from "@/modules/integrations/toolpacks";
+import { requireVaultRef } from "@/modules/vault/service";
 
 // Agent configuration CRUD — the config the whole system orbits (the same core the UI config
 // screen and the MCP `prompt_get/set` tools project over). All reads/writes are tenant-scoped;
@@ -282,6 +284,24 @@ export function assertSettingsTextSizes(
   }
 }
 
+// The write boundary for the agent's credential refs, and the only place a `vault:<id>` enters
+// either JSON bag. `requireVaultRef` is what the other six ref columns have been held to since #124;
+// the agent's two bags were left out of that sweep because they have no column to grep for, so a
+// PATCH carrying a vault entry NAME answered 200 and the agent then produced nothing at all — no
+// reply in production, "no runnable model configured" in the playground (#254).
+//
+// Canonical on the way in, not merely valid: requireVaultRef returns the one spelling every reader
+// agrees on, and it is written back where the ref was found.
+async function assertCredentialRefsResolve(
+  db: ScopedDb,
+  next: { modelConfig?: unknown; settings?: unknown },
+  stored: { modelConfig?: unknown; settings?: unknown },
+): Promise<void> {
+  for (const write of collectCredentialRefWrites(next, stored)) {
+    write.replace(await requireVaultRef(db, write.ref, write.path));
+  }
+}
+
 // Allowlist of editable fields. tenantId/id are never touched; modelConfig/settings must be
 // objects (the runtime's own parser validates their inner shape at load time).
 // NOTE: The EFFECTIVE follow-up state: an ENABLED agent with followUp.enabled, in ANY mode — the
@@ -383,10 +403,6 @@ export async function updateAgent(
       }
     }
     const updateData: Record<string, unknown> = { ...rest };
-    // NOTE: See normalizeSettingsForStorage — the host list is reduced to hosts on the way IN, on
-    // every write path, not only when it is read back.
-    const normalizedSettings = normalizeSettingsForStorage(rest.settings);
-    if (normalizedSettings) updateData.settings = normalizedSettings;
     if (hasBh) updateData.businessHoursId = bhId;
     if (hasFuh) updateData.followUpHoursId = fuhId;
     // NOTE: Arm the follow-up backlog fence on the OFF→ON transition of the effective state. The row
@@ -399,9 +415,10 @@ export async function updateAgent(
         enabled: boolean;
         mode: string;
         settings: unknown;
+        model_config: unknown;
         updated_at: Date;
       }>
-    >`SELECT enabled, mode, settings, updated_at FROM agents WHERE id = ${id} FOR UPDATE`;
+    >`SELECT enabled, mode, settings, model_config, updated_at FROM agents WHERE id = ${id} FOR UPDATE`;
     const before = beforeRows[0];
     // NOTE: The optimistic-concurrency check comes FIRST, on the locked row. A stale editor resends
     // the settings it loaded, so if the other writer edited a capped field our copy of it is an edit
@@ -422,6 +439,17 @@ export async function updateAgent(
     // NOTE: Inside the lock, against the row this write replaces — reading the stored bag separately
     // would compare against a value another writer could have changed in between.
     assertSettingsTextSizes(rest.settings, before?.settings);
+    // NOTE: Inside the lock and against the same row, for the reason above: "did this write change
+    // the ref" has to be asked of the value this write replaces. It also rewrites `rest` in place,
+    // so the normalization below copies the canonical bag rather than the submitted one.
+    await assertCredentialRefsResolve(db, rest, {
+      modelConfig: before?.model_config,
+      settings: before?.settings,
+    });
+    // NOTE: See normalizeSettingsForStorage — the host list is reduced to hosts on the way IN, on
+    // every write path, not only when it is read back.
+    const normalizedSettings = normalizeSettingsForStorage(rest.settings);
+    if (normalizedSettings) updateData.settings = normalizedSettings;
     if (before) {
       const after = {
         enabled: rest.enabled !== undefined ? rest.enabled : before.enabled,
@@ -574,6 +602,9 @@ export async function createAgent(
         );
       }
     }
+    // NOTE: Nothing is stored yet, so every ref the payload carries is one this write introduces.
+    // Rewrites `data` in place; both bags below read from it.
+    await assertCredentialRefsResolve(db, data, {});
     const createShape = {
       enabled: data.enabled ?? true,
       // NOTE: New agents are born in test mode (operator opt-in before going live).

--- a/src/modules/tenant-settings/service.ts
+++ b/src/modules/tenant-settings/service.ts
@@ -4,7 +4,7 @@ import basePrisma from "@/api/lib/prisma";
 import { AppError } from "@/lib/errors";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import { unprintableProblem } from "@/modules/documents/printable";
-import { tryResolveVaultEntry } from "@/modules/vault/service";
+import { requireVaultRef, vaultRefWhere } from "@/modules/vault/service";
 
 // Per-tenant settings live in the Tenant.settings JSON column. RLS scopes the row to the active
 // tenant (the runtime role may read/update its own row), so the same reader works at runtime
@@ -210,6 +210,18 @@ export async function updateEmbeddingSettings(
   patch: Partial<EmbeddingSettings>,
   base: PrismaClient = basePrisma,
 ): Promise<EmbeddingSettings> {
+  // The same boundary every other ref column has been held to since #124: `vault:<id>`, in this
+  // tenant, canonically spelled. Nothing checked this one, so a PATCH carrying a vault entry NAME
+  // stored it and indexing then failed with no credential the operator could see was wrong (#254).
+  // The block holds one field, so naming it IS changing it — there is no unrelated save to protect
+  // here, unlike the agent's bags.
+  const incoming = patch.credentialRef;
+  const credentialRef =
+    incoming == null
+      ? incoming
+      : await runScopedOn(base, ctx, (db) =>
+          requireVaultRef(db, incoming, "embedding.credentialRef"),
+        );
   return patchBlock(ctx, base, "embedding", (raw) => {
     const current = parseEmbeddingSettings(raw);
     // LOCKED to EMBEDDING_DEFAULTS (OpenAI + text-embedding-3-small) until the flexible-embeddings
@@ -219,9 +231,7 @@ export async function updateEmbeddingSettings(
     return embeddingSettingsSchema.parse({
       ...EMBEDDING_DEFAULTS,
       credentialRef:
-        patch.credentialRef !== undefined
-          ? patch.credentialRef
-          : current.credentialRef,
+        credentialRef !== undefined ? credentialRef : current.credentialRef,
     });
   });
 }
@@ -252,25 +262,35 @@ export async function updateLangfuse(
     if (input.credentialRef === null) {
       credentialRef = null;
     } else {
-      // Validate: ref must resolve and be a langfuse-kind entry.
-      const entry = await runScopedOn(base, ctx, (db) =>
-        tryResolveVaultEntry(db, input.credentialRef as string),
-      );
-      if (!entry) {
-        throw new AppError(
-          "credential ref not found in the vault",
-          400,
-          "errors.vaultRefNotFound",
+      // Validate: ref must resolve, in this tenant, and be a langfuse-kind entry.
+      // NOTE: requireVaultRef rather than tryResolveVaultEntry, which answered "not found" for two
+      // values that are something else. A lenient spelling (`vault:007`) resolved and was then
+      // stored verbatim, where it compares unequal against the id list the credential picker builds
+      // and reports a working credential as unavailable; and an entry created empty on purpose
+      // (credential_create) was refused for having no secret yet, which is the one case the write
+      // boundary admits deliberately. Both are the ref rule, so both answer to the ref check (#254).
+      const ref = input.credentialRef;
+      credentialRef = await runScopedOn(base, ctx, async (db) => {
+        const canonical = await requireVaultRef(
+          db,
+          ref,
+          "langfuse.credentialRef",
         );
-      }
-      if (entry.kind !== "langfuse") {
-        throw new AppError(
-          "credential must be of kind 'langfuse'",
-          400,
-          "errors.invalidCredentialKind",
-        );
-      }
-      credentialRef = input.credentialRef;
+        const entry = await db.vaultEntry.findFirst({
+          where: vaultRefWhere(canonical),
+          select: { kind: true },
+        });
+        if (entry?.kind !== "langfuse") {
+          throw new AppError(
+            "credential must be of kind 'langfuse'",
+            400,
+            "errors.invalidCredentialKind",
+            undefined,
+            "langfuse.credentialRef",
+          );
+        }
+        return canonical;
+      });
     }
   }
 

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -243,12 +243,20 @@ export async function resolveVaultRefByName(
 export async function requireVaultRef(
   db: ScopedDb,
   ref: string,
+  // The server's own name for the input this ref arrived in, when the caller has one — a dotted path
+  // into a bag it owns (`settings.tts.normalizeCredentialRef`). Optional because most callers refuse
+  // a column the client already named in the patch it sent; the agent's two bags are the ones that
+  // need it, where a ref can be any of eight fields across three editor tabs and the sentence alone
+  // would leave the console guessing which input to mark. See src/api/lib/refusal.ts.
+  field?: string,
 ): Promise<string> {
   const malformed = () =>
     new AppError(
       `"${ref}" is not a vault reference (expected vault:<id>)`,
       400,
       "errors.invalidVaultRef",
+      undefined,
+      field,
     );
   if (!ref.startsWith(VAULT_REF_PREFIX)) throw malformed();
   const raw = ref.slice(VAULT_REF_PREFIX.length);
@@ -268,6 +276,8 @@ export async function requireVaultRef(
       `vault secret "${ref}" not found`,
       400,
       "errors.vaultRefNotFound",
+      undefined,
+      field,
     );
   }
   return formatVaultRef(entry.id);

--- a/tests/modules/agents/credential-paths.test.ts
+++ b/tests/modules/agents/credential-paths.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { readBehaviorSettings } from "@/modules/agents/behavior-settings";
-import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
+import {
+  collectCredentialRefWrites,
+  SETTINGS_CREDENTIAL_PATHS,
+} from "@/modules/agents/credential-paths";
 import { credentialFieldTargets } from "@/modules/agents/transfer";
 
 // The list of settings paths that hold a credential ref has to equal what the behavior readers
@@ -77,5 +80,132 @@ describe("credentialFieldTargets", () => {
       tab: "behavior",
       sectionId: "memory",
     });
+  });
+});
+
+// What a write is allowed to put in the two bags. The rule is not "is this ref valid" but "does this
+// write introduce or change one", and the difference is the whole design: eight credential fields
+// live across three editor tabs, several only rendered with their section switched on, so refusing a
+// ref the write merely carried along would answer 400 naming a field the operator cannot open — and
+// one deleted vault entry would freeze every agent that named it, down to the switch that turns the
+// agent off.
+describe("collectCredentialRefWrites", () => {
+  const MODEL = { provider: "openai", model: "gpt-4o-mini" };
+  const paths = (
+    next: { modelConfig?: unknown; settings?: unknown },
+    stored: { modelConfig?: unknown; settings?: unknown } = {},
+  ) => collectCredentialRefWrites(next, stored).map((w) => w.path);
+
+  test("a bag the write does not send is a bag it does not touch", () => {
+    const stored = {
+      modelConfig: { ...MODEL, credentialRef: "vault:1" },
+      settings: { stt: { credentialRef: "vault:2" } },
+    };
+    expect(paths({}, stored)).toEqual([]);
+    expect(
+      paths({ modelConfig: { ...MODEL, credentialRef: "vault:1" } }, stored),
+    ).toEqual([]);
+  });
+
+  test("names every field an unconfigured agent's first save fills in", () => {
+    const settings: Record<string, unknown> = {};
+    for (const { path } of SETTINGS_CREDENTIAL_PATHS) {
+      let node = settings;
+      for (const step of path.slice(0, -1)) {
+        node[step] ??= {};
+        node = node[step] as Record<string, unknown>;
+      }
+      node[path[path.length - 1] as string] = "vault:9";
+    }
+    expect(
+      paths({
+        modelConfig: { ...MODEL, credentialRef: "vault:9" },
+        settings,
+      }).sort(),
+    ).toEqual(
+      [
+        "modelConfig.credentialRef",
+        ...SETTINGS_CREDENTIAL_PATHS.map(
+          ({ path }) => `settings.${path.join(".")}`,
+        ),
+      ].sort(),
+    );
+  });
+
+  test("a ref equal to the stored one is not a write at all", () => {
+    const bag = { guardrails: { credentialRef: "vault:7" } };
+    expect(paths({ settings: bag }, { settings: bag })).toEqual([]);
+    expect(
+      paths(
+        { settings: { guardrails: { credentialRef: "vault:8" } } },
+        { settings: bag },
+      ),
+    ).toEqual(["settings.guardrails.credentialRef"]);
+  });
+
+  test("a write that drops the block is not a write of a ref", () => {
+    // The stored bag holds one, the submitted bag does not: the save is REMOVING the credential, and
+    // there is nothing to check against the vault.
+    expect(
+      paths(
+        { settings: {} },
+        { settings: { stt: { credentialRef: "vault:7" } } },
+      ),
+    ).toEqual([]);
+  });
+
+  test("only a non-empty string counts as a ref", () => {
+    expect(
+      paths({
+        settings: {
+          stt: { credentialRef: "" },
+          vision: { credentialRef: 7 },
+          tts: { credentialRef: null },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  test("the stored comparison is per FIELD, not per block", () => {
+    // `tts` carries two credentials. Changing one while re-sending the other unchanged has to report
+    // exactly the one that moved, or a save of the normalizer's key drags the voice key along.
+    expect(
+      paths(
+        {
+          settings: {
+            tts: {
+              credentialRef: "vault:1",
+              normalizeCredentialRef: "vault:3",
+            },
+          },
+        },
+        {
+          settings: {
+            tts: {
+              credentialRef: "vault:1",
+              normalizeCredentialRef: "vault:2",
+            },
+          },
+        },
+      ),
+    ).toEqual(["settings.tts.normalizeCredentialRef"]);
+  });
+
+  test("replace rewrites the leaf where it was found, at any depth", () => {
+    const settings = {
+      memory: { compaction: { credentialRef: "vault:007", model: "gpt-4o" } },
+    };
+    const next = {
+      modelConfig: { ...MODEL, credentialRef: "vault:009" },
+      settings,
+    };
+    for (const w of collectCredentialRefWrites(next, {})) w.replace("vault:9");
+    expect(settings.memory.compaction).toEqual({
+      credentialRef: "vault:9",
+      // The sibling the walker knows nothing about is still there: rebuilding the bag from the
+      // declared paths would have dropped it.
+      model: "gpt-4o",
+    });
+    expect(next.modelConfig.credentialRef).toBe("vault:9");
   });
 });

--- a/tests/modules/vault/ref-write-boundary.test.ts
+++ b/tests/modules/vault/ref-write-boundary.test.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import type { TenantContext } from "@/lib/tenancy";
+import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
+import { createAgent, updateAgent } from "@/modules/agents/service";
 import {
   createAlertChannel,
   updateAlertChannel,
@@ -14,6 +16,11 @@ import {
   createMcpConnection,
   updateMcpConnection,
 } from "@/modules/mcp-connections/service";
+import {
+  getTenantSettings,
+  updateEmbeddingSettings,
+  updateLangfuse,
+} from "@/modules/tenant-settings/service";
 import {
   createToolDefinition,
   updateToolDefinition,
@@ -73,6 +80,11 @@ const uniq = (p: string) => `${p}-${process.pid}-${++seq}`;
 interface Boundary {
   // What the operator sees in the API, so a failure names the field rather than the test row.
   field: string;
+  // The name the REFUSAL puts on the wire (#231/#245), when this boundary names one. Absent for the
+  // six columns of #124: the patch key the client sent already is the name, and extending #245's
+  // sweep to them is its own change. Asserted in both directions so "these were checked" cannot be
+  // read into a boundary that answers without one.
+  wireField?: string;
   create: (ref: string) => Promise<bigint>;
   update: (id: bigint, ref: string) => Promise<unknown>;
   read: (id: bigint) => Promise<string | null>;
@@ -230,11 +242,107 @@ const boundaries: Boundary[] = [
   },
 ];
 
+// The agent keeps its refs inside two JSON bags rather than in columns of their own, which is how
+// they escaped the sweep the first time: there is no `credential_ref` column to grep for. The bags
+// are still a write boundary, and the same rule applies to them (issue #254).
+const MODEL_BASE = { provider: "openai", model: "gpt-4o-mini" };
+
+// A settings bag holding exactly one credential ref, at `path` — the shape a save of that one
+// section sends. Built from the path so a credential added to a NEW block is covered here the moment
+// it joins SETTINGS_CREDENTIAL_PATHS, rather than waiting for someone to remember this file.
+function settingsWithRef(
+  path: readonly string[],
+  ref: string,
+): Record<string, unknown> {
+  let node: Record<string, unknown> = {
+    [path[path.length - 1] as string]: ref,
+  };
+  for (let i = path.length - 2; i >= 0; i--) {
+    node = { [path[i] as string]: node };
+  }
+  return node;
+}
+
+function readStoredRef(bag: unknown, path: readonly string[]): string | null {
+  let node: unknown = bag;
+  for (const step of path) {
+    if (!node || typeof node !== "object") return null;
+    node = (node as Record<string, unknown>)[step];
+  }
+  return typeof node === "string" ? node : null;
+}
+
+const agentBoundaries: Boundary[] = [
+  {
+    field: "agent.modelConfig.credentialRef",
+    wireField: "modelConfig.credentialRef",
+    create: async (ref) =>
+      BigInt(
+        (
+          await createAgent(
+            ctx(),
+            {
+              name: uniq("agent"),
+              modelConfig: { ...MODEL_BASE, credentialRef: ref },
+            },
+            appDb,
+          )
+        ).id,
+      ),
+    update: (id, ref) =>
+      updateAgent(
+        ctx(),
+        id,
+        { modelConfig: { ...MODEL_BASE, credentialRef: ref } },
+        appDb,
+      ),
+    read: async (id) =>
+      readStoredRef(
+        (
+          await suDb.agent.findUnique({
+            where: { id },
+            select: { modelConfig: true },
+          })
+        )?.modelConfig,
+        ["credentialRef"],
+      ),
+  },
+  ...SETTINGS_CREDENTIAL_PATHS.map(({ path }) => ({
+    field: `agent.settings.${path.join(".")}`,
+    wireField: `settings.${path.join(".")}`,
+    create: async (ref: string) =>
+      BigInt(
+        (
+          await createAgent(
+            ctx(),
+            { name: uniq("agent"), settings: settingsWithRef(path, ref) },
+            appDb,
+          )
+        ).id,
+      ),
+    update: (id: bigint, ref: string) =>
+      updateAgent(ctx(), id, { settings: settingsWithRef(path, ref) }, appDb),
+    read: async (id: bigint) =>
+      readStoredRef(
+        (
+          await suDb.agent.findUnique({
+            where: { id },
+            select: { settings: true },
+          })
+        )?.settings,
+        path,
+      ),
+  })),
+];
+
 describe.skipIf(!dbUp)("vault ref write boundary", () => {
   let liveRef = "";
   let liveId = 0n;
   let pendingRef = "";
   let goneRef = "";
+  let lfRef = "";
+  let lfId = 0n;
+  let lfPendingRef = "";
 
   beforeAll(async () => {
     const t = await suDb.tenant.create({
@@ -266,11 +374,36 @@ describe.skipIf(!dbUp)("vault ref write boundary", () => {
     );
     goneRef = doomed.ref;
     await deleteVaultEntry(ctx(), doomed.id, appDb);
+    const lf = await createVaultEntry(
+      ctx(),
+      {
+        name: "lf-key",
+        value: { publicKey: "pk", secretKey: "sk" },
+        kind: "langfuse",
+        baseUrl: "https://cloud.langfuse.com",
+      },
+      undefined,
+      undefined,
+      appDb,
+    );
+    lfRef = lf.ref;
+    lfId = lf.id;
+    const lfUnfilled = await createPendingVaultEntry(
+      ctx(),
+      {
+        name: "lf-unfilled",
+        kind: "langfuse",
+        baseUrl: "https://cloud.langfuse.com",
+      },
+      appDb,
+    );
+    lfPendingRef = lfUnfilled.ref;
   });
 
   afterAll(async () => {
     if (tenantId) {
       for (const table of [
+        "agents",
         "webhook_subscriptions",
         "alert_channels",
         "mcp_server_connections",
@@ -291,7 +424,177 @@ describe.skipIf(!dbUp)("vault ref write boundary", () => {
     await appDb.$disconnect();
   });
 
-  for (const b of boundaries) {
+  // The agent is the one boundary whose write carries fields it is not about. Its editor saves the
+  // whole bag, and eight credential fields sit across three tabs — so "is this ref valid" is the
+  // wrong question and "does this write change it" is the right one. Without that, one deleted vault
+  // entry would freeze every agent that named it: no model change, no rename, not even the switch
+  // that turns the agent off.
+  describe("what an agent write leaves alone", () => {
+    // Seeded past the boundary on purpose: this is the state a row is ALREADY in, whether it was
+    // written before the check existed or its vault entry was deleted afterwards.
+    async function agentHoldingDeadRefs(): Promise<bigint> {
+      const row = await suDb.agent.create({
+        data: {
+          tenantId,
+          name: uniq("legacy"),
+          systemPrompt: "x",
+          modelConfig: { ...MODEL_BASE, credentialRef: "OpenAI Prod" },
+          settings: {
+            stt: { enabled: true, credentialRef: goneRef },
+            guardrails: { credentialRef: "another name" },
+          },
+        },
+      });
+      return row.id;
+    }
+
+    test("an unrelated field still saves with dead refs sitting in the row", async () => {
+      const id = await agentHoldingDeadRefs();
+      // The urgent one: switching the agent OFF must never depend on a credential.
+      const dto = await updateAgent(ctx(), id, { enabled: false }, appDb);
+      expect(dto.enabled).toBe(false);
+    });
+
+    test("re-sending the stored refs untouched is not a write of them", async () => {
+      const id = await agentHoldingDeadRefs();
+      // What the editor actually posts: the whole bag it loaded, with one field edited.
+      const dto = await updateAgent(
+        ctx(),
+        id,
+        {
+          name: "Renamed",
+          modelConfig: { ...MODEL_BASE, credentialRef: "OpenAI Prod" },
+          settings: {
+            stt: { enabled: false, credentialRef: goneRef },
+            guardrails: { credentialRef: "another name" },
+          },
+        },
+        appDb,
+      );
+      expect(dto.name).toBe("Renamed");
+      const row = await suDb.agent.findUniqueOrThrow({
+        where: { id },
+        select: { settings: true },
+      });
+      expect(readStoredRef(row.settings, ["stt", "credentialRef"])).toBe(
+        goneRef,
+      );
+    });
+
+    test("but touching one of them, in that same save, is refused by name", async () => {
+      const id = await agentHoldingDeadRefs();
+      await expect(
+        updateAgent(
+          ctx(),
+          id,
+          {
+            name: "Renamed",
+            settings: {
+              stt: { enabled: true, credentialRef: goneRef },
+              guardrails: { credentialRef: "a third name" },
+            },
+          },
+          appDb,
+        ),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        translationKey: "errors.invalidVaultRef",
+      });
+      // And the refusal wrote nothing: the rename did not land either.
+      const row = await suDb.agent.findUniqueOrThrow({
+        where: { id },
+        select: { name: true },
+      });
+      expect(row.name).not.toBe("Renamed");
+    });
+
+    test("a stale editor gets 409, not 400, when the other writer changed a ref", async () => {
+      // The precondition is answered on the locked row BEFORE this check, for the same reason the
+      // text caps are: a stale editor resends what it loaded, so the other writer's ref reads as an
+      // edit of ours. Answering 400 here would skip the editor's conflict flow entirely.
+      const id = await agentHoldingDeadRefs();
+      await expect(
+        updateAgent(
+          ctx(),
+          id,
+          { modelConfig: { ...MODEL_BASE, credentialRef: "some other name" } },
+          appDb,
+          { expectedUpdatedAt: new Date(0) },
+        ),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        translationKey: "errors.agentModifiedElsewhere",
+      });
+    });
+  });
+
+  // The tenant's two credential blocks. Neither is a column and neither was in the #124 sweep;
+  // embedding had no check at all, and langfuse had one that answered "not found" for two values
+  // that are something else.
+  describe("tenant settings credential blocks", () => {
+    test("embedding refuses a bare NAME, and stores a live ref canonically", async () => {
+      await expect(
+        updateEmbeddingSettings(ctx(), { credentialRef: "live-key" }, appDb),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        translationKey: "errors.invalidVaultRef",
+        field: "embedding.credentialRef",
+      });
+      await expect(
+        updateEmbeddingSettings(ctx(), { credentialRef: goneRef }, appDb),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        translationKey: "errors.vaultRefNotFound",
+        field: "embedding.credentialRef",
+      });
+      await updateEmbeddingSettings(
+        ctx(),
+        { credentialRef: `vault:00${liveId}` },
+        appDb,
+      );
+      expect(
+        (await getTenantSettings(ctx(), appDb)).embedding.credentialRef,
+      ).toBe(liveRef);
+      // null still clears it, without asking the vault about anything.
+      await updateEmbeddingSettings(ctx(), { credentialRef: null }, appDb);
+      expect(
+        (await getTenantSettings(ctx(), appDb)).embedding.credentialRef,
+      ).toBe(null);
+    });
+
+    test("langfuse refuses a bare NAME and keeps refusing the wrong kind", async () => {
+      await expect(
+        updateLangfuse(ctx(), { credentialRef: "lf-key" }, appDb),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        translationKey: "errors.invalidVaultRef",
+        field: "langfuse.credentialRef",
+      });
+      await expect(
+        updateLangfuse(ctx(), { credentialRef: liveRef }, appDb),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        translationKey: "errors.invalidCredentialKind",
+        field: "langfuse.credentialRef",
+      });
+    });
+
+    test("langfuse stores the canonical spelling, and admits an unfilled entry", async () => {
+      // `vault:007` resolved and was stored verbatim, which is exactly what makes the credential
+      // picker call a working credential unavailable; and an entry created empty on purpose was
+      // refused as "not found", which is a different fact with the same words.
+      await updateLangfuse(ctx(), { credentialRef: `vault:00${lfId}` }, appDb);
+      expect(
+        (await getTenantSettings(ctx(), appDb)).langfuse.credentialRef,
+      ).toBe(lfRef);
+      await updateLangfuse(ctx(), { credentialRef: lfPendingRef }, appDb);
+      expect(
+        (await getTenantSettings(ctx(), appDb)).langfuse.credentialRef,
+      ).toBe(lfPendingRef);
+    });
+  });
+
+  for (const b of [...boundaries, ...agentBoundaries]) {
     describe(b.field, () => {
       test("refuses a bare vault entry NAME on create", async () => {
         await expect(b.create("live-key")).rejects.toMatchObject({
@@ -369,6 +672,16 @@ describe.skipIf(!dbUp)("vault ref write boundary", () => {
         // credential_create. The picker is where "fill it" gets said.
         const id = await b.create(pendingRef);
         expect(await b.read(id)).toBe(pendingRef);
+      });
+
+      test("says which field it refused, or says nothing at all", async () => {
+        // The refusal is the only thing the console can key on: the sentence is localized and the
+        // agent keeps eight of these across three tabs, so without a name there is nothing to put
+        // the message next to. Both directions, so an entry that quietly stops naming one fails.
+        const raised = await b.create("live-key").catch((e: unknown) => e);
+        expect((raised as { field?: string }).field).toBe(
+          b.wireField as string,
+        );
       });
 
       test("refuses a bare NAME and a dead ref on update too", async () => {


### PR DESCRIPTION
`requireVaultRef` has been the rule for a stored credential reference since #124: `vault:<id>`, in
this tenant, in the one spelling every reader produces. Six columns answer to it. The agent's own
credentials do not, and neither does the tenant's embedding key, because they are not columns: they
live inside two JSON bags, and a sweep looking for a `credential_ref` column cannot see them.

So a REST `PATCH` carrying a vault entry NAME answered 200 and stored it. `vaultRefWhere` turns
anything that is not `vault:<id>` into `{ id: -1n }`, a filter that matches nothing, so every
resolver returns null: `loadAgentConfig` finds no model, the turn ends, and the operator gets
`agent has no runnable model configured` in the playground — the same sentence a never-configured
agent gets — or, in production, no reply at all. The only trace anywhere is one `logger.warn`.

**The report is right on every point, including both answers it proposed.** REST should refuse
rather than resolve names (six neighbouring endpoints document `never an entry name` in so many
words, and a name is genuinely ambiguous when two entries of different kinds share it), and
`vault:<id>` is the only contractual spelling.

## What now answers to the rule

| write | before | now |
| --- | --- | --- |
| `agent.modelConfig.credentialRef` | zod `z.string().min(1)` and nothing else | `requireVaultRef` |
| `agent.settings.*` — the seven `SETTINGS_CREDENTIAL_PATHS` | `z.record(z.string(), z.unknown())` | `requireVaultRef`, over the same list |
| tenant `embedding.credentialRef` | written through unchecked | `requireVaultRef` |
| tenant `langfuse.credentialRef` | `tryResolveVaultEntry` + kind | `requireVaultRef` + kind |

The seven settings paths are not enumerated here: they are read from `SETTINGS_CREDENTIAL_PATHS`,
which already has a guard walking the behavior readers for credential fields. A block that grows one
tomorrow is covered on the day it is written, in the boundary table too.

## Refuse what the write changes, not what it carries

The agent is the one boundary whose write arrives carrying fields it is not about: the editor posts
the whole bag, and eight credential fields sit across three tabs, several rendered only with their
section switched on. Checking the whole bag would answer 400 naming a field the operator has no way
to open — and since deleting a vault entry strands every ref that named it, one deletion would then
freeze every agent that referenced it: no model change, no rename, not even the switch that turns
the agent off.

So the boundary refuses only a ref the write **introduces or changes**, compared against the stored
row inside the `SELECT … FOR UPDATE` `updateAgent` already holds. This is the same rule, for the same
reason, as `collectOversizedTextChanges` (#122), and it sits in the same order: the optimistic-
concurrency check answers first, so a stale editor resending another writer's ref gets its 409 and
its conflict flow rather than a 400.

What a write leaves alone is reported instead of refused. The console already has that state:
`configHealth.ts` raises `unresolved` on the field itself.

## Two things the report counted as covered

`updateLangfuse` was listed as guarded, and it was — with `tryResolveVaultEntry`, which answered
`vaultRefNotFound` for two values that are something else:

- **a lenient spelling.** `vault:007` resolves (BigInt tolerates padding) and was stored verbatim,
  where it compares unequal against the id list the credential picker builds and reports a working
  credential as unavailable. This is the third question in the report, live on this path.
- **an entry created empty on purpose.** `credential_create` makes a PENDING entry precisely so
  config can be wired to a credential before its secret exists; the write boundary admits that
  deliberately. Langfuse refused it as "not found", which is a different fact in the same words.

## The refusal names the field

Landed after #245, so it follows that norm: `requireVaultRef` takes the server's own name for the
input and puts it on the wire (`settings.tts.normalizeCredentialRef`, `embedding.credentialRef`).
The agent needs it more than any other boundary — one sentence, eight possible fields — and these
are the paths `configHealth.ts` already maps. The six columns of #124 still answer without one: the
patch key the client sent is already their name, and extending #245's sweep to them is its own
change. The boundary table asserts that in both directions, so it cannot be read as "checked".

## Validation

**Proved by test.** `tests/modules/vault/ref-write-boundary.test.ts` grew from 6 boundaries to 14
(the same eight assertions each, against a live database): bare name, bare id, an id past
`2^63-1`, the spellings `BigInt` accepts and no writer produces, a ref whose entry was deleted, a
live ref stored canonically, a PENDING ref accepted, and the same on update. Red first: **61 failing
before the fix, 0 after.**

Then the rule itself, one mutation at a time (whole file, not `-t`):

| mutation | tests that fell |
| --- | --- |
| drop `ref === storedRef` (check the whole bag) | 5 |
| validate but do not write the canonical form back | 8 |
| take `modelConfig` out of the collector | 9 |
| accept the empty string as a ref | 1 |
| run the ref check ahead of the 409 precondition | 1 |
| `updateEmbeddingSettings` stores what it is handed | 1 |
| drop the langfuse kind check | 1 |

`bun check` green on the full suite (4957 pass, 0 fail), and `check:editions` green on both derived
trees. No derivation markers in any file touched, so the diff is 1:1 in both editions.

**NOT validated.** Nothing was exercised through a running console or a browser: the console side of
the new `field` (rendering a vault refusal next to the input it names) is untested here, and so is
whether `configHealth`'s existing `unresolved` line is what an operator actually sees for a ref this
boundary now leaves alone. No live provider call — the refusals happen before any credential is
resolved, so there is nothing to call. Agent **import** is untouched and deliberately so: it resolves
portable names against the vault and drops what does not resolve, with a warning, which is its own
documented contract.

Fixes #254
