### PR TITLE
Declare the tenant-selector refusal on every route that can answer it

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3882,6 +3882,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Conversations"
@@ -4982,6 +5004,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Metrics"
@@ -5023,6 +5067,28 @@
               "application/json": {
                 "schema": {
                   "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -5137,6 +5203,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1MetricsTimeseries"
@@ -5178,6 +5266,28 @@
               "application/json": {
                 "schema": {
                   "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -5356,6 +5466,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -5650,6 +5782,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -6570,6 +6724,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1AgentsByIdInboxesOut-of-office"
@@ -6980,6 +7156,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -10518,6 +10716,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1AgentsModelsList",
@@ -10707,6 +10927,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1AgentsTtsList",
@@ -10761,6 +11003,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -11239,6 +11503,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -12240,6 +12526,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Mcp-connections",
@@ -12487,6 +12795,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -13328,6 +13658,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Business-hours",
@@ -13722,6 +14074,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -15520,6 +15894,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Vault",
@@ -15752,6 +16148,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -17740,6 +18158,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Tenant-settings",
@@ -17962,6 +18402,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1Tenant-settingsEmbedding",
@@ -18133,6 +18595,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -18547,6 +19031,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1Tenant-settingsCompany",
@@ -18691,6 +19197,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Tenant-settingsCompanyLogo",
@@ -18743,6 +19271,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -18985,6 +19535,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1WebhooksSubscriptions",
@@ -19190,6 +19762,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -19757,6 +20351,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Api-keys",
@@ -19884,6 +20500,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -20143,6 +20781,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Audit"
@@ -20318,6 +20978,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -20523,6 +21205,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1LogsExport"
@@ -20633,6 +21337,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -20913,6 +21639,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -21826,6 +22574,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -26111,6 +26881,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Document-templates",
@@ -26427,6 +27219,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -27632,6 +28446,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1Document-templatesByIdReferences"
@@ -27737,6 +28573,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -30521,6 +31379,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1ChatwootDeployment",
@@ -30660,6 +31540,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -32051,6 +32953,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1ChatwootInboxes",
@@ -32127,6 +33051,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -32255,6 +33201,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1ChatwootInboxesByIdWidget-health"
@@ -32340,6 +33308,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"
@@ -32455,6 +33445,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1ChatwootService-window-templatesByAgentId"
@@ -32555,6 +33567,28 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1ChatwootLabelsByAgentId"
@@ -32640,6 +33674,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
                   "type": "object",
                   "required": [
                     "error"

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -268,7 +268,7 @@ export const agentsController = new Elysia({
         "List agents",
         "Returns a paginated list of agents for the tenant.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",
       query: t.Object({
         q: t.Optional(
@@ -374,7 +374,7 @@ export const agentsController = new Elysia({
         "List inboxes that answer out of hours",
         'The agent\'s bound inboxes whose Chatwoot inbox-level out-of-office reply is configured (working hours enabled AND a message set), read live from Chatwoot. Chatwoot\'s schedule is keyed on the day of the week alone, so it cannot express the dated closures this product\'s business hours can: the two calendars disagree on holidays by construction. An inbox on an unreachable Chatwoot account is omitted rather than reported, so an empty list means "nothing found", not "nothing to find".',
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -391,7 +391,7 @@ export const agentsController = new Elysia({
     }),
     {
       detail: doc("Create agent", "Creates a new agent for the tenant."),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         name: t.String({
@@ -689,7 +689,7 @@ export const agentsController = new Elysia({
         "Import agent config",
         "Recreates an agent (disabled) from an exported config, resolving references by name.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         export: t.Unknown({
@@ -1225,7 +1225,7 @@ export const agentsController = new Elysia({
         "List provider models",
         "Lists the available models for a model provider, using a vault credential reference.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         provider: t.String({
@@ -1286,7 +1286,7 @@ export const agentsController = new Elysia({
         "List TTS voices/models",
         "Lists the voices or models for a text-to-speech provider. OpenAI returns a curated set; ElevenLabs is fetched live with the vault credential.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         provider: t.String({

--- a/src/api/v1/alert-channels.controller.ts
+++ b/src/api/v1/alert-channels.controller.ts
@@ -55,7 +55,7 @@ export const alertChannelsController = new Elysia({
         "List alert channels",
         "Returns the tenant's alert channels; the token-bearing url is returned only as a masked preview.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .post(
@@ -117,7 +117,7 @@ export const alertChannelsController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .patch(

--- a/src/api/v1/api-keys.controller.ts
+++ b/src/api/v1/api-keys.controller.ts
@@ -43,7 +43,7 @@ export const apiKeysController = new Elysia({
         "List API keys",
         "Returns the tenant's API keys (display name, prefix, last-used and revoked timestamps); the hash and plaintext token never cross this surface.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .post(
@@ -74,7 +74,7 @@ export const apiKeysController = new Elysia({
             "Human-readable label for the key (1 to 120 characters).",
         }),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .delete(

--- a/src/api/v1/audit.controller.ts
+++ b/src/api/v1/audit.controller.ts
@@ -45,6 +45,6 @@ export const auditController = new Elysia({
         "List audit entries",
         "Lists tenant-scoped audit log entries.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   );

--- a/src/api/v1/business-hours.controller.ts
+++ b/src/api/v1/business-hours.controller.ts
@@ -130,7 +130,7 @@ export const businessHoursController = new Elysia({
         "List business hours",
         "List all business-hours schedules for the current tenant.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .get(
@@ -171,7 +171,7 @@ export const businessHoursController = new Elysia({
         "Create business hours",
         "Create a new business-hours schedule for the current tenant.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
       body: writeBody,
     },
   )

--- a/src/api/v1/chatwoot-admin.controller.ts
+++ b/src/api/v1/chatwoot-admin.controller.ts
@@ -83,7 +83,7 @@ export const chatwootAdminController = new Elysia({
         "Get Chatwoot deployment",
         "The tenant's Chatwoot deployment (base URL; admin-token presence) and its accounts. `deployment` is null when none is connected yet.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   // Register the deployment from a base URL + admin token, entered ONCE. Validates the credentials by
@@ -117,7 +117,7 @@ export const chatwootAdminController = new Elysia({
             "Chatwoot admin/user access token; encrypted at rest, never returned.",
         }),
       }),
-      response: errors(400, 401, 403, 409, 502),
+      response: errors(400, 401, 403, 404, 409, 502),
     },
   )
   // Rotate the deployment's admin token (validated against the live deployment before it persists).
@@ -378,7 +378,7 @@ export const chatwootAdminController = new Elysia({
         "List inboxes",
         "List the tenant's mirrored Chatwoot inboxes.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   // Live per-inbox bot status for the Channels UI: each bound inbox → "active" | "missing" (its
@@ -396,7 +396,7 @@ export const chatwootAdminController = new Elysia({
         "Reconcile inbox bot status",
         "Per bound inbox, whether its persona's Chatwoot Agent Bot still exists (active) or was deleted out-of-band (missing).",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Live health of a web-widget inbox's website_url (the WhatsApp→website-chat redirect target), so
@@ -420,7 +420,7 @@ export const chatwootAdminController = new Elysia({
       params: t.Object({
         id: t.String({ description: "Mirror inbox id (BigInt string)." }),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Live agents + teams for the handoff-targeting picker, scoped to the accounts the agent serves
@@ -445,7 +445,7 @@ export const chatwootAdminController = new Elysia({
       params: t.Object({
         agentId: t.String({ description: "Agent id (BigInt string)." }),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Approved WhatsApp HSM templates available to an agent's inbox(es), for the service-window
@@ -468,7 +468,7 @@ export const chatwootAdminController = new Elysia({
       params: t.Object({
         agentId: t.String({ description: "Agent id (BigInt string)." }),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Account labels available to an agent's inbox(es), for the follow-up step's label picker. Empty
@@ -491,7 +491,7 @@ export const chatwootAdminController = new Elysia({
       params: t.Object({
         agentId: t.String({ description: "Agent id (BigInt string)." }),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   // NOTE: Custom-attribute definitions available to an agent's inbox(es), for the attribute-context
@@ -514,7 +514,7 @@ export const chatwootAdminController = new Elysia({
       params: t.Object({
         agentId: t.String({ description: "Agent id (BigInt string)." }),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .patch(

--- a/src/api/v1/document-templates.controller.ts
+++ b/src/api/v1/document-templates.controller.ts
@@ -99,7 +99,7 @@ export const documentTemplatesController = new Elysia({
         "List document templates",
         "Lists the tenant's document templates.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .get(
@@ -143,7 +143,7 @@ export const documentTemplatesController = new Elysia({
         "Create document template",
         "Creates a document template from blocks, fields and style.",
       ),
-      response: errors(400, 401, 403, 409),
+      response: errors(400, 401, 403, 404, 409),
     },
   )
   .post(
@@ -274,7 +274,7 @@ export const documentTemplatesController = new Elysia({
         "List template references",
         "Agents that were granted this template, so deletion can warn first.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .patch(

--- a/src/api/v1/documents.controller.ts
+++ b/src/api/v1/documents.controller.ts
@@ -124,7 +124,7 @@ export const documentsController = new Elysia({
       // and one past 2^63-1 is refused by the range check rather than by the transport. A status the
       // route returns and the contract does not name is a status no generated client knows how to
       // handle — the same reason the issue route names 409.
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .post(

--- a/src/api/v1/integrations-admin.controller.ts
+++ b/src/api/v1/integrations-admin.controller.ts
@@ -142,7 +142,7 @@ export const integrationsAdminController = new Elysia({
         "List integration instances",
         "Returns the tenant's configured integration instances. The routeToken is omitted here; read a single instance to get it.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .get(

--- a/src/api/v1/logs.controller.ts
+++ b/src/api/v1/logs.controller.ts
@@ -112,7 +112,7 @@ export const logsController = new Elysia({
         "List execution logs",
         "Lists tenant-scoped execution-flow logs with keyset pagination.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Bulk export of the (filtered) execution-flow log as a downloadable file. Same filter surface as
@@ -186,6 +186,6 @@ export const logsController = new Elysia({
         "Export execution logs",
         "Exports the tenant-scoped execution-flow logs (matching the given filters) as a CSV or JSON file, newest first, up to a bounded row cap.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   );

--- a/src/api/v1/mcp-connections.controller.ts
+++ b/src/api/v1/mcp-connections.controller.ts
@@ -96,7 +96,7 @@ export const mcpConnectionsController = new Elysia({
         "List MCP connections",
         "Returns the tenant's consumed MCP server connections.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .get(
@@ -153,7 +153,7 @@ export const mcpConnectionsController = new Elysia({
         "Registers a new consumed MCP server connection for the tenant.",
       ),
       body: writeBody,
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .patch(

--- a/src/api/v1/tenant-settings.controller.ts
+++ b/src/api/v1/tenant-settings.controller.ts
@@ -70,7 +70,7 @@ export const tenantSettingsController = new Elysia({
         "Get tenant settings",
         "Returns the tenant's embedding, Langfuse and company-profile settings.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .put(
@@ -114,7 +114,7 @@ export const tenantSettingsController = new Elysia({
         "Update embedding settings",
         "Updates the tenant's RAG embedding configuration.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .put(
@@ -161,7 +161,7 @@ export const tenantSettingsController = new Elysia({
         "Update Langfuse settings",
         "Updates the tenant's Langfuse tracing configuration.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .post(
@@ -238,7 +238,7 @@ export const tenantSettingsController = new Elysia({
         "Update company profile",
         "Updates the letterhead the tenant's issued documents carry.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .post(
@@ -260,7 +260,7 @@ export const tenantSettingsController = new Elysia({
         "Upload company logo",
         "Stores the letterhead logo used by document templates whose header shows one.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .delete(
@@ -275,7 +275,7 @@ export const tenantSettingsController = new Elysia({
         "Remove company logo",
         "Clears the letterhead logo; documents fall back to a typographic header.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .get(

--- a/src/api/v1/tools.controller.ts
+++ b/src/api/v1/tools.controller.ts
@@ -154,7 +154,7 @@ export const toolsController = new Elysia({
         "List tools",
         "List all custom HTTP tool definitions for the current tenant.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .get(
@@ -218,7 +218,7 @@ export const toolsController = new Elysia({
         "Create tool",
         "Create a custom HTTP tool definition for the current tenant.",
       ),
-      response: errors(400, 401, 403, 409),
+      response: errors(400, 401, 403, 404, 409),
       body: writeBody,
     },
   )

--- a/src/api/v1/v1.controller.ts
+++ b/src/api/v1/v1.controller.ts
@@ -310,7 +310,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Conversations"],
       },
-      response: errors(400, 401),
+      response: errors(400, 401, 404),
     },
   )
   .get(
@@ -637,7 +637,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(400, 401),
+      response: errors(400, 401, 404),
     },
   )
   .get(
@@ -666,7 +666,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(401),
+      response: errors(401, 404),
     },
   )
   .get(
@@ -709,7 +709,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(400, 401),
+      response: errors(400, 401, 404),
     },
   )
   .get(
@@ -738,6 +738,6 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(401),
+      response: errors(401, 404),
     },
   );

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -67,7 +67,7 @@ export const vaultController = new Elysia({
         "List vault entries",
         "Returns the tenant's secret names, kinds and reference usage; the secret value is never returned.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .post(
@@ -123,7 +123,7 @@ export const vaultController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 409),
+      response: errors(400, 401, 403, 404, 409),
     },
   )
   .put(

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -61,7 +61,7 @@ export const webhooksController = new Elysia({
         "List webhook subscriptions",
         "Returns the tenant's outbound webhook subscriptions; the secret value never crosses this surface.",
       ),
-      response: errors(401, 403),
+      response: errors(401, 403, 404),
     },
   )
   .post(
@@ -107,7 +107,7 @@ export const webhooksController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 404),
     },
   )
   .patch(

--- a/tests/modules/tenant-selector-entry-points.test.ts
+++ b/tests/modules/tenant-selector-entry-points.test.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import type { PrismaClient as PrismaClientType } from "@/../generated/prisma/client";
 import { PrismaClient } from "@/../generated/prisma/client";
+import { createTenant } from "@/api/v1/tenants.admin.service";
+import { listTenants } from "@/api/v1/tenants.service";
 import { ActiveTenantNotFoundError, AppError } from "@/lib/errors";
 import { resolveRequestTenantContext, type TenantContext } from "@/lib/tenancy";
 import { issueDocument } from "@/modules/documents/issue";
@@ -415,22 +417,52 @@ describe("no REST controller hands a module a bare tenant id", () => {
   });
 });
 
+// The negative control for the two exemptions at the bottom of this file, and the reason they are
+// exemptions rather than routes nobody got around to converting: a FLEET operation answers the
+// selector instead of refusing it. `listTenants` and `createTenant` both branch to `asSuperAdminOn`
+// when the caller is a SUPER_ADMIN, so the id the selector carries is never looked up, and asking
+// their response maps to name a 404 would publish a status they cannot return.
+describe.skipIf(!dbUp)("a fleet route answers a dead selector", () => {
+  test("listing tenants returns the fleet rather than refusing", async () => {
+    const rows = await listTenants(fromSelector(deadId), appDb);
+    expect(Array.isArray(rows)).toBe(true);
+  });
+
+  // Written as "whatever it answers, it is not about the selector" because this file ships to both
+  // editions: the derivation swaps `tenants.admin.service` for a stub that refuses with
+  // `ProEditionError` in Free, so asserting the row gets created would fail there for a reason that
+  // has nothing to do with what is under test.
+  test("creating a tenant never refuses the selector", async () => {
+    const slug = `selsweep-fleet-${process.pid}`;
+    const err = await createTenant(
+      fromSelector(deadId),
+      { name: "SelSweepFleet", slug },
+      appDb,
+    )
+      .then(() => null)
+      .catch((e: unknown) => e);
+    try {
+      expect(err instanceof ActiveTenantNotFoundError).toBe(false);
+    } finally {
+      await suDb.tenant.deleteMany({ where: { slug } });
+    }
+  });
+});
+
 // The other half of "refuses, naming the selector": the CONTRACT has to name that refusal too.
 //
-// These routes could not answer 404 before — a dead selector read as an empty tenant, or was refused
-// by a fence of their own that already declared its 404. Making them refuse turned 404 into a status
-// they return on purpose, and a status a route returns that the contract does not name is a status no
-// generated client knows how to handle: `openapi.json` is committed and `bun openapi:check` gates it,
-// and the Eden types the console is built against come from the same declarations.
+// A status a route returns that the contract does not name is a status no generated client knows how
+// to handle: `openapi.json` is committed and `bun openapi:check` gates it, and the Eden types the
+// console is built against come from the same declarations. #284 declared the twelve routes it had
+// just converted; issue #297 is the fifty older ones, which could ALREADY answer 404 before that
+// change and did not say so, and it is why this sweep is no longer scoped to two files.
 //
-// Scoped to the two controllers this PR converted end to end, because they are the only ones where
-// every route that takes the context passes it to a scoped read — `integrations-admin` has
-// `/catalog`, which calls `ctxOrThrow` for authorization alone and correctly declares no 404, so a
-// file-wide rule there would be wrong rather than merely noisy.
-//
-// NOT a repo-wide sweep on purpose: the same predicate flags 50 more routes across 15 controllers
-// that could ALREADY answer 404 before this change and do not declare it. That is a real gap and a
-// separate one; fixing it here would mean rewriting response maps in files this PR never touches.
+// Measured for #297 over real HTTP — the whole app, a real Postgres, a SUPER_ADMIN cookie and an
+// `X-Tenant-Id` naming a tenant that does not exist. 48 of the 50 answered
+// `404 errors.tenantNotFound` carrying `X-Tenant-Id-Invalid`; the two that did not are the fleet
+// routes exempted below. Reachability is input-dependent and that is why it was measured rather than
+// read: `POST /v1/agents/tts/list` answers 200 for `provider: "openai"` (a curated list, no scoped
+// read) and 404 for `provider: "elevenlabs"`, which resolves a vault credential inside the scope.
 export function passesTheContextOn(routeBlock: string): boolean {
   // Used as a VALUE — an argument, an assignment, a property — rather than as a bare authorization
   // statement (`ctxOrThrow(tenantContext);`), which reaches no scoped read and so cannot 404.
@@ -446,6 +478,64 @@ function routeBlocks(source: string): string[] {
     m = re.exec(source);
   }
   return starts.map((s, i) => source.slice(s, starts[i + 1] ?? source.length));
+}
+
+// `GET /v1/knowledge/bases`, the way the published contract spells it: the controller's own prefix,
+// and `:id` rewritten as `{id}`.
+export function routeIdentity(
+  prefix: string,
+  block: string,
+): { verb: string; path: string } | null {
+  const verb = /^ {2}\.(\w+)\(/.exec(block)?.[1];
+  const route = /^ {2}\.\w+\(\s*\n?\s*"([^"]*)"/.exec(block)?.[1];
+  if (!verb || route === undefined) return null;
+  const joined = `${prefix}${route === "/" ? "" : route}`;
+  return {
+    verb: verb.toLowerCase(),
+    path: joined.replace(/:(\w+)/g, "{$1}"),
+  };
+}
+
+// The routes that pass the context on and STILL cannot answer 404, so the sweep would otherwise be
+// asking them to declare a status they never return — which is its own kind of wrong contract.
+//
+// Both are fleet operations: `listTenants` and `createTenant` branch to `asSuperAdminOn` for a
+// SUPER_ADMIN caller, so the id the selector carries is never looked up. Measured, with a dead
+// selector, both answered 200 (and `POST /v1/tenants` created the tenant). Pinned as behaviour by
+// the two rows in the DB-backed block above rather than only asserted here, because an exemption
+// that only lives in a list is an exemption nobody re-checks.
+const CANNOT_REFUSE_THE_SELECTOR = new Set([
+  "get /v1/tenants",
+  "post /v1/tenants",
+]);
+
+async function sweepRoutes(): Promise<
+  Array<{ file: string; verb: string; path: string; declared: string }>
+> {
+  const { Glob } = await import("bun");
+  const out: Array<{
+    file: string;
+    verb: string;
+    path: string;
+    declared: string;
+  }> = [];
+  for await (const rel of new Glob("**/*.controller.ts").scan("src/api")) {
+    const file = `src/api/${rel}`;
+    const source = await Bun.file(file).text();
+    const prefix = /new Elysia\(\{[^}]*prefix:\s*"([^"]+)"/.exec(source)?.[1];
+    if (!prefix) continue;
+    for (const block of routeBlocks(source)) {
+      if (!passesTheContextOn(block)) continue;
+      const id = routeIdentity(prefix, block);
+      if (!id) throw new Error(`unreadable route in ${file}`);
+      out.push({
+        file,
+        ...id,
+        declared: /response:\s*errors\(([^)]*)\)/.exec(block)?.[1] ?? "",
+      });
+    }
+  }
+  return out;
 }
 
 describe("a route that can refuse the selector declares that refusal", () => {
@@ -471,67 +561,55 @@ describe("a route that can refuse the selector declares that refusal", () => {
     expect(passesTheContextOn(AUTH_ONLY)).toBe(false);
   });
 
-  test("every knowledge and experiments route that passes it on names 404", async () => {
-    const offenders: string[] = [];
-    let checked = 0;
-    for (const file of [
-      "src/api/v1/knowledge.controller.ts",
-      "src/api/v1/experiments.controller.ts",
-    ]) {
-      const source = await Bun.file(file).text();
-      for (const block of routeBlocks(source)) {
-        if (!passesTheContextOn(block)) continue;
-        checked++;
-        const declared = /response:\s*errors\(([^)]*)\)/.exec(block)?.[1] ?? "";
-        if (!declared.includes("404")) {
-          offenders.push(
-            `${file}: ${/\n\s*"([^"]+)",/.exec(block)?.[1] ?? "?"} → errors(${declared})`,
-          );
-        }
-      }
-    }
+  test("the identity is the one the published contract uses", () => {
+    expect(routeIdentity("/v1/knowledge", PASSES_ON)).toEqual({
+      verb: "get",
+      path: "/v1/knowledge/bases",
+    });
+    expect(
+      routeIdentity(
+        "/v1/chatwoot",
+        `  .get(\n    "/inboxes/:id/widget-health",\n    async ({ tenantContext }) => {\n      const x = ctxOrThrow(tenantContext);\n    },\n  )`,
+      ),
+    ).toEqual({ verb: "get", path: "/v1/chatwoot/inboxes/{id}/widget-health" });
+  });
+
+  test("every v1 route that passes the context on names 404", async () => {
+    const routes = await sweepRoutes();
+    const offenders = routes
+      .filter((r) => !CANNOT_REFUSE_THE_SELECTOR.has(`${r.verb} ${r.path}`))
+      .filter((r) => !r.declared.includes("404"))
+      .map((r) => `${r.file}: ${r.verb} ${r.path} → errors(${r.declared})`);
     expect(offenders).toEqual([]);
     // …and the sweep is looking at something. A rule whose subject can become empty starts passing
     // for the wrong reason the day someone reshapes these files.
-    expect(checked).toBeGreaterThanOrEqual(20);
-  });
-
-  // The twelfth route, in a file the rule above cannot cover as a whole.
-  test("the integration create route names it too", async () => {
-    const source = await Bun.file(
-      "src/api/v1/integrations-admin.controller.ts",
-    ).text();
-    const create = routeBlocks(source).find((b) =>
-      b.includes("createIntegrationInstance("),
+    expect(routes.length).toBeGreaterThanOrEqual(150);
+    // An exemption for a route that no longer exists (renamed, moved, deleted) silently exempts
+    // nothing and hides the day it comes back under the same name. Every entry has to be met.
+    const seen = new Set(routes.map((r) => `${r.verb} ${r.path}`));
+    expect([...CANNOT_REFUSE_THE_SELECTOR].filter((k) => !seen.has(k))).toEqual(
+      [],
     );
-    expect(create).toBeDefined();
-    expect(
-      /response:\s*errors\(([^)]*)\)/.exec(create as string)?.[1],
-    ).toContain("404");
   });
 
-  // The contract as it is actually published, not only as it is declared in the source: `openapi.json`
-  // is the committed artifact and what a generated client reads.
-  test("the published contract carries the 404 for those routes", async () => {
+  // The contract as it is actually published, not only as it is declared in the source:
+  // `openapi.json` is the committed artifact and what a generated client reads.
+  test("the published contract carries the 404 for every one of them", async () => {
     const spec = (await Bun.file("openapi.json").json()) as {
       paths: Record<
         string,
         Record<string, { responses?: Record<string, unknown> }>
       >;
     };
-    const expected: Array<[string, string]> = [
-      ["/v1/knowledge/bases", "get"],
-      ["/v1/knowledge/bases", "post"],
-      ["/v1/knowledge/embedding-block", "get"],
-      ["/v1/knowledge/search", "post"],
-      ["/v1/knowledge/approvals", "get"],
-      ["/v1/experiments", "get"],
-      ["/v1/experiments", "post"],
-      ["/v1/integrations/instances", "post"],
-    ];
-    const missing = expected.filter(
-      ([path, verb]) => !spec.paths?.[path]?.[verb]?.responses?.["404"],
-    );
+    const routes = await sweepRoutes();
+    const missing = routes
+      .filter((r) => !CANNOT_REFUSE_THE_SELECTOR.has(`${r.verb} ${r.path}`))
+      .filter((r) => !spec.paths?.[r.path]?.[r.verb]?.responses?.["404"])
+      .map((r) => `${r.verb} ${r.path}`);
     expect(missing).toEqual([]);
+    // The published spec has to be the same set of routes the source sweep found: a path this test
+    // cannot look up would otherwise pass as "no 404 missing".
+    const unpublished = routes.filter((r) => !spec.paths?.[r.path]?.[r.verb]);
+    expect(unpublished.map((r) => `${r.verb} ${r.path}`)).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #297.

## What breaks

`runScopedOn` throws `ActiveTenantNotFoundError` (404, `errors.tenantNotFound`, carrying
`X-Tenant-Id-Invalid`) when a `SUPER_ADMIN` context names a tenant that does not exist: the
`X-Tenant-Id` selector the console persists in the browser, pointing at a tenant that has since been
deleted. Any route that hands the request's `TenantContext` to a scoped read reaches that throw.

159 routes hand the context on. 109 declared the 404. 50 did not, and a status a route returns that
the contract does not name is a status no generated client knows how to handle: `openapi.json` is a
committed artifact gated by `bun openapi:check`, and the Eden types the console is built against come
from the same declarations. #284 declared the eleven it had just introduced; these fifty are older
and could already answer 404 before that change.

## What the report got wrong: two of the fifty cannot answer it

The issue's predicate says a route passes the context on, not that the path it takes ends in a scoped
read. Probed with a dead selector, **48 of the 50 refuse and 2 do not**:

| route | with a dead selector | why |
| --- | --- | --- |
| `GET /v1/tenants` | `200` + the fleet list | `listTenants` branches to `asSuperAdminOn` for a `SUPER_ADMIN` caller, so the id is never looked up |
| `POST /v1/tenants` | `200` + the tenant created | `createTenant` does the same, and scopes its outbound event to the NEW tenant |

Declaring a 404 there would publish a status those routes cannot return, so they are exempted, and
the exemption is pinned by two rows in the DB-backed block rather than by a comment: a fleet route
answers the selector instead of refusing it. The sweep also refuses an exemption that no longer
matches a route, so a renamed route cannot inherit one silently.

Reachability turned out to be input-dependent, which is why it was measured rather than read:
`POST /v1/agents/tts/list` answers `200` for `provider: "openai"` (a curated list, no scoped read) and
`404` for `provider: "elevenlabs"`, which resolves a vault credential inside the scope.

The issue's other caveat was checked by reading, since the predicate keys on one spelling: eight
routes mention `tenantContext` without matching it, and none of them reaches a scoped read with the
caller's context. Three `mcp/me` routes pass `ctx.userId` to a query keyed on the user; `langfuse/test`,
`integrations/catalog` and `document-templates/starters` call `ctxOrThrow` for authorization alone;
`mcp/oauth/authorize` reads `ctx.userId` / `ctx.role` and writes an approval row; `documents/:id/pdf`
spells the context differently but already declares 404.

## The change

- 48 response maps gain `404`. That is the headline; nothing else in the request path moves.
- `openapi.json` regenerated: 48 `"404"` entries, no other route touched.
- The fence in `tests/modules/tenant-selector-entry-points.test.ts` becomes the repo-wide rule it was
  written to be. It was scoped to `knowledge.controller.ts` and `experiments.controller.ts` because
  those were the only files where the rule held for every route; now it sweeps every controller and
  checks both halves — the declaration in the source and the 404 in the published spec — keyed on the
  path as the contract spells it (`/v1/chatwoot/inboxes/{id}/widget-health`).

## Validation scope

**Proved by test** (`bun test tests/modules/tenant-selector-entry-points.test.ts`, 41 pass):

- the source sweep and the published-contract sweep both fail on the pre-change tree (reverting only
  the controllers and `openapi.json` turns them red, listing all 48 by name);
- five mutations of the fence, one at a time: predicate always false (2 fail), an exemption removed
  (2 fail), an exemption for a route that does not exist (1 fail), the `:id` → `{id}` rewrite dropped
  (2 fail), the root-route join dropped (1 fail);
- the two fleet routes answer rather than refuse (edition-agnostic: in Free the tenant-admin module is
  a stub that raises `ProEditionError`, which is not a refusal about the selector either).

**Proved live**, over real HTTP through the whole app against a real Postgres, with a `SUPER_ADMIN`
cookie and `X-Tenant-Id: max(tenants.id) + 1000000`:

- 48 routes answered `404 {"error":"Tenant not found"}` with `X-Tenant-Id-Invalid` naming the dead id;
- `POST /v1/chatwoot/deployment` was exercised against a real Chatwoot (fork 4.16.0, local) with a
  real user access token, because it fetches the profile BEFORE the scoped read: the fetch succeeds
  and the refusal that follows is the 404;
- `POST /v1/tenant-settings/company/logo` needed a decodable PNG to get that far (an invalid one is
  refused earlier, `400 Unsupported image type`);
- several routes validate their body first and only then reach the scope, so the probe had to send an
  input each one accepts (a resolvable outbound URL for the SSRF guard, a block with an id for a
  document template, a full agent export).

**Not validated**: nothing about what the console does with the newly declared 404 — the recovery
#265 added is unchanged and was not re-exercised, and no client code is touched here. The two
exempted routes were probed by their service functions and over HTTP, not against every possible
principal shape.
