### PR TITLE
Redact the 500 an unhandled error answers, not just the one code that never arrives

### DIFF
--- a/src/api/lib/unhandled-error.ts
+++ b/src/api/lib/unhandled-error.ts
@@ -1,0 +1,48 @@
+import {
+  ElysiaCustomStatusResponse,
+  InvalidCookieSignature,
+  InvalidFileType,
+  ParseError,
+  ValidationError,
+} from "elysia";
+
+// What the app is allowed to say when a request fails in a way nobody planned for.
+//
+// The policy is stated by EXCLUSION and keyed on the thrown value's IDENTITY: a value that IS one of
+// Elysia's own refusals keeps the answer Elysia gives it, and everything else is an unhandled failure
+// whose text never reaches the client outside development.
+//
+// Both halves of that sentence were learned the hard way (issue #263), and they are the same lesson
+// twice. The handler first redacted one named `code`, then two; both lists were short by construction,
+// because Elysia hands the handler the `code` PROPERTY of the thrown value when it has one, and every
+// library stamps its own — a Prisma `P2025` and a Node `EACCES` walked straight past a two-name list.
+// Widening to "any code we do not recognise" fixed the string case and left the numeric one: a
+// `DOMException` arrives as code `25` and a plain `Object.assign(new Error(…), { code: 23 })` as `23`,
+// neither of which is the `ElysiaCustomStatusResponse` a numeric code was assumed to mean. Both leaked.
+//
+// `code` is data the thrown value controls, so no rule written over it can be closed. Identity is not:
+// `instanceof` answers what the value IS, and nothing a library sets on an error can change it.
+//
+// NOTE: these must be imported as ESM, not `require`d. Measured: a `require("elysia")` inside this
+// module resolves a SECOND instance of the package, against which every `instanceof` is false — a
+// fail-open policy that still passes any test asserting only the redacted cases.
+export function isFrameworkRefusal(error: unknown): boolean {
+  return (
+    error instanceof ParseError ||
+    error instanceof ValidationError ||
+    error instanceof InvalidCookieSignature ||
+    error instanceof InvalidFileType ||
+    // A status the handler CHOSE (`status(418, …)`), not a failure. Turning one into a 500 would
+    // break a deliberate answer.
+    error instanceof ElysiaCustomStatusResponse
+  );
+}
+
+// The development-only detail. `error` is typed as `Error` at the call site but is not one at runtime
+// whenever a handler throws a primitive: `throw "boom"` reaches here as the string itself, and reading
+// `.stack ?? .message` off it yields undefined for both, so the response body became the literal
+// "undefined" — a debugging aid that hid the one thing being debugged.
+export function errorDetail(error: unknown): string {
+  if (error instanceof Error) return error.stack ?? error.message;
+  return String(error);
+}

--- a/src/api/lib/unhandled-error.ts
+++ b/src/api/lib/unhandled-error.ts
@@ -29,6 +29,12 @@ import {
 export function isFrameworkRefusal(error: unknown): boolean {
   return (
     error instanceof ParseError ||
+    // NOTE: since #255 a ValidationError is answered by its own branch in src/app.ts, upstream of
+    // the arm that consults this, so today it does not reach here. Listed anyway: this predicate
+    // enumerates Elysia's refusal types, not the subset the app currently routes past it, and the
+    // day that branch moves or narrows, a schema refusal that fell through would be answered as a
+    // blank 500 instead of 422. Measured on the post-#255 tree: a schema-refused body answers 422
+    // with the app's own sentence, and dropping this clause still fails the table test below.
     error instanceof ValidationError ||
     error instanceof InvalidCookieSignature ||
     error instanceof InvalidFileType ||

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import cors from "@elysiajs/cors";
 import { staticPlugin } from "@elysiajs/static";
-import Elysia, { type ValidationError } from "elysia";
+import Elysia, { NotFoundError, ValidationError } from "elysia";
 import { helmet } from "elysia-helmet";
 import api from "@/api";
 import { cspDirectives } from "@/api/lib/csp";
@@ -135,7 +135,7 @@ const app = new Elysia({
   // for it and the chain continues to the plugin regardless of order. VALIDATION is answered here
   // now (issue #255) and so DOES depend on this placement: the plugin has already charged it by the
   // time this handler returns.
-  .onError(({ path, error, code, request, set }) => {
+  .onError(({ path, error, request, set }) => {
     // NOTE: Handle BigInt parsing errors as 400 Bad Request
     if (error instanceof SyntaxError && error.message.includes("BigInt")) {
       set.status = 400;
@@ -149,9 +149,16 @@ const app = new Elysia({
     // before the plugin would hand back an uncharged budget to anyone willing to send a body the
     // schema refuses. Everything about the body and the log line is decided in api/lib/schema
     // -refusal.ts, including why the submitted value reaches neither.
-    if (code === "VALIDATION") {
+    //
+    // Keyed on IDENTITY, not on `code`. Elysia forwards the thrown value's own `code` property when
+    // it has one, so `code === "VALIDATION"` is also true of any plain error that happens to carry
+    // that string — measured: such an error was answered 422 in the app's schema vocabulary, and the
+    // `as ValidationError` cast this replaces was simply false about it. Issue #263 has the long
+    // version; the rule is that a branch deciding what a failure IS cannot read a property the
+    // failure sets.
+    if (error instanceof ValidationError) {
       const refusal = schemaRefusal(
-        error as ValidationError,
+        error,
         request.headers.get("accept-language"),
       );
       const line = "%s %s";
@@ -165,35 +172,35 @@ const app = new Elysia({
     }
 
     logger.error("%s\n%s", path, error);
-    switch (code) {
-      case "NOT_FOUND":
-        // NOTE: API endpoints respond with JSON 404. SPA paths normally
-        // don't reach here because the /* catch-all below serves
-        // index.html for any non-API, non-asset request.
-        if (path === "/api" || path.startsWith("/api/")) {
-          return Response.json({ error: "Not Found" }, { status: 404 });
-        }
-        return new Response("Not Found", { status: 404 });
-      default: {
-        // NOTE: everything that is not a refusal Elysia itself raised is an unhandled failure, and
-        // its text does not reach the client outside development. Stated by exclusion, and decided
-        // from the thrown VALUE rather than from `code`, because `code` is a property the value
-        // carries and any library can set it. The measurements behind both of those choices are in
-        // api/lib/unhandled-error.ts; the short version is that a redact-list keyed on `code` leaked
-        // twice, once through a string code and once through a numeric one.
-        if (isFrameworkRefusal(error)) return;
-        // NOTE: `set.status` too, not just the Response's. The access log in onAfterResponse reads
-        // `set.status`, and Elysia seeds it from the thrown value's own `status` property — so an
-        // error carrying `status: 401` is answered 500 here and LOGGED as 401 unless this line runs.
-        // Same reason the AppError arm above carries the same note; the BigInt arm needed it too.
-        set.status = 500;
-        const message =
-          config.env === "development"
-            ? errorDetail(error)
-            : "Something went wrong";
-        return new Response(message, { status: 500 });
+
+    if (error instanceof NotFoundError) {
+      // NOTE: API endpoints respond with JSON 404. SPA paths normally
+      // don't reach here because the /* catch-all below serves
+      // index.html for any non-API, non-asset request.
+      set.status = 404;
+      if (path === "/api" || path.startsWith("/api/")) {
+        return Response.json({ error: "Not Found" }, { status: 404 });
       }
+      return new Response("Not Found", { status: 404 });
     }
+
+    // NOTE: everything that is not a refusal Elysia itself raised is an unhandled failure, and
+    // its text does not reach the client outside development. Stated by exclusion, and decided
+    // from the thrown VALUE rather than from `code`, because `code` is a property the value
+    // carries and any library can set it. The measurements behind both of those choices are in
+    // api/lib/unhandled-error.ts; the short version is that a redact-list keyed on `code` leaked
+    // twice, once through a string code and once through a numeric one.
+    if (isFrameworkRefusal(error)) return;
+    // NOTE: `set.status` too, not just the Response's. The access log in onAfterResponse reads
+    // `set.status`, and Elysia seeds it from the thrown value's own `status` property — so an
+    // error carrying `status: 401` is answered 500 here and LOGGED as 401 unless this line runs.
+    // Same reason the AppError arm above carries the same note; the BigInt arm needed it too.
+    set.status = 500;
+    const message =
+      config.env === "development"
+        ? errorDetail(error)
+        : "Something went wrong";
+    return new Response(message, { status: 500 });
   })
   .use(
     await staticPlugin({

--- a/src/app.ts
+++ b/src/app.ts
@@ -138,6 +138,7 @@ const app = new Elysia({
   .onError(({ path, error, code, request, set }) => {
     // NOTE: Handle BigInt parsing errors as 400 Bad Request
     if (error instanceof SyntaxError && error.message.includes("BigInt")) {
+      set.status = 400;
       return new Response("Invalid ID format", { status: 400 });
     }
 
@@ -181,6 +182,11 @@ const app = new Elysia({
         // api/lib/unhandled-error.ts; the short version is that a redact-list keyed on `code` leaked
         // twice, once through a string code and once through a numeric one.
         if (isFrameworkRefusal(error)) return;
+        // NOTE: `set.status` too, not just the Response's. The access log in onAfterResponse reads
+        // `set.status`, and Elysia seeds it from the thrown value's own `status` property — so an
+        // error carrying `status: 401` is answered 500 here and LOGGED as 401 unless this line runs.
+        // Same reason the AppError arm above carries the same note; the BigInt arm needed it too.
+        set.status = 500;
         const message =
           config.env === "development"
             ? errorDetail(error)

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import logger from "@/api/lib/logger";
 import { parseOrigins } from "@/api/lib/origin";
 import { refusalBody, refusalHeaders } from "@/api/lib/refusal";
 import { schemaRefusal } from "@/api/lib/schema-refusal";
+import { errorDetail, isFrameworkRefusal } from "@/api/lib/unhandled-error";
 import { localeMiddleware } from "@/api/middlewares/locale";
 import {
   credentialRateLimitMiddleware,
@@ -172,14 +173,20 @@ const app = new Elysia({
           return Response.json({ error: "Not Found" }, { status: 404 });
         }
         return new Response("Not Found", { status: 404 });
-      case "INTERNAL_SERVER_ERROR": {
+      default: {
+        // NOTE: everything that is not a refusal Elysia itself raised is an unhandled failure, and
+        // its text does not reach the client outside development. Stated by exclusion, and decided
+        // from the thrown VALUE rather than from `code`, because `code` is a property the value
+        // carries and any library can set it. The measurements behind both of those choices are in
+        // api/lib/unhandled-error.ts; the short version is that a redact-list keyed on `code` leaked
+        // twice, once through a string code and once through a numeric one.
+        if (isFrameworkRefusal(error)) return;
         const message =
           config.env === "development"
-            ? (error.stack ?? error.message)
+            ? errorDetail(error)
             : "Something went wrong";
-        return new Response(`${message}`, { status: 500 });
+        return new Response(message, { status: 500 });
       }
-      default:
     }
   })
   .use(

--- a/tests/api/lib/unhandled-error.test.ts
+++ b/tests/api/lib/unhandled-error.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ElysiaCustomStatusResponse,
+  InvalidCookieSignature,
+  InvalidFileType,
+  ParseError,
+  t,
+  ValidationError,
+} from "elysia";
+import { errorDetail, isFrameworkRefusal } from "@/api/lib/unhandled-error";
+
+// The policy behind src/app.ts's 500, as a table. The wiring — that the handler actually consults
+// it, and what the client receives — is asserted over the real app in tests/api/refusal-wire.test.ts;
+// a table alone would prove the function and say nothing about the route.
+
+describe("isFrameworkRefusal", () => {
+  // Kept: each IS a refusal Elysia raised, and already answers with its own status and a body that
+  // is correct for the caller. Redacting them would replace a usable refusal with a blank 500.
+  test("a ParseError keeps its own answer", () => {
+    expect(isFrameworkRefusal(new ParseError())).toBe(true);
+  });
+
+  test("a ValidationError keeps its own answer", () => {
+    expect(
+      isFrameworkRefusal(
+        new ValidationError("body", t.Object({ a: t.String() }), {}),
+      ),
+    ).toBe(true);
+  });
+
+  test("a status the handler chose keeps its own answer", () => {
+    expect(
+      isFrameworkRefusal(new ElysiaCustomStatusResponse(418, "teapot")),
+    ).toBe(true);
+  });
+
+  // NOTE: these two complete Elysia's set of refusal types, and NEITHER is reachable from a route
+  // in this app today — nothing configures `cookie: { secrets }` (without a secret Elysia never
+  // verifies a signature, so it never raises the first) and no `t.File` constrains `type` (the one
+  // place that cared says so in a comment, because the check sniffs magic bytes). They are asserted
+  // here rather than over the wire for exactly that reason: the wire cannot produce them yet.
+  //
+  // Kept in the predicate anyway, and the reason is this PR's whole lesson. What kept leaking was a
+  // list of thrown things that was short by construction; a list trimmed to "the refusals this app
+  // happens to trigger today" is the same mistake pointed the other way, and it goes stale the day
+  // someone signs a cookie. Elysia's exported refusal types are a fixed, enumerable API, so the
+  // predicate enumerates all of them. Dropping either fails CLOSED (a legitimate 401 or 422 would
+  // become a generic 500), so this is about answering correctly, not about a leak.
+  test("an invalid cookie signature keeps its own answer", () => {
+    expect(isFrameworkRefusal(new InvalidCookieSignature("session"))).toBe(
+      true,
+    );
+  });
+
+  test("a rejected file type keeps its own answer", () => {
+    expect(isFrameworkRefusal(new InvalidFileType("file", "image/png"))).toBe(
+      true,
+    );
+  });
+
+  // Redacted: an unhandled failure, whatever it calls itself.
+  test("a plain Error is an unhandled failure", () => {
+    expect(isFrameworkRefusal(new Error("boom"))).toBe(false);
+  });
+
+  // The whole point of keying on identity. Every one of these carries a `code` that a rule written
+  // over `code` read as something it is not — the string half (Prisma, Node) and the numeric half
+  // (DOMException, and anything that assigns a number).
+  test.each([
+    [
+      "a Prisma-style code",
+      Object.assign(new Error("boom"), { code: "P2025" }),
+    ],
+    ["a Node errno code", Object.assign(new Error("boom"), { code: "EACCES" })],
+    ["a numeric code", Object.assign(new Error("boom"), { code: 23 })],
+    ["a DOMException", new DOMException("boom", "DataCloneError")],
+    [
+      "an error calling itself PARSE",
+      Object.assign(new Error("boom"), { code: "PARSE" }),
+    ],
+    [
+      "an error calling itself VALIDATION",
+      Object.assign(new Error("boom"), { code: "VALIDATION" }),
+    ],
+  ])("%s is still an unhandled failure", (_name, error) => {
+    expect(isFrameworkRefusal(error)).toBe(false);
+  });
+
+  // A thrown primitive is not a refusal either.
+  test.each([["boom"], [42], [null], [undefined]])(
+    "a thrown %p is an unhandled failure",
+    (thrown) => {
+      expect(isFrameworkRefusal(thrown)).toBe(false);
+    },
+  );
+});
+
+describe("errorDetail", () => {
+  test("an Error gives its stack", () => {
+    const e = new Error("boom");
+    expect(errorDetail(e)).toBe(e.stack ?? "boom");
+  });
+
+  test("an Error with no stack falls back to the message", () => {
+    const e = new Error("boom");
+    e.stack = undefined;
+    expect(errorDetail(e)).toBe("boom");
+  });
+
+  // The regression: `throw "boom"` reaches the handler as the string, and reading .stack ?? .message
+  // off it made the development response the literal "undefined".
+  test.each([
+    ["boom", "boom"],
+    [42, "42"],
+    [null, "null"],
+    [undefined, "undefined"],
+  ])("a thrown %p renders as %p", (thrown, expected) => {
+    expect(errorDetail(thrown)).toBe(expected as string);
+  });
+});

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -158,3 +158,142 @@ describe("a 404 about the tenant selector the session is carrying", () => {
     expect(body).toEqual({ error: "Tenant not found" });
   });
 });
+
+// ── issue #263 ───────────────────────────────────────────────────────────────────────────────────
+// The other half of what this app puts on the wire when something goes wrong. The refusals above are
+// the ones it MEANS to answer; these are the ones it did not plan for.
+//
+// `src/app.ts` redacts a 500 to "Something went wrong" outside development, but only in the
+// `INTERNAL_SERVER_ERROR` arm — and an unhandled error does not arrive with that code. It arrives as
+// `UNKNOWN`, falls through `default:`, and Elysia's built-in handler answers with the error's own
+// text, so whatever the message happened to carry went to the client.
+//
+// These live in THIS file rather than their own, and that is not filing convenience. A second test
+// file that drives the exported app singleton makes the routes registered above stop matching (they
+// answer 200 from the SPA catch-all instead of the refusal), reproducible with a six-line file and
+// not avoided by registering in `beforeAll`. Until that is understood, one file owns this app.
+
+// Stands in for anything an unhandled error's message can carry: a connection string, a query
+// fragment, a filesystem path, a third-party SDK payload. The assertions look for THIS, so they fail
+// on the disclosure itself rather than on a particular phrasing of the refusal.
+const SECRET = "postgres://user:hunter2@db.internal:5432/agents";
+
+app.get("/__unhandled/sync", () => {
+  throw new Error(`connection failed: ${SECRET}`);
+});
+app.get("/__unhandled/async", async () => {
+  await Promise.resolve();
+  throw new TypeError(`connection failed: ${SECRET}`);
+});
+app.get("/__unhandled/nonerror", () => {
+  throw `connection failed: ${SECRET}`;
+});
+// The shapes a two-name list walked past: the thrown value already carries a `code`, and Elysia
+// hands THAT to the handler instead of UNKNOWN. These are the errors whose message actually holds
+// something — a query fragment, a filesystem path.
+app.get("/__unhandled/prisma", () => {
+  throw Object.assign(new Error(`connection failed: ${SECRET}`), {
+    code: "P2025",
+  });
+});
+app.get("/__unhandled/fs", () => {
+  throw Object.assign(new Error(`connection failed: ${SECRET}`), {
+    code: "EACCES",
+  });
+});
+// The NUMERIC half of the same hole: Elysia copies these into `code` too, and a rule that read a
+// numeric code as "a status the handler chose" passed both straight through.
+app.get("/__unhandled/domexception", () => {
+  throw new DOMException(`connection failed: ${SECRET}`, "DataCloneError");
+});
+app.get("/__unhandled/numericcode", () => {
+  throw Object.assign(new Error(`connection failed: ${SECRET}`), { code: 23 });
+});
+// Not a throw at all: the handler returns fine and the FAILURE happens while the response is
+// serialized. This is the shape that surfaced the bug (issue #253), and the one that answered with
+// the error's class name rather than a bare message.
+app.get("/__unhandled/serialize", () => ({ id: 1n }));
+
+const UNHANDLED = [
+  "sync",
+  "async",
+  "nonerror",
+  "serialize",
+  "prisma",
+  "fs",
+  "domexception",
+  "numericcode",
+] as const;
+
+const unhandled = async (
+  shape: string,
+): Promise<{ status: number; body: string }> => {
+  const res = await app.handle(
+    new Request(`http://localhost/__unhandled/${shape}`),
+  );
+  return { status: res.status, body: await res.text() };
+};
+
+describe("an unhandled error, whatever shape it arrives in", () => {
+  test.each([...UNHANDLED])("%s still answers 500", async (shape) => {
+    expect((await unhandled(shape)).status).toBe(500);
+  });
+
+  // The finding itself.
+  test.each([...UNHANDLED])("%s does not leak the message", async (shape) => {
+    const { body } = await unhandled(shape);
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain("connection failed");
+  });
+
+  // Asserted positively, not as another "does not contain": the serialize shape answered
+  // `{"name":"TypeError","message":…}`, so a body carrying no secret can still name the class that
+  // failed. Pinning the whole body rules both out at once.
+  test.each([...UNHANDLED])(
+    "%s answers the redaction, nothing else",
+    async (shape) => {
+      expect((await unhandled(shape)).body).toBe("Something went wrong");
+    },
+  );
+});
+
+// The complement, and the reason the arm lists UNKNOWN and stops there. Both of these are rejected
+// before the handler and already have a specific, correct answer; folding them into the 500 arm
+// replaces a usable refusal with "Something went wrong". Measured while mutation-testing the fix:
+// adding either code to the arm changed nothing any test could see, which is what a guard with no
+// coverage looks like.
+// A status the handler CHOSE has to survive the redaction, or the guard would swallow deliberate
+// answers along with the accidents. This is the one member of the pass-through list that is not a
+// refusal Elysia raised on the caller's behalf, so it is asserted rather than assumed.
+app.get("/__chosen/teapot", ({ status }) => status(418, "deliberate"));
+
+describe("a status the handler chose is not an unhandled failure", () => {
+  test("it keeps its own code and body", async () => {
+    const res = await app.handle(
+      new Request("http://localhost/__chosen/teapot"),
+    );
+    expect(res.status).toBe(418);
+    expect(await res.text()).toBe("deliberate");
+  });
+});
+
+describe("a request refused before the handler keeps its own answer", () => {
+  const login = async (body: string): Promise<number> =>
+    (
+      await app.handle(
+        new Request("http://localhost/api/auth/login", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body,
+        }),
+      )
+    ).status;
+
+  test("a body that is not JSON stays 400 (PARSE)", async () => {
+    expect(await login("{ not json at all")).toBe(400);
+  });
+
+  test("a body the schema refuses stays 422 (VALIDATION)", async () => {
+    expect(await login(JSON.stringify({ nope: 1 }))).toBe(422);
+  });
+});

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
+import logger from "@/api/lib/logger";
 import { errors } from "@/api/lib/openapi";
 import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
 import {
@@ -213,6 +214,19 @@ app.get("/__unhandled/numericcode", () => {
 // serialized. This is the shape that surfaced the bug (issue #253), and the one that answered with
 // the error's class name rather than a bare message.
 app.get("/__unhandled/serialize", () => ({ id: 1n }));
+// An unhandled error that carries its OWN `status`. Elysia seeds `set.status` from that property
+// before this handler runs, and the access log reads `set.status`, not the Response's — so the two
+// disagree unless the arm syncs it.
+app.get("/__logged/carries-status", () => {
+  throw Object.assign(new Error(`connection failed: ${SECRET}`), {
+    status: 401,
+  });
+});
+// Not this PR's arm, but the same invariant, found by sweeping for it: the BigInt guard answers a
+// raw 400 and was logging 500.
+app.get("/__logged/bigint", () => {
+  throw new SyntaxError("Cannot convert 9007199254740993x to a BigInt");
+});
 
 const UNHANDLED = [
   "sync",
@@ -295,5 +309,43 @@ describe("a request refused before the handler keeps its own answer", () => {
 
   test("a body the schema refuses stays 422 (VALIDATION)", async () => {
     expect(await login(JSON.stringify({ nope: 1 }))).toBe(422);
+  });
+});
+
+// What the ACCESS LOG says happened, which is a different question from what the client got.
+// `onAfterResponse` logs `set.status`; a raw `Response` alone does not move it. Elysia seeds it from
+// the thrown value's own `status`, so an error carrying `status: 401` is answered 500 and recorded
+// as 401 — the response is right and the log is wrong, which is the worse of the two failures
+// because nothing on the wire shows it.
+describe("the access log records the status actually answered", () => {
+  // `onAfterResponse` runs after `handle` has already resolved, so the line is not there yet when
+  // the await returns. Poll for it and THROW when it never arrives: a bare timeout would let a
+  // missing access log read as `undefined` and turn a real regression into a wording mismatch.
+  const loggedStatusFor = async (path: string): Promise<string> => {
+    const spy = spyOn(logger, "info");
+    try {
+      await (await app.handle(new Request(`http://localhost${path}`))).text();
+      for (let i = 0; i < 100; i++) {
+        const call = spy.mock.calls.findLast((c) => c[0] === "%s %s [%s]");
+        if (call) return String(call[3]);
+        await Bun.sleep(5);
+      }
+      throw new Error(`no access log line for ${path} after 500ms`);
+    } finally {
+      spy.mockRestore();
+    }
+  };
+
+  const wireStatusFor = async (path: string): Promise<number> =>
+    (await app.handle(new Request(`http://localhost${path}`))).status;
+
+  test("an error carrying status: 401 is answered 500 and logged 500", async () => {
+    expect(await wireStatusFor("/__logged/carries-status")).toBe(500);
+    expect(await loggedStatusFor("/__logged/carries-status")).toBe("500");
+  });
+
+  test("the BigInt guard's raw 400 is logged as 400, not 500", async () => {
+    expect(await wireStatusFor("/__logged/bigint")).toBe(400);
+    expect(await loggedStatusFor("/__logged/bigint")).toBe("400");
   });
 });

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -46,14 +46,6 @@ app.get("/__refusal/ambient-tenant", () => {
 app.get("/__refusal/named-tenant", () => {
   throw new NotFoundError("Tenant not found", "errors.tenantNotFound");
 });
-// NOTE: Elysia freezes its route table on the first request it serves, and the app is a singleton
-// several test files import. A route registered after some OTHER file has already called `handle`
-// is silently dropped and answers the SPA catch-all instead, so the tests below passed or failed on
-// file ordering. Measured: two files that each register a route and hit it, run together, and the
-// one that registered second answered 200 `{}`. `compile()` rebuilds the table, and it has to stay
-// below the LAST route this file registers.
-app.compile();
-
 const refusal = async (
   path: string,
   lang: string,
@@ -280,6 +272,18 @@ describe("an unhandled error, whatever shape it arrives in", () => {
 // answers along with the accidents. This is the one member of the pass-through list that is not a
 // refusal Elysia raised on the caller's behalf, so it is asserted rather than assumed.
 app.get("/__chosen/teapot", ({ status }) => status(418, "deliberate"));
+
+// NOTE: Elysia freezes its route table on the first request it serves, and the app is a singleton
+// several test files import. A route registered after some OTHER file has already called `handle`
+// is silently dropped and answers the SPA catch-all instead, so the tests here passed or failed on
+// file ordering. Measured: two files that each register a route and hit it, run together, and the
+// one that registered second answered 200 `{}`. `compile()` rebuilds the table, and it has to stay
+// below the LAST route this file registers.
+//
+// Moved down here when the #263 block arrived below it. Measured with it left in place: every route
+// registered after it was missing, and 19 of this file's tests failed running the file ALONE. The
+// note above already said "below the LAST route"; the call simply stopped being there.
+app.compile();
 
 describe("a status the handler chose is not an unhandled failure", () => {
   test("it keeps its own code and body", async () => {

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
+import { NotFoundError as ElysiaNotFoundError } from "elysia";
 import logger from "@/api/lib/logger";
 import { errors } from "@/api/lib/openapi";
 import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
@@ -216,6 +217,36 @@ app.get("/__logged/carries-status", () => {
 });
 // Not this PR's arm, but the same invariant, found by sweeping for it: the BigInt guard answers a
 // raw 400 and was logging 500.
+// An unhandled failure that CALLS ITSELF one of Elysia's refusals. Elysia forwards the thrown
+// value's own `code`, so each of these used to be routed by the branch that reads `code` — the
+// VALIDATION one was answered 422 in the app's schema vocabulary and the NOT_FOUND one 404, neither
+// of which is what they are.
+const IMPOSTOR = [
+  "VALIDATION",
+  "NOT_FOUND",
+  "PARSE",
+  "INVALID_COOKIE_SIGNATURE",
+  "INVALID_FILE_TYPE",
+  "INTERNAL_SERVER_ERROR",
+] as const;
+for (const code of IMPOSTOR) {
+  app.get(`/__impostor/${code}`, () => {
+    throw Object.assign(new Error(`connection failed: ${SECRET}`), { code });
+  });
+}
+// The genuine article, to prove the guard tells them apart rather than just answering 500 to
+// everything: this one MUST keep its 404.
+app.get("/__real/notfound", () => {
+  // NOTE: Elysia's, aliased — this file already imports the APP's NotFoundError for the #252 block,
+  // and that one is an AppError answered by an entirely different arm.
+  throw new ElysiaNotFoundError();
+});
+// A genuine NotFoundError carrying a `status` of its own. Elysia seeds `set.status` from that
+// property, so this is the 404 arm's version of the `status: 401` case below: the wire says 404 and
+// the access log says 418 unless that arm syncs `set.status` too.
+app.get("/__real/notfound-status", () => {
+  throw Object.assign(new ElysiaNotFoundError(), { status: 418 });
+});
 app.get("/__logged/bigint", () => {
   throw new SyntaxError("Cannot convert 9007199254740993x to a BigInt");
 });
@@ -283,6 +314,34 @@ app.get("/__chosen/teapot", ({ status }) => status(418, "deliberate"));
 // Moved down here when the #263 block arrived below it. Measured with it left in place: every route
 // registered after it was missing, and 19 of this file's tests failed running the file ALONE. The
 // note above already said "below the LAST route"; the call simply stopped being there.
+
+// Telling a refusal from something wearing its name. The table in tests/api/lib/unhandled-error
+// .test.ts states that an error calling itself VALIDATION is an unhandled failure; these assert the
+// app actually routes it that way, which is a different claim and the one that was false — every
+// branch that read `code` answered the impostor as though it were the real thing.
+describe("an error that calls itself a framework refusal", () => {
+  test.each([...IMPOSTOR])(
+    "code %s is still an unhandled failure",
+    async (code) => {
+      const res = await app.handle(
+        new Request(`http://localhost/__impostor/${code}`),
+      );
+      const body = await res.text();
+      expect(res.status).toBe(500);
+      expect(body).toBe("Something went wrong");
+      expect(body).not.toContain(SECRET);
+    },
+  );
+
+  test("while the real NotFoundError keeps its 404", async () => {
+    const res = await app.handle(
+      new Request("http://localhost/__real/notfound"),
+    );
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("Not Found");
+  });
+});
+
 app.compile();
 
 describe("a status the handler chose is not an unhandled failure", () => {
@@ -346,6 +405,11 @@ describe("the access log records the status actually answered", () => {
   test("an error carrying status: 401 is answered 500 and logged 500", async () => {
     expect(await wireStatusFor("/__logged/carries-status")).toBe(500);
     expect(await loggedStatusFor("/__logged/carries-status")).toBe("500");
+  });
+
+  test("the 404 arm logs 404 even when the error carries another status", async () => {
+    expect(await wireStatusFor("/__real/notfound-status")).toBe(404);
+    expect(await loggedStatusFor("/__real/notfound-status")).toBe("404");
   });
 
   test("the BigInt guard's raw 400 is logged as 400, not 500", async () => {


### PR DESCRIPTION
Fixes #263.

## What was breaking

`src/app.ts` answers a 500 with `"Something went wrong"` outside development. That redaction lived in the `INTERNAL_SERVER_ERROR` arm alone — and an unhandled error does not arrive with that code. It arrives as `UNKNOWN`, falls through `default:` (which returned `undefined`), and Elysia's built-in handler answers with the error's own text.

Measured against the real app in production mode, before the fix: six ordinary failure shapes put a `postgres://user:hunter2@db.internal:5432/agents` connection string straight into the response body.

## The fix, and why it took the shape it did

The handler no longer reads `code` at all.

That is the whole story of this PR, and it was not the first design. `code` looks like the framework's classification of the failure, so the first version listed the codes to redact. **It is not.** Elysia forwards the `code` PROPERTY of the thrown value when it has one, and every library stamps its own. So a rule written over `code` is a rule the thrown value gets to influence, and each version of that rule leaked through a gap the previous one had not considered:

1. a two-name redact list — walked past by a Prisma `P2025` and a Node `EACCES`;
2. "any code we do not recognise, except numbers" — walked past by a `DOMException` (code 25) and a plain `Object.assign(new Error(…), { code: 23 })`;
3. an identity-keyed guard, but with `if (code === "VALIDATION")` and `switch (code) case "NOT_FOUND"` still upstream of it — so an ordinary error that merely *called itself* `VALIDATION` was answered 422 in the app's schema vocabulary and never reached the guard.

The invariant, stated once: **a branch deciding what a failure IS cannot read a property the failure sets.** Every branch now keys on `instanceof`:

```ts
if (error instanceof ValidationError) { …schema refusal… }
if (error instanceof NotFoundError)   { …404… }
if (isFrameworkRefusal(error)) return;   // Elysia's own refusal keeps Elysia's answer
set.status = 500;
return new Response(config.env === "development" ? errorDetail(error) : "Something went wrong", { status: 500 });
```

`src/api/lib/unhandled-error.ts` holds the policy: a value that IS one of Elysia's five exported refusal types keeps the answer Elysia gives it; everything else is an unhandled failure whose text stays out of the response outside development. Stated by exclusion, so a shape nobody anticipated is redacted by default rather than by being on a list.

Dropping the two `code` comparisons also deleted an `as ValidationError` cast that was not merely unchecked but **false** for exactly the errors in point 3 above — `schemaRefusal` was being handed something that was not a `ValidationError`. With them gone, `code` is unused and no longer destructured, so no future branch can reach for it out of habit.

**One trap the identity design introduces**, found by measuring rather than by reasoning: with `require("elysia")` instead of a static ESM `import`, a second instance of the package resolves and *every* `instanceof` is false — a fail-open policy that still passes any test asserting only the redacted cases. It is a `NOTE:` in the module, and mutating the import to `require` fails 6 tests.

## Two things fixed on the way, both found by sweeping rather than by the finding

- **The access log reported a status the client never got.** `onAfterResponse` logs `set.status`, not the `Response`'s status, and Elysia seeds `set.status` from the thrown value's own `status` property. An error carrying `status: 401` was answered 500 and **logged as 401** — the response right, the log wrong, which is the worse failure because nothing on the wire shows it. Every arm returning a raw `Response` now syncs `set.status`.
- **The BigInt guard was already wrong, before this PR existed.** It answers a raw 400 and was logging 500. Same invariant, so it is fixed here and flagged as pre-existing rather than stepped over.

## Where the tests live

In `tests/api/refusal-wire.test.ts`, beside the refusals already asserted there — same subject: what `src/app.ts` puts on the wire when a request goes wrong.

That file's `app.compile()` had to move. Elysia's `get fetch()` is a lazy getter that composes the general handler from the route table as it stands at that moment and then **redefines itself as a plain value property**; later `app.get(...)` calls mutate the router and nothing recomposes. The call has to sit below the LAST route the file registers — its own note says so — and the block added here landed underneath it. Measured with it left in place: every route below the call was missing and 19 of the file's tests failed running the file **alone**.

## Validation scope

**Proven against a real production boot.** The frontend was built (`bun run build`) and the app booted with `NODE_ENV=production` — `config.env === "production"`, the branch a deployment actually takes. Each shape driven through `app.handle` with a real `Request`, A/B against the same tree with the fix reverted:

| | without the fix | with the fix |
| --- | --- | --- |
| 6 unhandled shapes (`Error`, thrown string, Prisma `P2025`, Node `EACCES`, `DOMException`, numeric `code`) | **leaked** the connection string | `Something went wrong` |
| BigInt serialize failure | exposed the internal class and message | `Something went wrong` |
| 6 impostor codes (`VALIDATION`, `NOT_FOUND`, `PARSE`, `INVALID_COOKIE_SIGNATURE`, `INVALID_FILE_TYPE`, `INTERNAL_SERVER_ERROR`) | 422 / 404 / 500, misclassified | all **500 redacted** |
| control: real `ValidationError` | 422, app's own sentence | unchanged |
| control: real `NotFoundError`, `/api` route miss | 404 | unchanged |
| control: non-JSON body (PARSE) | 400 | 400 |
| control: `status(418, …)` | 418 | 418 |

Zero leaks, zero misclassifications, and every control unmoved — the change does what it claims and nothing beside it.

**Proven by test:** `tests/api/lib/unhandled-error.test.ts` states the policy as a table (all five refusal types kept; plain errors, thrown primitives and code-impersonating errors unhandled). `tests/api/refusal-wire.test.ts` asserts the same policy over the real app, which is the half a table cannot prove — that the handler consults the predicate at all, what the client receives, and what the access log records.

Full suite 5190 pass / 0 fail; `bun check` exit 0.

> Getting a trustworthy suite number needed its own step: runs were failing on a *different* long DB-backed test each time, none importing `@/app` or touching this diff, all passing in isolation. Cause was contention — several worktrees on the machine sharing one `secretaria_v4_test`. Given this worktree its own database, the run is 0 fail.

**Mutation-tested: 15 mutations, 0 survivors.** Each `instanceof` clause dropped (2/1/1/1/1 failures); `return true` (33); `errorDetail` without its non-`Error` branch (4); the predicate inverted at the call site (23); `require` instead of the ESM import (6); each `set.status` deleted (1 each) and `set.status = 501` (1); each identity check reverted to a `code` comparison (1 each).

Two of those rows exist because a mutation **survived** and I chased it rather than deleting the line: `InvalidCookieSignature` / `InvalidFileType` had no coverage at all (neither is reachable from a route today — nothing configures `cookie: { secrets }`, no `t.File` constrains `type`), and the `set.status = 404` on the 404 arm was a no-op until the case where it is not one (`NotFoundError` carrying `status: 418`) was measured and covered.

**Not validated:**

- The **development** arm (`error.stack ?? error.message`) is not exercised end to end. The production probe pins the redacted branch, and this PR does not change what development shows.
- The probe registers its own routes to throw each shape. It proves the handler's behaviour, not that any real route reaches it today with genuinely sensitive text. No survey was made of which error classes actually arrive here in a live deployment.
- `InvalidCookieSignature` and `InvalidFileType` are asserted at the predicate, not end to end, because the wire cannot currently produce them. If someone signs a cookie or constrains a file type, that path deserves a wire test then.
