### PR TITLE
Ask the episode's question at the three gates an inbound message reaches

### DIFF
--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -1427,7 +1427,7 @@ async function maybeConsumeCommandOrGate(params: {
     }
   }
 
-  // The EPISODE's activation, not this row's, for every gate below (issue #261). `/teste` means "this
+  // NOTE: The EPISODE's activation, not this row's, for every gate below (issue #261). `/teste` means "this
   // is me, testing", and a redirect episode is two conversations of one person: the stamp lands on the
   // row it was typed in, and the one bridge that copies it (above) runs ONCE, at link time, in one
   // direction. Outside that instant the two halves disagree, and the gates below — `/reset` and the

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -611,28 +611,6 @@ async function episodeActivationForWidget(
   });
 }
 
-async function isTestConversationActivated(params: {
-  tenantId: bigint;
-  instanceId: bigint;
-  conversationId: number | null;
-  base: PrismaClient;
-}): Promise<boolean> {
-  if (params.conversationId === null) return false;
-  const row = await runScopedOn(params.base, sysCtx(params.tenantId), (db) =>
-    db.conversation.findUnique({
-      where: {
-        tenantId_chatwootInstanceId_chatwootConversationId: {
-          tenantId: params.tenantId,
-          chatwootInstanceId: params.instanceId,
-          chatwootConversationId: params.conversationId as number,
-        },
-      },
-      select: { testActivatedAt: true },
-    }),
-  );
-  return row?.testActivatedAt != null;
-}
-
 // Eager media analysis: transcribe an incoming voice note (STT) and extract an incoming image/document
 // (vision) BEFORE arming/answering, writing the result back to Chatwoot and stashing it on the
 // in-memory event (the direct path reads it; the debounce flush re-reads from the attachment meta).
@@ -1447,6 +1425,34 @@ async function maybeConsumeCommandOrGate(params: {
       });
       ctx.conv.testActivatedAt = linked.testActivatedAt;
     }
+  }
+
+  // The EPISODE's activation, not this row's, for every gate below (issue #261). `/teste` means "this
+  // is me, testing", and a redirect episode is two conversations of one person: the stamp lands on the
+  // row it was typed in, and the one bridge that copies it (above) runs ONCE, at link time, in one
+  // direction. Outside that instant the two halves disagree, and the gates below — `/reset` and the
+  // test-mode silence — judged by whichever row they happened to hold.
+  //
+  // Resolved into the field the gates already read, which is what the propagation directly above does
+  // too, so this adds a source of truth rather than a second question. Safe for `/teste` itself: that
+  // branch writes a fresh stamp without reading this value.
+  //
+  // Costs nothing on the ordinary path — `needsEpisodeLookup` is false for a production agent, for a
+  // row already stamped, and for any conversation outside a redirect episode — and this gate runs on
+  // every inbound message.
+  if (ctx.agentSettings != null) {
+    ctx.conv.testActivatedAt = await episodeTestActivatedAt({
+      tenantId,
+      instanceId,
+      cfg: readChannelRedirectConfig(ctx.agentSettings),
+      agentMode: ctx.mode,
+      conv: {
+        testActivatedAt: ctx.conv.testActivatedAt,
+        contactId: ctx.conv.contactId,
+        chatwootInboxId: ctx.inboxChatwootId,
+      },
+      base,
+    });
   }
 
   // ── /teste: activate test mode for THIS conversation, ACK, consume. ──
@@ -2826,18 +2832,23 @@ export async function processChatwootDelivery(
   // Production analyzes every new incoming message. Some transports attach the audio just after
   // message_created, so the first useful attachment arrives on message_updated; analyze that update
   // without arming debounce or a second turn. Test mode keeps its cost fence and only analyzes a late
-  // attachment when this conversation was explicitly activated.
+  // attachment on an activated EPISODE (issue #261) — the unit the other two gates use. Asked of the
+  // row alone, an episode activated on the WhatsApp side got no transcription on the widget side, and
+  // the agent then answered a message it never heard.
   const activatedTestLateMedia =
     hasLateMedia &&
     rt?.enabled === true &&
     rt.mode === "test" &&
     act &&
-    (await isTestConversationActivated({
-      tenantId: params.tenantId,
-      instanceId: params.instanceId,
-      conversationId: n.conversationId,
+    n.conversationId !== null &&
+    (await episodeActivationForWidget(
+      params.tenantId,
+      params.instanceId,
+      n.conversationId,
+      readChannelRedirectConfig(rt.settings),
+      rt.mode,
       base,
-    }));
+    )) !== null;
   if (
     rt?.enabled &&
     ((isNewIncoming && rt.mode === "production") ||

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -13,6 +13,7 @@ import {
   parseSchedule,
   type ScheduleException,
 } from "@/modules/business-hours/hours";
+import { episodeTestActivatedAt } from "@/modules/channel-redirect/episode";
 import { readChannelRedirectConfig } from "@/modules/channel-redirect/service";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import {
@@ -527,6 +528,7 @@ async function loadConvRef(
   lastError: string | null;
   lastErrorAt: Date | null;
   testActivatedAt: Date | null;
+  contactId: bigint | null;
   lastFollowUpAt: Date | null;
   inbox: {
     id: bigint;
@@ -555,6 +557,7 @@ async function loadConvRef(
         lastError: true,
         lastErrorAt: true,
         testActivatedAt: true,
+        contactId: true,
         lastFollowUpAt: true,
         inbox: {
           select: {
@@ -834,6 +837,25 @@ export async function getConversationDetail(
         )?.chatwootAgentBotId ?? null)
       : null;
 
+  // The EPISODE's activation, not this row's (issue #261). A channel-redirect episode is two
+  // conversations of one contact and `/teste` stamps only the one it was typed in, so the row alone
+  // answers for half of it. Both readers below take this: the badge the console renders, and the
+  // follow-up estimate — and they have to agree with the gates in `webhook.ts`, which now answer the
+  // episode's question. A badge reading "awaiting /teste" over an agent that is answering is the
+  // console contradicting what the operator can see in the conversation.
+  const episodeActivatedAt = await episodeTestActivatedAt({
+    tenantId,
+    instanceId: conv.chatwootInstanceId,
+    cfg: readChannelRedirectConfig(agent?.settings),
+    agentMode: agent?.mode ?? "production",
+    conv: {
+      testActivatedAt: conv.testActivatedAt,
+      contactId: conv.contactId,
+      chatwootInboxId: conv.inbox?.chatwootInboxId ?? null,
+    },
+    base,
+  });
+
   // Follow-up journey (item 17): the agent's configured step count + the next PENDING follow-up job
   // for this conversation's thread. The job's runAt is an ESTIMATE — it fires on a background worker.
   let followUp: ConversationDetail["followUp"] = null;
@@ -858,7 +880,7 @@ export async function getConversationDetail(
       followUpEnabled: cfg.enabled,
       managedByRedirect,
       agentMode: agent?.mode ?? "production",
-      testActivatedAt: conv.testActivatedAt,
+      testActivatedAt: episodeActivatedAt,
       status: conv.status,
       assigneeType: conv.assigneeType,
       // The strict ownership answer, which this reader is the one that needs: nothing runs after the
@@ -1229,8 +1251,8 @@ export async function getConversationDetail(
       return parsed.success ? parsed.data.model : null;
     })(),
     outOfHours,
-    testActivatedAt: conv.testActivatedAt
-      ? conv.testActivatedAt.toISOString()
+    testActivatedAt: episodeActivatedAt
+      ? episodeActivatedAt.toISOString()
       : null,
     followUp,
     appointmentReminders,

--- a/tests/modules/chatwoot-reset.test.ts
+++ b/tests/modules/chatwoot-reset.test.ts
@@ -285,6 +285,56 @@ async function sendReset(
   });
 }
 
+// A `message_updated` carrying the audio that was not attached at creation time — the shape
+// `hasPendingInboundMediaUpdate` recognises. Eligible for eager STT only: it drives no turn.
+async function sendLateAudio(
+  convId: number,
+  inboxId: number,
+  audioUrl: string,
+): Promise<void> {
+  deliverySeq += 1;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const body = JSON.stringify({
+    event: "message_updated",
+    id: 9500 + deliverySeq,
+    content: "",
+    message_type: "incoming",
+    private: false,
+    attachments: [
+      { id: 77, file_type: "audio", data_url: audioUrl, transcribed_text: "" },
+    ],
+    conversation: {
+      id: convId,
+      inbox_id: inboxId,
+      status: "pending",
+      contact_inbox: { id: 301 },
+      meta: { assignee_type: null, assignee: null },
+    },
+  });
+  const r = await receiveChatwootWebhook({
+    routeToken,
+    rawBody: body,
+    getHeader: (name: string) =>
+      ({
+        "x-chatwoot-signature": `sha256=${createHmac("sha256", SECRET)
+          .update(`${nowSeconds}.${body}`)
+          .digest("hex")}`,
+        "x-chatwoot-timestamp": String(nowSeconds),
+        "x-chatwoot-delivery": `late-audio-${deliverySeq}`,
+      })[name.toLowerCase()] ?? null,
+    nowSeconds,
+    base: appDb,
+  });
+  await recordAndProcessChatwootDelivery({
+    tenantId,
+    instanceId: r.instanceId as bigint,
+    deliveryId: r.deliveryId as string,
+    agentBotId: r.agentBotId ?? null,
+    normalized: r.normalized as NonNullable<typeof r.normalized>,
+    base: appDb,
+  });
+}
+
 const attributeCalls = (calls: CwCall[]) =>
   calls.filter((c) => c.path.endsWith("/custom_attributes"));
 const ackCalls = (calls: CwCall[]) =>
@@ -1442,6 +1492,126 @@ describe.skipIf(!dbUp)(
         });
       }
     };
+
+    // Issue #261's third reader, and the one that is not a send gate at all: a COST fence. A test
+    // agent only pays for transcribing a late attachment on a conversation "explicitly activated",
+    // and it asks the row rather than the episode — so an episode activated on WhatsApp does not get
+    // its voice notes transcribed on the widget side, and the agent later answers a message it never
+    // heard.
+    test("a late voice note is transcribed when the episode is activated on the other half", async () => {
+      await withRedirectPair(async (_convId, _widgetThread) => {
+        await suDb.conversation.updateMany({
+          where: { tenantId, chatwootConversationId: 44 },
+          data: { testActivatedAt: null },
+        });
+        await suDb.conversation.updateMany({
+          where: { tenantId, chatwootConversationId: CONV_ID },
+          data: { testActivatedAt: new Date() },
+        });
+        // The fence only has an observable if STT is runnable at all: without it `resolveSttConfig`
+        // answers null and nothing is downloaded whatever the fence decides.
+        const mine = await suDb.conversation.findFirstOrThrow({
+          where: { tenantId, chatwootConversationId: CONV_ID },
+          select: { inbox: { select: { agentId: true } } },
+        });
+        const agentId = mine.inbox?.agentId as bigint;
+        const sttKey = await suDb.vaultEntry.create({
+          data: {
+            tenantId,
+            name: `stt-key-${Date.now()}`,
+            secret: encryptJson("sk-test"),
+          },
+          select: { id: true },
+        });
+        const withStt = await suDb.agent.findUniqueOrThrow({
+          where: { id: agentId },
+          select: { settings: true },
+        });
+        await suDb.agent.update({
+          where: { id: agentId },
+          data: {
+            settings: {
+              ...(withStt.settings as Record<string, unknown>),
+              stt: {
+                enabled: true,
+                provider: "openai",
+                model: "whisper-1",
+                credentialRef: `vault:${sttKey.id}`,
+              },
+            },
+          },
+        });
+        const cw = fakeChatwoot();
+        globalThis.fetch = cw.impl;
+        const audioUrl = "https://203.0.113.9:9/late-note.ogg";
+        await sendLateAudio(44, WIDGET_INBOX_ID, audioUrl);
+        // The fence's only observable is whether the analysis was paid for at all: eager media
+        // downloads the attachment. Before the fix nothing is fetched.
+        expect(cw.calls.some((c) => c.path.endsWith("/late-note.ogg"))).toBe(
+          true,
+        );
+      });
+    });
+
+    // Issue #261, the same wrong unit one gate earlier. An ordinary message on the widget half of an
+    // activated episode is met with the not-activated notice — telling an operator who activated the
+    // agent one message ago, on the other channel, to go and activate it.
+    //
+    // The gate spells its predicate inline (`ctx.mode === "test" && ctx.conv.testActivatedAt ===
+    // null`) instead of going through `isTestSilenced`, which is why a sweep for the shared predicate
+    // does not turn it up.
+    test("an ordinary message is not met with the not-activated notice when the episode is activated", async () => {
+      await withRedirectPair(async (_convId, _widgetThread) => {
+        await suDb.conversation.updateMany({
+          where: { tenantId, chatwootConversationId: 44 },
+          data: { testActivatedAt: null, testNoticeSentAt: null },
+        });
+        await suDb.conversation.updateMany({
+          where: { tenantId, chatwootConversationId: CONV_ID },
+          data: { testActivatedAt: new Date() },
+        });
+        const cw = fakeChatwoot();
+        globalThis.fetch = cw.impl;
+        await sendReset("oi, ainda tá aí?", 44, { inboxId: WIDGET_INBOX_ID });
+        const notices = ackCalls(cw.calls).filter((c) =>
+          JSON.stringify(c.body ?? {}).includes("modo teste"),
+        );
+        // Before the fix this is the one-shot notice, posted on an episode that IS activated.
+        expect(notices).toEqual([]);
+      });
+    });
+
+    // Issue #261: the activation the operator gave is on the OTHER half of the episode. `/teste` was
+    // typed on WhatsApp after the link, so the ENTRY row carries the stamp and the widget row — the
+    // one this command is typed on — has none.
+    //
+    // `shouldRunReset` reads that row alone, answers false, and the command falls through to the
+    // test-mode gate. That gate's notice is one-shot and an earlier message already spent it, so what
+    // the operator gets back for a typed command is NOTHING AT ALL: no ack, no cleanup, no reason.
+    test("/reset runs when the activation is on the episode's other half", async () => {
+      await withRedirectPair(async (_convId, _widgetThread) => {
+        // The mirror image of what the helper seeds: the widget unstamped, the entry activated.
+        await suDb.conversation.updateMany({
+          where: { tenantId, chatwootConversationId: 44 },
+          data: { testActivatedAt: null },
+        });
+        await suDb.conversation.updateMany({
+          where: { tenantId, chatwootConversationId: CONV_ID },
+          data: { testActivatedAt: new Date() },
+        });
+        // The one shot is already spent, which is what makes the silence total rather than merely
+        // wrong: without this the gate would at least repeat the not-activated notice.
+        await suDb.conversation.updateMany({
+          where: { tenantId, chatwootConversationId: 44 },
+          data: { testNoticeSentAt: new Date() },
+        });
+        const cw = fakeChatwoot();
+        globalThis.fetch = cw.impl;
+        await sendReset("/reset", 44, { inboxId: WIDGET_INBOX_ID });
+        // A typed command has to answer something. Before the fix this array is empty.
+        expect(ackCalls(cw.calls)).not.toEqual([]);
+      });
+    });
 
     // A ladder the worker had ALREADY picked up. Cancelling reaches PENDING rows only, so the row
     // survives — and this ladder's terminal stage posts a closing on both conversations and resolves

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -1095,6 +1095,87 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
   // The distinction the flag exists for: a sequence whose last step is configured to resolve the
   // conversation ends with the bot no longer owning it. That is a COMPLETED sequence, and the console
   // still has to draw its completion marker — liveness alone cannot tell it from an abandoned one.
+  // Issue #261, at the reader the OPERATOR looks at. The gates in `webhook.ts` answer the episode's
+  // question, so on the unstamped half of an activated episode the agent replies — and this endpoint,
+  // asking the row, would still hand the console "awaiting /teste". A badge that contradicts what the
+  // operator can read in the conversation is worse than no badge.
+  test("the detail of an episode's unstamped half reports the activation", async () => {
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId: tenant,
+        name: "FU Episode",
+        systemPrompt: "x",
+        mode: "test",
+        modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        settings: {
+          channelRedirect: {
+            enabled: true,
+            entryInboxId: 96,
+            widgetInboxId: 97,
+          },
+        },
+      },
+    });
+    const mk = (chatwootInboxId: number, name: string) =>
+      suDb.inbox.create({
+        data: {
+          tenantId: tenant,
+          chatwootInstanceId: inst,
+          chatwootInboxId,
+          name,
+          agentId: agent.id,
+        },
+      });
+    const entryInbox = await mk(96, "WhatsApp");
+    const widgetInbox = await mk(97, "Site");
+    const contact = await suDb.contact.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootContactId: 9601,
+        name: "Cliente",
+      },
+    });
+    const at = new Date("2026-06-19T10:00:00Z");
+    const mkConv = (
+      chatwootConversationId: number,
+      inboxId: bigint,
+      stamp: Date | null,
+    ) =>
+      suDb.conversation.create({
+        data: {
+          tenantId: tenant,
+          chatwootInstanceId: inst,
+          chatwootConversationId,
+          inboxId,
+          contactId: contact.id,
+          status: "pending",
+          threadId: `${tenant}:${inst}:${chatwootConversationId}`,
+          lastEventAt: at,
+          testActivatedAt: stamp,
+        },
+      });
+    // `/teste` typed on WhatsApp after the link: the entry row carries it, the widget row does not.
+    await mkConv(9602, entryInbox.id, at);
+    const widget = await mkConv(9603, widgetInbox.id, null);
+    try {
+      const d = await getConversationDetail(ctx(tenant), widget.id, appDb);
+      expect(d.testActivatedAt).toBe(at.toISOString());
+    } finally {
+      await suDb.conversation.deleteMany({
+        where: {
+          tenantId: tenant,
+          chatwootConversationId: { in: [9602, 9603] },
+        },
+      });
+      await suDb.contact.delete({ where: { id: contact.id } });
+      await suDb.inbox.deleteMany({
+        where: { id: { in: [entryInbox.id, widgetInbox.id] } },
+      });
+      await suDb.agent.delete({ where: { id: agent.id } });
+    }
+  });
+
   test("a sequence that finished by resolving the conversation is complete, not abandoned", async () => {
     const d = await getConversationDetail(
       ctx(tenant),


### PR DESCRIPTION
## What broke

Test-mode activation is a property of the **person** being served: `/teste` means "this is me,
testing", and that does not stop being true because the lead followed a link from WhatsApp into the
website chat. A channel-redirect episode is **two** conversations of one contact, and `/teste` stamps
only the row it was typed in. The one bridge between them (`shouldPropagateTestMode`) runs **once**,
at link time, in **one** direction.

#262 fixed the readers that send **proactively**. Three more judge the same episode by a single row,
and all three are reached by an ordinary **inbound message**.

## Measured

Episode state: agent in `mode: "test"`, `/teste` typed on WhatsApp **after** the link, so the entry
row carries the stamp and the widget row does not. Against a real Postgres and a Chatwoot double:

| reader | before | after |
| --- | --- | --- |
| the reactive silence gate | posts `🧪 …não responde automaticamente nesta conversa` | the agent answers |
| `/reset` on the widget half | **nothing at all** | runs, and acknowledges |
| the late-media cost fence | the voice note is never transcribed | it is |
| the console's conversation detail | badge reads `awaiting /teste` | reads activated |

`/reset` is the worst shape of the three. `shouldRunReset` reads the row, answers false, and the
command falls through to the test-mode gate — whose notice is **one-shot** (`testNoticeSentAt`), and
an earlier message already spent it. A typed command produces no ack, no cleanup and no explanation.

The third is not a send gate at all but a **cost** fence: a test agent only pays to transcribe a late
attachment on an activated conversation. Asked of the row, an episode activated on WhatsApp gets no
transcription on the widget side, and the agent then answers a message it never heard.

## The shape

`episodeTestActivatedAt` (added in #262) already answers "is this episode activated?", and already
gates its extra read behind `needsEpisodeLookup` — false for a production agent, for an
already-stamped row, and for any conversation outside a redirect episode. This wires it in.

**The two gates take it in one place, not two.** The gate context is built once and both readers take
`ctx.conv.testActivatedAt` from it, so the episode's answer is resolved into that field right where
the link-time propagation already assigns to it (`ctx.conv.testActivatedAt = linked.testActivatedAt`).
That keeps one source of truth for the whole function instead of asking the same question twice.
Safe for `/teste` itself: that branch writes a fresh stamp without reading the value.

**A fourth reader came out of review, and it is one this PR would otherwise have broken.** Widening
the gates means the agent now answers on the unstamped half — while `getConversationDetail` still
served the row's own stamp, so the console would draw `Test mode · awaiting /teste` over a
conversation the operator can watch the agent replying in. Before this PR the badge and the silence
agreed; only the fix makes them disagree, so it belongs here rather than in a follow-up. The same
endpoint had a **second** reader of that field (the follow-up estimate's `isFollowUpLive`), and both
now take one resolved value, computed once per response.

**The third reader loses its own helper.** `isTestConversationActivated` was a narrower copy of the
read `episodeActivationForWidget` already does, so it is deleted and the fence calls the shared one.
Net: two near-identical readers become one.

Nothing new is loaded. `contactId`, the inbox's `chatwootInboxId` and the agent's `settings` were
already selected by the gate's own context and by `inboxAgentRuntime`.

## Validation scope

**Proved by test** (DB-backed, against a real Postgres), all three in
`tests/modules/chatwoot-reset.test.ts`, which already had the redirect-pair harness:

- `/reset` typed on the unstamped half of an activated episode answers something. Red before: the
  assertion is on an **empty** array of Chatwoot calls, with the one-shot notice deliberately spent
  first so the silence is total.
- an ordinary message on that half is not met with the not-activated notice.
- a late voice note on that half is transcribed. **This one carries its own control**: with the
  widget row stamped instead of the sibling, the same test passes on the unfixed code — which is what
  proves the red comes from the fence and not from a harness that never reaches eager media at all.
  (It did not, at first: `resolveSttConfig` answers null without a credential, and nothing downloads
  whatever the fence decides.)
- `tests/modules/conversation-followup-estimate.test.ts` — the detail of an episode's unstamped half
  reports the activation.

Mutation: removing the episode resolution from the gate context drops **2** tests; making the
late-media fence stop asking drops **1**; serving the row's own stamp from the detail endpoint drops
**1**. Each call site is independently covered.

Full suite: 5212 pass, 0 fail.

**Proved live**, against a real Chatwoot: one contact with a WhatsApp conversation and a
website-widget one, `/teste` stamped on the **WhatsApp** row, and `redirectLinkedAt` set so the
one-shot bridge is **spent** — the issue's premise. Deliveries were driven through
`receiveChatwootWebhook` + `recordAndProcessChatwootDelivery` with no fake fetch, so every Chatwoot
call left the process for real.

| arm | code | posted to the widget | detail endpoint |
| --- | --- | --- | --- |
| `/reset` | this PR | the real ack, `private=false` | activated |
| `/reset` | reverted | **0** | `null` |
| ordinary message | this PR | 0 (no notice; the gate lets it through) | activated |
| ordinary message | reverted | the `🧪 modo teste` note, `private=true` | `null` |

The reverted arms are the defect end to end, and the app names both steps itself:
`/reset with test mode not active — deferring to the test-mode gate`, then `test-mode silent —
awaiting /teste`. Read back from Chatwoot's own `messages` table, not from the calls that sent them.

The one-shot matters: with `redirectLinkedAt` left null the first run of this harness could not tell
the arms apart, because `linkRedirectConversations` legitimately propagated the stamp and did the
fix's job for it.

**Not validated live**: the late-media fence, which needs a real STT credential to have any
observable at all (`resolveSttConfig` answers null without one and nothing downloads). It is covered
by the DB-backed test above, with its own control.

**Out of scope, deliberately.** `/reset`'s own cleanup stays scoped to the conversation it was typed
on. "The episode is activated" licenses the command to **run**; naming the other half reliably enough
to clear it too is #222, and this PR does not touch that.

Fixes #261


