### PR TITLE
Answer a flow-log assertion with the test's own rows, not a neighbour's

### DIFF
--- a/tests/graph/history-ceiling-turn.test.ts
+++ b/tests/graph/history-ceiling-turn.test.ts
@@ -134,24 +134,43 @@ async function generateLines(convId: number) {
   });
 }
 
-// The trail is written fire-and-forget, so wait for it before judging it.
+const isTrim = (r: { detail: unknown }) =>
+  typeof (r.detail as Record<string, unknown> | null)?.historyDropped ===
+  "number";
+
+// The two questions this file asks of the trail are NOT the same question, and one reader cannot
+// wait correctly for both. A trimmed turn writes TWO `generate`/`info` rows, its ordinary one and a
+// separate one for the trim (`onHistoryTrim` is its own `emitFlowEvent` in src/graph/runtime.ts).
+// Measured on this file: the no-ceiling thread produces 6 rows and 0 trims, the ceiling thread 8 and
+// 2. So a single reader waiting on the TOTAL count is satisfied by the six ordinary rows while both
+// trim writes are still in flight, and the positive test intermittently reads none.
+
+// "Did this thread trim?" — poll until a trim row lands. The line is what is being asserted, so
+// waiting for it is the whole job.
+async function waitForTrimLines(convId: number) {
+  let trims: Awaited<ReturnType<typeof generateLines>> = [];
+  for (let i = 0; i < 30 && trims.length === 0; i++) {
+    trims = (await generateLines(convId)).filter(isTrim);
+    if (trims.length === 0) await new Promise((r) => setTimeout(r, 100));
+  }
+  return trims;
+}
+
+// "Did this thread trim NOTHING?" — wait for the turns' own bookkeeping, then read once.
 //
-// NOTE: the wait is on the thread's own line COUNT, never on a trim line appearing. Polling for
-// something that must never arrive can only spend the whole timeout and then agree with itself,
-// which is what the no-ceiling assertion did: 3 of this file's 4 seconds were one test waiting out
-// 30 rounds to confirm an absence it already had the rows to prove.
-async function trimLines(convId: number, turns: number) {
+// NOTE: the landmark is the count of NON-trim rows, never a trim appearing: polling for something
+// that must never arrive can only spend the whole timeout and then agree with itself, which is what
+// this assertion used to do for 3 of the file's 4 seconds. And the landmark is sound rather than
+// approximate here, because `onHistoryTrim` fires only when the window actually dropped something
+// (src/graph/graph.ts): with the ceiling off there is no second write to lose a race to.
+async function trimLinesAfterTurns(convId: number, turns: number) {
   let rows: Awaited<ReturnType<typeof generateLines>> = [];
   for (let i = 0; i < 30; i++) {
     rows = await generateLines(convId);
-    if (rows.length >= turns) break;
+    if (rows.filter((r) => !isTrim(r)).length >= turns) break;
     await new Promise((r) => setTimeout(r, 100));
   }
-  return rows.filter(
-    (r) =>
-      typeof (r.detail as Record<string, unknown> | null)?.historyDropped ===
-      "number",
-  );
+  return rows.filter(isTrim);
 }
 
 describe.skipIf(!dbUp)("a turn under the agent's history ceiling", () => {
@@ -276,7 +295,7 @@ describe.skipIf(!dbUp)("a turn under the agent's history ceiling", () => {
       true,
     );
     // Six turns ran, so six lines are owed; among them, none may carry a trim.
-    expect(await trimLines(980, 6)).toHaveLength(0);
+    expect(await trimLinesAfterTurns(980, 6)).toHaveLength(0);
   });
 
   test("with a ceiling the oldest turns stop travelling, and the trail records it", async () => {
@@ -300,7 +319,7 @@ describe.skipIf(!dbUp)("a turn under the agent's history ceiling", () => {
     expect(last[0]?.getType()).toBe("system");
     expect(last[1]?.getType()).toBe("human");
 
-    const lines = await trimLines(981, 6);
+    const lines = await waitForTrimLines(981);
     expect(lines.length).toBeGreaterThan(0);
     for (const line of lines) {
       // INFO, never warn: warn fans out to the alert channels, and a working ceiling trims on

--- a/tests/graph/history-ceiling-turn.test.ts
+++ b/tests/graph/history-ceiling-turn.test.ts
@@ -156,13 +156,21 @@ async function waitForTrimLines(convId: number) {
   return trims;
 }
 
-// "Did this thread trim NOTHING?" — wait for the turns' own bookkeeping, then read once.
+// "Did this thread trim NOTHING?" — wait for the turns' own bookkeeping, then read.
 //
-// NOTE: the landmark is the count of NON-trim rows, never a trim appearing: polling for something
-// that must never arrive can only spend the whole timeout and then agree with itself, which is what
-// this assertion used to do for 3 of the file's 4 seconds. And the landmark is sound rather than
-// approximate here, because `onHistoryTrim` fires only when the window actually dropped something
-// (src/graph/graph.ts): with the ceiling off there is no second write to lose a race to.
+// The landmark is the count of NON-trim rows, never a trim appearing: polling for something that
+// must never arrive can only spend the whole timeout and then agree with itself, which is what this
+// assertion used to do for 3 of the file's 4 seconds.
+//
+// NOTE: an absence can only ever be asserted against a barrier, and `emitFlowEvent` offers none, so
+// this composes the two that exist. The turn's OWN row is dispatched after any trim row of the same
+// turn — `onHistoryTrim` runs while the history window is built, before the model call, and the
+// ordinary row closes the generate stage after it — so `turns` ordinary rows means every trim write
+// this thread could owe was already dispatched. The settle re-read covers the rest: two independent
+// transactions dispatched in order can still land out of order on a pool. Neither is a lock, which
+// is why the regression this corroborates is ALSO caught deterministically one assertion earlier:
+// `onHistoryTrim` fires only when the window dropped something (src/graph/graph.ts), and anything
+// dropped means the model no longer saw all 12 messages.
 async function trimLinesAfterTurns(convId: number, turns: number) {
   let rows: Awaited<ReturnType<typeof generateLines>> = [];
   for (let i = 0; i < 30; i++) {
@@ -170,7 +178,8 @@ async function trimLinesAfterTurns(convId: number, turns: number) {
     if (rows.filter((r) => !isTrim(r)).length >= turns) break;
     await new Promise((r) => setTimeout(r, 100));
   }
-  return rows.filter(isTrim);
+  await new Promise((r) => setTimeout(r, 100));
+  return (await generateLines(convId)).filter(isTrim);
 }
 
 describe.skipIf(!dbUp)("a turn under the agent's history ceiling", () => {

--- a/tests/graph/history-ceiling-turn.test.ts
+++ b/tests/graph/history-ceiling-turn.test.ts
@@ -118,22 +118,40 @@ async function setCeiling(maxHistoryTokens: number | null) {
   });
 }
 
-// The trail is written fire-and-forget, so the assertion polls instead of racing it.
-async function trimLines() {
+// The `generate` lines of ONE thread, scoped so that neither test below can answer with the other's
+// rows. Both run a thread in the same tenant and one of them asserts that NO trim line exists, which
+// read across the tenant is a claim about its neighbour: swapping the two `test()` blocks used to
+// turn this file red with `Received length: 2`, so the green depended on declaration order (#258).
+async function generateLines(convId: number) {
+  return suDb.executionLog.findMany({
+    where: {
+      tenantId,
+      stage: "generate",
+      level: "info",
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+    },
+    select: { detail: true, level: true },
+  });
+}
+
+// The trail is written fire-and-forget, so wait for it before judging it.
+//
+// NOTE: the wait is on the thread's own line COUNT, never on a trim line appearing. Polling for
+// something that must never arrive can only spend the whole timeout and then agree with itself,
+// which is what the no-ceiling assertion did: 3 of this file's 4 seconds were one test waiting out
+// 30 rounds to confirm an absence it already had the rows to prove.
+async function trimLines(convId: number, turns: number) {
+  let rows: Awaited<ReturnType<typeof generateLines>> = [];
   for (let i = 0; i < 30; i++) {
-    const rows = await suDb.executionLog.findMany({
-      where: { tenantId, stage: "generate", level: "info" },
-      select: { detail: true, level: true },
-    });
-    const hits = rows.filter(
-      (r) =>
-        typeof (r.detail as Record<string, unknown> | null)?.historyDropped ===
-        "number",
-    );
-    if (hits.length > 0) return hits;
+    rows = await generateLines(convId);
+    if (rows.length >= turns) break;
     await new Promise((r) => setTimeout(r, 100));
   }
-  return [];
+  return rows.filter(
+    (r) =>
+      typeof (r.detail as Record<string, unknown> | null)?.historyDropped ===
+      "number",
+  );
 }
 
 describe.skipIf(!dbUp)("a turn under the agent's history ceiling", () => {
@@ -257,7 +275,8 @@ describe.skipIf(!dbUp)("a turn under the agent's history ceiling", () => {
     expect(last.some((m) => String(m.content).includes(FIRST_QUESTION))).toBe(
       true,
     );
-    expect(await trimLines()).toHaveLength(0);
+    // Six turns ran, so six lines are owed; among them, none may carry a trim.
+    expect(await trimLines(980, 6)).toHaveLength(0);
   });
 
   test("with a ceiling the oldest turns stop travelling, and the trail records it", async () => {
@@ -281,7 +300,7 @@ describe.skipIf(!dbUp)("a turn under the agent's history ceiling", () => {
     expect(last[0]?.getType()).toBe("system");
     expect(last[1]?.getType()).toBe("human");
 
-    const lines = await trimLines();
+    const lines = await trimLines(981, 6);
     expect(lines.length).toBeGreaterThan(0);
     for (const line of lines) {
       // INFO, never warn: warn fans out to the alert channels, and a working ceiling trims on

--- a/tests/graph/nudge.test.ts
+++ b/tests/graph/nudge.test.ts
@@ -1532,8 +1532,15 @@ describe.skipIf(!dbUp)("runAgentNudge", () => {
     expect(outcome).toBe("messaged");
     let logged = false;
     for (let i = 0; i < 30 && !logged; i++) {
+      // Scoped to this nudge's own thread: 76 tests share the tenant, and `outcome`/`step` are
+      // values several of them write. Filtered by tenant alone this poll can exit on a neighbour's
+      // row and report a trail this turn never left (#258).
       const rows = await suDb.executionLog.findMany({
-        where: { tenantId, stage: "generate" },
+        where: {
+          tenantId,
+          stage: "generate",
+          threadId: `${tenantId}:${instanceId}:9912`,
+        },
         select: { detail: true },
       });
       logged = rows.some((r) => {
@@ -3605,7 +3612,12 @@ describe.skipIf(!dbUp)("runAgentNudge", () => {
     let logged = false;
     for (let i = 0; i < 30 && !logged; i++) {
       const rows = await suDb.executionLog.findMany({
-        where: { tenantId, stage: "generate", level: "warn" },
+        where: {
+          tenantId,
+          stage: "generate",
+          level: "warn",
+          threadId: `${tenantId}:${instanceId}:913`,
+        },
         select: { detail: true },
       });
       logged = rows.some(

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -373,7 +373,12 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     let retryLogged = false;
     for (let i = 0; i < 30 && !retryLogged; i++) {
       const rows = await suDb.executionLog.findMany({
-        where: { tenantId, stage: "generate", level: "warn" },
+        where: {
+          tenantId,
+          stage: "generate",
+          level: "warn",
+          threadId: `${tenantId}:${instanceId}:995`,
+        },
         select: { detail: true },
       });
       retryLogged = rows.some(
@@ -1083,11 +1088,18 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     const conversation = await suDb.conversation.findFirstOrThrow({
       where: { tenantId, chatwootConversationId: convId },
     });
-    const row = await suDb.executionLog.findFirstOrThrow({
-      where: { tenantId, stage: "handoff", conversationId: conversation.id },
-      orderBy: { id: "desc" },
-    });
-    return row.detail;
+    // Scoped since #123; the wait is the other half. `findFirstOrThrow` on a row that has not landed
+    // yet does not answer wrong, it THROWS, so what the scoping converted was a silent wrong answer
+    // into a spurious failure. Poll for the row this conversation owes (#258).
+    for (let i = 0; i < 30; i++) {
+      const row = await suDb.executionLog.findFirst({
+        where: { tenantId, stage: "handoff", conversationId: conversation.id },
+        orderBy: { id: "desc" },
+      });
+      if (row) return row.detail;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(`no handoff flow line for conv ${convId}`);
   }
 
   // NOTE: the guard for the reader above, not for the product. Before it was scoped, this returned
@@ -1234,7 +1246,11 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     let resolvedLogged = false;
     for (let i = 0; i < 30 && !resolvedLogged; i++) {
       const rows = await suDb.executionLog.findMany({
-        where: { tenantId, stage: "handoff" },
+        where: {
+          tenantId,
+          stage: "handoff",
+          threadId: `${tenantId}:${instanceId}:910`,
+        },
         select: { detail: true },
       });
       resolvedLogged = rows.some(
@@ -2227,16 +2243,28 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       ).toBe(true);
       // And the trail names the tool the operator granted, not a constant: an operator filtering for
       // it has to find the line it produced.
-      const flow = await suDb.executionLog.findMany({
-        where: { tenantId, stage: "tool" },
-        select: { detail: true },
-      });
-      const details = flow.map((f) => JSON.stringify(f.detail));
-      expect(
-        details.some(
-          (d) => d.includes("send_orcamento") && d.includes('"outcome":"sent"'),
-        ),
-      ).toBe(true);
+      // Scoped AND polled. This reader had neither, and the missing wait is the one that already
+      // cost a CI run on an unrelated PR: `emitFlowEvent` is fire-and-forget, so the `send_orcamento`
+      // line had simply not landed when the assertion read the table (#258).
+      let named = false;
+      for (let i = 0; i < 30 && !named; i++) {
+        const flow = await suDb.executionLog.findMany({
+          where: {
+            tenantId,
+            stage: "tool",
+            threadId: `${tenantId}:${instanceId}:941`,
+          },
+          select: { detail: true },
+        });
+        named = flow
+          .map((f) => JSON.stringify(f.detail))
+          .some(
+            (d) =>
+              d.includes("send_orcamento") && d.includes('"outcome":"sent"'),
+          );
+        if (!named) await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(named).toBe(true);
     } finally {
       await suDb.$executeRawUnsafe(
         `DELETE FROM agent_tool_selections WHERE tenant_id = ${tenantId}`,

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -1134,8 +1134,13 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     });
     // 8804 exists but never ran a turn, so the tenant's newest handoff row belongs to 8803.
     await seedConversation(8804, null, null, "open");
-    // One read, and awaited. 8804 never ran a turn, so no handoff write is in flight and there is
-    // nothing to poll for: the waiting reader would spend its whole 3s to agree, and it would spend
+    // The control has to be POSITIVE before the absence means anything: this test only detects an
+    // unscoped reader if there IS a neighbouring row for it to wrongly return, and 8803's row is
+    // written fire-and-forget, so without this wait the null below can mean "nothing has landed
+    // yet" and the test passes having proved nothing.
+    expect(await handoffDetail(8803)).toBeDefined();
+    // Then one read, awaited. 8804 never ran a turn, so no write of its own is in flight and there
+    // is nothing to poll for: the waiting reader would spend its whole 3s to agree, and would spend
     // it AFTER this test returned, because the assertion it was handed to was never awaited (#258).
     expect(await handoffRowNow(8804)).toBeNull();
   });

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -1084,6 +1084,18 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
   // silently returned the PREVIOUS test's row: 8801 writes `taken_over`, 8802 asserts
   // `ownership_lost`, and whichever write won the race decided the result. That is the ~1-in-4 CI
   // failure this file kept producing, on a machine slower than a dev laptop.
+  // One read, for the assertion that a conversation has NO handoff row.
+  async function handoffRowNow(convId: number) {
+    const conversation = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: convId },
+    });
+    return suDb.executionLog.findFirst({
+      where: { tenantId, stage: "handoff", conversationId: conversation.id },
+      orderBy: { id: "desc" },
+      select: { detail: true },
+    });
+  }
+
   async function handoffDetail(convId: number): Promise<unknown> {
     const conversation = await suDb.conversation.findFirstOrThrow({
       where: { tenantId, chatwootConversationId: convId },
@@ -1122,7 +1134,10 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     });
     // 8804 exists but never ran a turn, so the tenant's newest handoff row belongs to 8803.
     await seedConversation(8804, null, null, "open");
-    expect(handoffDetail(8804)).rejects.toThrow();
+    // One read, and awaited. 8804 never ran a turn, so no handoff write is in flight and there is
+    // nothing to poll for: the waiting reader would spend its whole 3s to agree, and it would spend
+    // it AFTER this test returned, because the assertion it was handed to was never awaited (#258).
+    expect(await handoffRowNow(8804)).toBeNull();
   });
 
   test("a human assignee is reported as a real takeover", async () => {

--- a/tests/graph/side-effect-flowlog.test.ts
+++ b/tests/graph/side-effect-flowlog.test.ts
@@ -98,7 +98,11 @@ async function pollToolRows(
   let rows: ToolRow[] = [];
   for (let i = 0; i < 50; i++) {
     rows = await suDb.executionLog.findMany({
-      where: { tenantId, stage: "tool" },
+      where: {
+        tenantId,
+        stage: "tool",
+        threadId: `${tenantId}:${instanceId}:950`,
+      },
       select: { level: true, status: true, errorMessage: true, detail: true },
     });
     if (predicate(rows)) return rows;

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -22,6 +22,13 @@ import { describe, expect, test } from "bun:test";
 // reader in an already-listed file trips this too, not only a new file. The classification is the
 // point of the ledger. `tenant-wide` is a real answer for a reader whose subject is the TABLE rather
 // than one turn's trail, and it is written down so it stays a decision instead of an omission.
+//
+// NOTE: the price of a ledger over the whole test tree is that ANY branch adding a reader anywhere
+// has to touch this file, and it will find out from this test rather than from review. That is the
+// intended cost — it is the same trade tests/lib/storable-write-sweep.test.ts makes over `src/` —
+// but it has one edge the other does not: an entry in a file the derivation drops from an edition
+// would make this red in that edition and green here. Every file listed below survives into both
+// today, and a reader added inside a `@full-only` test file is the case to watch for.
 
 type Reader = {
   /** 1-indexed line of the `executionLog.<method>(` that opens the call. */
@@ -124,7 +131,9 @@ const FLOWLOG_READERS: Record<string, [number, Scoping]> = {
   "tests/graph/runtime.test.ts": [7, "turn"],
   "tests/graph/side-effect-flowlog.test.ts": [1, "turn"],
   "tests/graph/tool-flowlog.test.ts": [1, "turn"],
-  "tests/modules/contact-auth-gate-e2e.test.ts": [2, "turn"],
+  "tests/modules/chatwoot-gate-trail.test.ts": [1, "turn"],
+  "tests/modules/contact-auth-gate-e2e.test.ts": [3, "turn"],
+  "tests/modules/debounce.test.ts": [1, "turn"],
   "tests/modules/flowlog-astral-detail.test.ts": [1, "turn"],
   "tests/modules/flowlog-detail-pii.test.ts": [1, "turn"],
   "tests/modules/flowlog-retention.test.ts": [1, "tenant-wide"],

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -35,6 +35,8 @@ type Reader = {
   line: number;
   /** Top-level keys of the call's `where: { ... }`, in source order. */
   keys: string[];
+  /** The `flowlog-scope:` marker above the call, when it declares something other than a turn. */
+  marker: Scoping | null;
 };
 
 // The keys that name the row THIS test produced. `tenantId` is deliberately absent: it is the file's
@@ -76,6 +78,28 @@ function splitTopLevel(s: string): string[] {
   return parts.map((p) => p.trim()).filter(Boolean);
 }
 
+// The exemption is declared AT the reader, never at a position in the ledger. A per-file exemption
+// travels to readers written later, and a per-INDEX one is worse than it looks: inserting a reader
+// above an exempt one silently hands it the exemption, which is what the array version did when a
+// `{ tenantId, stage }` reader was added at the top of guardrail-health and the suite stayed green.
+// A marker on the call site moves with the call site.
+const MARKER = /\/\/\s*flowlog-scope:\s*(turn|agent|seeded|tenant-wide)\b/;
+
+// NOTE: the marker is looked for in the comment block IMMEDIATELY above the call — consecutive
+// comment/blank lines and nothing else — so it cannot be inherited from a neighbouring reader's
+// explanation several statements up.
+function markerAbove(source: string, line: number): Scoping | null {
+  const lines = source.split("\n");
+  for (let i = line - 2; i >= 0; i--) {
+    const text = (lines[i] ?? "").trim();
+    if (text === "") continue;
+    if (!text.startsWith("//") && !text.startsWith("*")) return null;
+    const hit = MARKER.exec(text);
+    if (hit) return hit[1] as Scoping;
+  }
+  return null;
+}
+
 // NOTE: written against the delimiters rather than as one regex on purpose. The first version of
 // this scan matched `where` keys with `/(?:^|,|\{)\s*(\w+)\s*[,:}]/g`, which reads correctly and is
 // wrong: `findall` cannot overlap, so the comma that ends one key is consumed and the key after it
@@ -101,9 +125,15 @@ export function flowlogReaders(source: string): Reader[] {
         );
       }
     }
+    const line = source.slice(0, m.index).split("\n").length;
+    // Inside the call OR in the comment block above it. The first is what survives the formatter:
+    // it moved a marker off `await suDb.executionLog.findFirst({` onto the `(` the wrapper opened,
+    // and a marker the formatter can detach is a marker that silently stops applying.
+    const inside = MARKER.exec(args);
     out.push({
-      line: source.slice(0, m.index).split("\n").length,
+      line,
       keys,
+      marker: (inside?.[1] as Scoping | undefined) ?? markerAbove(source, line),
     });
   }
   return out;
@@ -125,26 +155,26 @@ export function isScoped(reader: Reader, scoping: Scoping): boolean {
   return reader.keys.some((k) => allowed.includes(k));
 }
 
-const FLOWLOG_READERS: Record<string, [number, Scoping]> = {
-  "tests/graph/history-ceiling-turn.test.ts": [1, "turn"],
-  "tests/graph/nudge.test.ts": [3, "turn"],
-  "tests/graph/runtime.test.ts": [7, "turn"],
-  "tests/graph/side-effect-flowlog.test.ts": [1, "turn"],
-  "tests/graph/tool-flowlog.test.ts": [1, "turn"],
-  "tests/modules/chatwoot-gate-trail.test.ts": [1, "turn"],
-  "tests/modules/contact-auth-gate-e2e.test.ts": [3, "turn"],
-  "tests/modules/debounce.test.ts": [1, "turn"],
-  "tests/modules/flowlog-astral-detail.test.ts": [1, "turn"],
-  "tests/modules/flowlog-detail-pii.test.ts": [1, "turn"],
-  "tests/modules/flowlog-retention.test.ts": [1, "tenant-wide"],
-  "tests/modules/flowlog.test.ts": [1, "turn"],
-  "tests/modules/guardrail-health.test.ts": [1, "seeded"],
-  "tests/modules/memory-compaction.test.ts": [3, "turn"],
-  "tests/modules/memory-dead-letter.test.ts": [1, "turn"],
-  "tests/modules/playground-guardrails.test.ts": [1, "agent"],
-  "tests/modules/stt.test.ts": [1, "turn"],
-  "tests/modules/tts-normalize-observability.test.ts": [1, "turn"],
-  "tests/modules/tts.test.ts": [2, "turn"],
+const FLOWLOG_READERS: Record<string, number> = {
+  "tests/graph/history-ceiling-turn.test.ts": 1,
+  "tests/graph/nudge.test.ts": 3,
+  "tests/graph/runtime.test.ts": 7,
+  "tests/graph/side-effect-flowlog.test.ts": 1,
+  "tests/graph/tool-flowlog.test.ts": 1,
+  "tests/modules/chatwoot-gate-trail.test.ts": 1,
+  "tests/modules/contact-auth-gate-e2e.test.ts": 3,
+  "tests/modules/debounce.test.ts": 1,
+  "tests/modules/flowlog-astral-detail.test.ts": 1,
+  "tests/modules/flowlog-detail-pii.test.ts": 1,
+  "tests/modules/flowlog-retention.test.ts": 1,
+  "tests/modules/flowlog.test.ts": 1,
+  "tests/modules/guardrail-health.test.ts": 1,
+  "tests/modules/memory-compaction.test.ts": 3,
+  "tests/modules/memory-dead-letter.test.ts": 1,
+  "tests/modules/playground-guardrails.test.ts": 1,
+  "tests/modules/stt.test.ts": 1,
+  "tests/modules/tts-normalize-observability.test.ts": 1,
+  "tests/modules/tts.test.ts": 2,
 };
 
 // Lives beside the rest of the flowlog family rather than in tests/tooling/, which the manifest
@@ -185,6 +215,11 @@ describe("the scan can actually tell a scoped reader from an unscoped one", () =
     await suDb.executionLog.count({
       where: { tenantId, stage: "memory", threadId },
     });`;
+  const MARKED = `
+    const rows = await suDb.executionLog.findMany({
+      // flowlog-scope: tenant-wide — the subject is the table, not one turn.
+      where: { tenantId },
+    });`;
   const BY_AGENT = `
     await suDb.executionLog.findFirst({
       where: { tenantId, agentId },
@@ -222,6 +257,20 @@ describe("the scan can actually tell a scoped reader from an unscoped one", () =
     expect(r ? isScoped(r, "turn") : true).toBe(false);
   });
 
+  test("a marker inside the call declares that reader's exemption", () => {
+    const [r] = flowlogReaders(MARKED);
+    expect(r?.marker).toBe("tenant-wide");
+  });
+
+  test("a marker does not reach the reader after it", () => {
+    // The failure the marker exists to prevent, in miniature. A per-file or per-index exemption
+    // hands itself to whatever is written next; this asserts the second reader is judged on its own.
+    const rs = flowlogReaders(`${MARKED}\n${UNSCOPED}`);
+    expect(rs.length).toBe(2);
+    expect(rs[1]?.marker).toBeNull();
+    expect(rs[1] ? isScoped(rs[1], "turn") : true).toBe(false);
+  });
+
   test("a nested filter object does not leak its inner keys", () => {
     // `path` and `equals` belong to the filter, not to the row, and counting them would let a reader
     // pass by naming a JSON path that happens to spell a scope key.
@@ -236,9 +285,7 @@ describe("every flow-log reader in the suite is accounted for", () => {
     const counts = Object.fromEntries(
       [...found].map(([f, rs]) => [f, rs.length]),
     );
-    const expected = Object.fromEntries(
-      Object.entries(FLOWLOG_READERS).map(([f, [n]]) => [f, n]),
-    );
+    const expected = { ...FLOWLOG_READERS };
     expect(counts).toEqual(expected);
   });
 
@@ -246,10 +293,12 @@ describe("every flow-log reader in the suite is accounted for", () => {
     const found = await scanTests();
     const unscoped: string[] = [];
     for (const [file, readers] of found) {
-      const scoping = FLOWLOG_READERS[file]?.[1] ?? "turn";
-      // `seeded` and `tenant-wide` are the two answers that legitimately have no scope key.
-      if (scoping === "seeded" || scoping === "tenant-wide") continue;
       for (const r of readers) {
+        // `turn` is the default precisely because it is the strict one: a reader that declares
+        // nothing is held to the strictest rule, and the three that are something else say so at
+        // their own call site.
+        const scoping = r.marker ?? "turn";
+        if (scoping === "seeded" || scoping === "tenant-wide") continue;
         if (!isScoped(r, scoping))
           unscoped.push(`${file}:${r.line} { ${r.keys.join(", ")} }`);
       }

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -32,7 +32,12 @@ type Reader = {
 
 // The keys that name the row THIS test produced. `tenantId` is deliberately absent: it is the file's
 // fence, and a reader that has only it is exactly the defect.
-const SCOPE_KEYS = ["conversationId", "threadId", "turnId", "agentId"];
+const TURN_KEYS = ["conversationId", "threadId", "turnId"];
+
+// `agentId` is NOT one of them, and is accepted only where the ledger says the file's tests own an
+// agent each. It names a row's agent, not its turn, so in a file where every test drives the same
+// agent it fences nothing: `{ tenantId, agentId }` is the tenant filter with extra words.
+const AGENT_KEY = "agentId";
 
 /** Index of the closer matching the opener at `from`, or -1. */
 function matchDelimiter(s: string, from: number, open: string, close: string) {
@@ -97,10 +102,6 @@ export function flowlogReaders(source: string): Reader[] {
   return out;
 }
 
-export function isScoped(reader: Reader): boolean {
-  return reader.keys.some((k) => SCOPE_KEYS.includes(k));
-}
-
 //   turn        scoped to the row this test produced, by conversationId / threadId / turnId
 //   agent       scoped to an agent this test owns, where every test in the file shares one tenant
 //               but not one agent (playground-guardrails spells out why at the call site)
@@ -111,10 +112,16 @@ export function isScoped(reader: Reader): boolean {
 //               tenant can say. Safe because the file holds a single test.
 type Scoping = "turn" | "agent" | "seeded" | "tenant-wide";
 
-const FLOWLOG_READERS: Record<string, [number, Scoping | string]> = {
+export function isScoped(reader: Reader, scoping: Scoping): boolean {
+  const allowed =
+    scoping === "agent" ? [...TURN_KEYS, AGENT_KEY] : [...TURN_KEYS];
+  return reader.keys.some((k) => allowed.includes(k));
+}
+
+const FLOWLOG_READERS: Record<string, [number, Scoping]> = {
   "tests/graph/history-ceiling-turn.test.ts": [1, "turn"],
   "tests/graph/nudge.test.ts": [3, "turn"],
-  "tests/graph/runtime.test.ts": [6, "turn"],
+  "tests/graph/runtime.test.ts": [7, "turn"],
   "tests/graph/side-effect-flowlog.test.ts": [1, "turn"],
   "tests/graph/tool-flowlog.test.ts": [1, "turn"],
   "tests/modules/contact-auth-gate-e2e.test.ts": [2, "turn"],
@@ -169,6 +176,10 @@ describe("the scan can actually tell a scoped reader from an unscoped one", () =
     await suDb.executionLog.count({
       where: { tenantId, stage: "memory", threadId },
     });`;
+  const BY_AGENT = `
+    await suDb.executionLog.findFirst({
+      where: { tenantId, agentId },
+    });`;
   const NESTED_FILTER = `
     await suDb.executionLog.findFirst({
       where: { tenantId, detail: { path: ["outcome"], equals: "sent" } },
@@ -177,12 +188,12 @@ describe("the scan can actually tell a scoped reader from an unscoped one", () =
   test("it flags a reader filtered by tenant alone", () => {
     const [r] = flowlogReaders(UNSCOPED);
     expect(r?.keys).toEqual(["tenantId", "stage"]);
-    expect(r ? isScoped(r) : true).toBe(false);
+    expect(r ? isScoped(r, "turn") : true).toBe(false);
   });
 
   test("it accepts one carrying the thread it produced", () => {
     const [r] = flowlogReaders(SCOPED);
-    expect(r ? isScoped(r) : false).toBe(true);
+    expect(r ? isScoped(r, "turn") : false).toBe(true);
   });
 
   test("a shorthand key AFTER a value is still seen", () => {
@@ -190,6 +201,16 @@ describe("the scan can actually tell a scoped reader from an unscoped one", () =
     // keys, and a regex that consumes the separator loses everything after the first pair.
     const [r] = flowlogReaders(SHORTHAND_AFTER_A_VALUE);
     expect(r?.keys).toEqual(["tenantId", "stage", "threadId"]);
+  });
+
+  test("agentId counts only where the ledger says the tests own an agent each", () => {
+    // The hole this closes: accepting `agentId` for every entry let a reader in a file where all 74
+    // tests drive ONE agent pass the guard while still answering with a neighbour's rows. The key is
+    // sufficient in playground-guardrails and nowhere else, so the ledger decides, not the key.
+    const [r] = flowlogReaders(BY_AGENT);
+    expect(r?.keys).toEqual(["tenantId", "agentId"]);
+    expect(r ? isScoped(r, "agent") : false).toBe(true);
+    expect(r ? isScoped(r, "turn") : true).toBe(false);
   });
 
   test("a nested filter object does not leak its inner keys", () => {
@@ -216,11 +237,11 @@ describe("every flow-log reader in the suite is accounted for", () => {
     const found = await scanTests();
     const unscoped: string[] = [];
     for (const [file, readers] of found) {
-      const scoping = FLOWLOG_READERS[file]?.[1];
+      const scoping = FLOWLOG_READERS[file]?.[1] ?? "turn";
       // `seeded` and `tenant-wide` are the two answers that legitimately have no scope key.
       if (scoping === "seeded" || scoping === "tenant-wide") continue;
       for (const r of readers) {
-        if (!isScoped(r))
+        if (!isScoped(r, scoping))
           unscoped.push(`${file}:${r.line} { ${r.keys.join(", ")} }`);
       }
     }

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "bun:test";
+
+// EVERY TEST THAT READS THE FLOW LOG, AND WHAT SCOPES IT.
+//
+// `emitFlowEvent` is fire-and-forget by design (src/modules/flowlog/service.ts): the hot WhatsApp
+// path must not pay write latency for six log lines. A test that asserts on those lines therefore
+// has two obligations, and the readers honoured them unevenly (issue #258).
+//
+//   SCOPE  a reader filtered only by `tenantId` returns rows of whatever else ran in the file. Every
+//          DB-backed test file seeds ONE tenant (`slug: <prefix>-${process.pid}`), so the tenant
+//          fences the FILE and nothing inside it: the neighbour a reader answers with is another
+//          test of the same file, never another file.
+//   WAIT   even a correctly scoped reader can run before the row lands, because nothing awaits the
+//          write.
+//
+// This file guards the first obligation only, and says so rather than implying a clean bill of
+// health. The second cannot be read off the source: "is there a wait" is a question about control
+// flow, and a poll loop is only correct when the assertion is that a line EXISTS — polling for an
+// absence just spends the timeout before answering. Those live as comments at the call sites.
+//
+// The ledger is per file with a count, following tests/lib/storable-write-sweep.test.ts: a NEW
+// reader in an already-listed file trips this too, not only a new file. The classification is the
+// point of the ledger. `tenant-wide` is a real answer for a reader whose subject is the TABLE rather
+// than one turn's trail, and it is written down so it stays a decision instead of an omission.
+
+type Reader = {
+  /** 1-indexed line of the `executionLog.<method>(` that opens the call. */
+  line: number;
+  /** Top-level keys of the call's `where: { ... }`, in source order. */
+  keys: string[];
+};
+
+// The keys that name the row THIS test produced. `tenantId` is deliberately absent: it is the file's
+// fence, and a reader that has only it is exactly the defect.
+const SCOPE_KEYS = ["conversationId", "threadId", "turnId", "agentId"];
+
+/** Index of the closer matching the opener at `from`, or -1. */
+function matchDelimiter(s: string, from: number, open: string, close: string) {
+  let depth = 0;
+  for (let i = from; i < s.length; i++) {
+    if (s[i] === open) depth += 1;
+    else if (s[i] === close) {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** Top-level (depth-0) comma split, so a nested object or template literal stays one part. */
+function splitTopLevel(s: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let cur = "";
+  for (const ch of s) {
+    if (ch === "{" || ch === "[" || ch === "(") depth += 1;
+    else if (ch === "}" || ch === "]" || ch === ")") depth -= 1;
+    if (ch === "," && depth === 0) {
+      parts.push(cur);
+      cur = "";
+    } else cur += ch;
+  }
+  parts.push(cur);
+  return parts.map((p) => p.trim()).filter(Boolean);
+}
+
+// NOTE: written against the delimiters rather than as one regex on purpose. The first version of
+// this scan matched `where` keys with `/(?:^|,|\{)\s*(\w+)\s*[,:}]/g`, which reads correctly and is
+// wrong: `findall` cannot overlap, so the comma that ends one key is consumed and the key after it
+// never matches. It reported `{ tenantId, stage, threadId }` as `[tenantId]` and put 21 readers on
+// the list instead of 9 — a scan that is generous in the direction that creates work nobody needs.
+export function flowlogReaders(source: string): Reader[] {
+  const out: Reader[] = [];
+  const call =
+    /executionLog\.(?:findMany|findFirst|findFirstOrThrow|findUnique|findUniqueOrThrow|count|aggregate|groupBy)\s*\(/g;
+  for (const m of source.matchAll(call)) {
+    const open = m.index + m[0].length - 1;
+    const close = matchDelimiter(source, open, "(", ")");
+    if (close < 0) continue;
+    const args = source.slice(open, close + 1);
+    const where = /where\s*:\s*\{/.exec(args);
+    let keys: string[] = [];
+    if (where) {
+      const braceOpen = where.index + where[0].length - 1;
+      const braceClose = matchDelimiter(args, braceOpen, "{", "}");
+      if (braceClose > 0) {
+        keys = splitTopLevel(args.slice(braceOpen + 1, braceClose)).map((p) =>
+          (p.split(":")[0] ?? "").trim(),
+        );
+      }
+    }
+    out.push({
+      line: source.slice(0, m.index).split("\n").length,
+      keys,
+    });
+  }
+  return out;
+}
+
+export function isScoped(reader: Reader): boolean {
+  return reader.keys.some((k) => SCOPE_KEYS.includes(k));
+}
+
+//   turn        scoped to the row this test produced, by conversationId / threadId / turnId
+//   agent       scoped to an agent this test owns, where every test in the file shares one tenant
+//               but not one agent (playground-guardrails spells out why at the call site)
+//   seeded      reads rows the test itself INSERTED with `executionLog.create`, awaited: there is no
+//               emit in the path, so neither obligation applies
+//   tenant-wide the subject is the table, not a turn. Scoping would defeat the assertion: the
+//               retention sweep proves WHICH rows survived it, which only an exhaustive read of the
+//               tenant can say. Safe because the file holds a single test.
+type Scoping = "turn" | "agent" | "seeded" | "tenant-wide";
+
+const FLOWLOG_READERS: Record<string, [number, Scoping | string]> = {
+  "tests/graph/history-ceiling-turn.test.ts": [1, "turn"],
+  "tests/graph/nudge.test.ts": [3, "turn"],
+  "tests/graph/runtime.test.ts": [6, "turn"],
+  "tests/graph/side-effect-flowlog.test.ts": [1, "turn"],
+  "tests/graph/tool-flowlog.test.ts": [1, "turn"],
+  "tests/modules/contact-auth-gate-e2e.test.ts": [2, "turn"],
+  "tests/modules/flowlog-astral-detail.test.ts": [1, "turn"],
+  "tests/modules/flowlog-detail-pii.test.ts": [1, "turn"],
+  "tests/modules/flowlog-retention.test.ts": [1, "tenant-wide"],
+  "tests/modules/flowlog.test.ts": [1, "turn"],
+  "tests/modules/guardrail-health.test.ts": [1, "seeded"],
+  "tests/modules/memory-compaction.test.ts": [3, "turn"],
+  "tests/modules/memory-dead-letter.test.ts": [1, "turn"],
+  "tests/modules/playground-guardrails.test.ts": [1, "agent"],
+  "tests/modules/stt.test.ts": [1, "turn"],
+  "tests/modules/tts-normalize-observability.test.ts": [1, "turn"],
+  "tests/modules/tts.test.ts": [2, "turn"],
+};
+
+// Lives beside the rest of the flowlog family rather than in tests/tooling/, which the manifest
+// drops from BOTH derived repos: a guard that does not exist in the public tree cannot stop the next
+// unscoped reader from being written there.
+//
+// The one file the scan skips, because its fixtures below are unscoped reads written on purpose.
+const SELF = "tests/modules/flowlog-reader-scope.test.ts";
+
+async function scanTests(): Promise<Map<string, Reader[]>> {
+  const { Glob } = await import("bun");
+  const found = new Map<string, Reader[]>();
+  for await (const rel of new Glob("**/*.{ts,tsx}").scan("tests")) {
+    const path = `tests/${rel}`;
+    if (path === SELF) continue;
+    const readers = flowlogReaders(await Bun.file(path).text());
+    if (readers.length > 0) found.set(path, readers);
+  }
+  return found;
+}
+
+// The positive control, and the reason it is not optional: a sweep that finds nothing passes exactly
+// like a sweep that finds everything, so without an offender the parser could return `[]` for every
+// file and this suite would stay green while guarding nothing (#266). These fixtures are the
+// offender, held as strings so the scan above cannot see them.
+describe("the scan can actually tell a scoped reader from an unscoped one", () => {
+  const UNSCOPED = `
+    const rows = await suDb.executionLog.findMany({
+      where: { tenantId, stage: "generate" },
+      select: { detail: true },
+    });`;
+  const SCOPED = `
+    const rows = await suDb.executionLog.findMany({
+      where: { tenantId, stage: "generate", threadId },
+      select: { detail: true },
+    });`;
+  const SHORTHAND_AFTER_A_VALUE = `
+    await suDb.executionLog.count({
+      where: { tenantId, stage: "memory", threadId },
+    });`;
+  const NESTED_FILTER = `
+    await suDb.executionLog.findFirst({
+      where: { tenantId, detail: { path: ["outcome"], equals: "sent" } },
+    });`;
+
+  test("it flags a reader filtered by tenant alone", () => {
+    const [r] = flowlogReaders(UNSCOPED);
+    expect(r?.keys).toEqual(["tenantId", "stage"]);
+    expect(r ? isScoped(r) : true).toBe(false);
+  });
+
+  test("it accepts one carrying the thread it produced", () => {
+    const [r] = flowlogReaders(SCOPED);
+    expect(r ? isScoped(r) : false).toBe(true);
+  });
+
+  test("a shorthand key AFTER a value is still seen", () => {
+    // The bug the first version of this parser had, pinned: `stage: "memory"` sits between the two
+    // keys, and a regex that consumes the separator loses everything after the first pair.
+    const [r] = flowlogReaders(SHORTHAND_AFTER_A_VALUE);
+    expect(r?.keys).toEqual(["tenantId", "stage", "threadId"]);
+  });
+
+  test("a nested filter object does not leak its inner keys", () => {
+    // `path` and `equals` belong to the filter, not to the row, and counting them would let a reader
+    // pass by naming a JSON path that happens to spell a scope key.
+    const [r] = flowlogReaders(NESTED_FILTER);
+    expect(r?.keys).toEqual(["tenantId", "detail"]);
+  });
+});
+
+describe("every flow-log reader in the suite is accounted for", () => {
+  test("the file list and the per-file counts still match", async () => {
+    const found = await scanTests();
+    const counts = Object.fromEntries(
+      [...found].map(([f, rs]) => [f, rs.length]),
+    );
+    const expected = Object.fromEntries(
+      Object.entries(FLOWLOG_READERS).map(([f, [n]]) => [f, n]),
+    );
+    expect(counts).toEqual(expected);
+  });
+
+  test("each one is scoped to what the test produced, or listed as not being", async () => {
+    const found = await scanTests();
+    const unscoped: string[] = [];
+    for (const [file, readers] of found) {
+      const scoping = FLOWLOG_READERS[file]?.[1];
+      // `seeded` and `tenant-wide` are the two answers that legitimately have no scope key.
+      if (scoping === "seeded" || scoping === "tenant-wide") continue;
+      for (const r of readers) {
+        if (!isScoped(r))
+          unscoped.push(`${file}:${r.line} { ${r.keys.join(", ")} }`);
+      }
+    }
+    expect(unscoped).toEqual([]);
+  });
+});

--- a/tests/modules/flowlog-retention.test.ts
+++ b/tests/modules/flowlog-retention.test.ts
@@ -89,6 +89,8 @@ describe.skipIf(!dbUp)("flowlog retention", () => {
     if (result.outcome === "reschedule") {
       expect(result.runAt.getTime()).toBeGreaterThan(Date.now() + 60_000);
     }
+    // flowlog-scope: tenant-wide — the assertion is WHICH rows survived the sweep, so it has to
+    // read the tenant exhaustively; a scoped read could not say that old1/old2 are gone.
     const remaining = await suDb.executionLog.findMany({
       where: { tenantId },
       select: { turnId: true },

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -334,6 +334,8 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
       },
       select: { id: true },
     });
+    // flowlog-scope: seeded — reads the row this test inserted above with `create`, awaited. No
+    // emit in the path, so neither the scope nor the wait obligation applies.
     const newer = await suDb.executionLog.findFirst({
       where: { tenantId: tenantA, turnId: "g6" },
       select: { id: true },

--- a/tests/modules/playground-guardrails.test.ts
+++ b/tests/modules/playground-guardrails.test.ts
@@ -401,6 +401,8 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     for (let i = 0; i < 50 && !detail; i++) {
       detail = (
         await suDb.executionLog.findFirst({
+          // flowlog-scope: agent — every test here shares the tenant but owns its agent, which is
+          // what fences this read (the note above says which neighbour it would otherwise take).
           where: {
             tenantId,
             agentId: agentDeadCredential,


### PR DESCRIPTION
## What was wrong

`emitFlowEvent` is fire-and-forget by design, so a test asserting on the lines it writes owes two things: a filter naming the row **this** test produced, and a wait for it to land. The readers honoured them unevenly.

**One correction to the issue's framing, and it narrows the work.** Every DB-backed file seeds its own tenant (`slug: <prefix>-${process.pid}`), so the tenant fences the *file* and nothing inside it. The neighbour a reader can answer with is always another test of the same file, never another file. That takes the sweep from "28 readers" down to the nine carrying no key of their own, plus the two that read a fire-and-forget row without waiting.

### The one that was live

`tests/graph/history-ceiling-turn.test.ts` shares its trail reader between two tests with opposite assertions: one runs a thread *without* a ceiling and asserts **no** trim line exists, the other runs one *with* a ceiling and asserts some do. Read across the tenant, the negative assertion is a claim about its neighbour. Swapping the two `test()` blocks:

```
expect(await trimLines()).toHaveLength(0);
error: expect(received).toHaveLength(expected)
Expected length: 0
Received length: 2
```

The green depended on declaration order. It also polled 30 rounds × 100ms for a line that must never arrive, so 3 of the file's 4 seconds were one test waiting out a timeout to confirm an absence it already had the rows to prove. **3.99s → 0.80s** for the file, and both tests pass in either order.

That file also turned out to need two readers rather than one, which only measuring showed: a trimmed turn writes **two** `generate`/`info` rows, its ordinary one and a separate one for the trim. Probed — the no-ceiling thread produces 6 rows and 0 trims, the ceiling thread 8 and 2 — so a single reader waiting on the total count is satisfied by the six ordinary rows while both trim writes are still in flight. The presence question polls for a trim; the absence question waits on the non-trim count and reads.

### The others

Measured, not assumed. For each remaining unscoped reader I excluded that test's own thread from the filter and re-ran: all four went red, so **no neighbour satisfies them today**. Latent, not live, and worth saying plainly rather than implying a fleet of live flakes.

The document-template reader in `runtime.test.ts` had neither obligation, and its missing wait is the one the issue already charges to a CI failure on an unrelated PR. `handoffDetail` was scoped in #123 but never waited: `findFirstOrThrow` on a row that has not landed does not answer wrong, it throws, so the scoping had converted a silent wrong answer into a spurious failure.

### Absences need a barrier, and neither had one

Both negative assertions were asserting into a race. The handoff one is the sharper case, because it is the test that proves the scoping works: it only detects an unscoped reader if there is a neighbouring row for one to wrongly return, and that row is written fire-and-forget, so its `null` could equally mean nothing had landed yet. It now waits for the neighbour's row first — the control is positive before the absence is read — and reads 8804 once, awaited. It had also been written without `await`, which was harmless while the reader was a single query and became a 3-second query loop running into later tests once it polled.

The trim absence has no barrier available, so it composes the two that exist: a turn's ordinary row is dispatched after any trim row of the same turn, so six ordinary rows means every trim write was dispatched, and a settle re-read covers two transactions landing out of order on a pool. Neither is a lock and the comment says so, which is acceptable because the regression both corroborate is caught deterministically an assertion earlier — anything dropped means the model no longer saw all 12 messages.

### Left alone, on purpose

Three readers legitimately carry no turn scope, and each says so at its own call site:

| reader | why |
| --- | --- |
| `flowlog-retention` | its subject is **which** rows survived the sweep, which no scoped read can answer; the file holds one test |
| `guardrail-health` | reads rows it inserted itself with `executionLog.create`, awaited — no emit in the path |
| `playground-guardrails` | scoped to the one agent its single test owns |

## The guard

A source scan over `tests/`, plus a per-file ledger of counts following `tests/lib/storable-write-sweep.test.ts`, so a **new reader in an already-listed file** trips it too and not only a new file. `turn` is the default because it is the strict rule; the exemptions are `// flowlog-scope:` markers at the call sites.

**The exemption lives at the reader, and getting there took two wrong shapes.** Per *file* was the first: it skipped validation for every reader in that file, so adding a `{ tenantId, stage }` reader to `guardrail-health` and bumping the count left the suite green with no scoping decision made at all. Per *index* was the second and worse: inserting a reader **above** the exempt one hands it the exemption, and the same mutation stayed green again. Position is not identity. The marker is read inside the call as well as in the comment block above it, because the formatter detached one — it lifted a marker off `executionLog.findFirst({` onto the `(` of the wrapper around it, and a marker the formatter can separate is one that silently stops applying.

Six fixtures give the scan a positive control, since a sweep that finds nothing passes exactly like one that finds everything. One pins a bug the first version of the parser actually had: a regex over `where` keys cannot overlap its own separators, so it read `{ tenantId, stage, threadId }` as `[tenantId]` and put 21 readers on the list instead of 9.

**The cost, recorded in the file rather than discovered later.** A ledger over the whole test tree means any branch adding a reader anywhere has to touch this list, and finds out from this test instead of from review. That already happened once inside this PR: #274 landed three new readers mid-review and this guard is what caught the drift, which no file-level intersection check would have.

## Validation scope

**Proven by test.** Both obligations at every reader the ledger accounts for. The live defect proven twice: the reordering that turns the file red before the change, and the same reordering staying green after. Every guard property mutation-proven — removing a reader's scope key names it, adding a reader to a listed file fails count and scope together, reclassifying the agent-scoped reader as `turn` flags it, and the exemption-leak mutation that passed under both earlier shapes now fails by name. Full suite green (5233 pass / 0 fail) against a real Postgres, `check:editions` green on both derived trees.

**Not validated.** The guard covers **scope only**. "Is there a wait" is a question about control flow that no source scan answers honestly, and a poll loop is only correct when the assertion is that a line *exists*. Those decisions live as comments at the call sites and nothing enforces them.

**The wait defects are reproduced, not just reasoned about.** Deferring the `emitFlowEvent` write by a fixed amount (a temporary local patch, never committed) makes the race deterministic, and the margin turns out to be tiny:

| reader, as it stood before this PR | write deferred one event-loop turn | +5ms | +600ms |
| --- | --- | --- | --- |
| document-template (`{ tenantId, stage: "tool" }`, no retry) | pass | **fail** | **fail** |
| `handoffDetail` (`findFirstOrThrow`, no retry) | **fail** | **fail** | **fail** |

The handoff reader loses on a single event-loop turn of deferral, which is what a ~1-in-4 CI failure looks like from the inside; the control confirms it passes 5/5 with the patch removed. The document-template reader had under 5ms of slack. Both readers as they stand in this PR pass at +600ms.

The four latent readers are measured latent **today**, against this tree. That is a statement about the current predicates, not a guarantee: a test added tomorrow whose row satisfies one of them would have made it live, which is the reason to scope them now rather than when it happens.

One edge the ledger has that `storable-write-sweep` does not: an entry in a test file the derivation drops from an edition would be red there and green here. All 17 listed files survive into both trees today, and that is checked by hand, not by this test.

Fixes #258
