### PR TITLE
Drop a dead tenant selection on the next request, not the next page load

### DIFF
--- a/src/api/lib/refusal.ts
+++ b/src/api/lib/refusal.ts
@@ -1,5 +1,6 @@
 import { getLocaleFromHeader, translateWithLocale } from "@/api/lib/i18n";
-import type { AppError } from "@/lib/errors";
+import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
+import { ActiveTenantNotFoundError, type AppError } from "@/lib/errors";
 
 // What a refusal ANSWERS. One place, because the two halves of it are decided by different things
 // and get confused for each other otherwise: the sentence is written for whoever is reading, in the
@@ -52,4 +53,13 @@ export function refusalBody(
   // nothing, which is worse than the honest silence of not naming a field at all.
   const field = error.field?.trim();
   return field ? { error: message, field } : { error: message };
+}
+
+// The other half of what a refusal answers, and the reason it is a separate function: the body is
+// what the OPERATOR reads and this is what the CLIENT acts on before anything reads the body at all.
+// Empty for every refusal but one, so `Response.json` keeps setting its own content type.
+export function refusalHeaders(error: AppError): Record<string, string> {
+  return error instanceof ActiveTenantNotFoundError
+    ? { [REJECTED_TENANT_SELECTOR_HEADER]: error.rejectedTenantId }
+    : {};
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import api from "@/api";
 import { cspDirectives } from "@/api/lib/csp";
 import logger from "@/api/lib/logger";
 import { parseOrigins } from "@/api/lib/origin";
-import { refusalBody } from "@/api/lib/refusal";
+import { refusalBody, refusalHeaders } from "@/api/lib/refusal";
 import { localeMiddleware } from "@/api/middlewares/locale";
 import {
   credentialRateLimitMiddleware,
@@ -111,7 +111,10 @@ const app = new Elysia({
     // NOTE: keep set.status in sync, because the access log in onAfterResponse reads it and a raw
     // Response alone would make a 4xx show up there as a 500.
     set.status = error.statusCode;
-    return Response.json(body, { status: error.statusCode });
+    return Response.json(body, {
+      status: error.statusCode,
+      headers: refusalHeaders(error),
+    });
   })
   .use(rateLimitMiddleware())
   .use(mcpTransportRateLimitMiddleware())

--- a/src/client/components/TenantSwitcher.tsx
+++ b/src/client/components/TenantSwitcher.tsx
@@ -8,8 +8,7 @@ import { useConfirmLeave } from "@/client/contexts/NavGuardContext";
 import { useTenantList } from "@/client/hooks/useTenantList";
 import { setActiveTenantId } from "@/client/lib/activeTenant";
 import { IS_FREE } from "@/client/lib/env";
-import { tenantSwitchTarget } from "@/client/lib/tenantSwitch";
-import { suppressUnloadPrompt } from "@/client/lib/unsavedGuard";
+import { reloadOntoSafeRoute } from "@/client/lib/tenantSwitch";
 import { cn } from "@/client/lib/utils";
 
 // Dedicated SUPER_ADMIN target-tenant picker mounted in the header (NOT inside the user menu).
@@ -77,14 +76,8 @@ export function TenantSwitcher() {
                   // prompt would otherwise leave the new tenant set while the UI
                   // stays put, surfacing the switch only on the next refresh.
                   confirmLeave(() => {
-                    suppressUnloadPrompt();
                     setActiveTenantId(value);
-                    // On a detail route the id belongs to the old tenant and won't exist in the new one,
-                    // so reloading in place would 404. Land on the list root instead. assign() is still
-                    // a full reload, so the TOCTOU-safe single-source-of-truth invariant holds.
-                    const target = tenantSwitchTarget(window.location.pathname);
-                    if (target) window.location.assign(target);
-                    else window.location.reload();
+                    reloadOntoSafeRoute();
                   });
                 }}
               >

--- a/src/client/hooks/useTenantList.ts
+++ b/src/client/hooks/useTenantList.ts
@@ -5,7 +5,7 @@ import {
   TENANTS_CHANGED_EVENT,
 } from "@/client/lib/activeTenant";
 import { api } from "@/client/lib/api";
-import { suppressUnloadPrompt } from "@/client/lib/unsavedGuard";
+import { reloadOntoSafeRoute } from "@/client/lib/tenantSwitch";
 
 // The SUPER_ADMIN's tenant list, plus the selection that survives it.
 //
@@ -60,12 +60,10 @@ export function useTenantList(enabled: boolean): TenantList {
           // clearing storage neither remounts nor retries them: a one-shot loader stays in its error
           // state until the operator retries it by hand. A full reload is what a tenant SWITCH
           // already does for the same reason (see TenantSwitcher), and the effective tenant changing
-          // out from under the console is the same kind of event. It cannot loop: nothing is stored
-          // any more, so the next reconciliation returns early with cleared false.
-          if (cleared) {
-            suppressUnloadPrompt();
-            window.location.reload();
-          }
+          // out from under the console is the same kind of event, down to landing off a detail route
+          // whose id belonged to the tenant that is gone. It cannot loop: nothing is stored any more,
+          // so the next reconciliation returns early with cleared false.
+          if (cleared) reloadOntoSafeRoute();
         })
         .catch(() => {});
     };

--- a/src/client/lib/activeTenant.ts
+++ b/src/client/lib/activeTenant.ts
@@ -54,3 +54,24 @@ export function reconcileActiveTenantId(tenantIds: string[]): {
   setActiveTenantId(null);
   return { activeId: null, cleared: true };
 }
+
+// The same question `reconcileActiveTenantId` asks at page load, asked by a single REFUSED REQUEST.
+//
+// The list-based reconciliation only runs on mount, so everything that kills a tenant mid-session is
+// invisible to it: deleted from another tab or by another operator, `tenant_delete` over MCP, the
+// console pointed at a different database. This path finds out on the next request instead of on the
+// next page load, from the id the boundary names (REJECTED_TENANT_SELECTOR_HEADER).
+//
+// It compares that id against what is stored rather than trusting the refusal, for the same reason
+// the reconciliation reads storage at call time: a request that went out under the old selection can
+// be refused AFTER the operator switched to a live tenant, and that newer choice is not this
+// answer's to discard.
+//
+// Returns whether it dropped anything, which is also the once-flag. A page has several requests in
+// flight and each answers 404; the first clears storage synchronously, so every later answer in the
+// burst finds nothing to clear and the caller reloads once rather than once per request.
+export function dropSelectionIfRejected(rejectedId: string): boolean {
+  if (getActiveTenantId() !== rejectedId) return false;
+  setActiveTenantId(null);
+  return true;
+}

--- a/src/client/lib/activeTenant.ts
+++ b/src/client/lib/activeTenant.ts
@@ -62,16 +62,19 @@ export function reconcileActiveTenantId(tenantIds: string[]): {
 // console pointed at a different database. This path finds out on the next request instead of on the
 // next page load, from the id the boundary names (REJECTED_TENANT_SELECTOR_HEADER).
 //
-// It compares that id against what is stored rather than trusting the refusal, for the same reason
-// the reconciliation reads storage at call time: a request that went out under the old selection can
-// be refused AFTER the operator switched to a live tenant, and that newer choice is not this
-// answer's to discard.
+// Answers whether the refusal is about the selection THIS window is running under. A DIFFERENT id is
+// not: the request went out under the old selection and came back after the operator had already
+// switched to a live tenant, and that newer choice is not this answer's to discard — the same reason
+// the reconciliation reads storage at call time rather than capturing it.
 //
-// Returns whether it dropped anything, which is also the once-flag. A page has several requests in
-// flight and each answers 404; the first clears storage synchronously, so every later answer in the
-// burst finds nothing to clear and the caller reloads once rather than once per request.
-export function dropSelectionIfRejected(rejectedId: string): boolean {
-  if (getActiveTenantId() !== rejectedId) return false;
+// Nothing stored still counts as ours, and that case is the multi-tab one: localStorage is shared
+// across tabs, so another tab may have cleared it while this one was still rendered against that
+// tenant and still sending it. Reading null as "someone else handled it" is what would leave that tab
+// on screen, sending no selector at all. What keeps the reload to one per window is
+// src/client/lib/tenantSelectorRecovery.ts, which is window state and not this.
+export function dropRejectedSelection(rejectedId: string): boolean {
+  const active = getActiveTenantId();
+  if (active !== null && active !== rejectedId) return false;
   setActiveTenantId(null);
   return true;
 }

--- a/src/client/lib/api.ts
+++ b/src/client/lib/api.ts
@@ -1,12 +1,8 @@
 import { treaty } from "@elysiajs/eden";
 import type { App } from "@/app";
-import {
-  dropSelectionIfRejected,
-  getActiveTenantId,
-} from "@/client/lib/activeTenant";
+import { getActiveTenantId } from "@/client/lib/activeTenant";
 import i18n from "@/client/lib/i18n";
-import { suppressUnloadPrompt } from "@/client/lib/unsavedGuard";
-import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
+import { recoverFromRejectedSelector } from "@/client/lib/tenantSelectorRecovery";
 
 // NOTE: `parseDate: false` disables Eden treaty's default JSON reviver that
 // auto-converts any string matching an ISO 8601 / RFC 1123 / dd-mm-yyyy regex
@@ -28,22 +24,17 @@ export const api = treaty<App>(window.location.origin, {
     return headers;
   },
   onResponse: (response) => {
-    const rejectedTenant = response.headers.get(
-      REJECTED_TENANT_SELECTOR_HEADER,
-    );
     if (response.status === 401) {
       window.dispatchEvent(new CustomEvent("auth:unauthorized"));
     } else if (response.status === 429) {
       // Surfaced as a coalesced global toast (see GlobalApiToasts) so every page gets clear
       // rate-limit feedback, not just the ones that read err.status into a DataBoundary.
       window.dispatchEvent(new CustomEvent("api:rate-limited"));
-    } else if (rejectedTenant && dropSelectionIfRejected(rejectedTenant)) {
-      // NOTE: the page on screen was built on the id that just died, and clearing storage neither
-      // remounts nor retries the requests it already sent: a one-shot loader would sit in its error
-      // state until someone retried it by hand. A tenant SWITCH reloads for the same reason (see
-      // TenantSwitcher), and this is the same event arriving from the other side.
-      suppressUnloadPrompt();
-      window.location.reload();
+    } else {
+      // NOTE: keyed on the header the boundary sets and never on the status: a 404 is also how an
+      // agent, a document or a tenant the page NAMED comes back missing, and none of those says
+      // anything about what the browser is holding. `mediaFetch` answers the same header.
+      recoverFromRejectedSelector(response);
     }
   },
   parseDate: false,

--- a/src/client/lib/api.ts
+++ b/src/client/lib/api.ts
@@ -1,7 +1,12 @@
 import { treaty } from "@elysiajs/eden";
 import type { App } from "@/app";
-import { getActiveTenantId } from "@/client/lib/activeTenant";
+import {
+  dropSelectionIfRejected,
+  getActiveTenantId,
+} from "@/client/lib/activeTenant";
 import i18n from "@/client/lib/i18n";
+import { suppressUnloadPrompt } from "@/client/lib/unsavedGuard";
+import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
 
 // NOTE: `parseDate: false` disables Eden treaty's default JSON reviver that
 // auto-converts any string matching an ISO 8601 / RFC 1123 / dd-mm-yyyy regex
@@ -23,12 +28,22 @@ export const api = treaty<App>(window.location.origin, {
     return headers;
   },
   onResponse: (response) => {
+    const rejectedTenant = response.headers.get(
+      REJECTED_TENANT_SELECTOR_HEADER,
+    );
     if (response.status === 401) {
       window.dispatchEvent(new CustomEvent("auth:unauthorized"));
     } else if (response.status === 429) {
       // Surfaced as a coalesced global toast (see GlobalApiToasts) so every page gets clear
       // rate-limit feedback, not just the ones that read err.status into a DataBoundary.
       window.dispatchEvent(new CustomEvent("api:rate-limited"));
+    } else if (rejectedTenant && dropSelectionIfRejected(rejectedTenant)) {
+      // NOTE: the page on screen was built on the id that just died, and clearing storage neither
+      // remounts nor retries the requests it already sent: a one-shot loader would sit in its error
+      // state until someone retried it by hand. A tenant SWITCH reloads for the same reason (see
+      // TenantSwitcher), and this is the same event arriving from the other side.
+      suppressUnloadPrompt();
+      window.location.reload();
     }
   },
   parseDate: false,

--- a/src/client/lib/media.ts
+++ b/src/client/lib/media.ts
@@ -1,11 +1,12 @@
 import { getActiveTenantId } from "@/client/lib/activeTenant";
+import { recoverFromRejectedSelector } from "@/client/lib/tenantSelectorRecovery";
 
 // Fetches a same-origin media blob (the playground media endpoint) carrying the SUPER_ADMIN's
 // active-tenant selector. Native <img>/<audio>/<a> requests omit the X-Tenant-Id header, so for a
 // SUPER_ADMIN (whose tenant is resolved ONLY from that header) the media endpoint would resolve a
 // null tenant and reply "A target tenant is required". The Eden client adds the header on every API
 // call (src/client/lib/api.ts); this mirrors it for the raw fetches that load media bytes.
-export function mediaFetch(
+export async function mediaFetch(
   url: string,
   init: RequestInit = {},
 ): Promise<Response> {
@@ -14,5 +15,15 @@ export function mediaFetch(
   };
   const tenantId = getActiveTenantId();
   if (tenantId) headers["X-Tenant-Id"] = tenantId;
-  return fetch(url, { ...init, credentials: "same-origin", headers });
+  const response = await fetch(url, {
+    ...init,
+    credentials: "same-origin",
+    headers,
+  });
+  // NOTE: sending the selector is what obliges this path to answer for its refusal too. Every caller
+  // here is a one-shot loader (a PDF, a preview, a logo) that reports its own 404 and stops, so
+  // without this the console would sit on a dead selection until some unrelated Eden call was
+  // refused. Same function as the treaty client's, because it is the same event.
+  recoverFromRejectedSelector(response);
+  return response;
 }

--- a/src/client/lib/tenantSelectorRecovery.ts
+++ b/src/client/lib/tenantSelectorRecovery.ts
@@ -1,5 +1,5 @@
 import { dropRejectedSelection } from "@/client/lib/activeTenant";
-import { suppressUnloadPrompt } from "@/client/lib/unsavedGuard";
+import { reloadOntoSafeRoute } from "@/client/lib/tenantSwitch";
 import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
 
 // What a window does when the server refuses the tenant selector it just sent.
@@ -27,9 +27,8 @@ export function recoverFromRejectedSelector(response: Response): boolean {
   w[RELOADING] = true;
   // NOTE: the page on screen was built on the id that just died, and clearing storage neither
   // remounts nor retries the requests it already sent: a one-shot loader would sit in its error state
-  // until someone retried it by hand. A tenant SWITCH reloads for the same reason (see
-  // TenantSwitcher), and this is the same event arriving from the other side.
-  suppressUnloadPrompt();
-  window.location.reload();
+  // until someone retried it by hand. A tenant SWITCH reloads for the same reason, and this is the
+  // same event arriving from the other side — including the detail route it has to land off of.
+  reloadOntoSafeRoute();
   return true;
 }

--- a/src/client/lib/tenantSelectorRecovery.ts
+++ b/src/client/lib/tenantSelectorRecovery.ts
@@ -1,0 +1,35 @@
+import { dropRejectedSelection } from "@/client/lib/activeTenant";
+import { suppressUnloadPrompt } from "@/client/lib/unsavedGuard";
+import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
+
+// What a window does when the server refuses the tenant selector it just sent.
+//
+// One function, because there are exactly TWO senders of that selector and they are not the same
+// transport: the Eden client, which attaches it to every API call, and `mediaFetch`, which mirrors it
+// on the raw fetches that load media bytes, PDF downloads and template previews (a native
+// `<img>`/`<a>` request cannot carry a header, which is why that path exists at all). A recovery
+// wired into one of them leaves the other holding a dead id until an unrelated request happens to
+// reach the boundary.
+//
+// The once-flag is per WINDOW, and deliberately not "is anything still stored": localStorage is
+// shared across tabs of the same origin, so the first tab to be refused clears it, and a second tab
+// still rendered on that tenant would read null, conclude someone else had dealt with it, and stay on
+// screen sending no selector at all. Every window that is told its selector is dead reloads itself,
+// exactly once. It lives on `window` because that is what it describes — window state, which a test
+// simulating a fresh page load can start clean, and a module-scope variable cannot.
+const RELOADING = "__tenantSelectorReloading";
+
+export function recoverFromRejectedSelector(response: Response): boolean {
+  const rejected = response.headers.get(REJECTED_TENANT_SELECTOR_HEADER);
+  if (!rejected || !dropRejectedSelection(rejected)) return false;
+  const w = window as unknown as Record<string, boolean | undefined>;
+  if (w[RELOADING]) return true;
+  w[RELOADING] = true;
+  // NOTE: the page on screen was built on the id that just died, and clearing storage neither
+  // remounts nor retries the requests it already sent: a one-shot loader would sit in its error state
+  // until someone retried it by hand. A tenant SWITCH reloads for the same reason (see
+  // TenantSwitcher), and this is the same event arriving from the other side.
+  suppressUnloadPrompt();
+  window.location.reload();
+  return true;
+}

--- a/src/client/lib/tenantSwitch.ts
+++ b/src/client/lib/tenantSwitch.ts
@@ -1,3 +1,5 @@
+import { suppressUnloadPrompt } from "@/client/lib/unsavedGuard";
+
 // Switching the active tenant does a full reload (the single TOCTOU-safe source of truth). On a
 // detail route whose id belongs to the OLD tenant (e.g. /agents/<id>), that id won't exist in the new
 // tenant, so reloading in place lands on an error page. tenantSwitchTarget maps such a route to its
@@ -17,4 +19,20 @@ export function tenantSwitchTarget(pathname: string): string | null {
     if (pattern.test(pathname)) return root;
   }
   return null;
+}
+
+// Take the console to a page that survives the effective tenant changing under it, and get out of
+// the way of the native unload prompt while doing it.
+//
+// Three things change the effective tenant, and they were spelling this out separately: the operator
+// switching (TenantSwitcher), the fleet list reconciling a selection that is gone (useTenantList),
+// and a request coming back refused (tenantSelectorRecovery). Only the first one mapped a detail
+// route to its list root, so the other two reloaded `/agents/<id>` in place — and the id belongs to a
+// tenant that is not there, which lands on an error page instead of a working list.
+export function reloadOntoSafeRoute(): void {
+  suppressUnloadPrompt();
+  const target = tenantSwitchTarget(window.location.pathname);
+  // `assign` is still a full reload, so the TOCTOU-safe single-source-of-truth invariant holds.
+  if (target) window.location.assign(target);
+  else window.location.reload();
 }

--- a/src/lib/console-params.ts
+++ b/src/lib/console-params.ts
@@ -1,4 +1,5 @@
-// Query parameters and routes that the SERVER writes into a console URL and the BROWSER reads back.
+// Names the SERVER writes and the BROWSER reads back: query parameters, routes, and one response
+// header.
 //
 // They live here, with no imports of their own, because both ends need them and the two ends have
 // opposite constraints: `src/modules/mcp/console-links.ts` builds the URLs and needs `config`
@@ -21,3 +22,16 @@ export const CONSOLE_ROUTES = {
   vault: "/resources/vault",
   integrations: "/resources/integrations",
 } as const;
+
+// Names the id on the 404 that refuses the tenant SELECTOR a request was carrying (the console's
+// stored `X-Tenant-Id`), which `ActiveTenantNotFoundError` separates from every other 404 answering
+// the same key and sentence (src/lib/errors.ts).
+//
+// A header rather than a code in the body because of who reads it: Eden's `onResponse` sees the
+// `Response` before the body is parsed, and reading the body there consumes the stream Eden is about
+// to read. The body's one machine-readable key is `field`, whose contract is an INPUT the operator
+// can go and fix (src/api/lib/refusal.ts); an ambient target is not one. Issue #252.
+//
+// NOTE: readable from script because the console is same-origin with the API. A cross-origin reader
+// would need it in `Access-Control-Expose-Headers`, which this app does not send.
+export const REJECTED_TENANT_SELECTOR_HEADER = "X-Tenant-Id-Invalid";

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -76,6 +76,19 @@ export class NotFoundError extends AppError {
   }
 }
 
+// NOTE: the tenant the request was AMBIENTLY scoped to is gone — the SUPER_ADMIN selector it carried
+// (the console's stored `X-Tenant-Id`) names a tenant that no longer exists. Same status, key and
+// sentence as the 404 for a tenant the caller NAMED, and a different fact: only this one says the
+// browser is holding something dead, and only this one obliges it to drop the selection. The
+// rejected id travels so the boundary can name it on the wire (src/api/lib/refusal.ts). Issue #252.
+export class ActiveTenantNotFoundError extends NotFoundError {
+  readonly rejectedTenantId: string;
+  constructor(tenantId: bigint | string) {
+    super("Tenant not found", "errors.tenantNotFound");
+    this.rejectedTenantId = String(tenantId);
+  }
+}
+
 // NOTE: uniform 401 for the inbound receptor. An unknown/disabled route token and a bad
 // auth signature must look identical (same status, same body) so the response never reveals
 // which token strings are live.

--- a/src/lib/tenancy/multi-tenant.ts
+++ b/src/lib/tenancy/multi-tenant.ts
@@ -1,6 +1,9 @@
 import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
-import { NotFoundError, TenantTargetRequiredError } from "@/lib/errors";
+import {
+  ActiveTenantNotFoundError,
+  TenantTargetRequiredError,
+} from "@/lib/errors";
 import type { ScopedDb, TenantContext } from "./context";
 
 // NOTE: the closure-extended `$extends` client is not the bare PrismaClient type, but it
@@ -110,8 +113,11 @@ async function requireTenantExists(
     select: { id: true },
   });
   if (!row) {
-    // The same status and key the MCP selector and `getTenant` already answer with.
-    throw new NotFoundError("Tenant not found", "errors.tenantNotFound");
+    // The same status and key the MCP selector and `getTenant` already answer with, in a class of
+    // its own: this is the only one of the seven that refuses the selector the CALLER WAS CARRYING
+    // rather than a tenant its request named, and the console has to tell them apart to know whether
+    // to drop what it has stored (src/lib/console-params.ts).
+    throw new ActiveTenantNotFoundError(tenantId);
   }
 }
 

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { errors } from "@/api/lib/openapi";
-import { AppError } from "@/lib/errors";
+import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
+import {
+  ActiveTenantNotFoundError,
+  AppError,
+  NotFoundError,
+} from "@/lib/errors";
 import { SettingsTextTooLongError } from "@/modules/agents/service";
 import { setupPrismaMock } from "@/tests/utils/prisma-mock";
 
@@ -31,11 +36,24 @@ app.get(
 app.get("/__refusal/unnamed", () => {
   throw new AppError("Forbidden", 403);
 });
+// The ambient refusal: nothing in the request named this tenant, it is the selector the session has
+// been carrying all along.
+app.get("/__refusal/ambient-tenant", () => {
+  throw new ActiveTenantNotFoundError(1234n);
+});
+// The caller-named refusal, spelled exactly as `getTenant` spells it today.
+app.get("/__refusal/named-tenant", () => {
+  throw new NotFoundError("Tenant not found", "errors.tenantNotFound");
+});
 
 const refusal = async (
   path: string,
   lang: string,
-): Promise<{ status: number; body: Record<string, unknown> }> => {
+): Promise<{
+  status: number;
+  rejected: string | null;
+  body: Record<string, unknown>;
+}> => {
   const res = await app.handle(
     new Request(`http://localhost${path}`, {
       headers: { "accept-language": lang },
@@ -43,6 +61,7 @@ const refusal = async (
   );
   return {
     status: res.status,
+    rejected: res.headers.get(REJECTED_TENANT_SELECTOR_HEADER),
     body: (await res.json()) as Record<string, unknown>,
   };
 };
@@ -78,5 +97,57 @@ describe("a refusal over the wire", () => {
     const { status, body } = await refusal("/__refusal/unnamed", "en");
     expect(status).toBe(403);
     expect(body).toEqual({ error: "Forbidden" });
+  });
+});
+
+// The one 404 that says something about the BROWSER'S OWN STATE, told apart from the six that do
+// not, on the same wire.
+//
+// `errors.tenantNotFound` is thrown from seven places and names two different facts: the ambient
+// selector this session is sending is dead (`requireTenantExists`, inside `runScopedOn`), or a
+// tenant the request NAMED does not exist (`GET /v1/tenants/:id` and the admin services). Only the
+// first obliges the client to drop what it is holding, and a client that reconciled on the key or on
+// the status alone would clear a perfectly good selection whenever the operator opened a tenant that
+// had just been deleted from the tenants list — a routine thing to do on that page.
+//
+// It rides in a HEADER rather than in the body because of who has to read it: `onResponse` in
+// src/client/lib/api.ts sees the `Response` before Eden parses it, and reading the body there
+// consumes the stream Eden is about to read. The body's one machine-readable key is `field`, whose
+// contract above is an INPUT the operator can go and fix; an ambient target is not one. Issue #252.
+describe("a 404 about the tenant selector the session is carrying", () => {
+  test("names the id it refused, so the client can match it against what it holds", async () => {
+    const { status, rejected } = await refusal(
+      "/__refusal/ambient-tenant",
+      "en",
+    );
+    expect(status).toBe(404);
+    expect(rejected).toBe("1234");
+  });
+
+  test("the body is the one it answers today", async () => {
+    // The signal rides beside the body, not in it: every existing reader of this refusal keeps
+    // reading the same keys, and `field` stays for refusals that are about an input.
+    const { body } = await refusal("/__refusal/ambient-tenant", "en");
+    expect(body).toEqual({ error: "Tenant not found" });
+  });
+
+  test("the sentence follows Accept-Language and the id does not", async () => {
+    const en = await refusal("/__refusal/ambient-tenant", "en");
+    const pt = await refusal("/__refusal/ambient-tenant", "pt-BR");
+    expect(pt.body.error).not.toBe(en.body.error);
+    expect(en.rejected).toBe("1234");
+    expect(pt.rejected).toBe("1234");
+  });
+
+  test("a 404 about a tenant the REQUEST named carries no such id", async () => {
+    // The decision this whole shape exists for. Same status, same key, same sentence — and the
+    // browser must not touch its selection over it.
+    const { status, rejected, body } = await refusal(
+      "/__refusal/named-tenant",
+      "en",
+    );
+    expect(status).toBe(404);
+    expect(rejected).toBeNull();
+    expect(body).toEqual({ error: "Tenant not found" });
   });
 });

--- a/tests/client/company-logo-url.test.tsx
+++ b/tests/client/company-logo-url.test.tsx
@@ -37,6 +37,9 @@ globalThis.fetch = (async () => {
   if (answer === "throws") throw new Error("offline");
   return {
     ok: answer === "ok",
+    // NOTE: present because `mediaFetch` reads them: a refused tenant selector is answered by a
+    // header, and a double that omits it makes the recovery throw inside every media load.
+    headers: new Headers(),
     blob: async () => {
       await new Promise<void>((resolve) => {
         releaseBody = resolve;

--- a/tests/client/components/TenantSwitcher.test.tsx
+++ b/tests/client/components/TenantSwitcher.test.tsx
@@ -37,6 +37,8 @@ let scripted: Array<{
 }> = [];
 const sentTenantHeaders: Array<string | null> = [];
 const reloads: number[] = [];
+const assigns: string[] = [];
+let pathname = "/dashboard";
 const realFetch = globalThis.fetch;
 const realLocation = window.location;
 
@@ -101,12 +103,22 @@ beforeEach(() => {
   tenantsFails = false;
   sentTenantHeaders.length = 0;
   reloads.length = 0;
+  assigns.length = 0;
+  pathname = "/dashboard";
   scripted = [];
   setActiveTenantId(null);
   installFetchStub();
   Object.defineProperty(window, "location", {
     configurable: true,
-    value: { ...realLocation, reload: () => reloads.push(1) },
+    value: {
+      ...realLocation,
+      // NOTE: a getter, because the route a test wants is set in the test body, after this ran.
+      get pathname() {
+        return pathname;
+      },
+      reload: () => reloads.push(1),
+      assign: (to: string) => assigns.push(to),
+    },
   });
 });
 
@@ -195,6 +207,20 @@ describe("a stored tenant the fleet no longer has", () => {
     first.release();
     await new Promise((r) => setTimeout(r, 30));
     expect(getActiveTenantId()).toBe("9");
+    expect(reloads.length).toBe(0);
+  });
+
+  test("on a detail route it lands on the list root, not on the dead id", async () => {
+    // The route names an agent of the tenant that is gone, so reloading in place would look that id
+    // up under whichever tenant is seeded next and answer 404. The switch already knew this; the
+    // reconciliation did not, and both now ask the same function (reloadOntoSafeRoute).
+    pathname = "/agents/42";
+    setActiveTenantId("999");
+    tenantsPayload = [{ id: "1", name: "Acme" }];
+    mount();
+    await waitFor(() => {
+      expect(assigns).toEqual(["/agents"]);
+    });
     expect(reloads.length).toBe(0);
   });
 

--- a/tests/client/lib/activeTenant.test.ts
+++ b/tests/client/lib/activeTenant.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
+  dropSelectionIfRejected,
   getActiveTenantId,
   reconcileActiveTenantId,
   setActiveTenantId,
@@ -63,5 +64,39 @@ describe("reconcileActiveTenantId", () => {
       cleared: false,
     });
     expect(getActiveTenantId()).toBe("3");
+  });
+});
+
+// The other end of the same question. `reconcileActiveTenantId` asks it at page load, against the
+// authoritative list; this one is asked by a single refused REQUEST, mid-session, and is the only
+// path that reaches the tenant deleted from another tab, deleted over MCP, or gone because the
+// console was pointed at a different database. Issue #252.
+//
+// It compares the id rather than trusting the refusal, for the same reason the reconciliation reads
+// storage at call time: a request that went out under the old selection can be refused AFTER the
+// operator has switched to a live tenant, and that newer choice is not this answer's to discard.
+describe("dropSelectionIfRejected", () => {
+  beforeEach(() => {
+    setActiveTenantId(null);
+  });
+
+  test("the selection the server refused is the selection it drops", () => {
+    setActiveTenantId("9");
+    expect(dropSelectionIfRejected("9")).toBe(true);
+    expect(getActiveTenantId()).toBeNull();
+  });
+
+  test("a refusal naming another id leaves the selection alone", () => {
+    setActiveTenantId("3");
+    expect(dropSelectionIfRejected("9")).toBe(false);
+    expect(getActiveTenantId()).toBe("3");
+  });
+
+  test("with nothing selected there is nothing to drop", () => {
+    // This is also the once-flag. A page has several requests in flight and each one answers 404;
+    // the first clears storage synchronously, so every later answer in the burst lands here and
+    // reports false, and the caller reloads once rather than once per request.
+    expect(dropSelectionIfRejected("9")).toBe(false);
+    expect(getActiveTenantId()).toBeNull();
   });
 });

--- a/tests/client/lib/activeTenant.test.ts
+++ b/tests/client/lib/activeTenant.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
-  dropSelectionIfRejected,
+  dropRejectedSelection,
   getActiveTenantId,
   reconcileActiveTenantId,
   setActiveTenantId,
@@ -71,32 +71,32 @@ describe("reconcileActiveTenantId", () => {
 // authoritative list; this one is asked by a single refused REQUEST, mid-session, and is the only
 // path that reaches the tenant deleted from another tab, deleted over MCP, or gone because the
 // console was pointed at a different database. Issue #252.
-//
-// It compares the id rather than trusting the refusal, for the same reason the reconciliation reads
-// storage at call time: a request that went out under the old selection can be refused AFTER the
-// operator has switched to a live tenant, and that newer choice is not this answer's to discard.
-describe("dropSelectionIfRejected", () => {
+describe("dropRejectedSelection", () => {
   beforeEach(() => {
     setActiveTenantId(null);
   });
 
   test("the selection the server refused is the selection it drops", () => {
     setActiveTenantId("9");
-    expect(dropSelectionIfRejected("9")).toBe(true);
+    expect(dropRejectedSelection("9")).toBe(true);
     expect(getActiveTenantId()).toBeNull();
   });
 
   test("a refusal naming another id leaves the selection alone", () => {
+    // The request went out under the old selection and was refused after the operator switched, so
+    // the newer choice is not this answer's to discard — the same reason the reconciliation reads
+    // storage at call time rather than capturing it when the request left.
     setActiveTenantId("3");
-    expect(dropSelectionIfRejected("9")).toBe(false);
+    expect(dropRejectedSelection("9")).toBe(false);
     expect(getActiveTenantId()).toBe("3");
   });
 
-  test("with nothing selected there is nothing to drop", () => {
-    // This is also the once-flag. A page has several requests in flight and each one answers 404;
-    // the first clears storage synchronously, so every later answer in the burst lands here and
-    // reports false, and the caller reloads once rather than once per request.
-    expect(dropSelectionIfRejected("9")).toBe(false);
+  test("nothing stored is still ours, because localStorage is shared across tabs", () => {
+    // The multi-tab case, and the reason this is not "did I have something to clear". Two tabs are
+    // open on the same tenant; the first to be refused clears the shared key. Reading null here as
+    // "someone else dealt with it" is what would leave the second tab on screen, rendered against a
+    // tenant that is gone and sending no selector at all.
+    expect(dropRejectedSelection("9")).toBe(true);
     expect(getActiveTenantId()).toBeNull();
   });
 });

--- a/tests/client/lib/api-rejected-tenant.test.ts
+++ b/tests/client/lib/api-rejected-tenant.test.ts
@@ -1,0 +1,99 @@
+/// <reference lib="dom" />
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  getActiveTenantId,
+  setActiveTenantId,
+} from "@/client/lib/activeTenant";
+import { api } from "@/client/lib/api";
+import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
+
+// The reconciliation that does NOT wait for a page load, driven through the real Eden client.
+//
+// `dropSelectionIfRejected` is a decision, and a decision nothing calls changes nothing: what this
+// file asserts is the call site. Until the console acts on the refusal, an operator who deletes the
+// tenant they are working in keeps a dead id in every request until they reload by hand, which is
+// the half of #223 that its fix did not reach.
+//
+// NOTE: every assertion reduces to a number, a string or a boolean BEFORE expect. A failing
+// expectation holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
+
+let responder: () => Response = () => new Response(null, { status: 204 });
+const reloads: number[] = [];
+const realFetch = globalThis.fetch;
+const realLocation = window.location;
+
+const refusal = (rejectedId: string | null) =>
+  new Response(JSON.stringify({ error: "Tenant not found" }), {
+    status: 404,
+    headers: {
+      "content-type": "application/json",
+      ...(rejectedId ? { [REJECTED_TENANT_SELECTOR_HEADER]: rejectedId } : {}),
+    },
+  });
+
+beforeEach(() => {
+  reloads.length = 0;
+  setActiveTenantId(null);
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (url.includes("/api/")) return responder();
+    return realFetch(input as RequestInfo | URL);
+  }) as typeof fetch;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...realLocation, reload: () => reloads.push(1) },
+  });
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: realLocation,
+  });
+  setActiveTenantId(null);
+});
+
+describe("a request refused because the selector it carried is dead", () => {
+  test("drops the selection and takes the page with it", async () => {
+    setActiveTenantId("999");
+    responder = () => refusal("999");
+    await api.api.v1.agents.get();
+    expect(getActiveTenantId()).toBeNull();
+    // The page on screen was built on that id and its one-shot loaders will not retry themselves,
+    // which is why a tenant SWITCH reloads for the same reason (see TenantSwitcher).
+    expect(reloads.length).toBe(1);
+  });
+
+  test("a burst of them reloads once, not once per request", async () => {
+    setActiveTenantId("999");
+    responder = () => refusal("999");
+    await Promise.all([
+      api.api.v1.agents.get(),
+      api.api.v1.tenants.get(),
+      api.api.v1.agents.get(),
+    ]);
+    expect(getActiveTenantId()).toBeNull();
+    expect(reloads.length).toBe(1);
+  });
+
+  test("a 404 that names no selector is left to the page that asked", async () => {
+    // The status alone is not the signal: an agent, a document or a tenant the operator NAMED can be
+    // missing, and none of those says anything about what the browser is holding.
+    setActiveTenantId("7");
+    responder = () => refusal(null);
+    await api.api.v1.agents.get();
+    expect(getActiveTenantId()).toBe("7");
+    expect(reloads.length).toBe(0);
+  });
+
+  test("a refusal naming an id the console has already left is ignored", async () => {
+    // The request went out under the old selection and was refused after the operator switched.
+    setActiveTenantId("7");
+    responder = () => refusal("999");
+    await api.api.v1.agents.get();
+    expect(getActiveTenantId()).toBe("7");
+    expect(reloads.length).toBe(0);
+  });
+});

--- a/tests/client/lib/tenantSelectorRecovery.test.ts
+++ b/tests/client/lib/tenantSelectorRecovery.test.ts
@@ -6,17 +6,20 @@ import {
   setActiveTenantId,
 } from "@/client/lib/activeTenant";
 import { api } from "@/client/lib/api";
+import { mediaFetch } from "@/client/lib/media";
 import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
 
-// The reconciliation that does NOT wait for a page load, driven through the real Eden client.
+// The recovery at both of its call sites, because a decision nothing calls changes nothing.
 //
-// `dropSelectionIfRejected` is a decision, and a decision nothing calls changes nothing: what this
-// file asserts is the call site. Until the console acts on the refusal, an operator who deletes the
-// tenant they are working in keeps a dead id in every request until they reload by hand, which is
-// the half of #223 that its fix did not reach.
+// Two things in the console send the tenant selector — the Eden client, on every API call, and
+// `mediaFetch`, on the raw fetches that carry media bytes, PDFs and previews — and until this both
+// of them could be told their selector was dead and do nothing about it. The `mediaFetch` half is
+// the one that stays broken longest when it is missed: every caller there is a one-shot loader that
+// reports its own 404 and stops, so the console would sit on a dead selection until some unrelated
+// treaty call happened to be refused. Issue #252.
 //
-// NOTE: every assertion reduces to a number, a string or a boolean BEFORE expect. A failing
-// expectation holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
+// NOTE: every assertion reduces to a string, number or boolean BEFORE expect. A failing expectation
+// holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
 
 let responder: () => Response = () => new Response(null, { status: 204 });
 const reloads: number[] = [];
@@ -35,6 +38,9 @@ const refusal = (rejectedId: string | null) =>
 beforeEach(() => {
   reloads.length = 0;
   setActiveTenantId(null);
+  // The per-window once-flag, reset because each test is a fresh page.
+  (window as unknown as Record<string, unknown>).__tenantSelectorReloading =
+    undefined;
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input instanceof Request ? input.url : input);
     if (url.includes("/api/")) return responder();
@@ -56,7 +62,7 @@ afterAll(() => {
 });
 
 describe("a request refused because the selector it carried is dead", () => {
-  test("drops the selection and takes the page with it", async () => {
+  test("through the API client: drops the selection and takes the page with it", async () => {
     setActiveTenantId("999");
     responder = () => refusal("999");
     await api.api.v1.agents.get();
@@ -66,15 +72,34 @@ describe("a request refused because the selector it carried is dead", () => {
     expect(reloads.length).toBe(1);
   });
 
-  test("a burst of them reloads once, not once per request", async () => {
+  test("through mediaFetch: the same, on the path a native <img> cannot take", async () => {
+    setActiveTenantId("999");
+    responder = () => refusal("999");
+    const res = await mediaFetch("/api/v1/documents/7/pdf");
+    // The caller still gets its own answer to report; the recovery is on top of it, not instead.
+    expect(res.status).toBe(404);
+    expect(getActiveTenantId()).toBeNull();
+    expect(reloads.length).toBe(1);
+  });
+
+  test("a burst reloads once, not once per request", async () => {
     setActiveTenantId("999");
     responder = () => refusal("999");
     await Promise.all([
       api.api.v1.agents.get(),
       api.api.v1.tenants.get(),
-      api.api.v1.agents.get(),
+      mediaFetch("/api/v1/documents/7/pdf"),
     ]);
     expect(getActiveTenantId()).toBeNull();
+    expect(reloads.length).toBe(1);
+  });
+
+  test("a tab whose storage another tab already cleared still reloads itself", async () => {
+    // localStorage is shared across tabs of the same origin. This tab is rendered against 999 and
+    // still sending it; the neighbour that was refused first cleared the key. Reading that as
+    // "already handled" is what would leave this tab on screen with no selector at all.
+    responder = () => refusal("999");
+    await api.api.v1.agents.get();
     expect(reloads.length).toBe(1);
   });
 
@@ -89,7 +114,6 @@ describe("a request refused because the selector it carried is dead", () => {
   });
 
   test("a refusal naming an id the console has already left is ignored", async () => {
-    // The request went out under the old selection and was refused after the operator switched.
     setActiveTenantId("7");
     responder = () => refusal("999");
     await api.api.v1.agents.get();

--- a/tests/client/lib/tenantSelectorRecovery.test.ts
+++ b/tests/client/lib/tenantSelectorRecovery.test.ts
@@ -22,7 +22,9 @@ import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
 // holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
 
 let responder: () => Response = () => new Response(null, { status: 204 });
+let pathname = "/dashboard";
 const reloads: number[] = [];
+const assigns: string[] = [];
 const realFetch = globalThis.fetch;
 const realLocation = window.location;
 
@@ -37,6 +39,8 @@ const refusal = (rejectedId: string | null) =>
 
 beforeEach(() => {
   reloads.length = 0;
+  assigns.length = 0;
+  pathname = "/dashboard";
   setActiveTenantId(null);
   // The per-window once-flag, reset because each test is a fresh page.
   (window as unknown as Record<string, unknown>).__tenantSelectorReloading =
@@ -48,7 +52,15 @@ beforeEach(() => {
   }) as typeof fetch;
   Object.defineProperty(window, "location", {
     configurable: true,
-    value: { ...realLocation, reload: () => reloads.push(1) },
+    value: {
+      ...realLocation,
+      // NOTE: a getter, because the route a test wants is set in the test body, after this ran.
+      get pathname() {
+        return pathname;
+      },
+      reload: () => reloads.push(1),
+      assign: (to: string) => assigns.push(to),
+    },
   });
 });
 
@@ -101,6 +113,17 @@ describe("a request refused because the selector it carried is dead", () => {
     responder = () => refusal("999");
     await api.api.v1.agents.get();
     expect(reloads.length).toBe(1);
+  });
+
+  test("on a detail route it lands on the list root, not on the dead id", async () => {
+    // The route names a resource of the tenant that just died, so reloading in place would answer
+    // 404 under whichever tenant /auth/me seeds next. Same answer a tenant SWITCH already gives.
+    pathname = "/agents/42";
+    setActiveTenantId("999");
+    responder = () => refusal("999");
+    await api.api.v1.agents.get();
+    expect(assigns).toEqual(["/agents"]);
+    expect(reloads.length).toBe(0);
   });
 
   test("a 404 that names no selector is left to the page that asked", async () => {

--- a/tests/lib/tenancy-unknown-target.test.ts
+++ b/tests/lib/tenancy-unknown-target.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import type { PrismaClient as PrismaClientType } from "@/../generated/prisma/client";
 import { PrismaClient } from "@/../generated/prisma/client";
-import { AppError } from "@/lib/errors";
+import { ActiveTenantNotFoundError, AppError } from "@/lib/errors";
 import {
   resolveRequestTenantContext,
   runScopedOn,
@@ -116,6 +116,14 @@ describe.skipIf(!dbUp)("a tenant selector that names no tenant", () => {
     // The key the MCP selector and GET /v1/tenants/:id already answer with, so the console shows one
     // sentence for one fact whichever transport asked.
     expect(app_err.translationKey).toBe("errors.tenantNotFound");
+    // And the class that separates this refusal from those: same status, same key, same sentence,
+    // and the only one of the seven that is about the selector the CALLER WAS CARRYING. It names the
+    // id it refused so the boundary can put it on the wire for the console to match against what it
+    // has stored (src/lib/console-params.ts). Issue #252.
+    expect(err instanceof ActiveTenantNotFoundError).toBe(true);
+    expect((err as ActiveTenantNotFoundError).rejectedTenantId).toBe(
+      String(deadId),
+    );
   });
 
   test("a live target still runs, and pays exactly one statement for the check", async () => {


### PR DESCRIPTION
Fixes #252

## What was broken

The console's stored `X-Tenant-Id` is reconciled against the fleet list on mount and on
`TENANTS_CHANGED_EVENT`, and nowhere else. Everything that kills a tenant mid-session is therefore
invisible to it: deleted from another tab or by another operator, `tenant_delete` over MCP, the
console pointed at a different database. The session keeps sending a selector for a tenant that is
not there until the operator reloads by hand.

What could reach that, and did not, is the 404 the boundary already raises. `requireTenantExists`
(inside `runScopedOn`) refuses the dead selector with `errors.tenantNotFound` — and so do six other
call sites, for a different fact: a tenant the request itself NAMED (`GET /v1/tenants/:id`, the admin
services). Only the first says anything about what the browser is holding. A client that reconciled
on the status or on the key alone would clear a perfectly good selection whenever the operator opened
a tenant someone had just deleted from the tenants list, which is a routine thing to do on that page.

## The shape

- `ActiveTenantNotFoundError` separates the ambient refusal from the six caller-named ones. Same
  status, same key, same sentence: the class is the only thing that differs, and it carries the id it
  refused.
- The boundary names that id in a response header, `X-Tenant-Id-Invalid`. A **header** rather than a
  code in the body because of who has to read it: Eden's `onResponse` sees the `Response` before the
  body is parsed, and reading the body there consumes the stream Eden is about to read. The body's
  one machine-readable key is `field`, whose contract is an INPUT the operator can go and fix; an
  ambient target is not one, so reusing it would have made that key mean two things.
- `recoverFromRejectedSelector` drops the selection when the header's id matches what this window is
  running under, then takes the page with it. **Both** senders of the selector call it: the Eden
  client and `mediaFetch` (the raw fetches behind PDF downloads, template previews and the
  letterhead, which a native `<img>`/`<a>` cannot carry a header on). Those two are the whole list —
  `mediaFetch` is the only remaining raw `fetch(` under `src/client`.
- A DIFFERENT id is ignored: the request went out under the old selection and came back after the
  operator had already switched, and that newer choice is not this answer's to discard.
- **Nothing stored still counts as ours**, and the once-flag is per WINDOW rather than "is anything
  still stored". `localStorage` is shared across tabs: the first tab to be refused clears it, and a
  second tab still rendered on that tenant would read null, conclude someone else had dealt with it,
  and stay on screen sending no selector at all.
- The reload is `reloadOntoSafeRoute()`, extracted into `tenantSwitch.ts` next to the route table it
  uses. Three things change the effective tenant under the console and each was spelling this out for
  itself: the switch mapped a detail route to its list root, while the fleet-list reconciliation and
  this recovery reloaded `/agents/<id>` in place — an id belonging to a tenant that is not there,
  which lands on an error page under whichever tenant `/auth/me` seeds next.

## What the issue asked that this does NOT change

The issue asks whether the tenants page's own `fetchTenants` should become `useTenantList`, so there
is one reader of the list instead of two that can disagree. It should not: they are different reads.
The page reads `/api/admin/tenants`, which carries a `userCount` aggregate per tenant; the header
reads `/api/v1/tenants`, which does not. Merging them would make every page load pay for user counts
the header never shows. Two readers of two endpoints is the right shape; what was missing was the
notification between them.

The issue's first path — the delete action on the tenants tab — is not in this repository's tenants
page, which is the ProGate view (multi-tenant management is Pro). It is fixed where that action
lives.

## Validation scope

Proven by test:

- Through the app the process actually serves (`app.handle`, so the real `onError`): the ambient
  refusal answers 404 with `X-Tenant-Id-Invalid: <id>`; the body is byte-for-byte the one it answers
  today; the sentence follows `Accept-Language` and the id does not; and **a 404 about a tenant the
  request NAMED carries no such header** — the negative case is the decision.
- Against a real Postgres (`tests/lib/tenancy-unknown-target.test.ts`): `runScopedOn` refuses an
  unknown selector with `ActiveTenantNotFoundError` naming that id, the callback never runs, a live
  target still costs exactly one statement, and an internally built context is not checked at all.
- Through the real Eden client and the real `mediaFetch`, with a stubbed transport: each drops the
  selection and takes the page with it; a mixed burst of three reloads once; a tab whose storage
  another tab already cleared still reloads itself; a detail route lands on the list root; a 404 with
  no header leaves the selection alone; a header naming an id the console has already left is
  ignored.
- The reconciliation path keeps its own coverage and gains the detail-route case
  (`TenantSwitcher.test.tsx`).
- Mutation-checked, each turning at least one of those red: inverting the `instanceof`, never sending
  the header, keying on status 404 instead of the header, dropping the id comparison, making a null
  selection not ours, removing the per-window flag, and removing the recovery from either sender.

Not validated:

- No browser run and no live server with a real session: the wire assertions go through the real app
  object, not over a socket, and the client assertions go through the real Eden client and
  `mediaFetch` with `fetch` stubbed.
- The switcher's own switch path, whose behaviour is unchanged but which now reaches
  `reloadOntoSafeRoute` through the shared function rather than inline. Driving the Radix menu was
  out of proportion for a refactor with no behaviour change.
- The playground routes cannot produce this refusal at all: they hand the raw selector to a
  system context, so the boundary check never runs there and a dead selection reads as an empty
  session list. That predates this change and is filed as #268.
- One test double had to grow a `headers` field (`tests/client/company-logo-url.test.tsx`): a fake
  response without one now throws inside `mediaFetch`. Fixed the double rather than making the
  recovery defensive against a shape a real `fetch` cannot return.
- `openapi.json` is unchanged (regenerated on the pinned Bun and compared): the header is not
  declared in the spec and no route schema moved.
