### PR TITLE
Take the playground's tenant from the request, not an id rebuilt from it

### DIFF
--- a/docs/playground.md
+++ b/docs/playground.md
@@ -44,6 +44,8 @@ Every turn the guardrail RAN on gets one, the clean verdicts included: the toggl
 
 The checkpointer is outside RLS, so the thread id is the tenant fence. Playground threads are `tenantId:playground:agentId:uuid`. A client-supplied `threadId` is honored **only** if it matches that exact shape for this tenant+agent; anything else (e.g. a real conversation's `tenantId:instanceId:convId`, or another agent's thread) is rejected and a fresh thread is generated. This stops a caller from reading another conversation's checkpointer history through the playground. Multi-turn memory works because the client holds the returned `threadId` across turns; Reset starts a new session.
 
+The database side is the request's own `TenantContext`, passed all the way down rather than an id lifted out of it. That is what makes the unknown-tenant check at `runScopedOn` apply here too: it is keyed on the caller's ROLE, so a fleet operator whose stored selection names a tenant that is gone gets a 404 naming the selector instead of an empty session list, and a tenant-scoped operator pays no extra statement. No module under `src/modules/playground/` builds a context of its own.
+
 ## REST + UI
 
 `POST /v1/agents/:id/playground { message, threadId? } → { reply, threadId, trace, sources }` (TENANT_ADMIN). The agent editor's **Playground** tab (`PlaygroundTab`) is a chat panel (Enter to send, Reset to restart) that holds the `threadId` in a ref; each agent reply is expandable into its `trace` + grounding `sources` (collapsible `<details>`). Tenant scoping is the `tenancyPlugin`; the thread fence is in the service.

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -721,7 +721,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         ...(await runPlaygroundTurn({
-          tenantId: ctx.tenantId as bigint,
+          ctx,
           agentId: BigInt(params.id),
           message: b.message,
           threadId: b.threadId,
@@ -755,7 +755,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         tools: await listPlaygroundTools({
-          tenantId: ctx.tenantId as bigint,
+          ctx,
           agentId: BigInt(params.id),
         }),
       };
@@ -789,7 +789,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         ...(await runPlaygroundFollowup({
-          tenantId: ctx.tenantId as bigint,
+          ctx,
           agentId: BigInt(params.id),
           threadId: b.threadId,
           context: b.context,
@@ -824,7 +824,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         ...(await runPlaygroundTranscribe({
-          tenantId: ctx.tenantId as bigint,
+          ctx,
           agentId: BigInt(params.id),
           file: b.file,
           overrides: parseDraft(b.draft),
@@ -875,7 +875,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         ...(await runPlaygroundAudioTurn({
-          tenantId: ctx.tenantId as bigint,
+          ctx,
           agentId: BigInt(params.id),
           file: b.file,
           threadId: b.threadId,
@@ -945,7 +945,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         ...(await runPlaygroundExtract({
-          tenantId: ctx.tenantId as bigint,
+          ctx,
           agentId: BigInt(params.id),
           file: b.file,
           overrides: parseDraft(b.draft),
@@ -997,7 +997,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         ...(await runPlaygroundFileTurn({
-          tenantId: ctx.tenantId as bigint,
+          ctx,
           agentId: BigInt(params.id),
           file: b.file,
           threadId: b.threadId,
@@ -1074,7 +1074,7 @@ export const agentsController = new Elysia({
         set.status = 404;
         return { error: "Not Found" };
       }
-      const blob = await getPlaygroundMedia(ctx.tenantId as bigint, mediaId);
+      const blob = await getPlaygroundMedia(ctx, mediaId);
       if (!blob) {
         set.status = 404;
         return { error: "Not Found" };
@@ -1110,10 +1110,7 @@ export const agentsController = new Elysia({
       const ctx = ctxOrThrow(tenantContext);
       return {
         instance: instanceIdentity,
-        sessions: await listPlaygroundSessions(
-          ctx.tenantId as bigint,
-          BigInt(params.id),
-        ),
+        sessions: await listPlaygroundSessions(ctx, BigInt(params.id)),
       };
     },
     {
@@ -1137,7 +1134,7 @@ export const agentsController = new Elysia({
       return {
         instance: instanceIdentity,
         turns: await getPlaygroundSessionTurns(
-          ctx.tenantId as bigint,
+          ctx,
           BigInt(params.id),
           params.threadId,
         ),
@@ -1165,11 +1162,7 @@ export const agentsController = new Elysia({
     "/:id/playground/sessions/:threadId",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      await deletePlaygroundSession(
-        ctx.tenantId as bigint,
-        BigInt(params.id),
-        params.threadId,
-      );
+      await deletePlaygroundSession(ctx, BigInt(params.id), params.threadId);
       return { instance: instanceIdentity, ok: true };
     },
     {

--- a/src/modules/mcp/server.ts
+++ b/src/modules/mcp/server.ts
@@ -486,7 +486,11 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
         eff,
       ) => {
         try {
-          const tenantId = eff.tenantId as bigint;
+          // The principal's OWN context, not an id rebuilt from it. A fleet token resolved its
+          // `tenant` selector on the way in (tenant-target.ts) and keeps SUPER_ADMIN, so the scoped
+          // boundary verifies the target once more and a tenant deleted between the two answers a
+          // refusal rather than an empty playground. Issue #268.
+          const ctx = principalCtx(eff);
           // Same parser as every other id: a padded or empty agent_id must not resolve to some
           // other agent's row.
           const parsedAgent = parseMcpId(args.agent_id, "agent_id");
@@ -506,7 +510,7 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
             const file = await mcpAttachmentToFile(args.attachment);
             res = isAudioMime(file.type)
               ? await runPlaygroundAudioTurn({
-                  tenantId,
+                  ctx,
                   agentId,
                   file,
                   threadId,
@@ -514,7 +518,7 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
                   guardrails,
                 })
               : await runPlaygroundFileTurn({
-                  tenantId,
+                  ctx,
                   agentId,
                   file,
                   threadId,
@@ -523,7 +527,7 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
                 });
           } else if (args.message?.trim()) {
             res = await runPlaygroundTurn({
-              tenantId,
+              ctx,
               agentId,
               message: args.message,
               threadId,

--- a/src/modules/playground/media.ts
+++ b/src/modules/playground/media.ts
@@ -8,17 +8,13 @@ import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 // belongs to. A per-tenant retention cap bounds storage (the playground is a test surface, not an
 // archive). All best-effort: a media-write hiccup must never break a turn.
 
-function sysCtx(tenantId: bigint): TenantContext {
-  return { tenantId, userId: null, role: "TENANT_ADMIN" };
-}
-
 export type PlaygroundMediaKind = "user_audio" | "tts_audio" | "user_file";
 
 // Keep at most this many media rows per tenant; older ones are pruned on each save.
 const MEDIA_RETENTION_PER_TENANT = 200;
 
 export interface SaveMediaParams {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   threadId: string;
   messageId: string;
@@ -35,10 +31,10 @@ export async function savePlaygroundMedia(
   params: SaveMediaParams,
 ): Promise<string | null> {
   try {
-    return await runScopedOn(base, sysCtx(params.tenantId), async (db) => {
+    return await runScopedOn(base, params.ctx, async (db) => {
       const row = await db.playgroundMedia.create({
         data: {
-          tenantId: params.tenantId,
+          tenantId: params.ctx.tenantId as bigint,
           agentId: params.agentId,
           threadId: params.threadId,
           messageId: params.messageId,
@@ -65,7 +61,7 @@ export async function savePlaygroundMedia(
           logger.info(
             "playground: pruned %d media rows past the retention cap (tenant=%s)",
             pruned.count,
-            String(params.tenantId),
+            String(params.ctx.tenantId),
           );
         }
       }
@@ -91,11 +87,11 @@ export interface MediaMeta {
 
 // Lists a thread's media (NO bytes) for joining onto reconstructed turns.
 export async function listThreadMedia(
-  tenantId: bigint,
+  ctx: TenantContext,
   threadId: string,
   base: PrismaClient = basePrisma,
 ): Promise<MediaMeta[]> {
-  const rows = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const rows = await runScopedOn(base, ctx, (db) =>
     db.playgroundMedia.findMany({
       where: { threadId },
       orderBy: { id: "asc" },
@@ -125,11 +121,11 @@ export interface MediaBlob {
 
 // Fetches one media blob by id (tenant-scoped). Null when absent / not this tenant's.
 export async function getPlaygroundMedia(
-  tenantId: bigint,
+  ctx: TenantContext,
   mediaId: bigint,
   base: PrismaClient = basePrisma,
 ): Promise<MediaBlob | null> {
-  const row = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const row = await runScopedOn(base, ctx, (db) =>
     db.playgroundMedia.findUnique({
       where: { id: mediaId },
       select: { mime: true, fileName: true, bytes: true },

--- a/src/modules/playground/service.ts
+++ b/src/modules/playground/service.ts
@@ -120,10 +120,6 @@ async function lastRenderedMessageId(
   }
 }
 
-function sysCtx(tenantId: bigint): TenantContext {
-  return { tenantId, userId: null, role: "TENANT_ADMIN" };
-}
-
 export interface PlaygroundDeps {
   makeModel?: (cfg: ResolvedModelConfig) => BaseChatModel;
   checkpointer?: BaseCheckpointSaver;
@@ -134,7 +130,12 @@ export interface PlaygroundDeps {
 }
 
 export interface PlaygroundTurnParams {
-  tenantId: bigint;
+  // The REQUEST's context, not an id lifted out of it, and every playground entry point takes the
+  // same. `runScopedOn` verifies an unknown tenant only for a SUPER_ADMIN caller, because the role
+  // is what separates an id that came from outside the process from one it read from a row: this
+  // module used to rebuild a TENANT_ADMIN context here, which told that check the id was internal
+  // and turned a dead console selection into an empty playground instead of a refusal (issue #268).
+  ctx: TenantContext;
   agentId: bigint;
   message: string;
   threadId?: string;
@@ -215,14 +216,15 @@ export function applyToolMocks(
 // vars come from `overrides.promptVars` when the operator simulates them. Throws the same
 // not-runnable errors as the turn path (agent missing vs no model credential).
 async function loadPlaygroundConfig(params: {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   threadId: string;
   base: PrismaClient;
   overrides?: AgentConfigOverrides;
 }): Promise<AgentConfig> {
-  const { tenantId, agentId, threadId, base } = params;
-  const loaded = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const { ctx, agentId, threadId, base } = params;
+  const tenantId = ctx.tenantId as bigint;
+  const loaded = await runScopedOn(base, ctx, (db) =>
     loadAgentConfig(
       db,
       { tenantId, instanceId: 0n, conversationId: 0, agentId, threadId },
@@ -231,7 +233,7 @@ async function loadPlaygroundConfig(params: {
   );
   if (!loaded) {
     // Agent missing OR no model credential configured — distinguish the two for the operator.
-    const exists = await runScopedOn(base, sysCtx(tenantId), (db) =>
+    const exists = await runScopedOn(base, ctx, (db) =>
       db.agent.findUnique({ where: { id: agentId }, select: { id: true } }),
     );
     if (!exists)
@@ -251,7 +253,7 @@ async function loadPlaygroundConfig(params: {
 function buildPlaygroundToolset(
   loaded: AgentConfig,
   params: {
-    tenantId: bigint;
+    ctx: TenantContext;
     threadId: string;
     base: PrismaClient;
     deps?: PlaygroundDeps;
@@ -260,7 +262,7 @@ function buildPlaygroundToolset(
   return buildToolset(
     loaded,
     {
-      tenantId: params.tenantId,
+      tenantId: params.ctx.tenantId as bigint,
       instanceId: 0n,
       base: params.base,
       client: {} as ChatwootClient,
@@ -286,7 +288,7 @@ function buildPlaygroundToolset(
 // toolset, applies the operator's `toolMocks` over the result, then the model+graph and tracing
 // callbacks. Returns `traceLabels` so callers can tag mocked/simulated results in the trace.
 async function buildPlaygroundGraph(params: {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   threadId: string;
   base: PrismaClient;
@@ -303,16 +305,17 @@ async function buildPlaygroundGraph(params: {
     tokens: number;
   }) => void;
 }) {
-  const { tenantId, agentId, threadId, base } = params;
+  const { ctx, agentId, threadId, base } = params;
+  const tenantId = ctx.tenantId as bigint;
   const loaded = await loadPlaygroundConfig({
-    tenantId,
+    ctx,
     agentId,
     threadId,
     base,
     overrides: params.overrides,
   });
   const rawTools = await buildPlaygroundToolset(loaded, {
-    tenantId,
+    ctx,
     threadId,
     base,
     deps: params.deps,
@@ -375,21 +378,24 @@ export interface PlaygroundToolInfo {
 // then classifies each tool by the loaded grant name-sets. MCP is best-effort (same network a turn
 // does); a failed MCP load just omits those tools, like a turn.
 export async function listPlaygroundTools(params: {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   base?: PrismaClient;
   deps?: PlaygroundDeps;
 }): Promise<PlaygroundToolInfo[]> {
   const base = params.base ?? basePrisma;
-  const threadId = newPlaygroundThreadId(params.tenantId, params.agentId);
+  const threadId = newPlaygroundThreadId(
+    params.ctx.tenantId as bigint,
+    params.agentId,
+  );
   const loaded = await loadPlaygroundConfig({
-    tenantId: params.tenantId,
+    ctx: params.ctx,
     agentId: params.agentId,
     threadId,
     base,
   });
   const tools = await buildPlaygroundToolset(loaded, {
-    tenantId: params.tenantId,
+    ctx: params.ctx,
     threadId,
     base,
     deps: params.deps,
@@ -444,7 +450,8 @@ function lastAiMessageId(messages: unknown[]): string | undefined {
 export async function runPlaygroundTurn(
   params: PlaygroundTurnParams,
 ): Promise<PlaygroundTurnResult> {
-  const { tenantId, agentId, message } = params;
+  const { ctx, agentId, message } = params;
+  const tenantId = ctx.tenantId as bigint;
   const base = params.base ?? basePrisma;
   const text = message.trim();
   if (!text) throw new AppError("empty message", 400, "errors.emptyMessage");
@@ -470,7 +477,7 @@ export async function runPlaygroundTurn(
   };
   const { graph, callbacks, loaded, tools, traceLabels } =
     await buildPlaygroundGraph({
-      tenantId,
+      ctx,
       agentId,
       threadId,
       base,
@@ -511,7 +518,7 @@ export async function runPlaygroundTurn(
   const saveInboundMedia = async (): Promise<string | undefined> =>
     params.userMedia
       ? ((await savePlaygroundMedia(base, {
-          tenantId,
+          ctx,
           agentId,
           threadId,
           messageId: humanId,
@@ -546,7 +553,7 @@ export async function runPlaygroundTurn(
     const blockedReply = screenedText(inGuard, text) ?? "";
     await upsertPlaygroundSession(
       base,
-      tenantId,
+      ctx,
       agentId,
       threadId,
       params.titleHint ?? text,
@@ -556,7 +563,7 @@ export async function runPlaygroundTurn(
     // SHOWS (see lastRenderedMessageId), which is not always what the thread ends on.
     const blockedMediaId = await saveInboundMedia();
     await savePlaygroundTurnNote(base, {
-      tenantId,
+      ctx,
       agentId,
       threadId,
       messageId: null,
@@ -624,7 +631,7 @@ export async function runPlaygroundTurn(
   ];
   await upsertPlaygroundSession(
     base,
-    tenantId,
+    ctx,
     agentId,
     threadId,
     params.titleHint ?? text,
@@ -644,7 +651,7 @@ export async function runPlaygroundTurn(
   // surface one operator drives.
   if (gTrace.length > 0) {
     await savePlaygroundTurnNote(base, {
-      tenantId,
+      ctx,
       agentId,
       threadId,
       messageId: lastAiMessageId(result.messages) ?? null,
@@ -704,7 +711,7 @@ export async function runPlaygroundTurn(
       if (tts && aiId) {
         ttsMediaId =
           (await savePlaygroundMedia(base, {
-            tenantId,
+            ctx,
             agentId,
             threadId,
             messageId: aiId,
@@ -734,7 +741,7 @@ export async function runPlaygroundTurn(
 }
 
 export interface PlaygroundFollowupParams {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   threadId?: string;
   // Optional operator-supplied situation note; overrides the default "inactive for ~N min" summary.
@@ -768,7 +775,8 @@ export interface PlaygroundFollowupResult {
 export async function runPlaygroundFollowup(
   params: PlaygroundFollowupParams,
 ): Promise<PlaygroundFollowupResult> {
-  const { tenantId, agentId } = params;
+  const { ctx, agentId } = params;
+  const tenantId = ctx.tenantId as bigint;
   const base = params.base ?? basePrisma;
 
   const threadId =
@@ -792,7 +800,7 @@ export async function runPlaygroundFollowup(
   };
   const { graph, callbacks, loaded, tools, traceLabels } =
     await buildPlaygroundGraph({
-      tenantId,
+      ctx,
       agentId,
       threadId,
       base,
@@ -821,7 +829,7 @@ export async function runPlaygroundFollowup(
 
   // Draft settings (if present) drive the follow-up instructions/delay so the simulation matches
   // what the operator is editing live; otherwise the saved settings.
-  const agent = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const agent = await runScopedOn(base, ctx, (db) =>
     db.agent.findUnique({ where: { id: agentId }, select: { settings: true } }),
   );
   const settings = params.overrides?.settings ?? agent?.settings;
@@ -905,7 +913,7 @@ export async function runPlaygroundFollowup(
   ];
   if (gTrace.length > 0) {
     await savePlaygroundTurnNote(base, {
-      tenantId,
+      ctx,
       agentId,
       threadId,
       messageId: lastAiMessageId(result.messages) ?? null,
@@ -920,7 +928,7 @@ export async function runPlaygroundFollowup(
     });
   }
   // Bump the session (or create one titled by the first message if the follow-up is the first turn).
-  await upsertPlaygroundSession(base, tenantId, agentId, threadId, "");
+  await upsertPlaygroundSession(base, ctx, agentId, threadId, "");
   return {
     reply,
     threadId,
@@ -961,7 +969,7 @@ async function normalizeAudioUpload(
 }
 
 export interface PlaygroundTranscribeOnlyParams {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   file: File;
   // Live draft (live-edit popup): its STT config overrides the saved one, so an unsaved credential
@@ -980,7 +988,7 @@ export async function runPlaygroundTranscribe(
 ): Promise<{ transcription: string }> {
   const { bytes, mimeType } = await normalizeAudioUpload(params.file);
   const transcription = await transcribePlaygroundAudio({
-    tenantId: params.tenantId,
+    ctx: params.ctx,
     agentId: params.agentId,
     audio: bytes,
     mimeType,
@@ -992,7 +1000,7 @@ export async function runPlaygroundTranscribe(
 }
 
 export interface PlaygroundAudioParams {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   file: File;
   threadId?: string;
@@ -1021,7 +1029,7 @@ export interface PlaygroundAudioResult extends PlaygroundTurnResult {
 export async function runPlaygroundAudioTurn(
   params: PlaygroundAudioParams,
 ): Promise<PlaygroundAudioResult> {
-  const { tenantId, agentId, file } = params;
+  const { ctx, agentId, file } = params;
   const { bytes, mimeType } = await normalizeAudioUpload(file);
 
   // Reuse the transcribe-only step's result when supplied (the UI shows it early); otherwise
@@ -1030,7 +1038,7 @@ export async function runPlaygroundAudioTurn(
     params.transcription !== undefined
       ? params.transcription
       : await transcribePlaygroundAudio({
-          tenantId,
+          ctx,
           agentId,
           audio: bytes,
           mimeType,
@@ -1046,7 +1054,7 @@ export async function runPlaygroundAudioTurn(
     attachmentTypes: ["audio"],
   });
   const turn = await runPlaygroundTurn({
-    tenantId,
+    ctx,
     agentId,
     message,
     threadId: params.threadId,
@@ -1084,7 +1092,7 @@ async function readFileUpload(file: File): Promise<ArrayBuffer> {
 export type PlaygroundExtractKind = "image" | "document" | "unsupported";
 
 export interface PlaygroundExtractOnlyParams {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   file: File;
   // Live draft (live-edit popup): its vision config overrides the saved one (test an unsaved key).
@@ -1104,14 +1112,14 @@ export async function runPlaygroundExtract(
   // Log the read as a `vision` stage on the Logs page (source=playground). This is step 1 of the
   // two-step UI flow, so the extraction runs HERE (step 2 reuses the result and skips it).
   const flow: FlowContext = {
-    tenantId: params.tenantId,
+    tenantId: params.ctx.tenantId as bigint,
     turnId: crypto.randomUUID(),
     source: "playground",
     agentId: params.agentId,
     base: params.base,
   };
   const { kind, text } = await extractPlaygroundFile({
-    tenantId: params.tenantId,
+    ctx: params.ctx,
     agentId: params.agentId,
     file: bytes,
     mimeType: params.file.type || null,
@@ -1124,7 +1132,7 @@ export async function runPlaygroundExtract(
 }
 
 export interface PlaygroundFileParams {
-  tenantId: bigint;
+  ctx: TenantContext;
   agentId: bigint;
   file: File;
   threadId?: string;
@@ -1153,14 +1161,14 @@ export interface PlaygroundFileResult extends PlaygroundTurnResult {
 // Playground-only read; falls back to a generic label if the agent/config vanished.
 async function resolveVisionLabel(
   base: PrismaClient,
-  tenantId: bigint,
+  ctx: TenantContext,
   agentId: bigint,
   draftSettings: unknown,
 ): Promise<{ provider: string; model: string | null }> {
   const cfg =
     draftSettings !== undefined
       ? readVisionConfig(draftSettings)
-      : await runScopedOn(base, sysCtx(tenantId), async (db) => {
+      : await runScopedOn(base, ctx, async (db) => {
           const agent = await db.agent.findUnique({
             where: { id: agentId },
             select: { settings: true },
@@ -1177,7 +1185,8 @@ async function resolveVisionLabel(
 export async function runPlaygroundFileTurn(
   params: PlaygroundFileParams,
 ): Promise<PlaygroundFileResult> {
-  const { tenantId, agentId, file } = params;
+  const { ctx, agentId, file } = params;
+  const tenantId = ctx.tenantId as bigint;
   const base = params.base ?? basePrisma;
   const bytes = await readFileUpload(file);
 
@@ -1187,7 +1196,7 @@ export async function runPlaygroundFileTurn(
     params.kind !== undefined && params.extracted !== undefined
       ? { kind: params.kind, text: params.extracted }
       : await extractPlaygroundFile({
-          tenantId,
+          ctx,
           agentId,
           file: bytes,
           mimeType: file.type || null,
@@ -1224,7 +1233,7 @@ export async function runPlaygroundFileTurn(
           });
 
   const turn = await runPlaygroundTurn({
-    tenantId,
+    ctx,
     agentId,
     message,
     threadId: params.threadId,
@@ -1249,7 +1258,7 @@ export async function runPlaygroundFileTurn(
   if (kind === "image" || kind === "document") {
     const label = await resolveVisionLabel(
       base,
-      tenantId,
+      ctx,
       agentId,
       params.overrides?.settings,
     );

--- a/src/modules/playground/sessions.ts
+++ b/src/modules/playground/sessions.ts
@@ -28,10 +28,6 @@ import { type LoadedTurnNote, listThreadTurnNotes } from "./turn-notes";
 // LangGraph checkpointer keyed by threadId — the single source of truth. Reopening a session
 // reconstructs the transcript from the checkpointer (no conversation body duplicated in our DB).
 
-function sysCtx(tenantId: bigint): TenantContext {
-  return { tenantId, userId: null, role: "TENANT_ADMIN" };
-}
-
 // Conversation native tools are always simulated in the playground, so label their results as such
 // on reopen too (the mock config isn't persisted, so mocked results show unlabeled on replay).
 const SIMULATED_TOOL_NAMES = new Set<string>(CONVERSATION_NATIVE_TOOL_NAMES);
@@ -386,15 +382,16 @@ export function applyTurnNotes(
 // reply. The title is set once (on create, from the first turn) and only bumped afterwards.
 export async function upsertPlaygroundSession(
   base: PrismaClient,
-  tenantId: bigint,
+  ctx: TenantContext,
   agentId: bigint,
   threadId: string,
   titleHint: string,
 ): Promise<void> {
+  const tenantId = ctx.tenantId as bigint;
   if (!isValidPlaygroundThread(threadId, tenantId, agentId)) return;
   const title = clipText(titleHint.replace(/\s+/g, " ").trim(), TITLE_MAX);
   try {
-    await runScopedOn(base, sysCtx(tenantId), (db) =>
+    await runScopedOn(base, ctx, (db) =>
       db.playgroundSession.upsert({
         where: { tenantId_threadId: { tenantId, threadId } },
         create: { tenantId, agentId, threadId, title },
@@ -416,11 +413,11 @@ export interface PlaygroundSessionMeta {
 }
 
 export async function listPlaygroundSessions(
-  tenantId: bigint,
+  ctx: TenantContext,
   agentId: bigint,
   base: PrismaClient = basePrisma,
 ): Promise<PlaygroundSessionMeta[]> {
-  const rows = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const rows = await runScopedOn(base, ctx, (db) =>
     db.playgroundSession.findMany({
       where: { agentId },
       orderBy: { updatedAt: "desc" },
@@ -439,15 +436,16 @@ export async function listPlaygroundSessions(
 // the authorization that this thread belongs to the tenant; the thread shape is re-validated too,
 // since the checkpointer is not under RLS (the thread prefix is its fence).
 export async function getPlaygroundSessionTurns(
-  tenantId: bigint,
+  ctx: TenantContext,
   agentId: bigint,
   threadId: string,
   base: PrismaClient = basePrisma,
 ): Promise<RebuiltTurn[]> {
+  const tenantId = ctx.tenantId as bigint;
   if (!isValidPlaygroundThread(threadId, tenantId, agentId)) {
     throw new NotFoundError("session not found", "errors.sessionNotFound");
   }
-  const exists = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const exists = await runScopedOn(base, ctx, (db) =>
     db.playgroundSession.findUnique({
       where: { tenantId_threadId: { tenantId, threadId } },
       select: { id: true },
@@ -474,7 +472,7 @@ export async function getPlaygroundSessionTurns(
   // persisting the simulated names WITH each turn — a column, a migration and a write on every
   // playground turn, for a badge on a historical session whose tool no longer exists. The trade is
   // not worth it; the limit is written here so the next reader knows it was weighed.
-  const documentTools = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const documentTools = await runScopedOn(base, ctx, (db) =>
     db.agentToolSelection.findMany({
       where: { agentId, source: "DOCUMENT" },
       select: { documentTemplate: { select: { slug: true } } },
@@ -488,12 +486,12 @@ export async function getPlaygroundSessionTurns(
         .filter((slug): slug is string => !!slug)
         .map(documentToolName),
     ),
-    await listThreadTurnNotes(base, tenantId, threadId),
+    await listThreadTurnNotes(base, ctx, threadId),
   );
 
   // Join persisted media onto the turns by message id (best-effort replay — if the checkpointer
   // didn't round-trip the message id, the media simply isn't re-attached, never an error).
-  const media = await listThreadMedia(tenantId, threadId, base);
+  const media = await listThreadMedia(ctx, threadId, base);
   if (media.length > 0) {
     const byMessage = new Map<string, RebuiltMedia[]>();
     for (const m of media) {
@@ -518,21 +516,29 @@ export async function getPlaygroundSessionTurns(
 // it and get the old conversation back with the moderation deleted: the raw replies a guardrail
 // replaced, presented as the agent's own (issue #136).
 export async function deletePlaygroundSession(
-  tenantId: bigint,
+  ctx: TenantContext,
   agentId: bigint,
   threadId: string,
   base: PrismaClient = basePrisma,
 ): Promise<void> {
+  const tenantId = ctx.tenantId as bigint;
   // The fence is what makes the line below safe to run at all: `deleteThread` is scoped by nothing,
   // and every Chatwoot conversation is a thread in the same checkpointer.
   if (!isValidPlaygroundThread(threadId, tenantId, agentId)) {
     throw new NotFoundError("session not found", "errors.sessionNotFound");
   }
+  // Before the unscoped delete below, and NOT as a side effect of the scoped block after it. The
+  // checkpointer lives outside RLS and carries no foreign key to `tenants`, so a tenant's playground
+  // threads OUTLIVE the tenant row: a stale selector can still name a thread that exists, and
+  // refusing afterwards would erase a transcript on a request that then reports itself refused.
+  // This is the same gate called earlier, not a second one: `runScopedOn` is where an unknown tenant
+  // is verified, and it verifies nothing at all for a caller whose id came from a row (issue #268).
+  await runScopedOn(base, ctx, async () => undefined);
   // First, and not swallowed: a delete that dropped our rows and left the thread would leave
   // exactly the state described above. Failing here leaves the session whole instead.
   const checkpointer = await getCheckpointer();
   await checkpointer.deleteThread(threadId);
-  await runScopedOn(base, sysCtx(tenantId), async (db) => {
+  await runScopedOn(base, ctx, async (db) => {
     // The transcript notes go with it. Left behind they would be orphans, and pruned separately
     // they would put a still-reloadable session back to the raw reply (issue #136).
     await db.playgroundTurnNote.deleteMany({ where: { agentId, threadId } });

--- a/src/modules/playground/turn-notes.ts
+++ b/src/modules/playground/turn-notes.ts
@@ -17,10 +17,6 @@ import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 // Turns it never ran on still come from the checkpointer alone, and a note that fails to write
 // costs the reload its annotation, never the turn.
 
-function sysCtx(tenantId: bigint): TenantContext {
-  return { tenantId, userId: null, role: "TENANT_ADMIN" };
-}
-
 // NOTE: There is deliberately no per-tenant cap here, unlike the media store. Bytes are what the
 // media cap exists to bound, and a screened session writes one short row per turn, bounded by an
 // operator typing turns by hand. Pruning one while its session is still reloadable would silently
@@ -46,16 +42,16 @@ export interface PlaygroundTurnNote {
 export async function savePlaygroundTurnNote(
   base: PrismaClient,
   params: PlaygroundTurnNote & {
-    tenantId: bigint;
+    ctx: TenantContext;
     agentId: bigint;
     threadId: string;
   },
 ): Promise<void> {
   try {
-    await runScopedOn(base, sysCtx(params.tenantId), async (db) => {
+    await runScopedOn(base, params.ctx, async (db) => {
       await db.playgroundTurnNote.create({
         data: {
-          tenantId: params.tenantId,
+          tenantId: params.ctx.tenantId as bigint,
           agentId: params.agentId,
           threadId: params.threadId,
           messageId: params.messageId,
@@ -82,10 +78,10 @@ export interface LoadedTurnNote extends PlaygroundTurnNote {
 
 export async function listThreadTurnNotes(
   base: PrismaClient,
-  tenantId: bigint,
+  ctx: TenantContext,
   threadId: string,
 ): Promise<LoadedTurnNote[]> {
-  const rows = await runScopedOn(base, sysCtx(tenantId), (db) =>
+  const rows = await runScopedOn(base, ctx, (db) =>
     db.playgroundTurnNote.findMany({
       where: { threadId },
       orderBy: { id: "asc" },

--- a/src/modules/stt/service.ts
+++ b/src/modules/stt/service.ts
@@ -219,7 +219,11 @@ export async function transcribeInboundAudio(
 }
 
 export interface PlaygroundTranscribeParams {
-  tenantId: bigint;
+  // The REQUEST's context, unlike the inbound path above, whose tenant id this process read from a
+  // row. Rebuilding one here would tell the unknown-tenant check at `runScopedOn` that a caller's
+  // stale selector was internal, and the operator would get "agent not found" for a tenant that is
+  // gone rather than a refusal naming the selection they are carrying (issue #268).
+  ctx: TenantContext;
   agentId: bigint;
   audio: ArrayBuffer;
   mimeType: string | null;
@@ -244,7 +248,7 @@ export async function transcribePlaygroundAudio(
   const cfg =
     params.settings !== undefined
       ? readSttConfig(params.settings)
-      : await runScopedOn(base, sysCtx(params.tenantId), async (db) => {
+      : await runScopedOn(base, params.ctx, async (db) => {
           const agent = await db.agent.findUnique({
             where: { id: params.agentId },
             select: { settings: true },
@@ -261,7 +265,7 @@ export async function transcribePlaygroundAudio(
       "errors.sttNotConfigured",
     );
   }
-  const entry = await runScopedOn(base, sysCtx(params.tenantId), (db) =>
+  const entry = await runScopedOn(base, params.ctx, (db) =>
     tryResolveVaultEntry<string>(db, cfg.credentialRef as string),
   );
   if (!entry) {

--- a/src/modules/vision/service.ts
+++ b/src/modules/vision/service.ts
@@ -253,7 +253,11 @@ export async function extractInboundFile(
 }
 
 export interface PlaygroundExtractParams {
-  tenantId: bigint;
+  // The REQUEST's context, unlike the inbound path above, whose tenant id this process read from a
+  // row. Rebuilding one here would tell the unknown-tenant check at `runScopedOn` that a caller's
+  // stale selector was internal, and the operator would get "agent not found" for a tenant that is
+  // gone rather than a refusal naming the selection they are carrying (issue #268).
+  ctx: TenantContext;
   agentId: bigint;
   file: ArrayBuffer;
   mimeType: string | null;
@@ -285,7 +289,7 @@ export async function extractPlaygroundFile(
   const cfg =
     params.settings !== undefined
       ? readVisionConfig(params.settings)
-      : await runScopedOn(base, sysCtx(params.tenantId), async (db) => {
+      : await runScopedOn(base, params.ctx, async (db) => {
           const agent = await db.agent.findUnique({
             where: { id: params.agentId },
             select: { settings: true },
@@ -302,7 +306,7 @@ export async function extractPlaygroundFile(
       "errors.visionNotConfigured",
     );
   }
-  const entry = await runScopedOn(base, sysCtx(params.tenantId), (db) =>
+  const entry = await runScopedOn(base, params.ctx, (db) =>
     tryResolveVaultEntry<string>(db, cfg.credentialRef as string),
   );
   if (!entry) {
@@ -351,7 +355,7 @@ export async function extractPlaygroundFile(
     // marker so the agent still answers. Misconfig (no credential/disabled) already threw above.
     logger.error(
       {
-        tenantId: String(params.tenantId),
+        tenantId: String(params.ctx.tenantId),
         agentId: String(params.agentId),
         provider: cfg.provider,
         mime: params.mimeType,

--- a/tests/modules/playground-capabilities.test.ts
+++ b/tests/modules/playground-capabilities.test.ts
@@ -11,7 +11,7 @@ describe("playground respects the enabled toggle", () => {
   test("vision disabled → not configured (no DB)", async () => {
     await expect(
       extractPlaygroundFile({
-        tenantId: 1n,
+        ctx: { tenantId: 1n, userId: null, role: "TENANT_ADMIN" },
         agentId: 1n,
         file: new ArrayBuffer(4),
         mimeType: "image/png",
@@ -29,7 +29,7 @@ describe("playground respects the enabled toggle", () => {
   test("stt disabled → not configured (no DB)", async () => {
     await expect(
       transcribePlaygroundAudio({
-        tenantId: 1n,
+        ctx: { tenantId: 1n, userId: null, role: "TENANT_ADMIN" },
         agentId: 1n,
         audio: new ArrayBuffer(4),
         mimeType: "audio/webm",
@@ -99,7 +99,7 @@ describe.skipIf(!dbUp)(
 
     test("a provider fetch failure → unsupported marker, not a throw", async () => {
       const res = await extractPlaygroundFile({
-        tenantId,
+        ctx: { tenantId, userId: null, role: "TENANT_ADMIN" },
         agentId: 1n,
         file: new ArrayBuffer(8),
         mimeType: "image/png",

--- a/tests/modules/playground-guardrails.test.ts
+++ b/tests/modules/playground-guardrails.test.ts
@@ -6,7 +6,7 @@ import { MemorySaver } from "@langchain/langgraph";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
-import { runScopedOn } from "@/lib/tenancy";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
   runPlaygroundFollowup,
   runPlaygroundTurn,
@@ -19,6 +19,12 @@ import {
 } from "@/modules/playground/sessions";
 import { listThreadTurnNotes } from "@/modules/playground/turn-notes";
 import { guardrailModel } from "../utils/scripted-models";
+
+// The context a console operator carries. The playground takes the REQUEST's context now, not an id
+// rebuilt from it, so these read exactly as the controller calls them (issue #268).
+function ctx(t: bigint): TenantContext {
+  return { tenantId: t, userId: null, role: "TENANT_ADMIN" };
+}
 
 // Issue #136: the playground ran the agent's graph directly and never screened anything, so the
 // operator read a reply the customer would never have received. These tests are written against
@@ -291,7 +297,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("an output violation replaces the reply the operator reads", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "e o concorrente?",
       base: appDb,
@@ -305,7 +311,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("an output violation with the silent action leaves no reply at all", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentSilent,
       message: "e o concorrente?",
       base: appDb,
@@ -320,7 +326,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("an input violation skips the graph: the agent model is never invoked", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "fale do concorrente",
       base: appDb,
@@ -335,7 +341,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("the verdict is annotated in the trace, with the direction and what it did", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "e o concorrente?",
       base: appDb,
@@ -355,7 +361,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a guardrail that cannot be built is fail-open, and says so in the trace", async () => {
     const m = models({ violated: false, breakJudge: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentBrokenGuard,
       message: "oi",
       base: appDb,
@@ -373,7 +379,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a guardrail whose credential is gone is unavailable, not silently off", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentDeadCredential,
       message: "oi",
       base: appDb,
@@ -414,7 +420,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a clean screening is annotated too", async () => {
     const m = models({ violated: false });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "oi",
       base: appDb,
@@ -431,7 +437,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("screening off leaves the raw reply and costs no guardrail call", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "e o concorrente?",
       guardrails: false,
@@ -449,7 +455,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("the trace keeps the screenings on the sides of the graph they ran on", async () => {
     const m = models({ violated: false, toolFirst: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentBoth,
       message: "quanto é 1+1?",
       base: appDb,
@@ -470,7 +476,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("an output trip is recorded for the reload, with the screened text", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "e o concorrente?",
       base: appDb,
@@ -490,7 +496,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("an input block is recorded with the customer's own text", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "fale do concorrente",
       base: appDb,
@@ -509,7 +515,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("an input block still persists the recording it blocked", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "<mensagem-de-audio>fale do concorrente</mensagem-de-audio>",
       userMedia: {
@@ -538,7 +544,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a turn the guardrail never touched writes no note", async () => {
     const m = models({ violated: false });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "oi",
       guardrails: false,
@@ -555,7 +561,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a suppressed follow-up is not reported as agent silence", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundFollowup({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentSilent,
       base: appDb,
       deps: deps(m),
@@ -573,7 +579,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a silently blocked message reports suppression", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInputSilent,
       message: "fale do concorrente",
       base: appDb,
@@ -589,7 +595,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a suppressed normal turn reports suppression, not an empty reply", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentSilent,
       message: "e o concorrente?",
       base: appDb,
@@ -602,7 +608,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a reply the guardrail left alone is not reported as suppressed", async () => {
     const m = models({ violated: false });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "oi",
       base: appDb,
@@ -618,7 +624,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a screened turn the agent left empty keeps its verdict on reload", async () => {
     const cp = new MemorySaver();
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "primeira",
       base: appDb,
@@ -634,7 +640,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     // "appended at the end" are the same position, so a test with one turn cannot tell a placed
     // verdict from a lost one that happened to land right.
     await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "segunda",
       threadId: r.threadId,
@@ -649,7 +655,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
             ?.checkpoint?.channel_values as { messages?: BaseMessage[] }
         )?.messages as BaseMessage[],
       ),
-      await listThreadTurnNotes(appDb, tenantId, r.threadId),
+      await listThreadTurnNotes(appDb, ctx(tenantId), r.threadId),
     );
     expect(turns.map((t) => `${t.role}:${t.text}`)).toEqual([
       "user:primeira",
@@ -680,7 +686,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
       },
     })) as never;
     const first = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "primeira",
       guardrails: false,
@@ -688,7 +694,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
       deps: { makeModel: silentModel },
     });
     await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "fale do concorrente",
       threadId: first.threadId,
@@ -696,7 +702,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
       deps: { makeModel: models({ violated: true }).make },
     });
     await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "terceira",
       threadId: first.threadId,
@@ -705,7 +711,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     });
 
     const turns = await getPlaygroundSessionTurns(
-      tenantId,
+      ctx(tenantId),
       agentInput,
       first.threadId,
       appDb,
@@ -748,7 +754,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
       },
     })) as never;
     const first = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "primeira",
       guardrails: false,
@@ -758,7 +764,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     // Turn 2, same thread: the input trips, so the turn exists only as a note.
     const m = models({ violated: true });
     await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentInput,
       message: "fale do concorrente",
       threadId: first.threadId,
@@ -844,7 +850,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("deleting the session takes its transcript notes with it", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "e o concorrente?",
       base: appDb,
@@ -853,7 +859,12 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     expect(
       await suDb.playgroundTurnNote.count({ where: { threadId: r.threadId } }),
     ).toBe(1);
-    await deletePlaygroundSession(tenantId, agentTemplate, r.threadId, appDb);
+    await deletePlaygroundSession(
+      ctx(tenantId),
+      agentTemplate,
+      r.threadId,
+      appDb,
+    );
     expect(
       await suDb.playgroundTurnNote.count({ where: { threadId: r.threadId } }),
     ).toBe(0);
@@ -868,7 +879,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   // reaches and the whole defect is the two stores disagreeing.
   test("a deleted session cannot be reopened with its raw replies", async () => {
     const first = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "fale do concorrente",
       base: appDb,
@@ -877,7 +888,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     expect(first.reply).toBe(TEMPLATE);
 
     await deletePlaygroundSession(
-      tenantId,
+      ctx(tenantId),
       agentTemplate,
       first.threadId,
       appDb,
@@ -886,7 +897,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     // The same id, reused the way a caller that kept it would. A reply of its own, so the raw one
     // the first turn left behind cannot be mistaken for this turn's.
     await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       message: "segunda",
       threadId: first.threadId,
@@ -899,7 +910,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     });
 
     const turns = await getPlaygroundSessionTurns(
-      tenantId,
+      ctx(tenantId),
       agentTemplate,
       first.threadId,
       appDb,
@@ -919,7 +930,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("a thread outside the fence is refused, not deleted", async () => {
     await expect(
       deletePlaygroundSession(
-        tenantId,
+        ctx(tenantId),
         agentTemplate,
         `${tenantId}:1:4242`,
         appDb,
@@ -932,7 +943,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
   test("the simulated follow-up is screened on the output direction", async () => {
     const m = models({ violated: true });
     const r = await runPlaygroundFollowup({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTemplate,
       base: appDb,
       deps: deps(m),

--- a/tests/modules/playground-tenant-selector.test.ts
+++ b/tests/modules/playground-tenant-selector.test.ts
@@ -1,0 +1,345 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import type { PrismaClient as PrismaClientType } from "@/../generated/prisma/client";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { getCheckpointer } from "@/graph/checkpointer";
+import { ActiveTenantNotFoundError, AppError } from "@/lib/errors";
+import { resolveRequestTenantContext, type TenantContext } from "@/lib/tenancy";
+import {
+  getPlaygroundMedia,
+  listThreadMedia,
+} from "@/modules/playground/media";
+import {
+  listPlaygroundTools,
+  runPlaygroundFollowup,
+  runPlaygroundTurn,
+} from "@/modules/playground/service";
+import {
+  deletePlaygroundSession,
+  getPlaygroundSessionTurns,
+  listPlaygroundSessions,
+} from "@/modules/playground/sessions";
+import { listThreadTurnNotes } from "@/modules/playground/turn-notes";
+import { transcribePlaygroundAudio } from "@/modules/stt/service";
+import { extractPlaygroundFile } from "@/modules/vision/service";
+
+// The playground was the one console surface that took the caller's tenant selector and handed it to
+// the database as an internally-trusted id, so the gate #223 put at `runScopedOn` never applied to
+// it. Every module rebuilt a context from the raw id (`sysCtx(tenantId)` -> role TENANT_ADMIN), and
+// the role IS the predicate: it is what separates an id that came from outside the process from one
+// this process read from a row.
+//
+// Measured before the change, against this database, with a selector naming a tenant that does not
+// exist. Five of the six entry points answered as though the tenant were real and merely empty:
+//
+//   listPlaygroundSessions   -> []          getPlaygroundMedia    -> null
+//   listThreadMedia          -> []          listThreadTurnNotes   -> []
+//   deletePlaygroundSession  -> undefined (a delete that "succeeded" on a tenant with no rows)
+//
+// while the same selector on any other route answered 404 `ActiveTenantNotFoundError`. The sixth,
+// getPlaygroundSessionTurns, did refuse, but for the wrong fact: its own session fence answered
+// "session not found", which tells the console nothing about the selector it is carrying and so
+// cannot trigger the recovery #265 added.
+//
+// The fix is to stop lying to the gate rather than to add a second one: the request's context goes
+// all the way down, so a TENANT_ADMIN operator still pays nothing (the role short-circuits the
+// check) and a fleet operator's dead selection is refused at the first scoped read. Issue #268.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const suDb = su as PrismaClient;
+const appDb = app as PrismaClient;
+
+afterAll(async () => {
+  await su?.$disconnect();
+  await app?.$disconnect();
+});
+
+let liveId = 0n;
+let deadId = 0n;
+const agentId = 1n;
+
+// The context the REST boundary actually builds from the header, rather than one written by hand:
+// what makes this reachable is that the selector is a string the browser persists.
+function fromSelector(tenantId: bigint): TenantContext {
+  const { context } = resolveRequestTenantContext(
+    { id: 1n, tenantId: null, role: "SUPER_ADMIN" },
+    String(tenantId),
+  );
+  if (!context) throw new Error("the boundary refused a SUPER_ADMIN principal");
+  return context;
+}
+
+// What a console operator carries: a tenant-scoped principal, whose id this process read from a row.
+function operator(tenantId: bigint): TenantContext {
+  return { tenantId, userId: 1n, role: "TENANT_ADMIN" };
+}
+
+function thread(tenantId: bigint): string {
+  return `${tenantId}:playground:${agentId}:00000000-0000-4000-8000-000000000000`;
+}
+
+// Counts the existence check, so "a console operator does not pay for this" is measured rather than
+// asserted.
+function counting(base: PrismaClient) {
+  const seen = { tenantFindUnique: 0 };
+  const client = base.$extends({
+    query: {
+      tenant: {
+        findUnique({ args, query }) {
+          seen.tenantFindUnique += 1;
+          return query(args);
+        },
+      },
+    },
+  });
+  return { client: client as unknown as PrismaClientType, seen };
+}
+
+describe.skipIf(!dbUp)(
+  "a playground call carrying a dead tenant selector",
+  () => {
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "PgSelector", slug: `pgsel-${process.pid}` },
+      });
+      liveId = t.id;
+      const max = await suDb.$queryRaw<
+        { m: bigint | null }[]
+      >`SELECT MAX(id) AS m FROM tenants`;
+      deadId = (max[0]?.m ?? 0n) + 1_000_000n;
+    });
+
+    afterAll(async () => {
+      if (liveId) await suDb.tenant.deleteMany({ where: { id: liveId } });
+    });
+
+    // One row per entry point the controller reaches, because the defect was per call site: the
+    // decision lives in `runScopedOn` and what this pins is that each of these actually reaches it
+    // with the caller's context.
+    const entryPoints: Array<
+      [string, (ctx: TenantContext) => Promise<unknown>]
+    > = [
+      [
+        "listPlaygroundSessions",
+        (ctx) => listPlaygroundSessions(ctx, agentId, appDb),
+      ],
+      [
+        "getPlaygroundSessionTurns",
+        (ctx) =>
+          getPlaygroundSessionTurns(
+            ctx,
+            agentId,
+            thread(ctx.tenantId as bigint),
+            appDb,
+          ),
+      ],
+      [
+        "deletePlaygroundSession",
+        (ctx) =>
+          deletePlaygroundSession(
+            ctx,
+            agentId,
+            thread(ctx.tenantId as bigint),
+            appDb,
+          ),
+      ],
+      ["getPlaygroundMedia", (ctx) => getPlaygroundMedia(ctx, 1n, appDb)],
+      [
+        "listThreadMedia",
+        (ctx) => listThreadMedia(ctx, thread(ctx.tenantId as bigint), appDb),
+      ],
+      [
+        "listThreadTurnNotes",
+        (ctx) =>
+          listThreadTurnNotes(appDb, ctx, thread(ctx.tenantId as bigint)),
+      ],
+      // The three the MCP transport reaches as well as the console. They refuse before a model is
+      // ever built: the first thing a turn does is load the agent's config, and that is a scoped
+      // read. No `deps` here on purpose, so a row that stopped refusing would fail on the missing
+      // model rather than pass quietly.
+      [
+        "runPlaygroundTurn",
+        (ctx) =>
+          runPlaygroundTurn({ ctx, agentId, message: "oi", base: appDb }),
+      ],
+      [
+        "runPlaygroundFollowup",
+        (ctx) => runPlaygroundFollowup({ ctx, agentId, base: appDb }),
+      ],
+      [
+        "listPlaygroundTools",
+        (ctx) => listPlaygroundTools({ ctx, agentId, base: appDb }),
+      ],
+      // The attachment preprocessing, which lives in the stt/vision modules rather than here and so
+      // is NOT covered by the source ledger below: those two files keep their `sysCtx` for the
+      // INBOUND path, whose tenant id this process read from a row. Only the playground pair takes
+      // the caller's context. No `settings` on purpose: a draft's settings short-circuit the config
+      // read, and the read is the whole point of the row.
+      [
+        "transcribePlaygroundAudio",
+        (ctx) =>
+          transcribePlaygroundAudio({
+            ctx,
+            agentId,
+            audio: new ArrayBuffer(8),
+            mimeType: "audio/webm",
+            base: appDb,
+          }),
+      ],
+      [
+        "extractPlaygroundFile",
+        (ctx) =>
+          extractPlaygroundFile({
+            ctx,
+            agentId,
+            file: new ArrayBuffer(8),
+            mimeType: "image/png",
+            base: appDb,
+          }),
+      ],
+    ];
+
+    for (const [name, call] of entryPoints) {
+      test(`${name} refuses it, naming the selector`, async () => {
+        const err = await call(fromSelector(deadId)).catch((e: unknown) => e);
+        expect(err instanceof AppError).toBe(true);
+        const appErr = err as AppError;
+        expect(appErr.statusCode).toBe(404);
+        // Not merely "a 404": the class that says WHICH fact is wrong. `errors.sessionNotFound` is
+        // also a 404 here and tells the console nothing about the selection it has stored.
+        expect(err instanceof ActiveTenantNotFoundError).toBe(true);
+        expect((err as ActiveTenantNotFoundError).rejectedTenantId).toBe(
+          String(deadId),
+        );
+      });
+    }
+
+    // The refusal has to land BEFORE the one thing on this path that is not scoped by anything.
+    //
+    // `deletePlaygroundSession` drops the checkpointer thread first on purpose (a delete that took our
+    // rows and left the thread would leave the orphan the fence exists to prevent). The checkpointer
+    // lives in its own schema, outside RLS, with no foreign key to `tenants`, so a tenant's playground
+    // threads OUTLIVE the tenant row. That is what makes a stale selector able to name a thread that
+    // still exists, and what would have made a request that reports itself refused erase a transcript
+    // on the way there.
+    test("it refuses before erasing the checkpointer thread it is allowed to name", async () => {
+      const dead = deadId;
+      const threadId = thread(dead);
+      const cp = await getCheckpointer();
+      await cp.put(
+        { configurable: { thread_id: threadId, checkpoint_ns: "" } },
+        {
+          v: 4,
+          id: `ck-${process.pid}`,
+          ts: new Date().toISOString(),
+          channel_values: {},
+          channel_versions: {},
+          versions_seen: {},
+        } as never,
+        { source: "input", step: -1, parents: {} } as never,
+        {},
+      );
+      // The premise, measured rather than assumed: the thread is there while its tenant is not.
+      expect(
+        await cp.getTuple({ configurable: { thread_id: threadId } }),
+      ).toBeDefined();
+
+      try {
+        const err = await deletePlaygroundSession(
+          fromSelector(dead),
+          agentId,
+          threadId,
+          appDb,
+        ).catch((e: unknown) => e);
+        expect(err instanceof ActiveTenantNotFoundError).toBe(true);
+        // And the transcript is still there. Before the fix this came back undefined: the refusal
+        // arrived, after the erase.
+        expect(
+          await cp.getTuple({ configurable: { thread_id: threadId } }),
+        ).toBeDefined();
+      } finally {
+        await cp.deleteThread(threadId);
+      }
+    });
+
+    test("a live selector still answers, and pays one statement for the check", async () => {
+      const { client, seen } = counting(appDb);
+      const out = await listPlaygroundSessions(
+        fromSelector(liveId),
+        agentId,
+        client,
+      );
+      expect(out).toEqual([]);
+      expect(seen.tenantFindUnique).toBe(1);
+    });
+
+    test("a console operator pays nothing, because the role is the predicate", async () => {
+      const { client, seen } = counting(appDb);
+      const out = await listPlaygroundSessions(
+        operator(liveId),
+        agentId,
+        client,
+      );
+      expect(out).toEqual([]);
+      expect(seen.tenantFindUnique).toBe(0);
+    });
+  },
+);
+
+// The half a decision table cannot cover. Everything above proves the FUNCTIONS refuse; it says
+// nothing about whether the next entry point added to this module rebuilds a context again, which
+// is exactly how the defect got in (#205). What is pinned here is that nowhere under
+// `src/modules/playground/` does a context get MADE: every one of them arrives from the caller.
+//
+// The predicate is extracted rather than inlined so the fence can be shown to catch something. A
+// sweep with no offender left in the tree passes whether or not it works (#266), so the fixture
+// below is the positive control: it is the exact shape that was in all four files.
+export function buildsATenantContext(source: string): boolean {
+  return /\brole:\s*"(?:TENANT_ADMIN|SUPER_ADMIN)"/.test(source);
+}
+
+describe("no playground module builds a tenant context of its own", () => {
+  const OFFENDER = `function sysCtx(tenantId: bigint): TenantContext {
+  return { tenantId, userId: null, role: "TENANT_ADMIN" };
+}`;
+
+  test("the predicate catches the shape that was there", () => {
+    expect(buildsATenantContext(OFFENDER)).toBe(true);
+    expect(
+      buildsATenantContext(
+        "await runScopedOn(base, ctx, (db) => db.x.findMany())",
+      ),
+    ).toBe(false);
+  });
+
+  test("no file under src/modules/playground builds one", async () => {
+    const { Glob } = await import("bun");
+    const offenders: string[] = [];
+    for await (const rel of new Glob("**/*.ts").scan(
+      "src/modules/playground",
+    )) {
+      const src = await Bun.file(`src/modules/playground/${rel}`).text();
+      if (buildsATenantContext(src)) offenders.push(rel);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/modules/playground.test.ts
+++ b/tests/modules/playground.test.ts
@@ -205,7 +205,7 @@ describe.skipIf(!dbUp)("playground", () => {
 
   test("a turn returns the reply and a tenant+agent-fenced thread id", async () => {
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentOk,
       message: "oi",
       base: appDb,
@@ -234,7 +234,7 @@ describe.skipIf(!dbUp)("playground", () => {
     const rewritten = "Oi! Sou o agente de teste, falado.";
     const model = new UsageReportingModel([REPLY, rewritten]);
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentAudio,
       message: "oi",
       forceAudio: true,
@@ -268,7 +268,7 @@ describe.skipIf(!dbUp)("playground", () => {
   test("a forged threadId (real conversation shape) is rejected → fresh thread", async () => {
     const forged = `${tenantId}:5:900`; // tenant:instance:conv — NOT a playground thread
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentOk,
       message: "oi",
       threadId: forged,
@@ -284,7 +284,7 @@ describe.skipIf(!dbUp)("playground", () => {
   test("a thread from a DIFFERENT agent is rejected → fresh thread", async () => {
     const otherAgentThread = `${tenantId}:playground:${agentDisabled}:abc`;
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentOk,
       message: "oi",
       threadId: otherAgentThread,
@@ -299,7 +299,7 @@ describe.skipIf(!dbUp)("playground", () => {
 
   test("works on a DISABLED agent (test before going live)", async () => {
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentDisabled,
       message: "oi",
       base: appDb,
@@ -311,7 +311,7 @@ describe.skipIf(!dbUp)("playground", () => {
   test("throws when the agent has no runnable model credential", async () => {
     await expect(
       runPlaygroundTurn({
-        tenantId,
+        ctx: ctx(tenantId),
         agentId: agentNoKey,
         message: "oi",
         base: appDb,
@@ -324,7 +324,7 @@ describe.skipIf(!dbUp)("playground", () => {
     // agentNoKey's SAVED model points at a missing credential; the draft override supplies a
     // working one, so the turn runs — proving the override replaces the saved config.
     const r = await runPlaygroundTurn({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentNoKey,
       message: "oi",
       overrides: {
@@ -353,7 +353,7 @@ describe.skipIf(!dbUp)("playground", () => {
 
   test("a follow-up returns the proactive reply (not silent) on a fenced thread", async () => {
     const r = await runPlaygroundFollowup({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentOk,
       base: appDb,
       deps: deps(),
@@ -367,7 +367,7 @@ describe.skipIf(!dbUp)("playground", () => {
 
   test("a follow-up with an empty model reply is reported as silent", async () => {
     const r = await runPlaygroundFollowup({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentOk,
       base: appDb,
       deps: {
@@ -381,7 +381,7 @@ describe.skipIf(!dbUp)("playground", () => {
 
   test("listPlaygroundTools classifies native/utility/http/rag and marks simulated", async () => {
     const tools = await listPlaygroundTools({
-      tenantId,
+      ctx: ctx(tenantId),
       agentId: agentTools,
       base: appDb,
     });
@@ -412,7 +412,11 @@ describe.skipIf(!dbUp)("playground", () => {
 
   test("listPlaygroundTools throws when the agent has no runnable model", async () => {
     await expect(
-      listPlaygroundTools({ tenantId, agentId: agentNoKey, base: appDb }),
+      listPlaygroundTools({
+        ctx: ctx(tenantId),
+        agentId: agentNoKey,
+        base: appDb,
+      }),
     ).rejects.toThrow();
   });
 
@@ -473,7 +477,7 @@ describe("runPlaygroundAudioTurn guards", () => {
   test("rejects an oversized audio file", async () => {
     await expect(
       runPlaygroundAudioTurn({
-        tenantId: 1n,
+        ctx: ctx(1n),
         agentId: 1n,
         file: fakeFile(30 * 1024 * 1024, "audio/webm"),
       }),
@@ -483,7 +487,7 @@ describe("runPlaygroundAudioTurn guards", () => {
   test("rejects a non-audio mime type", async () => {
     await expect(
       runPlaygroundAudioTurn({
-        tenantId: 1n,
+        ctx: ctx(1n),
         agentId: 1n,
         file: fakeFile(1000, "image/png"),
       }),


### PR DESCRIPTION
Fixes #268

## What was broken

`runScopedOn` verifies that a target tenant exists **only when the context's role is
`SUPER_ADMIN`** (`src/lib/tenancy/multi-tenant.ts`). That predicate is the whole design of the check
#223 added: an id that came from outside the process arrives with `SUPER_ADMIN` (the `X-Tenant-Id`
selector, an MCP `tenant` argument), while every context the process builds for itself carries an id
it just read from a row, and `TENANT_ADMIN`.

Every playground module broke that premise the same way:

```ts
function sysCtx(tenantId: bigint): TenantContext {
  return { tenantId, userId: null, role: "TENANT_ADMIN" };
}
```

Four copies, in `media.ts`, `sessions.ts`, `service.ts` and `turn-notes.ts`. The controller passed
`ctx.tenantId as bigint` and each module rebuilt a context around it, which told the check the id was
internal. Their siblings do the opposite: `/documents/:id/pdf` and `/document-templates/preview` pass
`ctx` itself.

## What it costs, measured

Against this project's Postgres, with a selector naming a tenant that does not exist, five of the six
entry points answered as though the tenant were real and merely empty:

```
listPlaygroundSessions   -> []           getPlaygroundMedia    -> null
listThreadMedia          -> []           listThreadTurnNotes   -> []
deletePlaygroundSession  -> undefined    (a delete that "succeeded" on a tenant with no rows)
```

while the same selector on any other route answered `404 ActiveTenantNotFoundError`. RLS scopes the
transaction to a tenant with no rows, so every read looks like a healthy answer about a real tenant.

The sixth, `getPlaygroundSessionTurns`, did refuse, but for the wrong fact: its own session fence
answered `errors.sessionNotFound`. That is a 404 about the session, not about the selector the caller
is carrying, so the console recovery #265 added (drop the stored selection, reload once) cannot fire
on it. The three heavier entry points the MCP transport also reaches (`runPlaygroundTurn`,
`runPlaygroundFollowup`, `listPlaygroundTools`) answered by loading the agent config from an empty
tenant.

## What this changes

The request's `TenantContext` goes all the way down, and the four `sysCtx` copies are gone. Nothing
under `src/modules/playground/` builds a context any more; every one arrives from the caller.

Both transports already had one in hand and were throwing it away:

- REST (`agents.controller.ts`) computed `ctxOrThrow(tenantContext)` and passed only `.tenantId`;
- MCP (`mcp/server.ts`) had the effective principal, which for a fleet token already resolved its
  `tenant` selector on the way in and keeps `SUPER_ADMIN`. It now passes `principalCtx(eff)`, so a
  tenant deleted between the selector resolving and the turn running answers a refusal.

**A console operator pays nothing**, and that is measured rather than asserted: a `TENANT_ADMIN`
context short-circuits the check, so the existence query is issued zero times. A fleet operator's
call pays one statement, inside a transaction that is already open.

Nothing changes about what the playground accepts. The thread fence
(`isValidPlaygroundThread`) is untouched, and so is every scoped query.

### The one place the refusal has to arrive early

`deletePlaygroundSession` deletes the checkpointer thread **before** its scoped DB work, and the
comment above that line explains why: a delete that dropped our rows and left the thread would leave
exactly the orphan the fence exists to prevent.

The first version of this PR left that alone and argued the ordering was harmless, on the grounds
that a tenant which does not exist has no threads. **That was wrong.** The checkpointer lives in its
own schema, outside RLS, with no foreign key to `tenants`, so a tenant's playground threads *outlive*
the tenant row. A stale selector can name a thread that is still there, and refusing after
`deleteThread` would erase a transcript on a request that then reports itself refused.

So the gate is invoked before the unscoped delete. It is the same gate called earlier, not a second
one with its own copy of the rule: `runScopedOn` is where an unknown tenant is verified, and it still
verifies nothing at all for a caller whose id came from a row.

### Attachment preprocessing is part of the same surface

`transcribePlaygroundAudio` and `extractPlaygroundFile` (in `stt/service.ts` and `vision/service.ts`)
rebuilt a context the same way, so the audio and file paths (the standalone preprocessing endpoints,
attachment turns, and MCP attachments) answered `errors.agentNotFound` or a credential error for a
tenant that is gone. Only the **playground** pair in those two files takes the caller's context; their
`sysCtx` stays for the INBOUND path, whose tenant id this process read from a row.

## Validation scope

**Proven by test** (`bun check`: 5224 pass, 0 fail)

- `tests/modules/playground-tenant-selector.test.ts`, DB-backed against a real tenant and a
  well-formed id that names none. Eleven entry points, one row each, because the defect was per call
  site: each must answer `ActiveTenantNotFoundError` (404, `errors.tenantNotFound`) and name the
  refused id, which is what the console matches against what it has stored. The three MCP-reached
  rows deliberately pass no `deps`, and the two preprocessing rows deliberately pass no `settings`,
  so a row that stopped refusing would fail on the missing model (or short-circuit the config read
  the row exists for) rather than pass quietly.
- The ordering, against the REAL checkpointer: a checkpoint is written on a playground thread, the
  tenant row is deleted, and the delete is called with the stale selector. It asserts the refusal
  AND that the tuple is still there. Its first assertion measures the premise rather than assuming
  it: the thread is present while its tenant is not.
- The two cost claims, counted with a Prisma extension rather than asserted: a live fleet selector
  issues exactly one `tenant.findUnique`, a `TENANT_ADMIN` operator issues zero.
- A source ledger, because a decision table proves the FUNCTIONS and says nothing about whether the
  next entry point added rebuilds a context again (#205). It asserts that no file under
  `src/modules/playground/` constructs a `TenantContext`. The predicate is exported and shown to
  catch the exact `sysCtx` shape that was there, since a sweep with no offender left in the tree
  passes whether or not it works (#266). Its limit is stated in the file: it cannot reach the
  stt/vision pair, because those files keep a legitimate `sysCtx` for the inbound path, so those two
  are covered by their table rows and by the param types instead.
- Red first: all nine rows failed before the change, on the behaviour above.
- Mutation: restoring the forged `TENANT_ADMIN` context at each of the five `runScopedOn` sites in
  the playground modules, one at a time, kills 3 / 2 / 2 / 1 / 2 tests; the same at the two
  preprocessing sites kills 1 each; removing the pre-delete gate kills 1. No survivors. The
  preprocessing pair is in the count because the first attempt at it had none: reverting the fix
  killed nothing, which is how it was found to be untested.

**Not validated**

- No live run against a deployed instance. Everything above was measured locally against the test
  database.
- The console side is untouched. The refusal now reaches it in the shape #265's recovery already
  understands, but nothing in the client was changed and no browser-level flow was exercised.
- `savePlaygroundMedia` / `savePlaygroundTurnNote` stay best-effort (they swallow their own
  failures). They now carry the caller's context like everything else, but a refusal there is still
  a warn line rather than a turn failure, unchanged. In practice the turn has already been refused
  at its first scoped read before either can run.
- The pre-delete gate costs one extra transaction on the delete-session route. For a `TENANT_ADMIN`
  caller it opens, sets the GUC and commits, issuing no query; it was not benchmarked beyond that.
- Nothing here touches the thread fence, RLS, or what any playground query selects.
