### PR TITLE
Apply the operator's tab icon before the browser fetches the bundled one

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,36 @@
       document.documentElement.dataset.theme = resolved;
     })();
   </script>
+
+  <!-- Apply the operator's icon before the first paint, for the same reason and from the same cache
+       as the title above. This one has to REMOVE the links declared above rather than add to them:
+       leaving them in place makes the browser fetch the bundled default too (measured in Chromium).
+       So it hands them to the bundle on the way out, which is what a cleared favicon restores.
+       Below the theme script on purpose: the variant follows the theme that script just resolved. -->
+  <script>
+    (function () {
+      var cfg;
+      try { cfg = JSON.parse(localStorage.getItem("@app:branding")); } catch (_) { }
+      var present = cfg && cfg.favicon;
+      if (!present) return;
+      var dark = document.documentElement.dataset.theme === "dark";
+      var variant = dark
+        ? (present.dark ? "dark" : present.light ? "light" : null)
+        : (present.light ? "light" : present.dark ? "dark" : null);
+      if (!variant) return;
+      var declared = [];
+      var links = document.querySelectorAll('link[rel~="icon"]');
+      for (var i = 0; i < links.length; i++) {
+        declared.push({ href: links[i].getAttribute("href") || "", media: links[i].getAttribute("media") });
+        links[i].remove();
+      }
+      window.__brandingDefaultFavicons = declared;
+      var link = document.createElement("link");
+      link.rel = "icon";
+      link.href = "/api/v1/branding/asset/favicon/" + variant + "?v=" + cfg.version;
+      document.head.appendChild(link);
+    })();
+  </script>
 </head>
 
 <body>

--- a/src/client/contexts/BrandingContext.tsx
+++ b/src/client/contexts/BrandingContext.tsx
@@ -10,10 +10,13 @@ import {
 } from "react";
 import { useTheme } from "@/client/contexts/ThemeContext";
 import { api } from "@/client/lib/api";
+import { applyFavicon } from "@/client/lib/favicon";
 import {
   BRANDABLE_KEY_TO_VAR,
   BRANDING_CACHE_KEY,
   type BrandableKey,
+  brandingAssetUrl,
+  pickVariant,
   resolveBrandName,
 } from "@/lib/branding";
 import { derivePalette } from "@/lib/palette";
@@ -65,26 +68,6 @@ interface BrandingContextValue {
 
 const BrandingContext = createContext<BrandingContextValue | null>(null);
 
-const ASSET_BASE = "/api/v1/branding/asset";
-
-function assetUrl(
-  kind: "logo" | "favicon",
-  variant: "dark" | "light",
-  version: string,
-): string {
-  return `${ASSET_BASE}/${kind}/${variant}?v=${version}`;
-}
-
-// Prefer the variant matching the active theme; fall back to the other if only one was uploaded.
-function pickVariant(
-  present: { dark: boolean; light: boolean },
-  theme: "light" | "dark",
-): "dark" | "light" | null {
-  if (theme === "dark")
-    return present.dark ? "dark" : present.light ? "light" : null;
-  return present.light ? "light" : present.dark ? "dark" : null;
-}
-
 // CSS vars we last set on <html>, so a re-apply (theme/mode change) clears them first
 // (setProperty is additive — without the reset, a no-longer-set var would linger).
 let appliedVars: string[] = [];
@@ -119,43 +102,6 @@ function applyColors(
   for (const [name, value] of Object.entries(vars))
     style.setProperty(name, value);
   appliedVars = Object.keys(vars);
-}
-
-// The page's bundled default favicon links (theme-media variants from index.html), snapshotted
-// ONCE before we ever override them — so removing the custom favicon can restore the default.
-let defaultFavicons: { href: string; media: string | null }[] | null = null;
-
-function snapshotDefaultFavicons(): void {
-  if (defaultFavicons !== null) return;
-  defaultFavicons = Array.from(
-    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
-  ).map((l) => ({
-    href: l.getAttribute("href") ?? "",
-    media: l.getAttribute("media"),
-  }));
-}
-
-// Apply the custom favicon, or (url=null) restore the bundled default. We rebuild the icon links
-// each call: a single link for the custom favicon (no media — the variant is driven by the app
-// theme, re-applied on change), or the snapshotted defaults when cleared.
-function applyFavicon(url: string | null): void {
-  if (typeof document === "undefined") return;
-  snapshotDefaultFavicons();
-  for (const l of Array.from(
-    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
-  )) {
-    l.remove();
-  }
-  const links = url
-    ? [{ href: url, media: null as string | null }]
-    : (defaultFavicons ?? []);
-  for (const { href, media } of links) {
-    const link = document.createElement("link");
-    link.rel = "icon";
-    link.href = href;
-    if (media) link.setAttribute("media", media);
-    document.head.appendChild(link);
-  }
 }
 
 export function BrandingProvider({ children }: { children: ReactNode }) {
@@ -200,13 +146,15 @@ export function BrandingProvider({ children }: { children: ReactNode }) {
   useLayoutEffect(() => {
     if (!config) return;
     const variant = pickVariant(config.favicon, resolvedTheme);
-    applyFavicon(variant ? assetUrl("favicon", variant, config.version) : null);
+    applyFavicon(
+      variant ? brandingAssetUrl("favicon", variant, config.version) : null,
+    );
   }, [config, resolvedTheme]);
 
   const logoUrl = useMemo(() => {
     if (!config) return null;
     const variant = pickVariant(config.logo, resolvedTheme);
-    return variant ? assetUrl("logo", variant, config.version) : null;
+    return variant ? brandingAssetUrl("logo", variant, config.version) : null;
   }, [config, resolvedTheme]);
 
   const value = useMemo<BrandingContextValue>(

--- a/src/client/lib/favicon.ts
+++ b/src/client/lib/favicon.ts
@@ -1,0 +1,62 @@
+import { BRANDING_DEFAULT_FAVICONS_KEY } from "@/lib/branding";
+
+// The page's icon links. Two of them are declared in `public/index.html` (the bundled defaults,
+// scoped by `prefers-color-scheme`); a configured favicon replaces them with a single link whose
+// variant follows the app theme instead. Applying one is a whole-set rebuild, so the declared
+// links have to be remembered somewhere before the first override, or clearing the favicon would
+// have nothing to restore.
+//
+// That "somewhere" is a single window property rather than a module variable, because the first
+// override does not always happen here: the inline <head> script applies the cached favicon before
+// this bundle exists, and it removes the declared links to keep the browser from fetching the
+// default (measured in Chromium: leaving them in place fetches both). Whichever of the two runs
+// first writes the property; the other reads it.
+
+export interface IconLink {
+  href: string;
+  media: string | null;
+}
+
+function stash(): IconLink[] | undefined {
+  return (globalThis as Record<string, unknown>)[
+    BRANDING_DEFAULT_FAVICONS_KEY
+  ] as IconLink[] | undefined;
+}
+
+function currentLinks(): IconLink[] {
+  return Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
+  ).map((l) => ({
+    href: l.getAttribute("href") ?? "",
+    media: l.getAttribute("media"),
+  }));
+}
+
+// The declared defaults, remembering them on the first call if the inline script did not.
+function declaredDefaults(): IconLink[] {
+  const remembered = stash();
+  if (remembered) return remembered;
+  const declared = currentLinks();
+  (globalThis as Record<string, unknown>)[BRANDING_DEFAULT_FAVICONS_KEY] =
+    declared;
+  return declared;
+}
+
+// Apply the custom favicon, or (url=null) restore the declared defaults.
+export function applyFavicon(url: string | null): void {
+  if (typeof document === "undefined") return;
+  const defaults = declaredDefaults();
+  for (const l of Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
+  )) {
+    l.remove();
+  }
+  const links = url ? [{ href: url, media: null }] : defaults;
+  for (const { href, media } of links) {
+    const link = document.createElement("link");
+    link.rel = "icon";
+    link.href = href;
+    if (media) link.setAttribute("media", media);
+    document.head.appendChild(link);
+  }
+}

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -63,3 +63,31 @@ export function resolveBrandName(
 ): string {
   return config?.brandName?.trim() || DEFAULT_BRAND_NAME;
 }
+
+// Where the branding binaries are served from. Public by design (they load before any auth
+// context), and long-cached, so every URL carries the config's `version` as the cache buster.
+export const BRANDING_ASSET_BASE = "/api/v1/branding/asset";
+
+export function brandingAssetUrl(
+  kind: "logo" | "favicon",
+  variant: "dark" | "light",
+  version: string,
+): string {
+  return `${BRANDING_ASSET_BASE}/${kind}/${variant}?v=${version}`;
+}
+
+// Prefer the variant matching the active theme; fall back to the other if only one was uploaded.
+export function pickVariant(
+  present: { dark: boolean; light: boolean },
+  theme: "light" | "dark",
+): "dark" | "light" | null {
+  if (theme === "dark")
+    return present.dark ? "dark" : present.light ? "light" : null;
+  return present.light ? "light" : present.dark ? "dark" : null;
+}
+
+// Where the page's DECLARED icon links are kept, so a cleared favicon can restore them. The inline
+// <head> script that applies the custom icon before the first paint has to remove them (leaving
+// them in place makes the browser fetch the default too), so it writes them here on the way out
+// and `applyFavicon` reads them back (#290).
+export const BRANDING_DEFAULT_FAVICONS_KEY = "__brandingDefaultFavicons";

--- a/tests/client/brand-favicon-preload.test.ts
+++ b/tests/client/brand-favicon-preload.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { applyFavicon } from "@/client/lib/favicon";
+import {
+  BRANDING_CACHE_KEY,
+  BRANDING_DEFAULT_FAVICONS_KEY,
+  brandingAssetUrl,
+  pickVariant,
+} from "@/lib/branding";
+
+// The browser requests the icon declared in `<head>`, and `applyFavicon` cannot swap the links
+// until the deferred module script has mounted. Measured in Chromium: leaving the declared links
+// in place and appending a custom one makes the browser fetch BOTH, so the only shape that keeps
+// the vendor's icon off the wire is removing them before the parser is done (#290).
+//
+// Removing them takes the declared defaults with it, and those are what a cleared favicon has to
+// restore. So the inline script hands them over, and this file exercises both ends of that
+// handover against the bytes the page actually ships.
+
+const INDEX_HTML = await Bun.file(
+  new URL("../../public/index.html", import.meta.url),
+).text();
+
+function parseIndex(): Document {
+  return new DOMParser().parseFromString(INDEX_HTML, "text/html");
+}
+
+function iconLinks(): { href: string | null; media: string | null }[] {
+  return Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
+  ).map((l) => ({
+    href: l.getAttribute("href"),
+    media: l.getAttribute("media"),
+  }));
+}
+
+// Reproduce what the parser does to `document`: put the declared icon links in the head, then run
+// each inline <head> script in document order. `new Function` evaluates in global scope, which is
+// where happy-dom put `document`, `localStorage` and `matchMedia`.
+function parseHead(): void {
+  const parsed = parseIndex();
+  for (const l of Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
+  )) {
+    l.remove();
+  }
+  for (const l of parsed.querySelectorAll('link[rel~="icon"]')) {
+    document.head.appendChild(l.cloneNode(true));
+  }
+  for (const script of parsed.querySelectorAll("head script:not([src])")) {
+    new Function(script.textContent ?? "")();
+  }
+}
+
+const DECLARED = [
+  { href: "./favicon-light.png", media: "(prefers-color-scheme: light)" },
+  { href: "./favicon-dark.png", media: "(prefers-color-scheme: dark)" },
+];
+
+const CACHED = { version: "v7", logo: { dark: false, light: false } };
+
+// One table, two implementations of the same rule: `pickVariant`, which the provider calls after
+// mount, and the inline script that has to agree with it before mount.
+const CASES: {
+  name: string;
+  present: { dark: boolean; light: boolean };
+  theme: "dark" | "light";
+  variant: "dark" | "light" | null;
+}[] = [
+  {
+    name: "both variants on a dark theme",
+    present: { dark: true, light: true },
+    theme: "dark",
+    variant: "dark",
+  },
+  {
+    name: "both variants on a light theme",
+    present: { dark: true, light: true },
+    theme: "light",
+    variant: "light",
+  },
+  {
+    name: "only the light variant on a dark theme",
+    present: { dark: false, light: true },
+    theme: "dark",
+    variant: "light",
+  },
+  {
+    name: "only the dark variant on a light theme",
+    present: { dark: true, light: false },
+    theme: "light",
+    variant: "dark",
+  },
+  {
+    name: "no variant uploaded",
+    present: { dark: false, light: false },
+    theme: "dark",
+    variant: null,
+  },
+];
+
+describe("the tab icon on the first paint", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (globalThis as Record<string, unknown>)[
+      BRANDING_DEFAULT_FAVICONS_KEY
+    ];
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  test("the declared icon links are the bundled defaults", () => {
+    const declared = Array.from(
+      parseIndex().querySelectorAll('link[rel~="icon"]'),
+    ).map((l) => ({
+      href: l.getAttribute("href"),
+      media: l.getAttribute("media"),
+    }));
+    expect(declared).toEqual(DECLARED);
+  });
+
+  for (const { name, present, theme, variant } of CASES) {
+    test(`${name} resolves to ${variant} after mount`, () => {
+      expect(pickVariant(present, theme)).toBe(variant);
+    });
+
+    test(`${name} is already on the tab before mount`, () => {
+      localStorage.setItem("@app:theme", theme);
+      localStorage.setItem(
+        BRANDING_CACHE_KEY,
+        JSON.stringify({ ...CACHED, favicon: present }),
+      );
+      parseHead();
+      expect(iconLinks()).toEqual(
+        variant
+          ? [
+              {
+                href: brandingAssetUrl("favicon", variant, CACHED.version),
+                media: null,
+              },
+            ]
+          : DECLARED,
+      );
+    });
+  }
+
+  // "auto" is the default preference and it is not a theme: only the attribute the theme script
+  // stamps carries the resolved one. With the OS on dark the two answers differ, which is what
+  // stops this script from reading `@app:theme` and picking the light icon for a dark page.
+  test("an auto preference follows the theme the page resolved, not the string stored", () => {
+    const realMatchMedia = globalThis.matchMedia;
+    globalThis.matchMedia = ((q: string) => ({
+      matches: q.includes("dark"),
+    })) as typeof globalThis.matchMedia;
+    try {
+      localStorage.setItem("@app:theme", "auto");
+      localStorage.setItem(
+        BRANDING_CACHE_KEY,
+        JSON.stringify({ ...CACHED, favicon: { dark: true, light: true } }),
+      );
+      parseHead();
+      expect(document.documentElement.dataset.theme).toBe("dark");
+      expect(iconLinks()).toEqual([
+        {
+          href: brandingAssetUrl("favicon", "dark", CACHED.version),
+          media: null,
+        },
+      ]);
+    } finally {
+      globalThis.matchMedia = realMatchMedia;
+    }
+  });
+
+  test("the declared links go with the script, not to the browser", () => {
+    localStorage.setItem("@app:theme", "dark");
+    localStorage.setItem(
+      BRANDING_CACHE_KEY,
+      JSON.stringify({ ...CACHED, favicon: { dark: true, light: true } }),
+    );
+    parseHead();
+    expect(
+      (globalThis as Record<string, unknown>)[BRANDING_DEFAULT_FAVICONS_KEY],
+    ).toEqual(DECLARED);
+  });
+
+  test("clearing the favicon restores the links the script removed", () => {
+    localStorage.setItem("@app:theme", "dark");
+    localStorage.setItem(
+      BRANDING_CACHE_KEY,
+      JSON.stringify({ ...CACHED, favicon: { dark: true, light: true } }),
+    );
+    parseHead();
+    applyFavicon(null);
+    expect(iconLinks()).toEqual(DECLARED);
+  });
+
+  test("a favicon applied after mount does not become the default", () => {
+    localStorage.setItem("@app:theme", "dark");
+    localStorage.setItem(
+      BRANDING_CACHE_KEY,
+      JSON.stringify({ ...CACHED, favicon: { dark: true, light: true } }),
+    );
+    parseHead();
+    applyFavicon(brandingAssetUrl("favicon", "light", "v8"));
+    applyFavicon(null);
+    expect(iconLinks()).toEqual(DECLARED);
+  });
+
+  test("with no script stash, the declared links are still what a clear restores", () => {
+    parseHead();
+    applyFavicon(brandingAssetUrl("favicon", "dark", "v7"));
+    applyFavicon(null);
+    expect(iconLinks()).toEqual(DECLARED);
+  });
+
+  test("a cold cache leaves the declared links alone", () => {
+    parseHead();
+    expect(iconLinks()).toEqual(DECLARED);
+    expect(
+      (globalThis as Record<string, unknown>)[BRANDING_DEFAULT_FAVICONS_KEY],
+    ).toBeUndefined();
+  });
+
+  test("an unreadable cache is not fatal", () => {
+    localStorage.setItem(BRANDING_CACHE_KEY, "{not json");
+    expect(() => parseHead()).not.toThrow();
+    expect(iconLinks()).toEqual(DECLARED);
+  });
+
+  test("a config with no favicon field at all leaves the declared links alone", () => {
+    localStorage.setItem(BRANDING_CACHE_KEY, JSON.stringify({ version: "v7" }));
+    parseHead();
+    expect(iconLinks()).toEqual(DECLARED);
+  });
+});


### PR DESCRIPTION
## What broke

`public/index.html` declares the two bundled icon links, and the browser resolves them the moment they are parsed. The configured favicon is applied only later, by `applyFavicon` in `BrandingContext`, which removes those links and appends one pointing at `/api/v1/branding/asset/favicon/<variant>?v=<version>`. That runs in a layout effect, so it cannot happen until the deferred `<script type="module">` has mounted, and the `localStorage` cache does not close the window: `readCache` is the `useState` seed *inside* React.

## The shape is a measurement, not a preference

The obvious fix is to append a custom link from an inline `<head>` script and leave the declared ones alone, so nothing has to be restored later. That does not work, and it is the first thing worth reporting.

Chromium, four pages differing only in what the inline script does, watching what actually goes on the wire:

| page | icons the browser requested |
| --- | --- |
| declared links only | `/default-dark.png` |
| script **appends** a custom link | `/custom.png` **and** `/default-dark.png` |
| script **removes** the declared links, then appends | **only** `/custom.png` |
| swap at 200 ms, the way the layout effect does today | `/default-dark.png`, then `/custom.png` |

So the vendor's icon stays off the wire only if the declared links are gone before the parser is done. Removing them takes with it the thing a cleared favicon has to restore, which is why this PR is bigger than the title one (#289) rather than a copy of it.

## The fix

An inline `<head>` script reads the same `@app:branding` cache the provider seeds itself from, picks the variant, removes the declared links and applies the custom one. On the way out it hands the declared links to the bundle, and `applyFavicon` reads them back.

Three things follow from that:

- **`applyFavicon` moves to `src/client/lib/favicon.ts`.** The declared defaults used to live in a module variable snapshotted on the first call, which is only correct while that first call is the first thing to touch the links. Now two different pieces of code can be first, so the fact has one home instead of two, and whichever runs first writes it.
- **The script sits below the theme script.** The variant follows the theme, and the stored preference is `auto` by default, which is not a theme. Only the attribute the theme script stamps carries the resolved one. Reading `@app:theme` instead would hand a light icon to a dark page, which is a different flash rather than the absence of one.
- **`pickVariant` and the asset URL move to `src/lib/branding.ts`,** next to `resolveBrandName` from #289, so the rules the inline script duplicates have one testable owner and one table drives both.

## Live exercise

Real Chromium, two production builds, **the same database**, with a favicon actually uploaded through `PUT /api/v1/branding/asset/favicon/{light,dark}` as SUPER_ADMIN. Only the code differs between the arms.

| arm | icons requested on a warm reload | links left in the DOM |
| --- | --- | --- |
| base `895607bf` | `/favicon-dark-kqzj48tr.png` | the custom asset |
| this branch | `/api/v1/branding/asset/favicon/dark` | the custom asset |

The defect reproduces through the base code and is gone on this branch, measured at the network layer rather than by reading the DOM: the base build puts the vendor's icon on the wire, this one never does.

**The restore path, live.** With the cache still warm, both favicon variants were deleted through the API. The page then ends up with both declared links, media queries intact:

```
["http://localhost:3290/favicon-light-ky10ev87.png|(prefers-color-scheme: light)",
 "http://localhost:3290/favicon-dark-kqzj48tr.png|(prefers-color-scheme: dark)"]
```

That is the handover working end to end in a browser: the script removed those links before React existed, and a cleared favicon still restored them.

**CSP**, enforced and not Report-Only: `script-src` carries four hashes, the new one being `sha256-luKZkRAizg1RTPhv+U2Cn3qVsTZyocpCpGeZqTnSorQ=`, and the script ran (the icon was applied), so the hash matches what the browser executed.

## Validation scope

**Proved by test** (`tests/client/brand-favicon-preload.test.ts`, 19 tests): the shipped bytes of `public/index.html` are parsed, the declared links are put in the head, and the inline `<head>` scripts run in document order, so the test exercises the file rather than a copy of its logic. One table drives both `pickVariant` and the script across five variant/theme combinations. Plus: the declared links are handed over rather than dropped, a cleared favicon restores them, a favicon applied *after* mount never becomes the new default, the same restore works when no script ran at all, and `auto` + an OS on dark picks the dark icon (the case that separates the resolved theme from the stored preference).

Red first: before the fix, 5 of the 19 failed, all of them cases where a configured icon should already be on the tab.

**Mutation battery**, 9 mutations, no survivors: appending instead of removing (4 fail), not handing over the declared links (3), inverted theme (2), no variant fallback in the script (2) and in `pickVariant` (2), a URL without the cache buster (4), `applyFavicon` ignoring the handover (3) and not remembering the defaults itself (1), and reading `@app:theme` instead of the resolved theme (1). That last one survived the first version of the auto-theme test, which passed for the wrong reason: with the OS on light, the preference and the resolved theme agree. The test now stubs `matchMedia` so they disagree.

**Not validated**: the cold-cache first visit, unchanged and still showing the bundled icon until the bundle mounts (deliberate, the same trade-off the colors and the brand name already carry). Nothing measured on a real deployment; every number is localhost. Chromium only, so Firefox and Safari icon-fetch timing is covered by reasoning rather than measurement.

Fixes #290
