### PR TITLE
Carry the operator's brand name onto the tab before the bundle mounts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,21 @@
   <link rel="icon" href="./favicon-light.png" media="(prefers-color-scheme: light)" />
   <link rel="icon" href="./favicon-dark.png" media="(prefers-color-scheme: dark)" />
   <title>fazer.ai agents</title>
+  <!-- Stamp the operator's brand name onto the tab before the first paint: BrandingProvider only
+       reaches document.title after the bundle mounts, and until then the <title> above is what the
+       tab shows. Same cache and same trade-off the provider already accepts for the brand colors,
+       so a returning visitor reads the name written on the last load and only a cold cache waits. -->
+  <script>
+    (function () {
+      var name;
+      // No localStorage, no cache yet (JSON.parse(null) yields null and reading a property off it
+      // throws), corrupt entry: every miss leaves `name` undefined and the <title> above standing.
+      try { name = JSON.parse(localStorage.getItem("@app:branding")).brandName; } catch (_) { }
+      // Blank counts as unconfigured, as after mount. The value goes in untrimmed on purpose: the
+      // `document.title` getter strips and collapses whitespace itself.
+      if (typeof name === "string" && name.trim()) document.title = name;
+    })();
+  </script>
   <script>
     (function () {
       var stored;

--- a/src/client/components/BrandFooter.tsx
+++ b/src/client/components/BrandFooter.tsx
@@ -1,7 +1,5 @@
-import {
-  DEFAULT_BRAND_NAME,
-  useBranding,
-} from "@/client/contexts/BrandingContext";
+import { useBranding } from "@/client/contexts/BrandingContext";
+import { DEFAULT_BRAND_NAME } from "@/lib/branding";
 
 // The auth-page footer: "© {year} {brandName}". The brand name follows the global white-label
 // config. When it is the default it links to the product site; a custom brand renders as plain

--- a/src/client/contexts/BrandingContext.tsx
+++ b/src/client/contexts/BrandingContext.tsx
@@ -10,7 +10,12 @@ import {
 } from "react";
 import { useTheme } from "@/client/contexts/ThemeContext";
 import { api } from "@/client/lib/api";
-import { BRANDABLE_KEY_TO_VAR, type BrandableKey } from "@/lib/branding";
+import {
+  BRANDABLE_KEY_TO_VAR,
+  BRANDING_CACHE_KEY,
+  type BrandableKey,
+  resolveBrandName,
+} from "@/lib/branding";
 import { derivePalette } from "@/lib/palette";
 
 // GLOBAL app identity/branding (applied app-wide — including anonymous pages like login/setup).
@@ -28,11 +33,9 @@ type BrandingData = NonNullable<
   Awaited<ReturnType<typeof api.api.v1.branding.get>>["data"]
 >;
 
-const CACHE_KEY = "@app:branding";
-
 function readCache(): BrandingData | null {
   try {
-    const raw = localStorage.getItem(CACHE_KEY);
+    const raw = localStorage.getItem(BRANDING_CACHE_KEY);
     return raw ? (JSON.parse(raw) as BrandingData) : null;
   } catch {
     return null;
@@ -41,16 +44,11 @@ function readCache(): BrandingData | null {
 
 function writeCache(config: BrandingData): void {
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify(config));
+    localStorage.setItem(BRANDING_CACHE_KEY, JSON.stringify(config));
   } catch {
     // NOTE: ignore quota / unavailable localStorage — the cache is a FOUC optimization only.
   }
 }
-
-// The white-label display name when none is configured (the product's own brand).
-// Exported so consumers (e.g. the auth-page footer) can tell the default apart
-// from an operator-configured name without re-hardcoding the string.
-export const DEFAULT_BRAND_NAME = "fazer.ai agents";
 
 interface BrandingContextValue {
   config: BrandingData | null;
@@ -186,7 +184,7 @@ export function BrandingProvider({ children }: { children: ReactNode }) {
     void refresh();
   }, [refresh]);
 
-  const brandName = config?.brandName?.trim() || DEFAULT_BRAND_NAME;
+  const brandName = resolveBrandName(config);
 
   // The document title follows the brand name (the default is the product's own brand).
   useLayoutEffect(() => {
@@ -229,7 +227,7 @@ export function BrandingProvider({ children }: { children: ReactNode }) {
 const DEFAULT_VALUE: BrandingContextValue = {
   config: null,
   logoUrl: null,
-  brandName: DEFAULT_BRAND_NAME,
+  brandName: resolveBrandName(null),
   // Outside the provider (isolated component tests) we render defaults immediately, never gated.
   ready: true,
   refresh: async () => {},

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -46,3 +46,20 @@ export function sanitizeBranding(input: unknown): Record<string, string> {
   }
   return out;
 }
+
+// The white-label display name when none is configured (the product's own brand). It is also the
+// `<title>` declared in `public/index.html`, so the cold-cache first paint already shows it.
+export const DEFAULT_BRAND_NAME = "fazer.ai agents";
+
+// Where the client caches the resolved global branding. Named here rather than in the provider
+// because a second reader lives outside the bundle: the inline <head> script that stamps the tab
+// title before React exists (#277).
+export const BRANDING_CACHE_KEY = "@app:branding";
+
+// The white-label name to display: the configured one, or the product's own. Blank and whitespace
+// count as unconfigured, and the configured name is displayed trimmed.
+export function resolveBrandName(
+  config: { brandName?: string | null } | null,
+): string {
+  return config?.brandName?.trim() || DEFAULT_BRAND_NAME;
+}

--- a/tests/client/brand-title-preload.test.ts
+++ b/tests/client/brand-title-preload.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  BRANDING_CACHE_KEY,
+  DEFAULT_BRAND_NAME,
+  resolveBrandName,
+} from "@/lib/branding";
+
+// The browser stamps the tab title the moment `<title>` is parsed, and `BrandingProvider` cannot
+// correct it until the deferred module script has been fetched, parsed and mounted. So the only
+// place that can carry the operator's name onto the FIRST paint is an inline <head> script, and
+// the only honest way to test one is to run the bytes the page ships (#277).
+
+const INDEX_HTML = await Bun.file(
+  new URL("../../public/index.html", import.meta.url),
+).text();
+
+function parseIndex(): Document {
+  return new DOMParser().parseFromString(INDEX_HTML, "text/html");
+}
+
+// Reproduce what the parser does to `document`: apply the declared <title>, then run each inline
+// <head> script in document order. `new Function` evaluates in global scope, which is where
+// happy-dom put `document`, `localStorage` and `matchMedia`.
+function parseHead(): void {
+  const parsed = parseIndex();
+  document.title = parsed.title;
+  for (const script of parsed.querySelectorAll("head script:not([src])")) {
+    new Function(script.textContent ?? "")();
+  }
+}
+
+// One table, two implementations of the same rule: the pure resolver the provider uses after mount,
+// and the inline script that has to agree with it before mount. The padded row is the one place the
+// two agree for different reasons: the resolver trims, and the script lets the `document.title`
+// getter strip and collapse the whitespace itself.
+const CASES: { name: string; cached: unknown; title: string }[] = [
+  {
+    name: "a configured name",
+    cached: { brandName: "Acme Co" },
+    title: "Acme Co",
+  },
+  {
+    name: "a padded name",
+    cached: { brandName: "  Acme Co  " },
+    title: "Acme Co",
+  },
+  {
+    name: "a blank name",
+    cached: { brandName: "   " },
+    title: DEFAULT_BRAND_NAME,
+  },
+  {
+    name: "a cleared name",
+    cached: { brandName: null },
+    title: DEFAULT_BRAND_NAME,
+  },
+  {
+    name: "a config with no name at all",
+    cached: {},
+    title: DEFAULT_BRAND_NAME,
+  },
+];
+
+describe("the tab title on the first paint", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.title = "";
+  });
+
+  test("the declared <title> is the product's own brand", () => {
+    expect(parseIndex().title).toBe(DEFAULT_BRAND_NAME);
+  });
+
+  for (const { name, cached, title } of CASES) {
+    test(`${name} resolves to "${title}" after mount`, () => {
+      expect(resolveBrandName(cached as { brandName?: string | null })).toBe(
+        title,
+      );
+    });
+
+    test(`${name} is already on the tab before mount`, () => {
+      localStorage.setItem(BRANDING_CACHE_KEY, JSON.stringify(cached));
+      parseHead();
+      expect(document.title).toBe(title);
+    });
+  }
+
+  test("a cold cache shows the product's own brand", () => {
+    parseHead();
+    expect(document.title).toBe(DEFAULT_BRAND_NAME);
+  });
+
+  test("an unreadable cache is not fatal", () => {
+    localStorage.setItem(BRANDING_CACHE_KEY, "{not json");
+    expect(() => parseHead()).not.toThrow();
+    expect(document.title).toBe(DEFAULT_BRAND_NAME);
+  });
+
+  test("the cached name never reaches the DOM as markup", () => {
+    localStorage.setItem(
+      BRANDING_CACHE_KEY,
+      JSON.stringify({ brandName: "<img src=x onerror=alert(1)>" }),
+    );
+    parseHead();
+    expect(document.title).toBe("<img src=x onerror=alert(1)>");
+    expect(document.querySelector("img")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What broke

`public/index.html` declares `<title>fazer.ai agents</title>`, and the browser stamps the tab the moment that tag is parsed. The configured name is applied only later, by the `document.title` layout effect in `BrandingProvider`, which cannot run until the deferred `<script type="module">` has been fetched, parsed and mounted. The `localStorage` branding cache does not close the window: `readCache` is the `useState` seed *inside* React, which is already past the point where the browser painted the default.

The theme already solves exactly this, two lines below: an inline `<head>` script reads `@app:theme` synchronously and stamps `data-theme` before the first paint. The brand name had no equivalent.

### Measured

Chromium, production build, CSP enforced, warm `@app:branding` cache, brand name `Acme Co`. A `MutationObserver` on `<head>` plus a 2 ms sampler records every change to `document.title`, timestamped from `performance.now()`. The two arms are the same server and the same page; the "before" arm is the shipped HTML with the new block stripped out in flight.

| arm | first title sampled | corrected at | default held the tab for |
| --- | --- | --- | --- |
| before | 6.4 ms `fazer.ai agents` | 219.2 ms | **212.8 ms** |
| after | 8.1 ms `Acme Co` | (already correct) | **0 ms** |

On localhost, with the bundle in cache. The window tracks how long the bundle takes to arrive and mount, so a real deployment is worse.

With the module bundle blocked entirely, the fix still stamps `Acme Co` (4.8 ms) and the pre-fix HTML still shows the default: the name is on the tab with no application JavaScript involved at all.

## The fix

An inline `<head>` script reads the same `@app:branding` cache the provider seeds itself from and stamps `document.title`. Same mechanism and same trade-off already accepted for the brand colors: a returning visitor is correct on the first paint, and only a cold cache waits for the bundle.

The name resolution moves to `src/lib/branding.ts` (`DEFAULT_BRAND_NAME`, `BRANDING_CACHE_KEY`, `resolveBrandName`), which already exists to keep server and client from drifting. That is what makes the duplication testable: the rule now has one owner in TypeScript, and one table in the test drives both it and the shipped inline script.

Two things the script deliberately does not do, both because a mutation showed the code was dead:

- no early return for a missing cache: `JSON.parse(null)` yields `null` and reading a property off it throws, so every miss (no `localStorage`, no entry, corrupt entry) lands in the same `catch` and leaves the declared `<title>` standing;
- no `trim()` on the value being assigned: the `document.title` getter strips and collapses whitespace itself. The `trim()` in the condition stays, because that is what makes a blank name fall back to the default.

## What of the report does not hold

Nothing. The mechanism, the file, the line and the reason the `localStorage` cache does not close the window are all as described.

The issue also offered server-side substitution as an alternative. It is not taken here, for a reason the issue could not have known: `staticPlugin` serves `/` from `dist/` directly, and only deep routes reach the `/*` catch-all where `indexHandler` lives. Substituting there would fix `/settings` and miss `/`, which is the common entry point. Closing that means intercepting the static route as well, which costs the byte-identical static asset, its caching, and a per-request read on the hottest path. In dev the handler is Bun's `HTMLBundle` object, so the same code would have to diverge between dev and prod on top of it.

## Validation scope

**Proved by test** (`tests/client/brand-title-preload.test.ts`, 14 assertions): the shipped bytes of `public/index.html` are parsed and its inline `<head>` scripts executed in document order, against a seeded `localStorage`, so the test exercises the file rather than a copy of its logic. One table drives both `resolveBrandName` and the script: configured, padded, blank, cleared, absent. Plus a cold cache, a corrupt entry, and that a name carrying markup reaches the tab as text and creates no element.

Red first: before the fix, 3 of the 14 failed, all three the cases where a configured name should already be on the tab.

**Mutation battery**, 7 mutations, no survivors: dropping the blank rule (1 fail), dropping the `catch` (2), reading a different storage key (3), reading a different field (3), writing markup instead of `.title` (3), the resolver dropping trim+blank (2), and `DEFAULT_BRAND_NAME` drifting from the declared `<title>` (6). Two earlier mutations *did* survive and both pointed at dead code, which is why the script above is shorter than the first draft.

**Proved live**, Chromium against a production-mode server: the A/B table above; the inline script executing under an **enforced** CSP (not Report-Only) with no violation; and `Content-Security-Policy: script-src` carrying `sha256-jUUIwW5IfAh9TdBF4wwHeB6Il4nKx/D9Zwnt+PUGqNU=`, the same hash `extractInlineScriptHashes` computes from `public/index.html` and from `dist/index.html`. `bun run build` preserves the inline script byte for byte, so the hash the server pins matches what the browser runs.

**Not validated**: the cold-cache first visit, which is unchanged and still shows the default until the bundle mounts (deliberate, the same trade-off the colors already carry). Nothing was measured on a real deployment; every number here is localhost. No i18n surface is touched, and no server code runs differently.

**Found while validating, not fixed here**: the favicon has the same defect, and it is now measured rather than assumed. With a warm cache and a configured favicon, the bundled default icons hold the tab for **181 ms** before `applyFavicon` swaps the `<link>` elements. Separate observable effect, separate fix; filed apart rather than folded in.

Fixes #277
