### PR TITLE
Pin every waiver ledger to its size, so silencing a new offender costs a second edit

### DIFF
--- a/tests/api/error-catalog.test.ts
+++ b/tests/api/error-catalog.test.ts
@@ -6,6 +6,7 @@ import apiEn from "@/api/locales/en.json";
 import apiPt from "@/api/locales/pt-BR.json";
 import clientEn from "@/client/locales/en.json";
 import clientPt from "@/client/locales/pt-BR.json";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
 
 // The guard for what `ErrorTranslationKey` (src/lib/errors.ts) cannot see.
 //
@@ -435,6 +436,15 @@ describe("the error catalog cannot be bypassed", () => {
     const dotted = [...API].filter((k) => k.split(".").length > 2);
     expect(dotted).toEqual([]);
   });
+
+  // The other direction of every waiver rule in this file, and the one none of them had: a ledger is
+  // subtracted from a set DERIVED from the tree, so appending to it both silences a new offender and
+  // satisfies the stale-waiver test. The size is the only fact the tree cannot supply.
+  // tests/utils/ledger.ts carries the measurement (issue #293).
+  test("the cast and legacy-token ledgers may only shrink", () => {
+    expectWaiverLedger("ALLOWED_CASTS", ALLOWED_CASTS, 0);
+    expectWaiverLedger("STORED_LEGACY_TOKENS", STORED_LEGACY_TOKENS, 3);
+  });
 });
 
 describe("both languages answer, and answer differently", () => {
@@ -735,6 +745,45 @@ describe("both languages answer, and answer differently", () => {
       (k) => pt[k] === en[k] && !ALLOWED_UNTRANSLATED.includes(`errors.${k}`),
     );
     expect(untranslated).toEqual([]);
+  });
+
+  // Same rule, same reason as the cast and legacy-token pin above.
+  test("the untranslated, keyless and say-less ledgers may only shrink", () => {
+    expectWaiverLedger("ALLOWED_UNTRANSLATED", ALLOWED_UNTRANSLATED, 0);
+    expectWaiverLedger("KEYLESS_BY_DESIGN", KEYLESS_BY_DESIGN, 1);
+    // PER EDITION, and the split is made by EXCLUSION rather than by two pins. Both ledgers hold
+    // entries inside `@full-only` blocks, waiving keys the Free extractor prunes, so waiver and key
+    // leave the Free tree together and the ledger is shorter there. Counting the entries every
+    // edition holds keeps one number right in all three trees.
+    //
+    // Not a second ledger to keep in sync by hand. A `@full-only` waiver missing from here leaves the
+    // full tree one OVER its pin, which is the same red as an append; and an entry listed here that
+    // is not actually marked stays in the Free ledger and leaves that tree one UNDER. The cheat this
+    // shape would otherwise invite — append to the ledger and to this list — is refused for the same
+    // reason: it only balances once the entry is genuinely inside a marker block.
+    //
+    // Runtime cannot answer this, which is what the shape above replaced: written as
+    // `IS_FREE ? 100 : 102` it failed in a derived Free tree, because the env var that flips
+    // `config.edition` is set by the Dockerfile and not by the test runner. Written with the markers
+    // inside the expression it passed everywhere and left the derived Free file unformatted, which
+    // `bun run lint` refuses in the public repo. Both measured.
+    const PRUNED_IN_FREE = [
+      "branding.faviconTitle",
+      "branding.logoTitle",
+      "unsupportedImageType",
+    ];
+    const inEveryEdition = (ledger: readonly string[]): readonly string[] =>
+      ledger.filter((k) => !PRUNED_IN_FREE.includes(k));
+    expectWaiverLedger(
+      "CLIENT_IDENTICAL_BY_DESIGN (excluding what Free prunes)",
+      inEveryEdition(CLIENT_IDENTICAL_BY_DESIGN),
+      100,
+    );
+    expectWaiverLedger(
+      "SAY_LESS_GRANDFATHERED (excluding what Free prunes)",
+      inEveryEdition(SAY_LESS_GRANDFATHERED),
+      25,
+    );
   });
 });
 

--- a/tests/api/error-catalog.test.ts
+++ b/tests/api/error-catalog.test.ts
@@ -751,38 +751,31 @@ describe("both languages answer, and answer differently", () => {
   test("the untranslated, keyless and say-less ledgers may only shrink", () => {
     expectWaiverLedger("ALLOWED_UNTRANSLATED", ALLOWED_UNTRANSLATED, 0);
     expectWaiverLedger("KEYLESS_BY_DESIGN", KEYLESS_BY_DESIGN, 1);
-    // PER EDITION, and the split is made by EXCLUSION rather than by two pins. Both ledgers hold
-    // entries inside `@full-only` blocks, waiving keys the Free extractor prunes, so waiver and key
-    // leave the Free tree together and the ledger is shorter there. Counting the entries every
-    // edition holds keeps one number right in all three trees.
+    // NOTE: PER EDITION, and the question is asked of the CATALOG. Both ledgers hold entries
+    // inside `@full-only` blocks, waiving keys the Free extractor prunes, so waiver and key leave
+    // that tree together: two entries from one ledger, one from the other.
     //
-    // Not a second ledger to keep in sync by hand. A `@full-only` waiver missing from here leaves the
-    // full tree one OVER its pin, which is the same red as an append; and an entry listed here that
-    // is not actually marked stays in the Free ledger and leaves that tree one UNDER. The cheat this
-    // shape would otherwise invite — append to the ledger and to this list — is refused for the same
-    // reason: it only balances once the entry is genuinely inside a marker block.
+    // Three cheaper signals were written first and every one of them is wrong somewhere, measured:
+    // `IS_FREE` reads "full" in a derived Free tree, because the env var that flips
+    // `config.edition` is set by the Dockerfile and not by the test runner; reading this file's own
+    // `@full-only` markers reads nothing in PRO, because the derivation strips the marker lines from
+    // both derived trees while keeping the Pro content; and a hand-kept list of the excluded names is
+    // a second waiver ledger, where appending to it and to the ledger balances the count in every
+    // tree. The catalog is not another proxy: these ledgers differ BECAUSE those keys do.
     //
-    // Runtime cannot answer this, which is what the shape above replaced: written as
-    // `IS_FREE ? 100 : 102` it failed in a derived Free tree, because the env var that flips
-    // `config.edition` is set by the Dockerfile and not by the test runner. Written with the markers
-    // inside the expression it passed everywhere and left the derived Free file unformatted, which
-    // `bun run lint` refuses in the public repo. Both measured.
-    const PRUNED_IN_FREE = [
-      "branding.faviconTitle",
-      "branding.logoTitle",
-      "unsupportedImageType",
-    ];
-    const inEveryEdition = (ledger: readonly string[]): readonly string[] =>
-      ledger.filter((k) => !PRUNED_IN_FREE.includes(k));
+    // The key it reads is one of the waived ones on purpose. Renamed or dropped, this reads "free"
+    // in the full tree and the pin goes red there, where someone can see it.
+    const hasProOnlyKeys =
+      "faviconTitle" in (clientEn.branding as Record<string, unknown>);
     expectWaiverLedger(
-      "CLIENT_IDENTICAL_BY_DESIGN (excluding what Free prunes)",
-      inEveryEdition(CLIENT_IDENTICAL_BY_DESIGN),
-      100,
+      "CLIENT_IDENTICAL_BY_DESIGN",
+      CLIENT_IDENTICAL_BY_DESIGN,
+      hasProOnlyKeys ? 102 : 100,
     );
     expectWaiverLedger(
-      "SAY_LESS_GRANDFATHERED (excluding what Free prunes)",
-      inEveryEdition(SAY_LESS_GRANDFATHERED),
-      25,
+      "SAY_LESS_GRANDFATHERED",
+      SAY_LESS_GRANDFATHERED,
+      hasProOnlyKeys ? 26 : 25,
     );
   });
 });

--- a/tests/api/lib/refusal-callsites.test.ts
+++ b/tests/api/lib/refusal-callsites.test.ts
@@ -3,6 +3,7 @@
  * the rule under test, and the template hole is the shape the rule reads.
  */
 import { describe, expect, test } from "bun:test";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
 
 // THE GUARD AGAINST THE NEXT REFUSAL THAT KNOWS A FIELD AND DOES NOT SAY SO.
 //
@@ -268,5 +269,12 @@ describe("a refusal that knows a field says so on the wire", () => {
     expect(
       topLevelArgs('`a, b`, 400, "k", { field, len: 1, max: 2 }, field'),
     ).toEqual(["`a, b`", "400", '"k"', "{ field, len: 1, max: 2 }", "field"]);
+  });
+
+  // The sweep skips any file named in the ledger, and the stale-entry rule only removes one that
+  // stopped matching, so a second file joins by being appended. Pinned at the one it was argued
+  // into. tests/utils/ledger.ts carries the measurement (issue #293).
+  test("the not-about-an-input ledger may only shrink", () => {
+    expectWaiverLedger("NOT_ABOUT_AN_INPUT", NOT_ABOUT_AN_INPUT, 1);
   });
 });

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -11,6 +11,7 @@ import {
   NotFoundError,
 } from "@/lib/errors";
 import { SettingsTextTooLongError } from "@/modules/agents/service";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
 import { setupPrismaMock } from "@/tests/utils/prisma-mock";
 
 // The refusal as the CLIENT receives it, through the app the process actually serves.
@@ -590,5 +591,13 @@ describe("every registered key, over the wire", () => {
     expect(differed.length).toBe(
       (await runSweep()).size - WIRE_IDENTICAL_IN_BOTH.length,
     );
+  });
+
+  // The ledger above is subtracted from a set derived from the catalog, so appending to it silences
+  // a key that was never translated AND keeps the assertion above true. Pinned at the size it was
+  // argued into, which here is zero: this ledger has to refuse its FIRST entry.
+  // tests/utils/ledger.ts carries the measurement (issue #293).
+  test("the wire-identical ledger may only shrink", () => {
+    expectWaiverLedger("WIRE_IDENTICAL_IN_BOTH", WIRE_IDENTICAL_IN_BOTH, 0);
   });
 });

--- a/tests/client/config-issue-i18n.test.ts
+++ b/tests/client/config-issue-i18n.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import en from "@/client/locales/en.json";
 import ptBR from "@/client/locales/pt-BR.json";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
 
 // Every ConfigIssueKey the editor can render needs copy under `editor.configIssue.*`, in every
 // locale. The lookup is dynamic (`t(\`editor.configIssue.${issue.key}\`)`), so a key with no entry
@@ -102,5 +103,13 @@ describe("config issue copy", () => {
         }
       }
     }
+  });
+
+  // Both lists above are subtracted from a key set READ OUT OF `configHealth.ts`, so appending to
+  // either one silences a key that has no copy, and nothing here would notice. Pinned at the size
+  // each was argued into: tests/utils/ledger.ts, issue #293.
+  test("the ledgers this file waives with may only shrink", () => {
+    expectWaiverLedger("HANDLED_ELSEWHERE", HANDLED_ELSEWHERE, 5);
+    expectWaiverLedger("CREDENTIAL_STATES_ONLY", CREDENTIAL_STATES_ONLY, 1);
   });
 });

--- a/tests/client/editor-text-caps.test.ts
+++ b/tests/client/editor-text-caps.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
 
 // A field whose stored value is clamped by its reader has to say so on the control, or the operator
 // meets the cap only in what the model receives. `maxLength` is the whole mechanism, which makes
@@ -51,6 +52,14 @@ describe("agent editor text caps", () => {
       }
     }
     expect(offenders).toEqual([]);
+  });
+
+  // "Stays honest" below is one direction only: it removes an entry whose file or field is gone. The
+  // other one is what lets a new uncapped textarea ship, because both lists are subtracted from a set
+  // read out of the editor sources. tests/utils/ledger.ts, issue #293.
+  test("the ledgers this file waives with may only shrink", () => {
+    expectWaiverLedger("UNCLAMPED_FILES", UNCLAMPED_FILES, 2);
+    expectWaiverLedger("UNCLAMPED_FIELDS", UNCLAMPED_FIELDS, 2);
   });
 
   test("the allowlist itself stays honest (every entry still exists)", () => {

--- a/tests/lib/ledger.test.ts
+++ b/tests/lib/ledger.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
+
+// The helper IS the guard, so it gets the same treatment every sweep in this suite gets: proven
+// against a fixture in both directions before it is pointed at live data. A pin that only ever ran
+// against ledgers already at their pinned size would pass whether or not it compared anything.
+describe("a waiver ledger is pinned to its size", () => {
+  test("an array at its pin passes, and one entry either way fails", () => {
+    expect(() => expectWaiverLedger("L", ["a", "b"], 2)).not.toThrow();
+    expect(() => expectWaiverLedger("L", ["a", "b", "c"], 2)).toThrow();
+    expect(() => expectWaiverLedger("L", ["a"], 2)).toThrow();
+  });
+
+  test("a record is measured by its keys, not by its values", () => {
+    expect(() =>
+      expectWaiverLedger("L", { a: "reason", b: "reason" }, 2),
+    ).not.toThrow();
+    expect(() => expectWaiverLedger("L", { a: "reason" }, 2)).toThrow();
+  });
+
+  // The strongest pin in the set, and the one most likely to be written by accident as `>= 0`: a
+  // ledger that is empty on purpose has to refuse its FIRST entry, not its second.
+  test("an empty ledger refuses its first entry", () => {
+    expect(() => expectWaiverLedger("L", [], 0)).not.toThrow();
+    expect(() => expectWaiverLedger("L", {}, 0)).not.toThrow();
+    expect(() => expectWaiverLedger("L", ["first"], 0)).toThrow();
+    expect(() => expectWaiverLedger("L", { first: "why" }, 0)).toThrow();
+  });
+
+  test("the failure names the ledger and says which way to fix it", () => {
+    expect(() => expectWaiverLedger("SOME_LEDGER", ["a"], 0)).toThrow(
+      /SOME_LEDGER is pinned at 0\. A waiver ledger may only shrink/,
+    );
+  });
+});

--- a/tests/lib/ledger.test.ts
+++ b/tests/lib/ledger.test.ts
@@ -27,6 +27,14 @@ describe("a waiver ledger is pinned to its size", () => {
     expect(() => expectWaiverLedger("L", { first: "why" }, 0)).toThrow();
   });
 
+  // A Set reaches `Object.keys` as an empty array, so a ledger written as one would report size 0
+  // and pass every pin above zero without comparing anything.
+  test("a Set is measured by its size, not by its enumerable keys", () => {
+    expect(() => expectWaiverLedger("L", new Set(["a", "b"]), 2)).not.toThrow();
+    expect(() => expectWaiverLedger("L", new Set(["a"]), 2)).toThrow();
+    expect(() => expectWaiverLedger("L", new Set(["a"]), 0)).toThrow();
+  });
+
   test("the failure names the ledger and says which way to fix it", () => {
     expect(() => expectWaiverLedger("SOME_LEDGER", ["a"], 0)).toThrow(
       /SOME_LEDGER is pinned at 0\. A waiver ledger may only shrink/,

--- a/tests/lib/tenancy.test.ts
+++ b/tests/lib/tenancy.test.ts
@@ -6,6 +6,7 @@ import {
   resolveRequestTenantContext,
   roleAtLeast,
 } from "@/lib/tenancy";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
 
 const superAdmin = { id: 1n, tenantId: null, role: "SUPER_ADMIN" as const };
 const tenantAdmin = { id: 2n, tenantId: 3n, role: "TENANT_ADMIN" as const };
@@ -150,5 +151,13 @@ describe("every model with a tenant_id is accounted for", () => {
         (m) => registered.has(m) || !withTenantId.includes(m),
       ),
     ).toEqual([]);
+  });
+
+  // Both assertions above read `registered` out of the tree, so the ledger is the one input neither
+  // of them can contradict: a model added to it is excused AND is not stale. Pinned at the thirteen
+  // it was argued into. Seven of those are recorded as "pre-existing gap, not audited", which is
+  // exactly why this list must not be where the eighth goes. tests/utils/ledger.ts, issue #293.
+  test("the unregistered-model ledger may only shrink", () => {
+    expectWaiverLedger("KNOWN_UNREGISTERED", KNOWN_UNREGISTERED, 13);
   });
 });

--- a/tests/utils/ledger.ts
+++ b/tests/utils/ledger.ts
@@ -1,0 +1,36 @@
+import { expect } from "bun:test";
+
+// A sweep that subtracts a hand-written ledger of known offenders is guarded in ONE direction by
+// construction, and every file that holds one tests that direction: the offender set is derived from
+// the tree, so an entry that stopped offending shows up as a waiver nobody removed.
+//
+// The other direction has no anchor in the tree at all. Appending one name silences a NEW offender
+// AND satisfies the stale-waiver rule, so the suite goes green. Measured on
+// `SAY_LESS_GRANDFATHERED`, against main: a fresh throw site whose message interpolates, on
+// `errors.agentNotFound`, whose catalog entry carries no placeholder, took
+// tests/api/error-catalog.test.ts from `1 fail` to `0 fail` by that append alone (issue #293).
+//
+// The SIZE is the only fact about a ledger the tree cannot supply, which is what makes it the anchor.
+// Pinning it does not make growth impossible in a file its author owns, and is not meant to: it makes
+// growth a SECOND edit, in a different place, that reads as a sentence in the diff. `- 26` / `+ 27`
+// says the backlog got worse; an appended string says nothing.
+//
+// EXACT, never an upper bound. A bound sitting above the truth is slack, and slack is one free append
+// per unit of it: a ledger worked from 26 down to 20 under `toBeLessThanOrEqual(26)` has six silent
+// appends banked. Exact equality makes working a ledger DOWN cost the same second edit that growing
+// it does, which is the trade this accepts.
+export function expectWaiverLedger(
+  name: string,
+  ledger: readonly unknown[] | Readonly<Record<string, unknown>>,
+  pinned: number,
+): void {
+  const size = Array.isArray(ledger)
+    ? ledger.length
+    : Object.keys(ledger).length;
+  expect(
+    size,
+    `${name} is pinned at ${pinned}. A waiver ledger may only shrink: if the sweep flagged something ` +
+      `new, fix it instead of listing it here. If you worked the ledger DOWN, lower the pin to match, ` +
+      `so no slack is left over for a future append to spend.`,
+  ).toBe(pinned);
+}

--- a/tests/utils/ledger.ts
+++ b/tests/utils/ledger.ts
@@ -21,12 +21,19 @@ import { expect } from "bun:test";
 // it does, which is the trade this accepts.
 export function expectWaiverLedger(
   name: string,
-  ledger: readonly unknown[] | Readonly<Record<string, unknown>>,
+  ledger:
+    | readonly unknown[]
+    | ReadonlySet<unknown>
+    | Readonly<Record<string, unknown>>,
   pinned: number,
 ): void {
+  // NOTE: a `Set` reaches `Object.keys` as `[]`, so a ledger written as one would report size 0 and
+  // pass every pin above zero silently. Two of the thirteen are Sets.
   const size = Array.isArray(ledger)
     ? ledger.length
-    : Object.keys(ledger).length;
+    : ledger instanceof Set
+      ? ledger.size
+      : Object.keys(ledger).length;
   expect(
     size,
     `${name} is pinned at ${pinned}. A waiver ledger may only shrink: if the sweep flagged something ` +


### PR DESCRIPTION
Fixes #293

## What was broken

Several sweeps in the suite read the tree, compute the set of call sites or models that break a rule,
and subtract a hand written ledger of the ones that predate it. Each of those ledgers is guarded in
one direction: a waiver whose subject was fixed, renamed or deleted has to leave, and every file
holding one tests exactly that.

Nothing guarded the other direction. The offender set is derived from the tree and the ledger is not,
so appending a name both silences a NEW offender and satisfies the stale waiver rule.
`SAY_LESS_GRANDFATHERED` states the missing property in its own comment ("may only ever SHRINK ... so
no NEW key can land in this shape"), and that was the only place it existed.

Measured against `main`, in three steps:

| | change | result |
| --- | --- | --- |
| A | add a throw site whose message interpolates, on `errors.agentNotFound`, whose catalog entry has no placeholder | `30 pass, 1 fail` |
| B | append `"agentNotFound",` to `SAY_LESS_GRANDFATHERED` | `31 pass, 0 fail` |
| C | B, with the pin this PR adds | `32 pass, 1 fail`, on the pin |

Thirteen ledgers were in that state, across six files:

| ledger | file | entries | what one appended line buys |
| --- | --- | --- | --- |
| `ALLOWED_CASTS` | `tests/api/error-catalog.test.ts` | 0 | an `as ErrorTranslationKey` cast stops being read |
| `ALLOWED_UNTRANSLATED` | `tests/api/error-catalog.test.ts` | 0 | an API sentence ships in one language |
| `WIRE_IDENTICAL_IN_BOTH` | `tests/api/refusal-wire.test.ts` | 0 | the same, over the wire |
| `KEYLESS_BY_DESIGN` | `tests/api/error-catalog.test.ts` | 1 | a new error subclass answers English to every caller |
| `NOT_ABOUT_AN_INPUT` | `tests/api/lib/refusal-callsites.test.ts` | 1 | a refusal names a field in prose and sends none |
| `CREDENTIAL_STATES_ONLY` | `tests/client/config-issue-i18n.test.ts` | 1 | an issue key ships with no pending or unresolved copy |
| `UNCLAMPED_FILES` | `tests/client/editor-text-caps.test.ts` | 2 | a whole editor tab's textareas stop declaring their cap |
| `UNCLAMPED_FIELDS` | `tests/client/editor-text-caps.test.ts` | 2 | one field does |
| `STORED_LEGACY_TOKENS` | `tests/api/error-catalog.test.ts` | 3 | a fourth dotted token, on a spelling being retired |
| `HANDLED_ELSEWHERE` | `tests/client/config-issue-i18n.test.ts` | 5 | an issue key renders the wrong fallback sentence |
| `KNOWN_UNREGISTERED` | `tests/lib/tenancy.test.ts` | 13 | a tenant scoped model skips the anti spoof override |
| `SAY_LESS_GRANDFATHERED` | `tests/api/error-catalog.test.ts` | 26 | a refusal answers with less than the call site knew |
| `CLIENT_IDENTICAL_BY_DESIGN` | `tests/api/error-catalog.test.ts` | 102 | a UI string ships untranslated |

`KNOWN_UNREGISTERED` is the one with teeth: seven of its thirteen entries are recorded as
"pre-existing gap, not audited" on models that carry `tenantId`.

Not every hand written constant in a sweep belongs here, and the discriminator is polarity: appending
to these EXCUSES an offender. `PARAMLESS_CLASSES` accuses one, so growing it makes the rule stricter.
`FLOWLOG_READERS`, `GUARD_CALLS`, `BOUNDARIES`, `BARE_SLICES` and `ERROR_COLUMN_LINES` are censuses
compared with `toEqual` over counts, which already have this property. `WORKFLOWS_USING_BUN` is a
census with its own completeness test.

## What changed

`tests/utils/ledger.ts` holds one assertion, and the reasoning for it. Each ledger is pinned to the
size it was argued into, **exactly** rather than as an upper bound: a bound sitting above the truth is
slack, and slack is one free append per unit of it, so a ledger worked from 26 down to 20 under
`toBeLessThanOrEqual(26)` would have six silent appends banked. Exact equality makes working a ledger
DOWN cost the same second edit that growing it does.

A pinned size does not make growth impossible in a file its author owns, and is not meant to. It makes
growth a second edit, in a different place, that reads as a sentence in the diff: `- 26` / `+ 27` says
the backlog got worse, where an appended string says nothing.

The suite already had the shape that does this. `FLOWLOG_READERS` in
`tests/modules/flowlog-reader-scope.test.ts` is a map of file to reader count compared with `toEqual`,
so it cannot absorb one more entry. What this adds is that treatment for the ledgers that excuse
offenders rather than census them.

Two ledgers hold entries inside `@full-only` blocks, waiving keys the Free extractor prunes, so waiver
and key leave the Free tree together and the ledger is shorter there. The pin asks the **catalog**
whether those keys are present. Three cheaper signals were written first and each is wrong somewhere,
all measured, and all three are recorded at the call site:

- `IS_FREE` reads `"full"` in a derived Free tree, because the env var that flips `config.edition` is
  set by the Dockerfile and not by the test runner;
- putting the markers inside the pin expression passes everywhere and leaves the derived file
  unformatted, which `bun run lint` refuses here;
- reading this file's own `@full-only` markers works in master and reads nothing in **Pro**, because
  the derivation strips the marker lines from both derived trees while keeping the Pro content;
- a hand kept list of the excluded names is a second waiver ledger, and appending to it and to the
  real ledger balances the count in every tree.

The catalog is not another proxy: these ledgers differ *because* those keys do.

## Review round 1

Three findings, all read, two fixed and one answered:

- **The exclusion list was a second waiver ledger.** Correct, and the comment on it claimed the
  opposite. Replaced, twice, as above.
- **Four ledgers the sweep missed.** Correct. The sweep behind the first commit was piped through
  `head` and reported a subset as the whole list, and its pattern matched neither `new Set(...)` nor a
  ledger indexed rather than searched. `expectWaiverLedger` grew `Set` support with them, which was
  itself a defect waiting: a `Set` reaches `Object.keys` as `[]`, so a ledger written as one would
  have reported size 0 and passed every pin above zero.
- **Comment tags.** Answered rather than applied. `CLAUDE.md` asks for a tag on a comment inside a
  body, and exempts "the docstring directly above a declaration". A comment introducing a `test(...)`
  is that test's docstring, and the suite spells it that way 1124 times against 53 tagged. The two
  comments genuinely inside a callback body took `// NOTE:`.

## Validation scope

Proven by test:

- 15 mutations, one at a time: 13 appending a plausible entry to one ledger, one counting a `Set` with
  `Object.keys`, one pointing the edition signal at a key that does not exist. 15 red, 0 survivors,
  and in every case the failing test is the intended one.
- The A/B/C above, end to end, with a real new offender in `src/`.
- `tests/lib/ledger.test.ts` proves the assertion against fixtures in both directions, for arrays,
  records and Sets, including the case that matters most: a ledger pinned at 0 has to refuse its
  FIRST entry, not its second.
- Full suite: 5331 pass, 0 fail. `bun check`, `bun run derive:check` and `bun run check:editions`
  clean.
- Both derived trees built and their touched files run there, after `bun i18n:extract`: Free 113
  pass / 0 fail, Pro 113 pass / 0 fail, `biome check` clean on all eight files in both. This is the
  step that caught two of the three rejected shapes.

Not validated:

- Nothing here reaches a running server, a database or a provider, and nothing in `src/` changed, so
  there is no live behaviour to validate. The diff is eight test files.
- One route past a pin is left open by construction and is only closed in the other tree: wrapping a
  new waiver in a `@full-only` block keeps the full tree's count right, and the Free tree then holds
  the offender without its waiver, so the sweep there names it. That is asserted at the level of the
  rule, not end to end with a synthetic locale key.
- The pins are numbers a person maintains. This PR makes them fail when a ledger grows; it cannot make
  a number honest, and it does not try to.
