### PR TITLE
Ask whether the episode is activated, not whether the row is

### DIFF
--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -6,6 +6,8 @@ import { withKeyedQueue } from "@/lib/locks";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { clipText } from "@/lib/text";
 import { isTestSilenced } from "@/modules/agents/test-mode";
+import { episodeTestActivatedAt } from "@/modules/channel-redirect/episode";
+import { readChannelRedirectConfig } from "@/modules/channel-redirect/service";
 import { loadChatwootClient } from "@/modules/chatwoot/instance";
 import {
   parseLiveConversation,
@@ -289,6 +291,7 @@ export async function runAgentNudge(
         assigneeName: true,
         lastInboundAt: true,
         testActivatedAt: true,
+        contactId: true,
       },
     });
     if (!conv?.inboxId) return null;
@@ -306,9 +309,31 @@ export async function runAgentNudge(
     // hasn't been activated with /teste. Covers EVERY nudge caller (follow-up + inbound events).
     const agent = await db.agent.findUnique({
       where: { id: inbox.agentId },
-      select: { mode: true },
+      select: { mode: true, settings: true },
     });
-    if (agent && isTestSilenced(agent.mode, conv.testActivatedAt)) {
+    if (
+      agent &&
+      isTestSilenced(
+        agent.mode,
+        // The EPISODE's activation, not this row's: a redirect episode is two conversations of one
+        // person, and `/teste` stamps only the one it was typed in. Asked on the caller's connection
+        // — this runs inside the thread claim, where a second connection would stall on the pool
+        // (issue #249).
+        await episodeTestActivatedAt({
+          tenantId,
+          instanceId,
+          cfg: readChannelRedirectConfig(agent.settings),
+          agentMode: agent.mode,
+          conv: {
+            testActivatedAt: conv.testActivatedAt,
+            contactId: conv.contactId,
+            chatwootInboxId: inbox.chatwootInboxId,
+          },
+          base,
+          scoped: db,
+        }),
+      )
+    ) {
       return "silenced" as const;
     }
     const cfg = await loadAgentConfig(db, {

--- a/src/modules/channel-redirect/episode.ts
+++ b/src/modules/channel-redirect/episode.ts
@@ -1,0 +1,138 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+import logger from "@/api/lib/logger";
+import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
+import type { ChannelRedirectConfig } from "./service";
+
+// Test-mode activation is a property of the PERSON being served, not of a channel: `/teste` means
+// "this is me, testing", and that does not stop being true because the lead followed a link from
+// WhatsApp into the website chat. A redirect episode is two conversations of one contact
+// (`service.ts`'s header), so the stamp `/teste` writes on one row answers for an episode whose other
+// half it does not hold.
+//
+// The bridge that exists today runs ONCE, at link time, in ONE direction (`shouldPropagateTestMode`,
+// WhatsApp → widget). Every activation outside that instant leaves the two halves disagreeing, and
+// each reader then judges by whichever row it happened to load: the ladder messages the WhatsApp
+// conversation while asking the widget row, the reactive gate silences a chat whose sibling is
+// activated, and `/reset` refuses to run from the unstamped side.
+//
+// So the question every one of them asks is the EPISODE's, and this module answers it.
+
+function sysCtx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}
+
+// Which half of a redirect episode a conversation is, read from its inbox. `null` means the
+// conversation is not part of one — the episode question does not arise, and nothing is looked up.
+//
+// Pure, and the gate for everything below: a deployment with the feature off, or an inbox that is
+// neither side, never pays for a sibling read.
+export function redirectSide(
+  cfg: ChannelRedirectConfig,
+  chatwootInboxId: number | null,
+): "entry" | "widget" | null {
+  if (!cfg.enabled || chatwootInboxId === null) return null;
+  if (cfg.entryInboxId !== null && cfg.entryInboxId === chatwootInboxId)
+    return "entry";
+  if (cfg.widgetInboxId !== null && cfg.widgetInboxId === chatwootInboxId)
+    return "widget";
+  return null;
+}
+
+export interface EpisodeLookupInputs {
+  // Agent.mode — a production agent is never silenced, so it never asks.
+  agentMode: string;
+  // The stamp on the conversation the caller already has in hand.
+  ownTestActivatedAt: Date | null;
+  // Which half of an episode that conversation is; null = not part of one.
+  side: "entry" | "widget" | null;
+}
+
+// Pure: whether the sibling has to be read at all. Three ways to answer without touching the
+// database, and each one carries a real call site — the reactive gate runs on EVERY inbound message,
+// so this predicate is what keeps that path free:
+//
+//   - a production agent has no activation question;
+//   - a row already stamped IS the answer, whatever the sibling says (the episode is activated as
+//     soon as either half is, so a stamped row can never be overturned);
+//   - a conversation outside a redirect episode has no sibling to ask.
+export function needsEpisodeLookup(s: EpisodeLookupInputs): boolean {
+  return (
+    s.agentMode === "test" && s.ownTestActivatedAt === null && s.side !== null
+  );
+}
+
+export interface EpisodeActivationParams {
+  tenantId: bigint;
+  instanceId: bigint;
+  cfg: ChannelRedirectConfig;
+  agentMode: string;
+  conv: {
+    // The conversation the caller holds: its own stamp, its contact, and the inbox that says which
+    // half of the episode it is.
+    testActivatedAt: Date | null;
+    contactId: bigint | null;
+    chatwootInboxId: number | null;
+  };
+  base: PrismaClient;
+  // The caller's connection when it has one. Same rule the ladder's fences follow: asked from inside
+  // a thread claim, a second connection would stall on an exhausted pool while the advisory lock is
+  // held, and DB_POOL_MAX=1 is a supported setting.
+  scoped?: ScopedDb;
+}
+
+// The episode's activation stamp: this conversation's own, or — when it has none — its redirect
+// sibling's. Returns null when the episode is not activated anywhere, which is the answer
+// `isTestSilenced` already knows how to read, so every call site keeps the predicate it had.
+//
+// The sibling is the same contact's conversation on the OTHER side's inbox. That is the same pairing
+// the ladder already uses to pick its destination (#222 covers what is wrong with it): this read
+// makes no new assumption, it asks about the rows the callers were already acting on.
+//
+// A sibling read that fails falls back to the row's own answer — which, by the guard above, is null.
+// So an unreadable sibling reads as "not activated" and the agent stays quiet. That is the OPPOSITE
+// direction from the ladder's liveness fence, which fails open, and deliberately: there the cost of
+// an unknown is a follow-up the customer should have received, here it is a test agent messaging a
+// real lead. Silence is the safe failure for this question and only this one.
+export async function episodeTestActivatedAt(
+  p: EpisodeActivationParams,
+): Promise<Date | null> {
+  const side = redirectSide(p.cfg, p.conv.chatwootInboxId);
+  if (
+    !needsEpisodeLookup({
+      agentMode: p.agentMode,
+      ownTestActivatedAt: p.conv.testActivatedAt,
+      side,
+    })
+  )
+    return p.conv.testActivatedAt;
+  if (p.conv.contactId === null) return null;
+  const siblingInboxId =
+    side === "widget" ? p.cfg.entryInboxId : p.cfg.widgetInboxId;
+  if (siblingInboxId === null) return null;
+  const read = (db: ScopedDb) =>
+    db.conversation.findFirst({
+      where: {
+        contactId: p.conv.contactId,
+        chatwootInstanceId: p.instanceId,
+        inbox: { chatwootInboxId: siblingInboxId },
+      },
+      select: { testActivatedAt: true },
+      // The activated sibling FIRST, so a contact with several conversations on that inbox cannot
+      // hide the activation behind a newer unstamped one. Ordering, not filtering: `testActivatedAt`
+      // is the answer, and asking for the greatest of them is the episode's answer whichever row
+      // carries it.
+      orderBy: { testActivatedAt: { sort: "desc", nulls: "last" } },
+    });
+  const sibling = await (p.scoped
+    ? read(p.scoped)
+    : runScopedOn(p.base, sysCtx(p.tenantId), read)
+  ).catch((err: unknown) => {
+    logger.warn(
+      "channel-redirect: could not read the episode sibling's activation (contact=%s): %s",
+      String(p.conv.contactId),
+      err instanceof Error ? err.message : String(err),
+    );
+    return null;
+  });
+  return sibling?.testActivatedAt ?? null;
+}

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -24,6 +24,7 @@ import {
   proactiveSendMode,
   readServiceWindowConfig,
 } from "@/modules/service-window/service";
+import { episodeTestActivatedAt } from "./episode";
 import { interpolateLink, resolveRedirectLink } from "./gate";
 import {
   type ChannelRedirectConfig,
@@ -444,9 +445,31 @@ export async function redirectFollowUpHandler(
           chatwootConversationId: parsed.conversationId,
         },
       },
-      select: { testActivatedAt: true },
+      select: {
+        testActivatedAt: true,
+        contactId: true,
+        inbox: { select: { chatwootInboxId: true } },
+      },
     });
-    return { agent, testActivatedAt: conv?.testActivatedAt ?? null };
+    return {
+      agent,
+      // The EPISODE's activation, not this row's. The ladder is keyed by the widget thread but two of
+      // its three stages message the WhatsApp sibling, so a row read on its own answers for a
+      // destination whose state it does not hold (issue #249).
+      testActivatedAt: await episodeTestActivatedAt({
+        tenantId,
+        instanceId: parsed.instanceId,
+        cfg: readChannelRedirectConfig(agent.settings),
+        agentMode: agent.mode,
+        conv: {
+          testActivatedAt: conv?.testActivatedAt ?? null,
+          contactId: conv?.contactId ?? null,
+          chatwootInboxId: conv?.inbox?.chatwootInboxId ?? null,
+        },
+        base,
+        scoped: db,
+      }),
+    };
   });
   if (!loaded) return { outcome: "done" };
   const { agent } = loaded;
@@ -489,7 +512,9 @@ export async function redirectFollowUpHandler(
     // message abandons its watermark and the customer gets it twice. `strict` is the ask that runs
     // BEFORE anything is written — inside the thread's critical section, ahead of the divider and
     // the checkpoint — where guessing recreates the memory /reset just cleared and nothing later
-    // catches it. Only the RETIREMENT half changes: liveness stays fail-open in both.
+    // catches it. Only the RETIREMENT half changes: liveness stays fail-open in both — including the
+    // episode read inside it, which falls back to the row's own (null) answer rather than failing
+    // open, because that is the answer this fence gave before that read existed.
     opts: { strict?: boolean } = {},
   ): Promise<LadderVerdict> => {
     const read = async (db: ScopedDb) => {
@@ -535,12 +560,31 @@ export async function redirectFollowUpHandler(
               chatwootConversationId: parsed.conversationId,
             },
           },
-          select: { testActivatedAt: true },
+          select: {
+            testActivatedAt: true,
+            contactId: true,
+            inbox: { select: { chatwootInboxId: true } },
+          },
         });
         return isRedirectFollowUpLive({
           agentEnabled: a.enabled,
           agentMode: a.mode,
-          testActivatedAt: c?.testActivatedAt ?? null,
+          // The episode's answer, on this same connection. A sibling read that fails returns this
+          // row's own answer — which, to have got here, is null — so the worst a failure can do is
+          // reproduce the behaviour this call replaced. It can lose the fix, never invent a refusal.
+          testActivatedAt: await episodeTestActivatedAt({
+            tenantId,
+            instanceId: parsed.instanceId,
+            cfg,
+            agentMode: a.mode,
+            conv: {
+              testActivatedAt: c?.testActivatedAt ?? null,
+              contactId: c?.contactId ?? null,
+              chatwootInboxId: c?.inbox?.chatwootInboxId ?? null,
+            },
+            base,
+            scoped: db,
+          }),
         })
           ? ("go" as const)
           : ("stood-down" as const);

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -35,6 +35,7 @@ import {
   scheduleCanClose,
 } from "@/modules/business-hours/hours";
 import { linkRedirectConversations } from "@/modules/channel-redirect/cross-link";
+import { episodeTestActivatedAt } from "@/modules/channel-redirect/episode";
 import {
   armRedirectChatFollowUp,
   deliverRedirectClosing,
@@ -44,6 +45,7 @@ import {
 } from "@/modules/channel-redirect/followup";
 import { runRedirectGate } from "@/modules/channel-redirect/gate";
 import {
+  type ChannelRedirectConfig,
   isRedirectEntryInbox,
   readChannelRedirectConfig,
 } from "@/modules/channel-redirect/service";
@@ -563,12 +565,16 @@ export function hasPendingInboundMediaUpdate(
   );
 }
 
-// The widget conversation's /teste stamp, for the resolve-triggered closing gate. Its own read
-// rather than the boolean above, because the liveness predicate takes the stamp itself.
-async function widgetTestActivatedAt(
+// The EPISODE's /teste stamp, for the resolve-triggered closing gate. Its own read rather than the
+// boolean above, because the liveness predicate takes the stamp itself — and the episode's answer
+// rather than this row's, because what this gate protects is a message to the WhatsApp SIBLING
+// (`closeChat: false`), a conversation whose activation the widget row does not hold (issue #249).
+async function episodeActivationForWidget(
   tenantId: bigint,
   instanceId: bigint,
   conversationId: number,
+  cfg: ChannelRedirectConfig,
+  agentMode: string,
   base: PrismaClient,
 ): Promise<Date | null> {
   const row = await runScopedOn(base, sysCtx(tenantId), (db) =>
@@ -580,10 +586,25 @@ async function widgetTestActivatedAt(
           chatwootConversationId: conversationId,
         },
       },
-      select: { testActivatedAt: true },
+      select: {
+        testActivatedAt: true,
+        contactId: true,
+        inbox: { select: { chatwootInboxId: true } },
+      },
     }),
   );
-  return row?.testActivatedAt ?? null;
+  return episodeTestActivatedAt({
+    tenantId,
+    instanceId,
+    cfg,
+    agentMode,
+    conv: {
+      testActivatedAt: row?.testActivatedAt ?? null,
+      contactId: row?.contactId ?? null,
+      chatwootInboxId: row?.inbox?.chatwootInboxId ?? null,
+    },
+    base,
+  });
 }
 
 async function isTestConversationActivated(params: {
@@ -2673,20 +2694,18 @@ export async function processChatwootDelivery(
               // nothing to look up.
               testActivatedAt:
                 closingRt.mode === "test"
-                  ? await widgetTestActivatedAt(
+                  ? await episodeActivationForWidget(
                       params.tenantId,
                       params.instanceId,
                       conversationId,
+                      redirectCfg,
+                      closingRt.mode,
                       base,
                     )
                   : null,
             });
           if (closingLive && redirectCfg.entryInboxId !== null) {
             const outcome = await deliverRedirectClosing({
-              // The answer above is older than the sibling lookup, the client build and this
-              // function's own reads, and this path has no job to ask about — so the switch is
-              // re-asked from inside, at the same points (issue #246). Fail OPEN on a read that
-              // fails: a conversation resolves once, so a transient error must not cost the closing.
               // The gate above is older than the sibling lookup, the client build and this
               // function's own reads, and this path has no job to ask about — so the switch is
               // re-asked from inside, at the same points the ladder asks (issue #246). One read, and
@@ -2712,10 +2731,12 @@ export async function processChatwootDelivery(
                 // relation to select through — so it would take raw SQL or a schema change, for a
                 // window one query wide on a test agent, on the path where the operator has just
                 // resolved the conversation by hand.
-                const testActivatedAt = await widgetTestActivatedAt(
+                const testActivatedAt = await episodeActivationForWidget(
                   params.tenantId,
                   params.instanceId,
                   conversationId,
+                  redirectCfg,
+                  rt.mode,
                   base,
                 ).catch(() => new Date());
                 return isRedirectFollowUpLive({

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -425,6 +425,40 @@ describe.skipIf(!dbUp)(
       }
     });
 
+    // Issue #249: the activation the operator gave is on the OTHER half of the episode. This gate's
+    // own conversation is the widget, but what it protects is a message to the WhatsApp SIBLING
+    // (`closeChat: false`) — the conversation that carries the stamp. Judged by the widget row alone
+    // it reads as "never activated" and the goodbye is dropped on an episode that is activated, on
+    // the very channel it would have messaged.
+    test("a test agent activated on the sibling still posts the goodbye", async () => {
+      await suDb.agent.update({
+        where: { id: agent },
+        data: { enabled: true, mode: "test" },
+      });
+      await rearm();
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: WIDGET },
+        data: { testActivatedAt: null },
+      });
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: SIBLING },
+        data: { testActivatedAt: new Date() },
+      });
+      try {
+        await resolveWidget();
+        expect(wire.filter((u) => u.includes("/messages"))).not.toEqual([]);
+      } finally {
+        await suDb.agent.update({
+          where: { id: agent },
+          data: { mode: "production" },
+        });
+        await suDb.conversation.updateMany({
+          where: { tenantId: tid, chatwootConversationId: SIBLING },
+          data: { testActivatedAt: null },
+        });
+      }
+    });
+
     // Issue #246: the runtime is read, and then compaction arming, the ladder cancel and the closing's
     // own reads all run before anything is posted. The switch is re-asked from inside for that window.
     test("switched off while the closing reads posts nothing", async () => {

--- a/tests/modules/channel-redirect-episode.test.ts
+++ b/tests/modules/channel-redirect-episode.test.ts
@@ -1,0 +1,345 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import {
+  episodeTestActivatedAt,
+  needsEpisodeLookup,
+  redirectSide,
+} from "@/modules/channel-redirect/episode";
+import {
+  CHANNEL_REDIRECT_DEFAULTS,
+  type ChannelRedirectConfig,
+} from "@/modules/channel-redirect/service";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+const ENTRY_INBOX = 210;
+const WIDGET_INBOX = 211;
+
+const cfg: ChannelRedirectConfig = {
+  ...CHANNEL_REDIRECT_DEFAULTS,
+  enabled: true,
+  entryInboxId: ENTRY_INBOX,
+  widgetInboxId: WIDGET_INBOX,
+};
+
+describe("redirectSide", () => {
+  test("names the half a conversation is by its inbox", () => {
+    expect(redirectSide(cfg, ENTRY_INBOX)).toBe("entry");
+    expect(redirectSide(cfg, WIDGET_INBOX)).toBe("widget");
+  });
+
+  test("an inbox outside the pair is not part of an episode", () => {
+    expect(redirectSide(cfg, 999)).toBeNull();
+    expect(redirectSide(cfg, null)).toBeNull();
+  });
+
+  // The feature switched off makes every conversation a plain one, whatever the inbox ids still say.
+  // This is what keeps a deployment that never used the redirect from paying for a sibling read.
+  test("a disabled redirect has no sides at all", () => {
+    expect(redirectSide({ ...cfg, enabled: false }, ENTRY_INBOX)).toBeNull();
+  });
+
+  test("a half that is not provisioned yet is not a side", () => {
+    expect(
+      redirectSide({ ...cfg, widgetInboxId: null }, WIDGET_INBOX),
+    ).toBeNull(
+      // Null must not match a null inbox id either — the guard is on the id, not on the pairing.
+    );
+    expect(redirectSide({ ...cfg, entryInboxId: null }, null)).toBeNull();
+  });
+});
+
+// Each row is a reason NOT to touch the database, and the reactive gate runs on every inbound
+// message, so this is the predicate that keeps that path free.
+describe("needsEpisodeLookup", () => {
+  const base = {
+    agentMode: "test",
+    ownTestActivatedAt: null,
+    side: "widget" as const,
+  };
+
+  test("asks only when all three hold", () => {
+    expect(needsEpisodeLookup(base)).toBe(true);
+  });
+
+  test("a production agent has no activation question", () => {
+    expect(needsEpisodeLookup({ ...base, agentMode: "production" })).toBe(
+      false,
+    );
+  });
+
+  // A stamped row is the whole answer: the episode is activated as soon as EITHER half is, so no
+  // sibling can overturn it. Reading one would be a query whose result cannot change the outcome.
+  test("a row already stamped is the answer", () => {
+    expect(
+      needsEpisodeLookup({ ...base, ownTestActivatedAt: new Date() }),
+    ).toBe(false);
+  });
+
+  test("a conversation outside an episode has no sibling to ask", () => {
+    expect(needsEpisodeLookup({ ...base, side: null })).toBe(false);
+  });
+});
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.TEST_MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+describe.skipIf(!dbUp)("episodeTestActivatedAt", () => {
+  let tenantId = 0n;
+  let instanceId = 0n;
+  let contactId: bigint | null = null;
+  const ENTRY_CONV = 8101;
+  const WIDGET_CONV = 8102;
+  // A SECOND conversation of the same contact on the entry inbox, more recent than the first. The
+  // pairing this module inherits picks among these, and the ordering rule below is what stops a
+  // newer unstamped row from hiding the activation.
+  const ENTRY_CONV_NEWER = 8103;
+
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "EPI", slug: `epi-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 21,
+      baseUrl: "https://203.0.113.21:9",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const agent = await suDb.agent.create({
+      data: { tenantId, name: "A", systemPrompt: "x", mode: "test" },
+    });
+    const entryInbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: ENTRY_INBOX,
+        name: "WhatsApp",
+        agentId: agent.id,
+      },
+    });
+    const widgetInbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: WIDGET_INBOX,
+        name: "Site",
+        agentId: agent.id,
+      },
+    });
+    const contact = await suDb.contact.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootContactId: 8100,
+        name: "Cliente",
+      },
+    });
+    contactId = contact.id;
+    for (const [conv, inboxId, lastEventAt] of [
+      [ENTRY_CONV, entryInbox.id, new Date(Date.now() - 60_000)],
+      [ENTRY_CONV_NEWER, entryInbox.id, new Date()],
+      [WIDGET_CONV, widgetInbox.id, new Date()],
+    ] as const) {
+      await suDb.conversation.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          inboxId,
+          contactId: contact.id,
+          chatwootConversationId: conv,
+          status: "pending",
+          threadId: `${tenantId}:${instanceId}:${conv}`,
+          lastEventAt,
+        },
+      });
+    }
+  });
+
+  afterAll(async () => {
+    if (!dbUp) return;
+    await suDb.tenant.delete({ where: { id: tenantId } }).catch(() => {});
+  });
+
+  const stampEntry = async (conv: number, at: Date | null) => {
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: conv },
+      data: { testActivatedAt: at },
+    });
+  };
+  const clearEntries = async () => {
+    await stampEntry(ENTRY_CONV, null);
+    await stampEntry(ENTRY_CONV_NEWER, null);
+  };
+  const askFromWidget = (
+    own: Date | null,
+    over: Partial<Parameters<typeof episodeTestActivatedAt>[0]> = {},
+  ) =>
+    episodeTestActivatedAt({
+      tenantId,
+      instanceId,
+      cfg,
+      agentMode: "test",
+      conv: {
+        testActivatedAt: own,
+        contactId,
+        chatwootInboxId: WIDGET_INBOX,
+      },
+      base: appDb,
+      ...over,
+    });
+
+  test("an unstamped widget inherits the entry side's activation", async () => {
+    const at = new Date("2026-08-20T10:00:00Z");
+    await stampEntry(ENTRY_CONV, at);
+    try {
+      expect((await askFromWidget(null))?.toISOString()).toBe(at.toISOString());
+    } finally {
+      await clearEntries();
+    }
+  });
+
+  // The other direction, which the link-time propagation has never covered: `/teste` typed in the
+  // chat is the same person saying the same thing.
+  test("an unstamped entry inherits the widget side's activation", async () => {
+    const at = new Date("2026-08-20T11:00:00Z");
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: WIDGET_CONV },
+      data: { testActivatedAt: at },
+    });
+    try {
+      const got = await episodeTestActivatedAt({
+        tenantId,
+        instanceId,
+        cfg,
+        agentMode: "test",
+        conv: {
+          testActivatedAt: null,
+          contactId,
+          chatwootInboxId: ENTRY_INBOX,
+        },
+        base: appDb,
+      });
+      expect(got?.toISOString()).toBe(at.toISOString());
+    } finally {
+      await suDb.conversation.updateMany({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        data: { testActivatedAt: null },
+      });
+    }
+  });
+
+  // The ordering rule, and the only test that can fail if it is dropped: the NEWER entry conversation
+  // is unstamped and the older one carries the activation. Picked by recency — which is how the
+  // destination is picked — this answers null and the episode reads as never activated.
+  test("an activation on an older sibling is not hidden by a newer unstamped one", async () => {
+    const at = new Date("2026-08-20T12:00:00Z");
+    await stampEntry(ENTRY_CONV, at);
+    await stampEntry(ENTRY_CONV_NEWER, null);
+    try {
+      expect((await askFromWidget(null))?.toISOString()).toBe(at.toISOString());
+    } finally {
+      await clearEntries();
+    }
+  });
+
+  test("no activation anywhere in the episode answers null", async () => {
+    expect(await askFromWidget(null)).toBeNull();
+  });
+
+  test("a row that carries its own stamp answers with it", async () => {
+    const own = new Date("2026-08-20T09:00:00Z");
+    expect((await askFromWidget(own))?.toISOString()).toBe(own.toISOString());
+  });
+
+  // A production agent is never silenced, so the question does not arise and the row's own value —
+  // whatever it is — comes straight back.
+  test("a production agent never asks", async () => {
+    const at = new Date("2026-08-20T13:00:00Z");
+    await stampEntry(ENTRY_CONV, at);
+    try {
+      expect(await askFromWidget(null, { agentMode: "production" })).toBeNull();
+    } finally {
+      await clearEntries();
+    }
+  });
+
+  test("a conversation outside the pair never asks", async () => {
+    const at = new Date("2026-08-20T14:00:00Z");
+    await stampEntry(ENTRY_CONV, at);
+    try {
+      expect(
+        await askFromWidget(null, {
+          conv: { testActivatedAt: null, contactId, chatwootInboxId: 999 },
+        }),
+      ).toBeNull();
+    } finally {
+      await clearEntries();
+    }
+  });
+
+  // A contactless conversation has no pairing to follow, so there is nothing to inherit.
+  test("a conversation with no contact answers with its own value", async () => {
+    const at = new Date("2026-08-20T15:00:00Z");
+    await stampEntry(ENTRY_CONV, at);
+    try {
+      expect(
+        await askFromWidget(null, {
+          conv: {
+            testActivatedAt: null,
+            contactId: null,
+            chatwootInboxId: WIDGET_INBOX,
+          },
+        }),
+      ).toBeNull();
+    } finally {
+      await clearEntries();
+    }
+  });
+
+  // The failure direction, and it is the OPPOSITE of the ladder's liveness fence. There an unknown
+  // answer means "send anyway", because the cost is a follow-up the customer should have had. Here an
+  // unknown answer means silence, because the cost is a test agent messaging a real lead — and it is
+  // exactly the behaviour this call replaced, so a failed read can lose the fix, never invent a
+  // refusal.
+  test("a sibling read that fails leaves the row's own answer standing", async () => {
+    const at = new Date("2026-08-20T16:00:00Z");
+    await stampEntry(ENTRY_CONV, at);
+    const failing = appDb.$extends({
+      query: {
+        conversation: {
+          async findFirst() {
+            throw new Error("sibling read is down");
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+    try {
+      expect(await askFromWidget(null, { base: failing })).toBeNull();
+    } finally {
+      await clearEntries();
+    }
+  });
+});

--- a/tests/modules/channel-redirect-episode.test.ts
+++ b/tests/modules/channel-redirect-episode.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
+import { runScopedOn } from "@/lib/tenancy";
 import {
   episodeTestActivatedAt,
   needsEpisodeLookup,
@@ -324,6 +325,41 @@ describe.skipIf(!dbUp)("episodeTestActivatedAt", () => {
   // unknown answer means silence, because the cost is a test agent messaging a real lead — and it is
   // exactly the behaviour this call replaced, so a failed read can lose the fix, never invent a
   // refusal.
+  // The reason this module takes the caller's connection at all, measured rather than argued. Every
+  // call site asks from inside a scoped transaction, and `runScopedOn` PINS a pooled connection for
+  // the length of it — the ladder's fences hold an advisory lock in that same transaction. A sibling
+  // read that opens its OWN asks a pinned pool for a second connection, and `DB_POOL_MAX=1` is a
+  // supported setting.
+  //
+  // What makes that worth a test rather than a comment is the failure being SILENT. The read is
+  // swallowed as "no activation" (the test above), so on that setting the agent goes straight back
+  // to judging by the row alone: the very defect this module exists to fix, reintroduced by the
+  // connection it asked on, with nothing failing anywhere to say so.
+  test("the sibling read answers inside a pinned transaction, on a pool of one", async () => {
+    const at = new Date("2026-08-20T17:00:00Z");
+    await stampEntry(ENTRY_CONV, at);
+    const onePool = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl as string, max: 1 }),
+    });
+    try {
+      const answers = await runScopedOn(
+        onePool,
+        { tenantId, userId: null, role: "TENANT_ADMIN" } as never,
+        async (scoped) => ({
+          // Handed the transaction's own connection: reads the sibling and sees the activation.
+          shared: await askFromWidget(null, { base: onePool, scoped }),
+          // Opening its own from in here is the bug, and the swallow turns it into "not activated".
+          own: await askFromWidget(null, { base: onePool }),
+        }),
+      );
+      expect(answers.shared?.toISOString()).toBe(at.toISOString());
+      expect(answers.own).toBeNull();
+    } finally {
+      await onePool.$disconnect();
+      await clearEntries();
+    }
+  });
+
   test("a sibling read that fails leaves the row's own answer standing", async () => {
     const at = new Date("2026-08-20T16:00:00Z");
     await stampEntry(ENTRY_CONV, at);

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -1706,6 +1706,94 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     // The control the negative above needs: a fence that stood every ladder down would pass it.
     expect(s.sent.map(([c]) => c)).toEqual([WIDGET_CONV]);
   });
+
+  // ── The episode's activation, not the row's ──────────────────────────────────────────────────────
+  // A redirect episode is TWO conversations of one person, and `/teste` stamps only the one it was
+  // typed in. The bridge between them (`shouldPropagateTestMode`) runs ONCE, at link time, WhatsApp →
+  // widget — so an activation that lands after the link, or on the other side, leaves the two halves
+  // disagreeing about a question that has one answer per PERSON: the operator activated the agent,
+  // not a channel. The ladder then judges every send by the WIDGET row, including the two stages whose
+  // destination is the WhatsApp conversation.
+  const setStamps = async (widget: Date | null, entry: Date | null) => {
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: WIDGET_CONV },
+      data: { testActivatedAt: widget, redirectClosedAt: null },
+    });
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: ENTRY_CONV },
+      data: { testActivatedAt: entry },
+    });
+  };
+  const restoreProduction = async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: { enabled: true, mode: "production" },
+    });
+    await setStamps(null, null);
+  };
+  const asTestAgent = async (widget: Date | null, entry: Date | null) => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: { enabled: true, mode: "test" },
+    });
+    await setStamps(widget, entry);
+  };
+
+  // `/teste` typed on WhatsApp AFTER the link: the entry row carries the stamp, the widget row does
+  // not, and the one-shot propagation is already spent. Stage 2's destination IS the entry
+  // conversation — the activated one — so the ladder goes mute on the very channel that was activated.
+  test("stage 2 sends when the activation is on the side it messages", async () => {
+    await asTestAgent(null, new Date());
+    const job = await claimed("whatsapp");
+    const s = stubClient();
+    wire.length = 0;
+    globalThis.fetch = httpDouble;
+    try {
+      await redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      await restoreProduction();
+    }
+    expect(wire.filter((u) => u.includes("/messages"))).toHaveLength(1);
+  });
+
+  // The same activation, one stage earlier. Stage 1 messages the WIDGET, so this is the half of the
+  // episode whose own row is unstamped — and it still has to speak, because the person who typed
+  // `/teste` on WhatsApp is the person now sitting in this chat.
+  test("stage 1 nudges when the activation is on the sibling", async () => {
+    await asTestAgent(null, new Date());
+    const job = await claimed();
+    const s = stubClient();
+    try {
+      await redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      await restoreProduction();
+    }
+    expect(s.sent.map(([c]) => c)).toEqual([WIDGET_CONV]);
+  });
+
+  // The control both need: with NEITHER side stamped the episode is not activated, and the ladder
+  // stays silent. Without this, an implementation that simply stopped asking would pass the two above.
+  test("an episode with no activation anywhere stays silent", async () => {
+    await asTestAgent(null, null);
+    const job = await claimed();
+    const s = stubClient();
+    try {
+      await redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s.makeClient,
+      });
+    } finally {
+      await restoreProduction();
+    }
+    expect(s.sent).toEqual([]);
+  });
 });
 
 describe("isRedirectFollowUpLive", () => {


### PR DESCRIPTION
## What broke

Test-mode activation is a property of the **person** being served: `/teste` means "this is me,
testing", and that does not stop being true because the lead followed a link from WhatsApp into the
website chat. `docs/channel-redirect.md` says as much about the one bridge that exists today — it
propagates the activation "so an operator testing the flow does not re-activate in the chat".

But the stamp is written per conversation **row**, and a redirect episode is **two** rows. The bridge
(`shouldPropagateTestMode`) runs **once**, at link time, in **one direction** (WhatsApp → widget), and
`linkRedirect` stamps `redirectLinkedAt` in the same update, so it is a one-shot. Nothing else writes
`testActivatedAt`.

Every activation outside that instant leaves the two halves disagreeing about a question that has one
answer per person — and every proactive send judged the episode by the **widget** row, including the
sends whose destination is the WhatsApp conversation.

## Measured

`/teste` typed on WhatsApp **after** the link — entry row stamped, widget row `null`, one-shot spent —
against a real Postgres:

| reader | destination | before |
| --- | --- | --- |
| ladder stage 1, chat nudge | widget conversation | nothing sent |
| ladder stage 2, link re-send | **entry** conversation | nothing sent |
| resolve-triggered closing | **entry** conversation | goodbye dropped |

Three readers, three different gates — `runAgentNudge`'s own test-mode gate, the ladder's liveness
fence, and the closing gate in `webhook.ts` — and all three read the widget row. The last one is the
clearest case that the row is the wrong unit: that path runs with `closeChat: false`, so the only
message it sends goes to the conversation that **carries** the stamp it refuses to look at.

**What does not reproduce.** #220's report also described the mirror-image case (widget stamped, entry
`null`) as a false positive, on the grounds that stage 2 then posts "a real send to a lead who never
typed `/teste`". That does not hold: `resolveWhatsAppSibling` filters by `contactId`, so the
destination is always the same person. The webhook's redirect gate also sits *after* the test-mode
gate (`a test agent must not auto-redirect real leads`), so in a test episode the entry side is
stamped before a link is ever sent. That case is correct behaviour and this PR does not change it —
the new read only fires on a row that has **no** stamp of its own.

## The shape

One question, asked where the row was asked before: **is this episode activated?**, answered by either
half. `episodeTestActivatedAt` returns the row's own stamp, or — only when it has none — the redirect
sibling's, and every caller keeps the `isTestSilenced` predicate it already had.

No schema change. The two rows the question spans are the rows these callers already act on when they
pick a destination, so this makes no new assumption about the pair: whether that pair is the *right*
pair is #222, pre-existing, and untouched either way — the closing already messages and resolves
whatever that lookup returns.

Four properties are load-bearing, each pinned by a test:

- **The common path never touches the database.** `needsEpisodeLookup` is false for a production
  agent, for an already-stamped row (the episode is activated as soon as either half is, so no sibling
  can overturn it), and for any conversation outside a redirect episode. `runAgentNudge`'s gate runs on
  every proactive send, so this is what keeps it free.
- **The sibling is ordered by the activation, not by recency.** A contact with several conversations
  on the entry inbox would otherwise hide the stamp behind a newer unstamped row — which is exactly how
  the destination is picked, and exactly the failure this question must not inherit.
- **It falls back rather than failing open**, which is the opposite of the liveness fence around it.
  A sibling read that fails returns the row's own answer, and by the guard above that answer is `null`
  — so the agent stays quiet. That is precisely the behaviour this call replaced: a failed read can
  lose the fix and never invent a refusal. Stated inline next to #227's "liveness stays fail-open in
  both", so that invariant still reads true.
- **It asks on the caller's connection.** Every call site asks from inside a scoped transaction, and
  `runScopedOn` pins a pooled connection for the length of it — the ladder's fences hold an advisory
  lock in that same one. A sibling read that opens its **own** asks a pinned pool for a second
  connection, and `DB_POOL_MAX=1` is a supported setting. The same rule `jobRetired` states, and now
  the same shape of test: on a pool of one, the two arms side by side. Handed the transaction's
  connection it answers in 17ms; opening its own it stalls for two seconds and then answers `null`,
  which is this fix silently gone — the agent back to judging by the row alone, with nothing failing
  anywhere to say so.

## Validation scope

**Proved by test** (DB-backed, against a real Postgres):

- `tests/modules/channel-redirect-followup.test.ts` — both ladder stages send when the activation is
  on the half they are **not** keyed by, plus the control: an episode with no activation anywhere
  stays silent.
- `tests/modules/channel-redirect-closing-origin.test.ts` — a resolve on the widget still posts the
  goodbye when the activation is on the sibling.
- `tests/modules/channel-redirect-episode.test.ts` — the decision tables for `redirectSide` and
  `needsEpisodeLookup`, both inheritance directions, the ordering rule (an activation on an *older*
  sibling is not hidden by a newer unstamped one), the three no-lookup paths, a contactless
  conversation, a sibling read that throws, and the read answered from inside a pinned transaction on
  a pool of one.

Twelve mutations, twelve caught, no survivors: dropping the `orderBy`, each of `needsEpisodeLookup`'s
three terms, mirroring the sibling side, dropping the `enabled` guard, turning the failure into an
activation, removing the call from each of the four call sites independently, and ignoring the caller's
connection so the sibling read opens its own.

Full suite: 4993 pass, 0 fail.

**Proved live**, against a real Chatwoot carrying the fork's `redirect_tokens` endpoint. One contact
with two conversations — a baileys WhatsApp inbox and the website widget — `/teste` stamped on the
**WhatsApp** row only, and stage 2 driven through `redirectFollowUpHandler` with no injected client,
since that stage builds its own. Three arms on the same live state:

| arm | code | activation | posted to the WhatsApp sibling |
| --- | --- | --- | --- |
| A | this PR | on the sibling | **1** |
| B | reverted to the row's own stamp | on the sibling | 0 |
| C | this PR | nowhere | 0 |

Arm A's message was read back from Chatwoot's own `messages` table rather than from the call that
sent it: `message_type=1`, `private=false`, `sender_type=AgentBot`, on the WhatsApp inbox, carrying a
redirect token minted against that same Chatwoot in the same run. Arm B is the defect reproduced end
to end; arm C is the guard still holding, so the fix is not simply "send more".

**Not validated**: the rate at which a real deployment reaches these episode states, and the three
inbound-message readers below.

**Deliberately out of scope.** The same root cause reaches three more readers, all in `webhook.ts` and
all triggered by an **inbound message** rather than by a proactive send: `/reset` (its `shouldRunReset`
call), the reactive silence gate (which spells `ctx.mode === "test" && ctx.conv.testActivatedAt ===
null` inline rather than going through `isTestSilenced`, so a sweep for the shared predicate misses
it), and the late-media fence (`isTestConversationActivated`).
Measured and filed as #261 — the widget gets the not-activated notice, and `/reset` on the unstamped
half answers with **nothing at all**, because the notice's one-shot watermark was already spent by the
message before it. `/reset` additionally needs a decision this PR does not make: "the episode is
activated" licenses the command to run, but what it clears is scoped to the conversation it was typed
on, and naming the episode's other half reliably is #222.

Fixes #249




