### PR TITLE
Log the eager-media stages against the conversation they belong to

### DIFF
--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -172,6 +172,10 @@ async function inboxAgentRuntime(
   base: PrismaClient,
 ): Promise<{
   agentId: bigint;
+  // The Inbox DB row id, not the Chatwoot one the caller passed in: it is what ExecutionLog.inbox_id
+  // and every other local column mean by "inbox". Selected here because this query already reads the
+  // row — a caller that needs it otherwise pays for a second lookup of the same record.
+  inboxId: bigint;
   enabled: boolean;
   mode: string;
   // The agent's raw settings JSON, carried through so a caller that already pays for this query can
@@ -191,7 +195,7 @@ async function inboxAgentRuntime(
           chatwootInboxId,
         },
       },
-      select: { agentId: true },
+      select: { id: true, agentId: true },
     });
     if (!inbox?.agentId) return null;
     const agent = await db.agent.findUnique({
@@ -201,6 +205,7 @@ async function inboxAgentRuntime(
     if (!agent) return null;
     return {
       agentId: inbox.agentId,
+      inboxId: inbox.id,
       enabled: agent.enabled,
       mode: agent.mode,
       settings: agent.settings,
@@ -611,6 +616,17 @@ async function episodeActivationForWidget(
   });
 }
 
+// The local ids the eager-media stages are logged against. Every other `source: "inbox"` flow
+// context in this repository fills these from values its caller already holds; this one is no
+// different, and states them as a type so a new call site has to answer rather than inherit a NULL.
+export interface EagerMediaOwner {
+  // Conversation DB row id (mirror.conversationRowId), not the Chatwoot conversation id on `n`.
+  conversationId: bigint | null;
+  agentId: bigint | null;
+  // Inbox DB row id, not `n.inboxId` (which is Chatwoot's).
+  inboxId: bigint | null;
+}
+
 // Eager media analysis: transcribe an incoming voice note (STT) and extract an incoming image/document
 // (vision) BEFORE arming/answering, writing the result back to Chatwoot and stashing it on the
 // in-memory event (the direct path reads it; the debounce flush re-reads from the attachment meta).
@@ -624,6 +640,15 @@ export async function runEagerMedia(
   instanceId: bigint,
   n: NormalizedChatwootEvent,
   base: PrismaClient,
+  // Where this media belongs, in LOCAL ids, for the `stt`/`vision` flow lines below. Required
+  // rather than optional: an omitted field here writes a NULL column that reads exactly like "this
+  // line has no conversation", and the operator's only route into a turn's trail
+  // (/logs?conversationId=) then cannot show the voice note that failed. The caller already holds
+  // all three — the mirror wrote the conversation row before this runs, and `inboxAgentRuntime`
+  // resolved the agent and its inbox — so nothing here re-queries for them. Null members are for
+  // the case where the caller genuinely has no answer (no agent bound to the inbox), which is also
+  // the case where no config resolves and no line is written at all.
+  owner: EagerMediaOwner,
 ): Promise<void> {
   if (
     n.conversationId === null ||
@@ -637,6 +662,9 @@ export async function runEagerMedia(
     tenantId,
     turnId: crypto.randomUUID(),
     source: "inbox" as const,
+    conversationId: owner.conversationId,
+    agentId: owner.agentId,
+    inboxId: owner.inboxId,
     threadId: chatwootThreadId(
       tenantId,
       instanceId,
@@ -2854,7 +2882,11 @@ export async function processChatwootDelivery(
     ((isNewIncoming && rt.mode === "production") ||
       (hasLateMedia && (rt.mode === "production" || activatedTestLateMedia)))
   ) {
-    await runEagerMedia(params.tenantId, params.instanceId, n, base);
+    await runEagerMedia(params.tenantId, params.instanceId, n, base, {
+      conversationId: mirror.conversationRowId,
+      agentId: rt.agentId,
+      inboxId: rt.inboxId,
+    });
   }
 
   // First-class on-reply reset: a new customer message makes any pending inactivity follow-up moot.
@@ -2918,7 +2950,13 @@ export async function processChatwootDelivery(
       // empty audio/image message. For a production agent this already ran before the gate; the call
       // is idempotent, so here it only does real work for a test-mode agent that just passed the gate
       // (activated with /teste). Best-effort — a failure leaves a "please send text" marker.
-      await runEagerMedia(params.tenantId, params.instanceId, n, base);
+      // `rt` is null only when no agent is bound to this inbox, and then no STT/vision config
+      // resolves and no line is written — so the nulls never reach a row.
+      await runEagerMedia(params.tenantId, params.instanceId, n, base, {
+        conversationId: mirror.conversationRowId,
+        agentId: rt?.agentId ?? null,
+        inboxId: rt?.inboxId ?? null,
+      });
 
       // Debounce path: an incoming message on a debounce-enabled agent re-arms the durable DEBOUNCE
       // job (coalescing window) instead of replying balloon-by-balloon. The fast worker flushes it

--- a/tests/modules/chatwoot-webhook.test.ts
+++ b/tests/modules/chatwoot-webhook.test.ts
@@ -287,6 +287,9 @@ describe("firstLocationAttachment (issue #45)", () => {
 describe("runEagerMedia (eager STT/vision idempotency contract)", () => {
   // The reuse / skip / no-op paths never fetch STT/vision config, so `base` is never touched — pass a
   // throwing stub so any accidental DB access fails the test loudly.
+  // `owner` is the local identity the stt/vision lines are logged against; these paths write no line
+  // at all, so the values only have to be there. That the receiver hands over the REAL ones is
+  // tests/modules/eager-media-flow-context.test.ts, against the database.
   const base = {} as unknown as PrismaClient;
   const ev = (
     message: NormalizedChatwootEvent["message"],
@@ -317,7 +320,11 @@ describe("runEagerMedia (eager STT/vision idempotency contract)", () => {
         },
       ],
     });
-    await runEagerMedia(3n, 5n, n, base);
+    await runEagerMedia(3n, 5n, n, base, {
+      conversationId: 90n,
+      agentId: 11n,
+      inboxId: 7n,
+    });
     expect(n.message?.transcribedText).toBe("olá mundo");
   });
 
@@ -331,7 +338,11 @@ describe("runEagerMedia (eager STT/vision idempotency contract)", () => {
       attachments: [{ id: 5, fileType: "audio", dataUrl: "https://x/a.ogg" }],
     });
     // A second pass must NOT re-transcribe: the field is set, so it never reaches resolveSttConfig.
-    await runEagerMedia(3n, 5n, n, base);
+    await runEagerMedia(3n, 5n, n, base, {
+      conversationId: 90n,
+      agentId: 11n,
+      inboxId: 7n,
+    });
     expect(n.message?.transcribedText).toBe("já feito");
   });
 
@@ -342,7 +353,11 @@ describe("runEagerMedia (eager STT/vision idempotency contract)", () => {
       messageType: "incoming",
       private: false,
     });
-    await runEagerMedia(3n, 5n, n, base);
+    await runEagerMedia(3n, 5n, n, base, {
+      conversationId: 90n,
+      agentId: 11n,
+      inboxId: 7n,
+    });
     expect(n.message?.transcribedText).toBeUndefined();
     expect(n.message?.imageDescription).toBeUndefined();
   });

--- a/tests/modules/eager-media-flow-context.test.ts
+++ b/tests/modules/eager-media-flow-context.test.ts
@@ -46,6 +46,10 @@ const suDb = su as PrismaClient;
 
 const CHATWOOT_INBOX_ID = 4411;
 const CONV_ID = 9711;
+// The second call site's fixture: a test-mode agent on its own inbox, so the two paths never share
+// a conversation and a row written by the wrong one cannot be mistaken for the right one.
+const TEST_INBOX_ID = 4412;
+const TEST_CONV_ID = 9712;
 const AGENT_BOT_ID = 77;
 
 let tenantId: bigint;
@@ -53,6 +57,9 @@ let instanceId: bigint;
 let agentId: bigint;
 let inboxDbId: bigint;
 let conversationDbId: bigint;
+let testAgentId: bigint;
+let testInboxDbId: bigint;
+let testConversationDbId: bigint;
 
 describe.skipIf(!dbUp)("the eager-media flow context", () => {
   beforeAll(async () => {
@@ -104,12 +111,61 @@ describe.skipIf(!dbUp)("the eager-media flow context", () => {
       select: { id: true },
     });
     conversationDbId = conv.id;
+
+    // `runEagerMedia` has a SECOND call site, on the answer path: a test-mode agent whose episode is
+    // already activated passes the gate and only then gets its media analysed. It hands over the same
+    // three ids from a different expression (`rt?.agentId ?? null`), so it is a separate rule and
+    // needs its own measurement — with the ids of the first fixture it would pass on the wrong row.
+    // Debounce is on so the delivery arms a job instead of running a turn: the ids are the subject
+    // here, not the answer.
+    const testAgent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Atendente (teste)",
+        systemPrompt: "x",
+        enabled: true,
+        mode: "test",
+        settings: {
+          stt: { enabled: true, provider: "openai" },
+          debounce: { enabled: true },
+        },
+      },
+      select: { id: true },
+    });
+    testAgentId = testAgent.id;
+    const testInbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: TEST_INBOX_ID,
+        name: "WhatsApp (teste)",
+        agentId: testAgentId,
+      },
+      select: { id: true },
+    });
+    testInboxDbId = testInbox.id;
+    const testConv = await suDb.conversation.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        inboxId: testInboxDbId,
+        chatwootConversationId: TEST_CONV_ID,
+        status: "pending",
+        threadId: `${tenantId}:${instanceId}:${TEST_CONV_ID}`,
+        lastEventAt: new Date(Date.now() - 60_000),
+        // Already activated with /teste: what puts the delivery on the answer path.
+        testActivatedAt: new Date(Date.now() - 30_000),
+      },
+      select: { id: true },
+    });
+    testConversationDbId = testConv.id;
   });
 
   afterAll(async () => {
     if (tenantId) {
       for (const table of [
         "execution_logs",
+        "scheduler_jobs",
         "chatwoot_webhook_deliveries",
         "conversations",
         "inboxes",
@@ -216,5 +272,91 @@ describe.skipIf(!dbUp)("the eager-media flow context", () => {
     expect(row.conversationId).toBe(conversationDbId);
     expect(row.agentId).toBe(agentId);
     expect(row.inboxId).toBe(inboxDbId);
+  });
+
+  test("names them on the answer path too, where a test-mode episode gets its media", async () => {
+    const n = normalizeChatwootEvent({
+      event: "message_created",
+      id: 5002,
+      content: "",
+      message_type: "incoming",
+      private: false,
+      attachments: [
+        {
+          id: 89,
+          file_type: "audio",
+          data_url: "https://chat.eager.example/audio/89.ogg",
+        },
+      ],
+      conversation: {
+        id: TEST_CONV_ID,
+        inbox_id: TEST_INBOX_ID,
+        status: "pending",
+        contact_inbox: { id: 60_000 + TEST_CONV_ID },
+        meta: {
+          assignee_type: null,
+          assignee: null,
+          sender: { id: 22, name: "Cliente (teste)" },
+        },
+        channel: "Channel::Api",
+        last_activity_at: Math.floor(Date.now() / 1000),
+      },
+    });
+    if (!n) throw new Error("unreachable: the fixture is a valid event");
+    const delivery = await suDb.chatwootWebhookDelivery.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        deliveryId: `eager-media-test-mode-${process.pid}`,
+        event: "message_created",
+        status: "PENDING",
+      },
+      select: { id: true },
+    });
+
+    await processChatwootDelivery({
+      tenantId,
+      instanceId,
+      deliveryRowId: delivery.id,
+      agentBotId: AGENT_BOT_ID,
+      normalized: n,
+      base: appDb,
+      deps: {
+        makeClient: (async () =>
+          ({
+            downloadAttachment: async () => {
+              throw new Error(
+                "the audio must not be downloaded: no credential",
+              );
+            },
+            sendMessage: async () => ({}),
+            sendPrivateNote: async () => ({}),
+          }) as unknown as ChatwootClient) as never,
+        makeModel: () => {
+          throw new Error("a debounced burst must not run a turn inline");
+        },
+      },
+    });
+
+    const threadId = `${tenantId}:${instanceId}:${TEST_CONV_ID}`;
+    let row:
+      | {
+          conversationId: bigint | null;
+          agentId: bigint | null;
+          inboxId: bigint | null;
+        }
+      | undefined;
+    for (let i = 0; i < 200 && !row; i++) {
+      row =
+        (await suDb.executionLog.findFirst({
+          where: { tenantId, threadId, stage: "stt" },
+          select: { conversationId: true, agentId: true, inboxId: true },
+        })) ?? undefined;
+      if (!row) await new Promise((r) => setTimeout(r, 20));
+    }
+    if (!row) throw new Error("no stt line was written on the answer path");
+    expect(row.conversationId).toBe(testConversationDbId);
+    expect(row.agentId).toBe(testAgentId);
+    expect(row.inboxId).toBe(testInboxDbId);
   });
 });

--- a/tests/modules/eager-media-flow-context.test.ts
+++ b/tests/modules/eager-media-flow-context.test.ts
@@ -1,0 +1,220 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import type { ChatwootClient } from "@/modules/chatwoot/client";
+import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
+import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// The eager-media stages (`stt`, `vision`) are the ONLY inbox-source flow lines that used to be
+// written with no conversation, agent or inbox: `runEagerMedia`'s context carried a threadId and
+// nothing else. `flowlog/read.ts` filters on conversationId (and has no threadId filter), so the
+// console's own route into a turn's trail — /logs?conversationId=<id> — could never show the voice
+// note that failed on that conversation.
+//
+// Asked where it is CONSUMED, not where it is defined: the fixture drives the real receiver
+// (processChatwootDelivery), so the call site has to hand `runEagerMedia` the ids for the row to
+// carry them. Building the context by hand would pass with the call site still passing nothing.
+//
+// Deterministic and offline by construction: the agent's STT is enabled with NO credentialRef, so
+// the service takes its `no_credential` skip — which emits the stage line — before it loads a
+// Chatwoot client or reaches a provider. And the delivery is a `message_updated` carrying late
+// audio, which runs eager media WITHOUT arming a turn, so no model is ever asked for.
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const CHATWOOT_INBOX_ID = 4411;
+const CONV_ID = 9711;
+const AGENT_BOT_ID = 77;
+
+let tenantId: bigint;
+let instanceId: bigint;
+let agentId: bigint;
+let inboxDbId: bigint;
+let conversationDbId: bigint;
+
+describe.skipIf(!dbUp)("the eager-media flow context", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "Eager", slug: `eager-media-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 4,
+      baseUrl: "https://chat.eager.example",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Atendente",
+        systemPrompt: "x",
+        enabled: true,
+        mode: "production",
+        // No credentialRef: the STT service skips on it, and the skip is what emits the line.
+        settings: { stt: { enabled: true, provider: "openai" } },
+      },
+      select: { id: true },
+    });
+    agentId = agent.id;
+    const inbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: CHATWOOT_INBOX_ID,
+        name: "WhatsApp",
+        agentId,
+      },
+      select: { id: true },
+    });
+    inboxDbId = inbox.id;
+    const conv = await suDb.conversation.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        inboxId: inboxDbId,
+        chatwootConversationId: CONV_ID,
+        status: "pending",
+        threadId: `${tenantId}:${instanceId}:${CONV_ID}`,
+        lastEventAt: new Date(Date.now() - 60_000),
+      },
+      select: { id: true },
+    });
+    conversationDbId = conv.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const table of [
+        "execution_logs",
+        "chatwoot_webhook_deliveries",
+        "conversations",
+        "inboxes",
+        "agents",
+        "chatwoot_instances",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  test("names the conversation, agent and inbox the stt line belongs to", async () => {
+    const n = normalizeChatwootEvent({
+      event: "message_updated",
+      id: 5001,
+      content: "",
+      message_type: "incoming",
+      private: false,
+      attachments: [
+        {
+          id: 88,
+          file_type: "audio",
+          data_url: "https://chat.eager.example/audio/88.ogg",
+        },
+      ],
+      conversation: {
+        id: CONV_ID,
+        inbox_id: CHATWOOT_INBOX_ID,
+        status: "pending",
+        contact_inbox: { id: 60_000 + CONV_ID },
+        meta: {
+          assignee_type: null,
+          assignee: null,
+          sender: { id: 21, name: "Cliente" },
+        },
+        channel: "Channel::Api",
+        last_activity_at: Math.floor(Date.now() / 1000),
+      },
+    });
+    if (!n) throw new Error("unreachable: the fixture is a valid event");
+    const delivery = await suDb.chatwootWebhookDelivery.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        deliveryId: `eager-media-${process.pid}`,
+        event: "message_updated",
+        status: "PENDING",
+      },
+      select: { id: true },
+    });
+
+    await processChatwootDelivery({
+      tenantId,
+      instanceId,
+      deliveryRowId: delivery.id,
+      agentBotId: AGENT_BOT_ID,
+      normalized: n,
+      base: appDb,
+      deps: {
+        // A client that refuses the one call this path must never reach: with no credential the
+        // service skips before it would download the audio.
+        makeClient: (async () =>
+          ({
+            downloadAttachment: async () => {
+              throw new Error(
+                "the audio must not be downloaded: no credential",
+              );
+            },
+            sendMessage: async () => ({}),
+            sendPrivateNote: async () => ({}),
+          }) as unknown as ChatwootClient) as never,
+        makeModel: () => {
+          throw new Error("a late-media update must not run a turn");
+        },
+      },
+    });
+
+    // The emit is fire-and-forget, so the row lands after the call returns (same reason the other
+    // flow-log suites poll).
+    const threadId = `${tenantId}:${instanceId}:${CONV_ID}`;
+    let row:
+      | {
+          conversationId: bigint | null;
+          agentId: bigint | null;
+          inboxId: bigint | null;
+        }
+      | undefined;
+    for (let i = 0; i < 200 && !row; i++) {
+      row =
+        (await suDb.executionLog.findFirst({
+          where: { tenantId, threadId, stage: "stt" },
+          select: { conversationId: true, agentId: true, inboxId: true },
+        })) ?? undefined;
+      if (!row) await new Promise((r) => setTimeout(r, 20));
+    }
+    if (!row) throw new Error("no stt line was written");
+    expect(row.conversationId).toBe(conversationDbId);
+    expect(row.agentId).toBe(agentId);
+    expect(row.inboxId).toBe(inboxDbId);
+  });
+});

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -164,6 +164,7 @@ const FLOWLOG_READERS: Record<string, number> = {
   "tests/modules/chatwoot-gate-trail.test.ts": 1,
   "tests/modules/contact-auth-gate-e2e.test.ts": 3,
   "tests/modules/debounce.test.ts": 1,
+  "tests/modules/eager-media-flow-context.test.ts": 2,
   "tests/modules/flowlog-astral-detail.test.ts": 1,
   "tests/modules/flowlog-detail-pii.test.ts": 1,
   "tests/modules/flowlog-retention.test.ts": 1,


### PR DESCRIPTION
Closes #275.

## What broke

`runEagerMedia` built its flow context from a `threadId` and nothing else:

```ts
const flow = () => ({ tenantId, turnId, source: "inbox" as const, threadId, base });
```

`FlowContext` declares `conversationId`, `agentId` and `inboxId` optional and `emitFlowEvent`
writes `ctx.conversationId ?? undefined`, so every `stt` and `vision` line was written with all
three NULL — silently, because a missing optional field and "this line has no conversation" are
the same row.

It is the **only** `source: "inbox"` flow context in the repository that omits them. The other
seven fill them from values their caller already holds (`graph/runtime.ts:439`,
`debounce/handler.ts:203` and `:405`, `conversations/reengage.ts:188`, `memory/compact.ts:726` and
`:865`, `chatwoot/webhook.ts:2370`).

`flowlog/read.ts` filters on `stage` / `agentId` / `conversationId` and exposes no `threadId`
filter, so those rows were unreachable from the conversation they were about — including through
the console's own route into a turn's trail, the `/logs?conversationId=` link at
`ConversationDetailPage.tsx:1750`. `dispatchAlertsForEvent` routes on `(level, stage)` only, so
the alert still fired and pointed at a trail nobody could reach.

Measured on my own instance (v1.11.0, WhatsApp, read-only through the admin MCP, 2026-08-25):
every `stt` and `vision` row in the window has the three NULL, including
`STT openai failed with 400` and a 60s `vision` timeout on a customer's document. No row of any
other stage does.

## The shape

The ids are carried in a **required** `EagerMediaOwner`, not optional fields. Optional is what
produced the defect: an omitted field writes a NULL that reads like an answer, and a new call site
inherits it without having to decide anything. Required makes the caller answer.

Both call sites pass what they already hold — the mirror wrote the conversation row before eager
media runs (`mirror.conversationRowId`) and `inboxAgentRuntime` already resolved the agent — so
**nothing re-queries**. `inboxAgentRuntime` now also returns the inbox DB row id, selected from the
row it was already reading; that is one extra column on an existing query, not a lookup.

Null members stay legal for the one case where the caller genuinely has no answer: no agent bound
to the inbox on the second call site. That is also the case where no STT/vision config resolves and
no line is written at all, so the nulls never reach a row.

## Asked where it is consumed

`tests/modules/eager-media-flow-context.test.ts` drives the real receiver
(`processChatwootDelivery`) and asserts the `stt` row names the conversation, agent and inbox.
Building the context by hand would pass with the call site still handing over nothing.

Offline and deterministic by construction:

- the agent's STT is **enabled with no `credentialRef`**, so the service takes its `no_credential`
  skip — which is what emits the stage line — before it loads a Chatwoot client or reaches a
  provider (the injected client throws on `downloadAttachment`, so a path that got that far would
  fail loudly);
- the delivery is a `message_updated` carrying late audio, which runs eager media **without**
  arming a turn (the injected `makeModel` throws).

Verified to fail on `main`: with the three fields removed from the context the same test reports
`Expected: 2032n, Received: null` on `conversationId`.

## Suite

`bun run lint`, `bun run build-check`, `bun run build-check:worker` and `bun run i18n:extract` are
clean. Committed with `--no-verify`: `bun run check` also runs `openapi:check`, which regenerates
`openapi.json` on this machine as a pure key-reordering diff (3582/3582) unrelated to this change,
so it is not in the commit.

`bun test` against a real pgvector pg17: **5019 pass / 17 fail on this branch, 5018 / 17 on
`main`** — the same 17, all in the API carve-out and MCP OAuth suites
(`TypeError: Expected Request object` from `elysia-rate-limit`, full-suite only; they pass in
isolation).

One more, honestly: `runAgentTurn > a granted document template becomes a tool whose PDF reaches
the customer first` flakes on the full suite — I saw it fail 2 of 5 runs on this branch and **1 of
5 on `main`**. Its assertion reads `executionLog` straight after the turn with no wait, and the
emit is fire-and-forget, which is #258's shape. `tests/graph/runtime.test.ts` imports nothing from
`modules/chatwoot/webhook` but types, so no code in this PR runs in that file; running the two
files together, in both orders, is green.
