### PR TITLE
Reclaim a squatted redirect identifier instead of dying on the 422

### DIFF
--- a/docs/channel-redirect.md
+++ b/docs/channel-redirect.md
@@ -49,6 +49,30 @@ conversation link). The gate is called from
   `hmac_verified` flag is what makes Chatwoot resume the contact's conversation across sessions/devices
   (`Api::V1::Widget::BaseController#conversations` → `conversations.last`), so re-entry never forks a new
   conversation.
+- **The identifier is settled per contact, and then kept.** Before minting, the gate reads what the
+  WhatsApp contact carries. If it is already `fzwa:<X>` (or a moved value, below) it is kept as is and
+  nothing is written: a live token was minted for it, and links outlive the resend cooldown by design
+  (24h), so re-deriving a value on each delivery would detach the one issued minutes ago.
+- **A held identifier is answered by taking a different one.** `identifier` is unique per Chatwoot
+  account, so if any other contact holds `fzwa:<X>` the stamp is refused with
+  `422 Identifier has already been taken`, and with a fixed value every later redirect for that lead
+  fails the same way, permanently and in silence. The gate stamps `fzwa:<X>:<8 random hex>` instead and
+  mints the token for **that** value. The old one is abandoned where it sits: whoever holds it keeps
+  it, inert, because this side never asks for it again.
+  - A contact that moved keeps its value **even if the base later becomes free**, for the same reason
+    it is kept at all: a token is out there carrying it.
+  - Unification still happens through the normal path: the widget identifies with whatever the token
+    carries, and Chatwoot merges that contact onto whoever holds it, which is the WhatsApp contact.
+  - Squatting stops working, because an identifier that does not exist until it is minted cannot be
+    claimed in advance.
+  - The read-then-write is serialized per contact (process-local), so two deliveries arriving together
+    cannot mint two different suffixes and leave one of the links pointing at a value the contact no
+    longer holds.
+  - Nothing about the other contact is read, trusted or written. That is deliberate: this API has no
+    way to answer "who holds exactly this identifier" (`/contacts/search` matches a substring across
+    four fields, 15 rows a page; `/contacts/filter` is exact but case-insensitive, paged the same way,
+    and its base narrows to `contact_type: 'lead'` once `crm_v2` is on) and no conditional write, so
+    any repair aimed at the holder rests on an answer that can be wrong or stale.
 
 ### Cross-conversation link (on merge)
 

--- a/src/modules/channel-redirect/gate.ts
+++ b/src/modules/channel-redirect/gate.ts
@@ -1,7 +1,10 @@
+import { randomBytes } from "node:crypto";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
+import { withKeyedQueue } from "@/lib/locks";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { clipText } from "@/lib/text";
+import { ChatwootApiError } from "@/modules/chatwoot/client";
 import { loadChatwootClient } from "@/modules/chatwoot/instance";
 import { buildWidgetUrl, normalizeWebsiteUrl } from "./link";
 import {
@@ -44,6 +47,89 @@ export interface ResolveRedirectLinkParams {
   base: PrismaClient;
 }
 
+// Whether an identifier a contact is already carrying is one this gate gave it: the base value, or the
+// base with a suffix. Anything else (no identifier, a WhatsApp LID, another lead's value) is not ours,
+// and the caller takes one instead.
+export function isOurIdentifier(current: string, base: string): boolean {
+  return current === base || current.startsWith(`${base}:`);
+}
+
+// Settle which redirect identifier this contact carries, and return it, because the token has to be
+// minted for whatever the answer is.
+//
+// READ FIRST, and keep what is already there. `fzwa:<X>` is unique per Chatwoot account, so when
+// another contact holds it the stamp is refused with a 422 and, with a fixed value, every later
+// redirect for this lead fails the same way, permanently and in silence (#269). The answer to that
+// refusal is to take `fzwa:<X>:<random>` instead. But an identifier this contact ALREADY carries is
+// the one live tokens were minted for, and links outlive the resend cooldown by design (24h), so
+// re-deriving a value on each delivery would detach the link issued minutes ago. That applies both
+// ways: a contact that moved keeps its suffix even if the base has since become free, because a token
+// is out there carrying the suffix.
+//
+// So this writes only when the contact has no identifier of ours yet, which also means the ordinary
+// path costs one call, a read, instead of a pointless re-stamp of a value already in place.
+//
+// WHY IT MOVES INSTEAD OF TAKING THE VALUE BACK. The alternative is to find the holder and clear it,
+// and that is unbuildable on this API: nothing there answers "who holds exactly this identifier".
+// `/contacts/search` matches a substring across name, email, phone and identifier, 15 rows a page.
+// `/contacts/filter` is exact but case-INSENSITIVE while the unique index is not, is paged the same
+// way, and its `resolved_contacts` base narrows to `contact_type: 'lead'` once `crm_v2` is on, which
+// hides the widget visitor it would be looking for. And there is no conditional write, so even a
+// correct answer can go stale between the read and the PUT and clear an identifier nobody meant to
+// touch. Moving needs none of it: the account cannot refuse a value nobody has, the write stays on OUR
+// contact, and no other contact is read, trusted or modified. Squatting stops working too, since an
+// identifier that does not exist until it is minted cannot be claimed in advance.
+//
+// Serialized per contact because the whole thing is read-then-write over the network: two deliveries
+// for one lead arriving together would otherwise both read "nothing yet", mint two different suffixes
+// and leave one of the two links pointing at a value the contact no longer holds. The queue is
+// process-local, which is the same invariant the rest of the gate already runs under.
+//
+// Keyed by INSTANCE and contact, because a Chatwoot contact id is unique inside one account and not
+// beyond it (schema.prisma says so on `Contact`, and `ChatwootClient.targetKey` scopes its own keys the
+// same way). A bare contact id would put two tenants that happen to share the number behind one queue,
+// so a slow round trip on one Chatwoot server would hold up a redirect on another.
+export function identifierQueueKey(
+  instanceId: bigint,
+  chatwootContactId: number,
+): string {
+  return `redirect-identifier:${instanceId}:${chatwootContactId}`;
+}
+
+async function settleIdentifier(
+  admin: Awaited<ReturnType<typeof loadChatwootClient>>,
+  instanceId: bigint,
+  chatwootContactId: number,
+  base: string,
+): Promise<string> {
+  return withKeyedQueue(
+    identifierQueueKey(instanceId, chatwootContactId),
+    async () => {
+      const current = await admin.getContactIdentifier(chatwootContactId);
+      if (current !== null && isOurIdentifier(current, base)) return current;
+      try {
+        await admin.updateContact(chatwootContactId, { identifier: base });
+        return base;
+      } catch (err) {
+        if (!(err instanceof ChatwootApiError) || err.status !== 422) throw err;
+        // Random rather than a counter: a counter would have to be stored somewhere, and its next value
+        // is as claimable in advance as the first one was.
+        const moved = `${base}:${randomBytes(4).toString("hex")}`;
+        logger.info(
+          "channel-redirect: identifier %s is held by another contact; contact %d takes %s instead",
+          base,
+          chatwootContactId,
+          moved,
+        );
+        // A second refusal is not a collision worth chasing: it means a 1-in-4-billion clash, or a 422
+        // that was never about the identifier. Either belongs to the caller's catch.
+        await admin.updateContact(chatwootContactId, { identifier: moved });
+        return moved;
+      }
+    },
+  );
+}
+
 // Stamp the `fzwa:` identifier on the WhatsApp contact (so the widget-side resolve merges the widget
 // contact onto it) + mint a single-use redirect token, then build the widget link. Shared by the
 // reactive gate (the first redirect) and the proactive WhatsApp follow-up (which re-sends the link).
@@ -52,12 +138,19 @@ export interface ResolveRedirectLinkParams {
 export async function resolveRedirectLink(
   p: ResolveRedirectLinkParams,
 ): Promise<string | null> {
-  const identifier = `fzwa:${p.chatwootContactId}`;
   try {
     const admin = await loadChatwootClient(p.tenantId, p.instanceId, {
       base: p.base,
     });
-    await admin.updateContact(p.chatwootContactId, { identifier });
+    // Minted for whatever this contact actually carries, which is not always the value it would be
+    // asked for: one another contact holds is answered by taking a different one, and one already in
+    // place is kept because a live token was minted for it.
+    const identifier = await settleIdentifier(
+      admin,
+      p.instanceId,
+      p.chatwootContactId,
+      `fzwa:${p.chatwootContactId}`,
+    );
     const { token, websiteUrl } = await admin.mintRedirectToken({
       inboxId: p.widgetInboxId,
       identifier,

--- a/src/modules/chatwoot/client.ts
+++ b/src/modules/chatwoot/client.ts
@@ -995,10 +995,15 @@ export class ChatwootClient {
   // Update a contact's identity fields (admin token). `PUT /contacts/:id` assigns the provided
   // attributes; used to stamp a stable `identifier` on the WhatsApp contact so the widget's
   // setUser(identifier, …) merges the website conversation onto it. Only provided fields are sent.
+  //
+  // `identifier: null` CLEARS it, and null is the only way to clear it: the unique index is
+  // `(identifier, account_id)` with no partial predicate, so an empty string is a value like any other
+  // and a second contact cleared that way collides with the first. Postgres does not consider two
+  // NULLs equal, so nulls never do.
   updateContact(
     contactId: number,
     fields: {
-      identifier?: string;
+      identifier?: string | null;
       phone_number?: string;
       email?: string;
       name?: string;
@@ -1010,6 +1015,19 @@ export class ChatwootClient {
       `/contacts/${contactId}`,
       fields,
     );
+  }
+
+  // A contact's current `identifier` (admin token), or null when it has none. Addressed by id, so
+  // unlike the search and filter endpoints there is no paging, no case folding and no scope that can
+  // hide the row: `GET /contacts/:id` answers about exactly the contact asked for.
+  async getContactIdentifier(contactId: number): Promise<string | null> {
+    const res = (await this.request(
+      this.config.adminToken,
+      "GET",
+      `/contacts/${contactId}`,
+    )) as { payload?: { identifier?: unknown } } | null;
+    const id = res?.payload?.identifier;
+    return typeof id === "string" && id.length > 0 ? id : null;
   }
 
   // Merge two contacts (admin token): moves the mergee's conversations/contact_inboxes onto the base

--- a/tests/modules/channel-redirect-gate.test.ts
+++ b/tests/modules/channel-redirect-gate.test.ts
@@ -1,8 +1,18 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
-import { runRedirectGate } from "@/modules/channel-redirect/gate";
+import {
+  identifierQueueKey,
+  runRedirectGate,
+} from "@/modules/channel-redirect/gate";
 import { readChannelRedirectConfig } from "@/modules/channel-redirect/service";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
@@ -46,6 +56,55 @@ let tenantId: bigint;
 let instanceId: bigint;
 let realFetch: typeof globalThis.fetch;
 
+// Chatwoot's contact identity, as the fork actually implements it. `identifier` is unique per account
+// (`uniq_identifier_per_account_contact`, and `validates :identifier, uniqueness: { scope: :account_id }`),
+// so `PUT /contacts/:id` answers 422 with the Rails validation message the moment another contact holds
+// the value — and answers 200 when the SAME contact already holds it, because uniqueness excludes the
+// record being saved. `POST /contacts/filter` answers an exact question, case-insensitively.
+// `POST /actions/contact_merge` destroys the mergee and the base keeps the attributes it already had,
+// inheriting only the blank ones.
+const contacts = new Map<number, { identifier: string | null }>();
+// What the double was ASKED to do, so a test can assert the recovery ran (or did not).
+const calls: {
+  merges: Array<{ base: number; mergee: number }>;
+  stamps: number;
+  // The two acts of the recovery, counted so a test can prove one did not happen. "Did not merge" is
+  // not the same as "did not run": the recovery has a second, non-destructive half.
+  searches: number;
+  unlinks: number;
+  mintedFor: string[];
+  selfReads: number;
+} = {
+  merges: [],
+  stamps: 0,
+  searches: 0,
+  unlinks: 0,
+  mintedFor: [],
+  selfReads: 0,
+};
+// The race the recovery has to survive: the holder released the identifier between the 422 and the
+// lookup that asks who holds it. Set by the test that pins what happens when nobody is found.
+let releaseHolderAfterCollision = false;
+// Answers the stamp with this status instead of looking at identity at all. Used to pin which
+// failures are allowed to reach the recovery.
+let failStampWith: number | null = null;
+// Fails only the FIRST stamp, so what the recovery does afterwards is observable instead of being
+// swallowed by a double that refuses everything.
+let failFirstStampWith: number | null = null;
+// Fails the Nth PUT to a contact, counting them all: the stamp that gets refused, the unlink, and the
+// stamp after it. Lets a test land the first half of the transfer and refuse the second.
+let failNthStampWith: { n: number; status: number } | null = null;
+let contactWrites = 0;
+
+function seedChatwootContact(id: number, identifier: string | null): void {
+  contacts.set(id, { identifier });
+}
+
+function ownerOf(identifier: string): number | undefined {
+  for (const [id, c] of contacts) if (c.identifier === identifier) return id;
+  return undefined;
+}
+
 function installChatwootDouble(): void {
   realFetch = globalThis.fetch;
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -55,12 +114,101 @@ function installChatwootDouble(): void {
         status,
         headers: { "content-type": "application/json" },
       });
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+
     if (url.endsWith("/redirect_tokens") && init?.method === "POST") {
+      // What the token was minted FOR. The widget identifies with this value, so a token carrying the
+      // old identifier would hand the lead to whoever holds it.
+      calls.mintedFor.push(String(body.identifier));
       return json({
         token: "tok-123",
         website_url: "https://chat.example.com",
       });
     }
+
+    if (url.endsWith("/contacts/filter") && init?.method === "POST") {
+      calls.searches++;
+      // Case-INSENSITIVE, the way the fork's filter is for this attribute (`text_case_insensitive`,
+      // and `filter_values` downcases the input), so the double can answer with a contact the client
+      // has to reject itself.
+      const wanted = String(
+        body?.payload?.[0]?.values?.[0] ?? "",
+      ).toLowerCase();
+      const payload = [...contacts.entries()]
+        .filter(([, c]) => c.identifier?.toLowerCase() === wanted)
+        .map(([id, c]) => ({ id, identifier: c.identifier }));
+      return json({ meta: { count: payload.length }, payload });
+    }
+
+    if (url.endsWith("/actions/contact_merge") && init?.method === "POST") {
+      const base = Number(body.base_contact_id);
+      const mergee = Number(body.mergee_contact_id);
+      calls.merges.push({ base, mergee });
+      const m = contacts.get(mergee);
+      const b = contacts.get(base);
+      if (!m || !b) return json({ message: "not found" }, 404);
+      // merge_and_remove_mergee_contact: the mergee is destroyed, and the BASE's attributes win
+      // (`mergee_attributes.deep_merge(base_attributes)` after compact_blank). So the mergee's
+      // identifier survives onto the base only when the base had none.
+      if (!b.identifier) b.identifier = m.identifier;
+      contacts.delete(mergee);
+      return json({ id: base });
+    }
+
+    const get = url.match(/\/contacts\/(\d+)$/);
+    if (get && (init?.method ?? "GET") === "GET") {
+      calls.selfReads++;
+      const c = contacts.get(Number(get[1]));
+      return json({
+        payload: { id: Number(get[1]), identifier: c?.identifier },
+      });
+    }
+
+    const put = url.match(/\/contacts\/(\d+)$/);
+    if (
+      put &&
+      init?.method === "PUT" &&
+      (typeof body.identifier === "string" || body.identifier === null)
+    ) {
+      const id = Number(put[1]);
+      // A null identifier is the UNLINK, not a stamp of ours.
+      if (body.identifier !== null) calls.stamps++;
+      if (failStampWith !== null)
+        return json({ message: "boom" }, failStampWith);
+      if (failFirstStampWith !== null) {
+        const status = failFirstStampWith;
+        failFirstStampWith = null;
+        return json({ message: "boom" }, status);
+      }
+      contactWrites++;
+      if (failNthStampWith !== null && contactWrites === failNthStampWith.n) {
+        return json({ message: "boom" }, failNthStampWith.status);
+      }
+      // Clearing is always allowed: `allow_blank` skips the validation and Postgres does not consider
+      // two NULLs equal, so no unique index stands in the way.
+      if (body.identifier === null) {
+        calls.unlinks++;
+        const cleared = contacts.get(id);
+        if (cleared) cleared.identifier = null;
+        return json({ id });
+      }
+      const holder = ownerOf(body.identifier);
+      if (holder !== undefined && holder !== id) {
+        if (releaseHolderAfterCollision) contacts.delete(holder);
+        return json(
+          {
+            message: "Identifier has already been taken",
+            attributes: ["identifier"],
+          },
+          422,
+        );
+      }
+      const c = contacts.get(id) ?? { identifier: null };
+      c.identifier = body.identifier;
+      contacts.set(id, c);
+      return json({ id });
+    }
+
     return json({});
   }) as typeof globalThis.fetch;
 }
@@ -77,7 +225,7 @@ const cfg = readChannelRedirectConfig({
 
 async function seedConversation(
   chatwootConversationId: number,
-): Promise<{ id: bigint; contactId: bigint }> {
+): Promise<{ id: bigint; contactId: bigint; chatwootContactId: number }> {
   const contact = await suDb.contact.create({
     data: {
       chatwootInstanceId: instanceId,
@@ -116,7 +264,11 @@ async function seedConversation(
     },
     select: { id: true },
   });
-  return { id: conv.id, contactId: contact.id };
+  return {
+    id: conv.id,
+    contactId: contact.id,
+    chatwootContactId: 4000 + chatwootConversationId,
+  };
 }
 
 describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
@@ -133,6 +285,21 @@ describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
       adminToken: encryptJson("ADMIN"),
     });
     instanceId = inst.id;
+  });
+
+  beforeEach(() => {
+    contacts.clear();
+    calls.merges = [];
+    calls.stamps = 0;
+    calls.searches = 0;
+    calls.unlinks = 0;
+    calls.mintedFor = [];
+    calls.selfReads = 0;
+    releaseHolderAfterCollision = false;
+    failStampWith = null;
+    failFirstStampWith = null;
+    failNthStampWith = null;
+    contactWrites = 0;
   });
 
   afterAll(async () => {
@@ -204,5 +371,380 @@ describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
     });
     expect(row?.redirectSentAt).not.toBeNull();
     expect(row?.redirectCount).toBe(1);
+  });
+
+  test("a contact already carrying the value is not written to again", async () => {
+    const conv = await seedConversation(7305);
+    // The ordinary case for a lead already stamped: the value is in place, a live token was minted
+    // for it, and re-deriving or re-writing it buys nothing.
+    seedChatwootContact(
+      conv.chatwootContactId,
+      `fzwa:${conv.chatwootContactId}`,
+    );
+    const sent: string[] = [];
+
+    const outcome = await runRedirectGate({
+      tenantId,
+      instanceId,
+      conversationId: 7305,
+      conv: {
+        id: conv.id,
+        contactId: conv.contactId,
+        redirectSentAt: null,
+        redirectCount: 0,
+      },
+      cfg,
+      clonedMessage: null,
+      now: new Date(),
+      base: appDb,
+      send: async (text: string) => {
+        sent.push(text);
+        return true;
+      },
+    });
+
+    expect(outcome).toBe("sent");
+    expect(calls.stamps).toBe(0);
+    expect(calls.mintedFor).toEqual([`fzwa:${conv.chatwootContactId}`]);
+  });
+  test("a WhatsApp contact that already carries another identifier still ends up holding ours", async () => {
+    const conv = await seedConversation(7306);
+    // The state the report describes: the WhatsApp contact carries a WhatsApp LID identifier of its
+    // own, which the stamp overwrites. What it must NOT do is leave the contact on that LID while the
+    // token is minted for something else, since the widget identifies by the token's value.
+    seedChatwootContact(conv.chatwootContactId, "554899990000@lid");
+    seedChatwootContact(99003, `fzwa:${conv.chatwootContactId}`);
+    const sent: string[] = [];
+
+    const outcome = await runRedirectGate({
+      tenantId,
+      instanceId,
+      conversationId: 7306,
+      conv: {
+        id: conv.id,
+        contactId: conv.contactId,
+        redirectSentAt: null,
+        redirectCount: 0,
+      },
+      cfg,
+      clonedMessage: null,
+      now: new Date(),
+      base: appDb,
+      send: async (text: string) => {
+        sent.push(text);
+        return true;
+      },
+    });
+
+    expect(outcome).toBe("sent");
+    const taken = contacts.get(conv.chatwootContactId)?.identifier;
+    expect(taken).toMatch(
+      new RegExp(`^fzwa:${conv.chatwootContactId}:[0-9a-f]{8}$`),
+    );
+    expect(calls.mintedFor).toEqual([taken as string]);
+    // The holder keeps what it had; nothing here writes to a contact that is not ours.
+    expect(contacts.get(99003)?.identifier).toBe(
+      `fzwa:${conv.chatwootContactId}`,
+    );
+  });
+
+  test("a stamp that fails for any reason other than the identifier reaches no recovery at all", async () => {
+    const conv = await seedConversation(7307);
+    seedChatwootContact(conv.chatwootContactId, null);
+    seedChatwootContact(99004, `fzwa:${conv.chatwootContactId}`);
+    // A 500 is transient and says nothing about the identifier, so it is not answered by taking a
+    // different one: the lead would end up on a value it moved to for no reason, and a transient
+    // failure would silently rotate the identifier of every lead it touched. Only the FIRST write
+    // fails here, so a second attempt would visibly succeed if the guard were not there.
+    failFirstStampWith = 500;
+    const sent: string[] = [];
+
+    const outcome = await runRedirectGate({
+      tenantId,
+      instanceId,
+      conversationId: 7307,
+      conv: {
+        id: conv.id,
+        contactId: conv.contactId,
+        redirectSentAt: null,
+        redirectCount: 0,
+      },
+      cfg,
+      clonedMessage: null,
+      now: new Date(),
+      base: appDb,
+      send: async (text: string) => {
+        sent.push(text);
+        return true;
+      },
+    });
+
+    expect(outcome).toBe("misconfigured");
+    expect(sent).toEqual([]);
+    // Nothing moved: our contact holds no identifier, no token was minted, and the contact that
+    // happens to hold the value is untouched.
+    expect(contacts.get(conv.chatwootContactId)?.identifier).toBeNull();
+    expect(calls.mintedFor).toEqual([]);
+    expect(contacts.get(99004)?.identifier).toBe(
+      `fzwa:${conv.chatwootContactId}`,
+    );
+  });
+
+  test("a held identifier is answered by taking a different one, and the token carries it", async () => {
+    const conv = await seedConversation(7303);
+    // The state the report measured: the WhatsApp contact does not hold `fzwa:<its own id>`, and some
+    // other contact does. Every later redirect for this lead used to die on the 422 that answers it.
+    seedChatwootContact(conv.chatwootContactId, null);
+    seedChatwootContact(99001, `fzwa:${conv.chatwootContactId}`);
+    const sent: string[] = [];
+
+    const outcome = await runRedirectGate({
+      tenantId,
+      instanceId,
+      conversationId: 7303,
+      conv: {
+        id: conv.id,
+        contactId: conv.contactId,
+        redirectSentAt: null,
+        redirectCount: 0,
+      },
+      cfg,
+      clonedMessage: null,
+      now: new Date(),
+      base: appDb,
+      send: async (text: string) => {
+        sent.push(text);
+        return true;
+      },
+    });
+
+    expect(outcome).toBe("sent");
+    expect(sent[0]).toContain("https://chat.example.com");
+
+    // Ours now, under a value nobody could have claimed in advance.
+    const taken = contacts.get(conv.chatwootContactId)?.identifier;
+    expect(taken).toMatch(
+      new RegExp(`^fzwa:${conv.chatwootContactId}:[0-9a-f]{8}$`),
+    );
+    // THE TOKEN CARRIES THAT ONE. Minting for the original value would send the widget to identify as
+    // the contact still holding it, handing the lead to a stranger.
+    expect(calls.mintedFor).toEqual([taken as string]);
+    // And the other contact is left exactly as it was: not merged, not stripped, not read.
+    expect(contacts.get(99001)?.identifier).toBe(
+      `fzwa:${conv.chatwootContactId}`,
+    );
+    expect(calls.merges).toEqual([]);
+    expect(calls.unlinks).toBe(0);
+    expect(calls.searches).toBe(0);
+  });
+
+  test("two leads colliding on the same value both get served, with different ones", async () => {
+    const first = await seedConversation(7312);
+    const second = await seedConversation(7313);
+    seedChatwootContact(first.chatwootContactId, null);
+    seedChatwootContact(second.chatwootContactId, null);
+    seedChatwootContact(99007, `fzwa:${first.chatwootContactId}`);
+    seedChatwootContact(99008, `fzwa:${second.chatwootContactId}`);
+
+    for (const [convId, conv] of [
+      [7312, first],
+      [7313, second],
+    ] as const) {
+      const outcome = await runRedirectGate({
+        tenantId,
+        instanceId,
+        conversationId: convId,
+        conv: {
+          id: conv.id,
+          contactId: conv.contactId,
+          redirectSentAt: null,
+          redirectCount: 0,
+        },
+        cfg,
+        clonedMessage: null,
+        now: new Date(),
+        base: appDb,
+        send: async () => true,
+      });
+      expect(outcome).toBe("sent");
+    }
+
+    const a = contacts.get(first.chatwootContactId)?.identifier;
+    const b = contacts.get(second.chatwootContactId)?.identifier;
+    expect(a).not.toBe(b);
+    expect(calls.mintedFor).toEqual([a as string, b as string]);
+  });
+  test("a contact that already moved keeps the value it moved to", async () => {
+    const conv = await seedConversation(7319);
+    // The second delivery for a lead whose base value is held elsewhere. Minting a fresh suffix here
+    // would leave the link issued minutes ago pointing at a value this contact no longer has, and
+    // links outlive the resend cooldown by design (24h).
+    seedChatwootContact(conv.chatwootContactId, null);
+    seedChatwootContact(99013, `fzwa:${conv.chatwootContactId}`);
+
+    const run = () =>
+      runRedirectGate({
+        tenantId,
+        instanceId,
+        conversationId: 7319,
+        conv: {
+          id: conv.id,
+          contactId: conv.contactId,
+          redirectSentAt: null,
+          redirectCount: 0,
+        },
+        cfg,
+        clonedMessage: null,
+        now: new Date(),
+        base: appDb,
+        send: async () => true,
+      });
+
+    expect(await run()).toBe("sent");
+    const first = contacts.get(conv.chatwootContactId)?.identifier;
+    expect(await run()).toBe("sent");
+    const second = contacts.get(conv.chatwootContactId)?.identifier;
+
+    expect(second).toBe(first as string);
+    // Both tokens carry it, so either link resolves onto this contact.
+    expect(calls.mintedFor).toEqual([first as string, first as string]);
+  });
+
+  test("an identifier that is not one of ours is not reused", async () => {
+    const conv = await seedConversation(7320);
+    // A WhatsApp LID, or any other value: the base is held elsewhere, and what this contact happens to
+    // carry says nothing about a link this gate ever issued.
+    seedChatwootContact(conv.chatwootContactId, "554899990000@lid");
+    seedChatwootContact(99014, `fzwa:${conv.chatwootContactId}`);
+
+    const outcome = await runRedirectGate({
+      tenantId,
+      instanceId,
+      conversationId: 7320,
+      conv: {
+        id: conv.id,
+        contactId: conv.contactId,
+        redirectSentAt: null,
+        redirectCount: 0,
+      },
+      cfg,
+      clonedMessage: null,
+      now: new Date(),
+      base: appDb,
+      send: async () => true,
+    });
+
+    expect(outcome).toBe("sent");
+    const taken = contacts.get(conv.chatwootContactId)?.identifier;
+    expect(taken).toMatch(
+      new RegExp(`^fzwa:${conv.chatwootContactId}:[0-9a-f]{8}$`),
+    );
+    expect(calls.mintedFor).toEqual([taken as string]);
+  });
+
+  test("the ordinary path reads, and writes only what is not there yet", async () => {
+    const conv = await seedConversation(7321);
+    seedChatwootContact(conv.chatwootContactId, null);
+
+    await runRedirectGate({
+      tenantId,
+      instanceId,
+      conversationId: 7321,
+      conv: {
+        id: conv.id,
+        contactId: conv.contactId,
+        redirectSentAt: null,
+        redirectCount: 0,
+      },
+      cfg,
+      clonedMessage: null,
+      now: new Date(),
+      base: appDb,
+      send: async () => true,
+    });
+
+    // One read to see what the contact carries, one write because it carried nothing.
+    expect(calls.selfReads).toBe(1);
+    expect(calls.stamps).toBe(1);
+  });
+  test("a contact that moved keeps its value even after the base becomes free", async () => {
+    const conv = await seedConversation(7322);
+    seedChatwootContact(conv.chatwootContactId, null);
+    seedChatwootContact(99015, `fzwa:${conv.chatwootContactId}`);
+
+    const run = () =>
+      runRedirectGate({
+        tenantId,
+        instanceId,
+        conversationId: 7322,
+        conv: {
+          id: conv.id,
+          contactId: conv.contactId,
+          redirectSentAt: null,
+          redirectCount: 0,
+        },
+        cfg,
+        clonedMessage: null,
+        now: new Date(),
+        base: appDb,
+        send: async () => true,
+      });
+
+    expect(await run()).toBe("sent");
+    const moved = contacts.get(conv.chatwootContactId)?.identifier;
+    expect(moved).toMatch(
+      new RegExp(`^fzwa:${conv.chatwootContactId}:[0-9a-f]{8}$`),
+    );
+
+    // The holder goes away: deleted, merged, or simply cleared. The base value is free now, and
+    // reclaiming it would strand the token minted for the suffix, which is live for 24h.
+    contacts.delete(99015);
+    expect(await run()).toBe("sent");
+
+    expect(contacts.get(conv.chatwootContactId)?.identifier).toBe(
+      moved as string,
+    );
+    expect(calls.mintedFor).toEqual([moved as string, moved as string]);
+  });
+
+  test("two deliveries recovering the same contact at once settle on one value", async () => {
+    const conv = await seedConversation(7323);
+    seedChatwootContact(conv.chatwootContactId, null);
+    seedChatwootContact(99016, `fzwa:${conv.chatwootContactId}`);
+
+    // Both read the contact before either has written, if nothing serializes them, and each mints a
+    // token for its own suffix: one of the two links is dead on arrival.
+    const both = await Promise.all(
+      [7323, 7323].map(() =>
+        runRedirectGate({
+          tenantId,
+          instanceId,
+          conversationId: 7323,
+          conv: {
+            id: conv.id,
+            contactId: conv.contactId,
+            redirectSentAt: null,
+            redirectCount: 0,
+          },
+          cfg,
+          clonedMessage: null,
+          now: new Date(),
+          base: appDb,
+          send: async () => true,
+        }),
+      ),
+    );
+
+    expect(both).toEqual(["sent", "sent"]);
+    const settled = contacts.get(conv.chatwootContactId)?.identifier;
+    expect(new Set(calls.mintedFor)).toEqual(new Set([settled as string]));
+  });
+  test("the queue key separates instances that share a contact number", async () => {
+    // A Chatwoot contact id is unique inside one account and not beyond it, so two tenants can both
+    // have contact 42. Sharing a queue between them means a slow round trip on one Chatwoot server
+    // holds up a redirect on another.
+    expect(identifierQueueKey(1n, 42)).not.toBe(identifierQueueKey(2n, 42));
+    expect(identifierQueueKey(1n, 42)).toBe(identifierQueueKey(1n, 42));
+    expect(identifierQueueKey(1n, 42)).not.toBe(identifierQueueKey(1n, 43));
   });
 });

--- a/tests/modules/chatwoot-client.test.ts
+++ b/tests/modules/chatwoot-client.test.ts
@@ -498,4 +498,17 @@ describe("ChatwootClient", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.headers[CHATWOOT_AUTH_HEADER]).toBe("ADMIN_TOK");
   });
+
+  test("updateContact can clear an identifier with null", async () => {
+    // The unique index is `(identifier, account_id)` with no partial predicate, so an empty string is
+    // a value like any other and a second contact cleared that way would collide with the first.
+    const { fetchImpl, calls } = stub(200, {});
+    const client = await createChatwootClient(baseConfig, {
+      fetchImpl,
+      assertSafe: passthroughSafe,
+    });
+    await client.updateContact(7, { identifier: null });
+    expect(calls[0]?.method).toBe("PUT");
+    expect(calls[0]?.body).toEqual({ identifier: null });
+  });
 });


### PR DESCRIPTION
Fixes #269

## What broke

`resolveRedirectLink` stamps `fzwa:<chatwootContactId>` on the WhatsApp contact so the widget side can
merge onto it. It stamps **without asking who already holds the value**, and `identifier` is unique per
Chatwoot account (`uniq_identifier_per_account_contact`, plus `validates :identifier, uniqueness: { scope: :account_id }`).
So once anything else holds it, `PUT /contacts/:id` answers `422 Identifier has already been taken`, the
whole body falls into one catch that logs a warn and returns `null`, and the gate reports
`misconfigured` for that lead **forever**: every later attempt stamps the same value and is refused the
same way.

The failure is silent and per-contact, which is why the funnel looks intermittent rather than broken:
it keeps working for leads that never completed a crossing and is permanently dead for the ones that
did. The report measured three weeks of one install: 3 invites delivered, **0** conversations with
`redirect_linked_at` set, and one orphan `fzwa:` contact holding the identifier of a WhatsApp contact.

## The fix

The gate settles which identifier the WhatsApp contact carries before minting, and mints for that.

It **reads first and keeps what is there.** An identifier already in place is the one live tokens were
minted for, and links outlive the resend cooldown by design (24h), so re-deriving a value on each
delivery would detach the link issued minutes ago. That also means the ordinary path costs one call, a
read, instead of re-stamping a value already in place.

When nothing of ours is there and `fzwa:<X>` is **held by another contact**, the stamp is refused, and
the gate takes `fzwa:<X>:<8 random hex>` instead. The old value is abandoned where it sits: whoever
holds it keeps it, inert, because this side never asks for it again. A contact that moved keeps that
value even if the base later becomes free, for the same reason it is kept at all.

Unification still happens through the normal path, since the widget identifies with whatever the token
carries and Chatwoot merges that contact onto whoever holds it. And squatting stops working, because an
identifier that does not exist until it is minted cannot be claimed in advance.

The read-then-write is serialized per contact, process-local: two deliveries for one lead arriving
together would otherwise both read "nothing yet", mint two different suffixes, and leave one of the two
links pointing at a value the contact no longer holds. The queue key carries the **instance**, since a
Chatwoot contact id is unique inside one account and not beyond it, and a bare number would put two
tenants that happen to share it behind one queue.

## Why it moves instead of taking the value back

Taking it back is the obvious repair, and it was the design through five review rounds: find who holds
`fzwa:<X>`, then either merge that contact into the lead or strip the identifier off it. Each round
found a different reason it does not hold up, and together they say the same thing: **this API cannot
answer "who holds exactly this identifier", and cannot be told to write conditionally**.

- `GET /contacts/search` matches a **substring** across name, email, phone and identifier, 15 rows a
  page, so the holder is one row in an unbounded result set that has to be paged behind a cap that is
  a guess.
- `POST /contacts/filter` asks an exact question but is **case-insensitive** for this attribute while
  the unique index is not, is paged the same way, and its `resolved_contacts` base narrows to
  `contact_type: 'lead'` the moment `crm_v2` is enabled, which hides exactly the widget visitor it
  would be looking for.
- There is **no conditional write**, so even a correct answer can go stale between the read and the
  PUT, and the write would then clear an identifier nobody meant to touch.

And merging specifically needs one more thing that does not exist: proof that the holder is this lead's
own earlier crossing. Holding the identifier is not proof (the value is derived from a sequential
contact id, and an inbox without `hmac_mandatory` waves through any identify carrying no hash, for
`setUser` and a later `update` alike); `hmac_verified` is not proof (it is sticky across a later
identifier change); `hmac_mandatory` on this inbox is not proof (identifiers are unique per **account**
while that flag is per inbox and describes only its configuration now). A merge moves the holder's
conversations onto the lead **and** hands its holder the lead's contact through the contact_inbox it
carries across, so getting that wrong is a takeover built out of a bug fix. Recording the provenance
that would make it safe is a fork change, tracked in #286.

Moving needs none of it: the account cannot refuse a value nobody has, the write stays on our own
contact, and no other contact is read, trusted or modified.

## What I could not reproduce

**How the identifier reached the other contact in the first place.** The report's own evidence is
solid: `Contact.find(<WA_ID>)` exists and does not hold `fzwa:<WA_ID>`, and another contact does. But
the fork's `ContactIdentifyAction` merges the widget contact **into** whoever holds the identifier, so
that state can only arise if nobody held it at the moment of the crossing, and I could not find the
path that empties it. Two candidates are ruled out: WhatsApp routes by the contact_inbox `source_id`
and never writes `identifier` on the contact (`Whatsapp::IdentifierSyncService` writes `source_id`,
`phone_number` and `additional_attributes` only), and the history importer writes `identifier` only
when the field is blank.

This does not change the fix. The gate has to survive an identifier it does not hold whatever put it
there, and the ways to get there that need no exotic explanation (a race between the stamp and the
crossing, a CSV import, an operator merging contacts in the dashboard) are not closable from this side
anyway.

## What is deliberately not here

The report's third suggestion, an execution-log entry for the gate, is its own change: the flow log's
stage vocabulary is closed, so a `redirect` stage means a new entry in `FLOW_STAGES`, its label in the
client's i18n catalogs, and a `turnId` for a path that runs before any turn exists. What this PR does
instead is name the move in the operator's log: the line says which identifier was held and which one
this contact took instead, where before every failure shared one generic warn line.

The secondary observation in #269 (a `/teste` on the redirect entry inbox consumed without activating
test mode) is now #270. The two gates are ordered correctly in the source, so it is a different defect
in a different path.

## Validation scope

**Proven by test.** 13 gate-level tests against a Chatwoot double that implements the identity rules the
fork actually has (unique-per-account identifier, and 422 with the Rails validation message): a held
identifier is answered by taking a suffixed one **and the token is minted for that value**, which is
the half that matters, since minting for the original would send the widget to identify as the contact
still holding it; the other contact comes out unread, unmerged and unmodified; a contact already
carrying a value is not written to again, and neither is one that already moved, including after the
base becomes free; two deliveries recovering the same contact at once settle on one value; two leads
colliding on the same base both get served, with different ones; an identifier that is not one of ours
(a WhatsApp LID) is never reused; a stamp that fails for any reason other than the identifier moves
nothing and mints nothing. **11 mutations run, 11 killed**, among them minting the base instead of the
moved value, a fixed suffix, ignoring what the contact already carries, dropping the per-contact
queue, and dropping the instance from its key.

**Proven live, end to end, against a real Chatwoot** (the fork at 4.16.0, running locally with its own
Postgres/Redis and Sidekiq). The reported state was built on the server: a WhatsApp contact holding no
identifier, and another contact holding `fzwa:<its id>`.

1. **The bug reproduces.** `main`'s gate answers with
   `ChatwootApiError: Chatwoot API 422 for PUT /contacts/59`, raised at the same two frames the report
   shows (`client.ts` request → `resolveRedirectLink`), and no link is minted.
2. **The fix repairs it.** The same call on this branch logs
   `identifier fzwa:59 is held by another contact; contact 59 takes fzwa:59:0943f664 instead` and
   returns the widget link. On the server: contact 59 now holds `fzwa:59:0943f664`, the Redis token
   payload is `{"inbox_id":8,"identifier":"fzwa:59:0943f664"}`, and the other contact is **alive and
   untouched**, still holding `fzwa:59`.
3. **Unification still happens.** Posting that token to `POST /api/v1/widget/redirect_token` as a fresh
   widget visitor answered `{"conversation_id":1}`; the visitor contact was **destroyed by Chatwoot's
   own merge**, and the WhatsApp contact came out carrying the `Channel::WebWidget` contact_inbox and
   the conversation. That is the claim this design rests on, measured rather than read.

This covers what the design depends on: that a `PUT /contacts/:id` with a value nobody holds succeeds,
that a held one is refused with 422, that `GET /contacts/:id` reports the identifier, that
`/redirect_tokens` stores the value it is given, and that the widget identifies by that value.

**Not validated.** The suffix path was exercised on a local instance of the fork, not against a
production install, so anything specific to a deployment's own data (a `crm_v2` account, an inbox with
mandatory HMAC) is covered by reading rather than by measurement. The per-contact queue's concurrency
is proven against the double, not against two real deliveries racing. And the state that produces the
collision in the wild is still reproduced by construction: I could not find the path that empties the
WhatsApp contact's identifier in the first place, which is written above.
