### PR TITLE
Take a refused proactive turn back out of the conversation history

### DIFF
--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -1164,9 +1164,9 @@ export async function runAgentNudge(
       graphThreadId,
       produced: result.messages,
     }).catch((err) => {
-      // Best-effort, and loudly: the send was already suppressed, so a failed rollback costs the next
-      // turn a message the customer never saw, which is the defect this exists to close, and nothing more.
-      // Throwing would turn a correct refusal into a retried job.
+      // NOTE: best-effort, and loudly. The send was already suppressed, so a failed rollback costs
+      // the next turn a message the customer never saw, which is the defect this exists to close,
+      // and nothing more. Throwing would turn a correct refusal into a retried job.
       logger.warn(
         { err, conversationId: String(conversationId) },
         "agentNudge: could not roll back the refused turn",
@@ -1181,9 +1181,9 @@ export async function runAgentNudge(
         plan.ids.length,
       );
     } else if (plan?.reason === "another-invoke-is-reading") {
-      // The one keep that is a MISS rather than a decision about this turn: the history still holds a
-      // message the customer never received, and the next turn will read it. Logged at warn so the
-      // case has a name in the logs instead of looking like a rollback that ran.
+      // NOTE: the one keep that is a MISS rather than a decision about this turn. The history still
+      // holds a message the customer never received, and the next turn will read it. Logged at warn
+      // so the case has a name in the logs instead of looking like a rollback that ran.
       logger.warn(
         "agentNudge could not roll back a refused turn, another invoke holds the thread: conv=%s outcome=%s",
         String(conversationId),

--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -1180,6 +1180,15 @@ export async function runAgentNudge(
         outcome,
         plan.ids.length,
       );
+    } else if (plan?.reason === "another-invoke-is-reading") {
+      // The one keep that is a MISS rather than a decision about this turn: the history still holds a
+      // message the customer never received, and the next turn will read it. Logged at warn so the
+      // case has a name in the logs instead of looking like a rollback that ran.
+      logger.warn(
+        "agentNudge could not roll back a refused turn, another invoke holds the thread: conv=%s outcome=%s",
+        String(conversationId),
+        outcome,
+      );
     }
     return outcome;
   };

--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -59,6 +59,7 @@ import {
   buildToolset,
   loadAgentConfig,
 } from "./prepare";
+import { undoRefusedTurn } from "./refused-turn";
 import type { RuntimeDeps } from "./runtime";
 import { buildThreadStateGraph, THREAD_STATE_NODE } from "./thread-state";
 import { buildNativeTools, handoffAnsweredTheTurn } from "./tools/native";
@@ -1147,6 +1148,42 @@ export async function runAgentNudge(
   } finally {
     if (claimedGraphThread) clearTurnInFlight(graphThreadId);
   }
+  // Every refusal from here on suppresses the send and leaves the generated pair checkpointed, which
+  // is what `refuse` is for: it takes the outcome back out through the rollback instead of returning
+  // it straight. Written as one closure and used at every post-generation refusal rather than inlined
+  // at each, so a ninth refusal that forgets it is a diff a reader can see, and one a source sweep
+  // can fail on (tests/graph/refused-turn-callsites.test.ts). Issue #251.
+  //
+  // It never decides WHETHER to roll back. `undoRefusedTurn` reads the channel and answers that, so a
+  // turn that ran a tool, or one whose messages another writer already took, keeps what it has.
+  const refuse = async (
+    outcome: RunAgentNudgeOutcome,
+  ): Promise<RunAgentNudgeOutcome> => {
+    const plan = await undoRefusedTurn({
+      checkpointer,
+      graphThreadId,
+      produced: result.messages,
+    }).catch((err) => {
+      // Best-effort, and loudly: the send was already suppressed, so a failed rollback costs the next
+      // turn a message the customer never saw, which is the defect this exists to close, and nothing more.
+      // Throwing would turn a correct refusal into a retried job.
+      logger.warn(
+        { err, conversationId: String(conversationId) },
+        "agentNudge: could not roll back the refused turn",
+      );
+      return null;
+    });
+    if (plan?.action === "remove") {
+      logger.info(
+        "agentNudge rolled back a refused turn: conv=%s outcome=%s messages=%d",
+        String(conversationId),
+        outcome,
+        plan.ids.length,
+      );
+    }
+    return outcome;
+  };
+
   // Silence via the explicit sentinel / narrated-emptiness guard (never post that), else strip any
   // stray sentinel occurrence from a real reply so it can't leak into the customer message.
   const replyRaw = lastAssistantText(result.messages);
@@ -1183,7 +1220,7 @@ export async function runAgentNudge(
   //
   // The later checks answer for later model calls — the guardrail judge's, and the screening inside
   // deliverPromisedLine — not for this one.
-  if (!(await stillWanted())) return "stale";
+  if (!(await stillWanted())) return refuse("stale");
 
   let canMessagePost: boolean;
   if (handedOff) {
@@ -1195,13 +1232,14 @@ export async function runAgentNudge(
     // check above this block answers for the model call, not for this round trip. Above the
     // `unavailable` return as well, so a retired run reports what it is rather than asking for a
     // retry it must not get.
-    if (!(await stillWanted())) return "stale";
+    if (!(await stillWanted())) return refuse("stale");
     // Fail closed: nothing has been posted yet, so a probe that could not run costs a retry and
     // nothing else.
-    if (owned === "unavailable") return "live-unavailable";
+    if (owned === "unavailable") return refuse("live-unavailable");
     // The live-gated caller asked for certainty and gets an abort; an event nudge downgrades to a
     // private note instead, which is the shape it has always had.
-    if (owned === "not-ours" && params.requireLiveBotOwnership) return "stale";
+    if (owned === "not-ours" && params.requireLiveBotOwnership)
+      return refuse("stale");
     canMessagePost = owned === "ours";
   }
 
@@ -1225,7 +1263,7 @@ export async function runAgentNudge(
   // just cleared and re-armed the sequence the command ended — and the post-actions below would have
   // relabelled and resolved it on the way out. The transfer itself still stands: the tool ran inside
   // the graph and this fence was never able to reverse it.
-  if (promised === "stale") return "stale";
+  if (promised === "stale") return refuse("stale");
   if (promised) {
     if (promised !== "silent") markFollowUp(promised);
     await applyPostActions({ canMessage: canMessagePost });
@@ -1300,12 +1338,12 @@ export async function runAgentNudge(
         !guardrailLeftAMark(decision) &&
         params.requireLiveBotOwnership
       ) {
-        return "live-unavailable";
+        return refuse("live-unavailable");
       }
       // A KNOWN takeover ends the episode either way: that outcome does not retry, so it costs no
       // repetition — and "the human owns it" is a different fact from "we could not ask".
       if (owned === "not-ours" && params.requireLiveBotOwnership)
-        return "stale";
+        return refuse("stale");
       canMessagePost = owned === "ours";
     }
 
@@ -1315,7 +1353,7 @@ export async function runAgentNudge(
     // ABOVE the suppression branch, for the reason the check outside this block sits above the silent
     // one: suppression posts no message but still fires the post-actions, so a check placed after it
     // guards only the sends and lets the judge's stretch of time reach the labels and the resolve.
-    if (!(await stillWanted())) return "stale";
+    if (!(await stillWanted())) return refuse("stale");
     if (screened === null) {
       await applyPostActions({ canMessage: canMessagePost });
       return "silent";

--- a/src/graph/refused-turn.ts
+++ b/src/graph/refused-turn.ts
@@ -1,0 +1,124 @@
+import type { AIMessage, BaseMessage } from "@langchain/core/messages";
+import { RemoveMessage } from "@langchain/core/messages";
+import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
+import { withKeyedQueue } from "@/lib/locks";
+import { clearTurnInFlight, markTurnInFlight } from "./inflight";
+import { isNudgeTurn } from "./markers";
+import { buildThreadStateGraph, THREAD_STATE_NODE } from "./thread-state";
+
+// WHAT A PROACTIVE TURN LEAVES BEHIND WHEN IT IS REFUSED AFTER IT WAS GENERATED.
+//
+// `runAgentNudge` invokes the graph, and the graph checkpoints as it runs: the nudge directive and
+// the assistant's answer are in the thread's history the moment `invoke` returns. Every refusal that
+// comes AFTER that point suppresses the send and leaves the pair there: an operator took the
+// conversation, a `/reset` retired the job, the agent was switched off mid-turn. The customer never
+// received the message, and the NEXT turn reads it as something they did, and answers "as I
+// mentioned" about a sentence nobody was shown (issue #251).
+//
+// Measured before this module existed, against the test database, with the job retired during
+// generation:
+//
+//   OUTCOME: stale   SENT TO CUSTOMER: []
+//   channel: [human] An external system event just occurred…   [ai] Oi, ainda precisa de ajuda?
+//
+// Removing it is the only shape that leaves the history equal to what the customer received. The two
+// alternatives were weighed and rejected in the issue: DELIVERING what was generated is wrong in the
+// direction that matters (the refusals exist precisely because the conversation stopped being ours to
+// write in), and MARKING the turn as undelivered keeps the text in every prompt from here on and
+// makes every reader of the history responsible for understanding the mark.
+//
+// The mechanism is the one memory compaction already uses (src/modules/memory/compact.ts): name the
+// ids, never REMOVE_ALL_MESSAGES, so a message that arrived from anywhere else is left alone.
+
+export type RollbackPlan =
+  | { action: "remove"; ids: string[] }
+  | { action: "keep"; reason: "no-turn-found" | "tool-ran" | "already-gone" };
+
+// A tool call is the line between a turn that only SAID something and one that DID something. The
+// transfer is the case that forces it: `handoffAnsweredTheTurn` hands the conversation to the human
+// queue from inside the graph, and `runAgentNudge` says so in its own words: "the transfer itself
+// still stands: the tool ran inside the graph and this fence was never able to reverse it". Erasing
+// the turn would erase the only record of an act that really happened, to the outside world, and no
+// removal here can undo. So the question is asked of the whole slice and answered conservatively:
+// any tool call at all, and the turn stays.
+function actedOnTheWorld(slice: readonly BaseMessage[]): boolean {
+  return slice.some(
+    (m) =>
+      m.getType() === "tool" || ((m as AIMessage).tool_calls?.length ?? 0) > 0,
+  );
+}
+
+// `produced` is THIS invoke's own view of the channel (what `graph.invoke` returned), and `present`
+// is what the channel holds when the removal is about to be written. They are read at different
+// moments on purpose: between them sit the ownership probe and the guardrail judge, which are model
+// calls and Chatwoot round trips, and anything can have rewritten the thread in that time. The
+// reducer THROWS on a `RemoveMessage` whose id it cannot find ("Attempting to delete a message with
+// an ID that doesn't exist"), so intersecting is what keeps a rollback from turning a suppressed
+// follow-up into a failed job.
+export function planTurnRollback(
+  produced: readonly BaseMessage[],
+  present: ReadonlySet<string>,
+): RollbackPlan {
+  // The LAST one, not the first: the thread can already carry the directive of an earlier nudge that
+  // ended silent, and that one belongs to a turn nobody refused. Everything from here on is what
+  // this invoke appended, because the invoke loads the channel and then adds its own to the end.
+  let start = -1;
+  for (let i = produced.length - 1; i >= 0; i--) {
+    const m = produced[i];
+    if (m !== undefined && isNudgeTurn(m)) {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) return { action: "keep", reason: "no-turn-found" };
+  const slice = produced.slice(start);
+  if (actedOnTheWorld(slice)) return { action: "keep", reason: "tool-ran" };
+  const ids = slice
+    .map((m) => m.id)
+    .filter((id): id is string => typeof id === "string" && present.has(id));
+  if (ids.length === 0) return { action: "keep", reason: "already-gone" };
+  return { action: "remove", ids };
+}
+
+// Reads the channel and writes the removal under the SAME key the append and the compaction rewrite
+// take (`ingest:<graphThreadId>`), so the read and the write are one step as far as those two are
+// concerned. The in-flight claim is taken for the length of it as well: compaction stands down on a
+// claimed thread, and a rewrite landing between this read and this write would be deciding about a
+// channel that is one message away from changing.
+export async function undoRefusedTurn(params: {
+  checkpointer: BaseCheckpointSaver;
+  graphThreadId: string;
+  produced: readonly BaseMessage[];
+}): Promise<RollbackPlan> {
+  const { checkpointer, graphThreadId, produced } = params;
+  const graph = buildThreadStateGraph(checkpointer);
+  const threadCfg = { configurable: { thread_id: graphThreadId } };
+  return withKeyedQueue(`ingest:${graphThreadId}`, async () => {
+    markTurnInFlight(graphThreadId);
+    try {
+      const current = ((
+        (await graph.getState(threadCfg)).values as
+          | { messages?: BaseMessage[] }
+          | undefined
+      )?.messages ?? []) as BaseMessage[];
+      const plan = planTurnRollback(
+        produced,
+        new Set(
+          current
+            .map((m) => m.id)
+            .filter((id): id is string => typeof id === "string"),
+        ),
+      );
+      if (plan.action === "remove") {
+        await graph.updateState(
+          threadCfg,
+          { messages: plan.ids.map((id) => new RemoveMessage({ id })) },
+          THREAD_STATE_NODE,
+        );
+      }
+      return plan;
+    } finally {
+      clearTurnInFlight(graphThreadId);
+    }
+  });
+}

--- a/src/graph/refused-turn.ts
+++ b/src/graph/refused-turn.ts
@@ -134,6 +134,16 @@ export function planTurnRollback(
 //
 // The nudge's own claim is already released by the time any refusal reaches here (the `finally` that
 // clears it sits above them all), so this never stands down on account of itself.
+//
+// WHERE THIS STOPS, because the check reads a count rather than holding a gate. It excludes an invoke
+// that is ALREADY in flight; it cannot exclude one that starts a moment later, loads the refused turn
+// and saves it back when it finishes. The window is widest on the fallback thread, where a
+// conversation with no `contactInboxId` makes the graph thread and the conversation thread the same
+// key, and `runLoadedTurn` marks that key before it takes any lock. Closing it would mean holding a
+// critical section across another invoke, which is the pool inversion #227 removed for issue #225, so
+// it is deliberately not attempted. Losing that race costs exactly what happens today with no
+// rollback at all: the refused turn stays in the history. The rollback is best-effort against a
+// concurrent invoke, and never worse than not having run.
 export async function undoRefusedTurn(params: {
   checkpointer: BaseCheckpointSaver;
   graphThreadId: string;

--- a/src/graph/refused-turn.ts
+++ b/src/graph/refused-turn.ts
@@ -2,7 +2,11 @@ import type { AIMessage, BaseMessage } from "@langchain/core/messages";
 import { RemoveMessage } from "@langchain/core/messages";
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 import { withKeyedQueue } from "@/lib/locks";
-import { clearTurnInFlight, markTurnInFlight } from "./inflight";
+import {
+  clearTurnInFlight,
+  isTurnInFlight,
+  markTurnInFlight,
+} from "./inflight";
 import { isNudgeTurn } from "./markers";
 import { buildThreadStateGraph, THREAD_STATE_NODE } from "./thread-state";
 
@@ -32,7 +36,14 @@ import { buildThreadStateGraph, THREAD_STATE_NODE } from "./thread-state";
 
 export type RollbackPlan =
   | { action: "remove"; ids: string[] }
-  | { action: "keep"; reason: "no-turn-found" | "tool-ran" | "already-gone" };
+  | {
+      action: "keep";
+      reason:
+        | "no-turn-found"
+        | "tool-ran"
+        | "already-gone"
+        | "another-invoke-is-reading";
+    };
 
 // A tool call is the line between a turn that only SAID something and one that DID something. The
 // transfer is the case that forces it: `handoffAnsweredTheTurn` hands the conversation to the human
@@ -82,9 +93,23 @@ export function planTurnRollback(
 
 // Reads the channel and writes the removal under the SAME key the append and the compaction rewrite
 // take (`ingest:<graphThreadId>`), so the read and the write are one step as far as those two are
-// concerned. The in-flight claim is taken for the length of it as well: compaction stands down on a
-// claimed thread, and a rewrite landing between this read and this write would be deciding about a
-// channel that is one message away from changing.
+// concerned.
+//
+// THE QUEUE IS NOT ENOUGH, AND THE COUNT IS WHY. A turn takes that key to mark itself and RELEASES
+// it before the model runs, so an invoke in flight is not holding anything this could queue behind.
+// What it is holding is a claim in `src/graph/inflight.ts`, and the hazard that registry exists for
+// is exactly this one: an invoke is a read-modify-write of the WHOLE channel, so one that loaded the
+// refused turn will save it back the moment it finishes, undoing a removal written underneath it.
+//
+// Memory compaction answers this by reading the count before adding its own claim and standing down
+// (`isTurnInFlight` -> "busy"), and so does this. The difference is what standing down costs: a
+// deferred compaction runs again at the next attendance boundary, and a deferred rollback has no
+// later, so the refused turn stays in the history. That is the honest outcome rather than a better
+// one: writing a removal that another invoke is about to undo leaves the same history and a
+// checkpoint that says otherwise. It is named and logged so the case is visible instead of silent.
+//
+// The nudge's own claim is already released by the time any refusal reaches here (the `finally` that
+// clears it sits above them all), so this never stands down on account of itself.
 export async function undoRefusedTurn(params: {
   checkpointer: BaseCheckpointSaver;
   graphThreadId: string;
@@ -94,6 +119,11 @@ export async function undoRefusedTurn(params: {
   const graph = buildThreadStateGraph(checkpointer);
   const threadCfg = { configurable: { thread_id: graphThreadId } };
   return withKeyedQueue(`ingest:${graphThreadId}`, async () => {
+    if (isTurnInFlight(graphThreadId)) {
+      return { action: "keep", reason: "another-invoke-is-reading" };
+    }
+    // Taken only once the answer above is no, and for the length of the read and the write: it is
+    // what keeps a compaction from rewriting the channel between them.
     markTurnInFlight(graphThreadId);
     try {
       const current = ((

--- a/src/graph/refused-turn.ts
+++ b/src/graph/refused-turn.ts
@@ -59,18 +59,36 @@ function actedOnTheWorld(slice: readonly BaseMessage[]): boolean {
   );
 }
 
-// `produced` is THIS invoke's own view of the channel (what `graph.invoke` returned), and `present`
+// AN ID IS NOT AN IDENTITY ON THIS CHANNEL, and memory compaction is why. Its rewrite REUSES the id
+// of the first message it replaces for the rendered memory head, deliberately, because the reducer
+// replaces a same-id message in place and appends an unknown-id one at the end, and a memory head
+// sitting after the conversation is a footnote rather than a header (docs/graph.md). A compaction
+// that lands between the invoke and this plan can therefore hand the refused directive's id to the
+// head of an entire attendance, and a removal that only asked "is the id still there?" would delete
+// that head. Losing a summary is worse than the residue this exists to clear, so the current message
+// has to still BE the one this invoke produced, not merely occupy its id.
+function isStillTheSameMessage(
+  current: BaseMessage,
+  produced: BaseMessage,
+): boolean {
+  if (current.getType() !== produced.getType()) return false;
+  const text = (m: BaseMessage) =>
+    typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+  return text(current) === text(produced);
+}
+
+// `produced` is THIS invoke's own view of the channel (what `graph.invoke` returned), and `current`
 // is what the channel holds when the removal is about to be written. They are read at different
 // moments on purpose: between them sit the ownership probe and the guardrail judge, which are model
 // calls and Chatwoot round trips, and anything can have rewritten the thread in that time. The
 // reducer THROWS on a `RemoveMessage` whose id it cannot find ("Attempting to delete a message with
-// an ID that doesn't exist"), so intersecting is what keeps a rollback from turning a suppressed
-// follow-up into a failed job.
+// an ID that doesn't exist"), so a message that left has to be dropped from the plan rather than
+// named in it.
 export function planTurnRollback(
   produced: readonly BaseMessage[],
-  present: ReadonlySet<string>,
+  current: readonly BaseMessage[],
 ): RollbackPlan {
-  // The LAST one, not the first: the thread can already carry the directive of an earlier nudge that
+  // NOTE: the LAST one, not the first: the thread can already carry the directive of an earlier nudge that
   // ended silent, and that one belongs to a turn nobody refused. Everything from here on is what
   // this invoke appended, because the invoke loads the channel and then adds its own to the end.
   let start = -1;
@@ -84,9 +102,15 @@ export function planTurnRollback(
   if (start === -1) return { action: "keep", reason: "no-turn-found" };
   const slice = produced.slice(start);
   if (actedOnTheWorld(slice)) return { action: "keep", reason: "tool-ran" };
+  const byId = new Map<string, BaseMessage>();
+  for (const m of current) if (typeof m.id === "string") byId.set(m.id, m);
   const ids = slice
-    .map((m) => m.id)
-    .filter((id): id is string => typeof id === "string" && present.has(id));
+    .filter((m) => {
+      if (typeof m.id !== "string") return false;
+      const now = byId.get(m.id);
+      return now !== undefined && isStillTheSameMessage(now, m);
+    })
+    .map((m) => m.id as string);
   if (ids.length === 0) return { action: "keep", reason: "already-gone" };
   return { action: "remove", ids };
 }
@@ -122,8 +146,8 @@ export async function undoRefusedTurn(params: {
     if (isTurnInFlight(graphThreadId)) {
       return { action: "keep", reason: "another-invoke-is-reading" };
     }
-    // Taken only once the answer above is no, and for the length of the read and the write: it is
-    // what keeps a compaction from rewriting the channel between them.
+    // NOTE: taken only once the answer above is no, and for the length of the read and the write: it
+    // is what keeps a compaction from rewriting the channel between them.
     markTurnInFlight(graphThreadId);
     try {
       const current = ((
@@ -131,14 +155,7 @@ export async function undoRefusedTurn(params: {
           | { messages?: BaseMessage[] }
           | undefined
       )?.messages ?? []) as BaseMessage[];
-      const plan = planTurnRollback(
-        produced,
-        new Set(
-          current
-            .map((m) => m.id)
-            .filter((id): id is string => typeof id === "string"),
-        ),
-      );
+      const plan = planTurnRollback(produced, current);
       if (plan.action === "remove") {
         await graph.updateState(
           threadCfg,

--- a/tests/graph/nudge-refused-rollback.test.ts
+++ b/tests/graph/nudge-refused-rollback.test.ts
@@ -11,6 +11,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import { contactInboxThreadId } from "@/graph/checkpointer";
+import { clearTurnInFlight, markTurnInFlight } from "@/graph/inflight";
 import { isNudgeTurn } from "@/graph/markers";
 import { runAgentNudge } from "@/graph/nudge";
 import { buildThreadStateGraph, THREAD_STATE_NODE } from "@/graph/thread-state";
@@ -344,6 +345,55 @@ describe.skipIf(!dbUp)(
       expect(
         after.some((m) => ((m as AIMessage).tool_calls?.length ?? 0) > 0),
       ).toBe(true);
+    });
+
+    // The hazard `src/graph/inflight.ts` exists for, asked from this side: a reactive turn invoking on
+    // this same memory thread is a read-modify-write of the whole channel, so it will save back
+    // whatever it loaded. A removal written underneath it is undone the moment it finishes, and the
+    // history ends up exactly where it started with a checkpoint claiming otherwise. Standing down is
+    // the honest answer, and this pins that it stands down rather than writing that checkpoint.
+    test("another invoke holding the thread defers the rollback instead of racing it", async () => {
+      const contactInboxId = 7254;
+      await seedConv(9254, contactInboxId);
+      const graphThreadId = contactInboxThreadId(
+        tenantId,
+        instanceId,
+        contactInboxId,
+      );
+      const checkpointer = new MemorySaver();
+      await seedHistory(checkpointer, graphThreadId);
+      const s = stub();
+      let wanted = true;
+      // A reactive turn that started before this nudge and has not finished. Released in the finally,
+      // or every later test on this thread would inherit the claim.
+      markTurnInFlight(graphThreadId);
+      let outcome: string;
+      try {
+        outcome = await runAgentNudge({
+          tenantId,
+          threadId: `${tenantId}:${instanceId}:9254`,
+          nudge: { source: "followup", kind: "inactivity", step: 1 },
+          stillWanted: async () => wanted,
+          base: appDb,
+          deps: {
+            makeModel: () =>
+              new RetiringModel(() => {
+                wanted = false;
+              }, "Oi, ainda precisa de ajuda?"),
+            makeClient: s.makeClient,
+            checkpointer,
+            persistUsage: async () => {},
+          },
+        });
+      } finally {
+        clearTurnInFlight(graphThreadId);
+      }
+
+      expect(outcome).toBe("stale");
+      expect(s.messages).toEqual([]);
+      const after = await channel(checkpointer, graphThreadId);
+      expect(after.some((m) => isNudgeTurn(m))).toBe(true);
+      expect(after.map(textOf).join("\n")).toContain("ainda precisa de ajuda");
     });
 
     test("a turn that reached the customer stays in the history, where it belongs", async () => {

--- a/tests/graph/nudge-refused-rollback.test.ts
+++ b/tests/graph/nudge-refused-rollback.test.ts
@@ -1,0 +1,382 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import {
+  AIMessage,
+  type BaseMessage,
+  HumanMessage,
+} from "@langchain/core/messages";
+import type { ChatResult } from "@langchain/core/outputs";
+import { MemorySaver } from "@langchain/langgraph";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { contactInboxThreadId } from "@/graph/checkpointer";
+import { isNudgeTurn } from "@/graph/markers";
+import { runAgentNudge } from "@/graph/nudge";
+import { buildThreadStateGraph, THREAD_STATE_NODE } from "@/graph/thread-state";
+import type { ChatwootClient } from "@/modules/chatwoot/client";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// THE EFFECT, WHERE THE ISSUE SAYS IT IS: the memory thread, after a proactive turn was generated and
+// then refused. `tests/graph/refused-turn.test.ts` proves the RULE; this proves the turn actually
+// reaches it, through the real `runAgentNudge`, with a real checkpointer.
+//
+// Measured on `main`, with the job retired during generation. This is the state the file exists to end:
+//
+//   OUTCOME: stale   SENT TO CUSTOMER: []
+//   channel: [human] An external system event just occurred…   [ai] Oi, ainda precisa de ajuda?
+//
+// Issue #251.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let instanceId = 0n;
+let inboxDbId = 0n;
+
+// The retirement lands DURING generation, which is the only position that produces the defect: a
+// `/reset` before the run starts never reaches the invoke, and one after the send is too late to
+// suppress anything.
+class RetiringModel extends BaseChatModel {
+  constructor(
+    private readonly retire: () => void,
+    private readonly text: string,
+  ) {
+    super({});
+  }
+  _llmType() {
+    return "retiring";
+  }
+  async _generate(): Promise<ChatResult> {
+    this.retire();
+    return {
+      generations: [{ text: this.text, message: new AIMessage(this.text) }],
+    };
+  }
+}
+
+// The same retirement, on a turn that transferred the conversation first. The tool call is the whole
+// point: it happened, to the outside world, and the history is the only record of it.
+class RetiringHandoffModel {
+  constructor(
+    private readonly retire: () => void,
+    private readonly reply: string,
+  ) {}
+  async invoke(): Promise<AIMessage> {
+    return new AIMessage(this.reply);
+  }
+  bindTools(_tools: unknown) {
+    const self = this;
+    let n = 0;
+    return {
+      async invoke(): Promise<AIMessage> {
+        n++;
+        if (n === 1) {
+          return new AIMessage({
+            content: "",
+            tool_calls: [
+              {
+                name: "handoff_to_human",
+                args: { customerMessage: "Já te transfiro." },
+                id: "call_handoff",
+              },
+            ],
+          });
+        }
+        self.retire();
+        return new AIMessage(self.reply);
+      },
+    };
+  }
+}
+
+function stub() {
+  const messages: Array<[number, string]> = [];
+  const notes: Array<[number, string]> = [];
+  const client = {
+    sendMessage: async (c: number, t: string) => {
+      messages.push([c, t]);
+      return {};
+    },
+    sendPrivateNote: async (c: number, t: string) => {
+      notes.push([c, t]);
+      return {};
+    },
+    getConversationLabels: async () => [],
+    setConversationLabels: async () => ({}),
+    toggleStatus: async () => ({}),
+    getConversation: async () => ({
+      id: 1,
+      status: "pending",
+      meta: { assignee: null },
+    }),
+  } as unknown as ChatwootClient;
+  return { messages, notes, client, makeClient: async () => client };
+}
+
+async function seedConv(convId: number, contactInboxId: number) {
+  await suDb.conversation.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      inboxId: inboxDbId,
+      chatwootConversationId: convId,
+      contactInboxId,
+      status: "pending",
+      assigneeType: null,
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      lastEventAt: new Date(),
+      lastInboundAt: new Date(),
+    },
+  });
+}
+
+// The attendance that was already on the thread before the nudge fired. Every assertion below is
+// about what SURVIVES as much as about what goes: a rollback that took the customer's own words with
+// it would be a worse defect than the one it fixes.
+async function seedHistory(
+  checkpointer: MemorySaver,
+  graphThreadId: string,
+): Promise<void> {
+  await buildThreadStateGraph(checkpointer).updateState(
+    { configurable: { thread_id: graphThreadId } },
+    {
+      messages: [
+        new HumanMessage({ id: "hist-1", content: "bom dia" }),
+        new AIMessage({ id: "hist-2", content: "Bom dia! Como posso ajudar?" }),
+      ],
+    },
+    THREAD_STATE_NODE,
+  );
+}
+
+async function channel(
+  checkpointer: MemorySaver,
+  graphThreadId: string,
+): Promise<BaseMessage[]> {
+  const state = await buildThreadStateGraph(checkpointer).getState({
+    configurable: { thread_id: graphThreadId },
+  });
+  return ((state.values as { messages?: BaseMessage[] } | undefined)
+    ?.messages ?? []) as BaseMessage[];
+}
+
+const textOf = (m: BaseMessage): string =>
+  typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+
+describe.skipIf(!dbUp)(
+  "a refused proactive turn leaves no trace in memory",
+  () => {
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "RB", slug: `rb-${process.pid}` },
+      });
+      tenantId = t.id;
+      const inst = await seedChatwootInstance(suDb, {
+        tenantId,
+        accountId: 9,
+        baseUrl: "https://chat.example.com",
+        adminToken: encryptJson("ADMIN"),
+      });
+      instanceId = inst.id;
+      const vault = await suDb.vaultEntry.create({
+        data: { tenantId, name: "k", secret: encryptJson("sk") },
+        select: { id: true },
+      });
+      const agent = await suDb.agent.create({
+        data: {
+          tenantId,
+          name: "Atendente",
+          systemPrompt: "Você é prestativa.",
+          modelConfig: {
+            provider: "openai",
+            model: "gpt-4o-mini",
+            credentialRef: `vault:${vault.id}`,
+          },
+        },
+      });
+      await suDb.chatwootAgentBot.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          agentId: agent.id,
+          chatwootAgentBotId: 9,
+          accessToken: encryptJson("BOT"),
+          webhookSecret: encryptJson("S"),
+          webhookRouteTokenHash: `rb-route-${process.pid}`,
+          name: "Atendente",
+        },
+      });
+      const inbox = await suDb.inbox.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootInboxId: 7,
+          name: "Suporte",
+          agentId: agent.id,
+          channelType: "Channel::Whatsapp",
+          provider: "whatsapp_cloud",
+        },
+      });
+      inboxDbId = inbox.id;
+    });
+
+    afterAll(async () => {
+      if (tenantId) {
+        for (const table of [
+          "llm_usage",
+          "scheduler_jobs",
+          "agent_threads",
+          "conversations",
+          "inboxes",
+          "agents",
+          "vault_entries",
+          "chatwoot_instances",
+        ]) {
+          await suDb.$executeRawUnsafe(
+            `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+          );
+        }
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM tenants WHERE id = ${tenantId}`,
+        );
+      }
+      await suDb.$disconnect();
+      await appDb.$disconnect();
+    });
+
+    test("a job retired during generation takes its turn back out of the history", async () => {
+      const contactInboxId = 7251;
+      await seedConv(9251, contactInboxId);
+      const graphThreadId = contactInboxThreadId(
+        tenantId,
+        instanceId,
+        contactInboxId,
+      );
+      const checkpointer = new MemorySaver();
+      await seedHistory(checkpointer, graphThreadId);
+      const s = stub();
+      let wanted = true;
+      const outcome = await runAgentNudge({
+        tenantId,
+        threadId: `${tenantId}:${instanceId}:9251`,
+        nudge: { source: "followup", kind: "inactivity", step: 1 },
+        stillWanted: async () => wanted,
+        base: appDb,
+        deps: {
+          makeModel: () =>
+            new RetiringModel(() => {
+              wanted = false;
+            }, "Oi, ainda precisa de ajuda?"),
+          makeClient: s.makeClient,
+          checkpointer,
+          persistUsage: async () => {},
+        },
+      });
+
+      expect(outcome).toBe("stale");
+      expect(s.messages).toEqual([]);
+      expect(s.notes).toEqual([]);
+      const after = await channel(checkpointer, graphThreadId);
+      // The turn is gone…
+      expect(after.some((m) => isNudgeTurn(m))).toBe(false);
+      expect(after.map(textOf).join("\n")).not.toContain(
+        "ainda precisa de ajuda",
+      );
+      // …and the attendance it fired on top of is untouched.
+      expect(after.map((m) => m.id)).toEqual(["hist-1", "hist-2"]);
+    });
+
+    test("a turn that transferred the conversation keeps its history, refused or not", async () => {
+      const contactInboxId = 7252;
+      await seedConv(9252, contactInboxId);
+      const graphThreadId = contactInboxThreadId(
+        tenantId,
+        instanceId,
+        contactInboxId,
+      );
+      const checkpointer = new MemorySaver();
+      await seedHistory(checkpointer, graphThreadId);
+      const s = stub();
+      let wanted = true;
+      const outcome = await runAgentNudge({
+        tenantId,
+        threadId: `${tenantId}:${instanceId}:9252`,
+        nudge: { source: "followup", kind: "inactivity", step: 1 },
+        stillWanted: async () => wanted,
+        base: appDb,
+        deps: {
+          makeModel: () =>
+            new RetiringHandoffModel(() => {
+              wanted = false;
+            }, "Vou te transferir para um atendente.") as never,
+          makeClient: s.makeClient,
+          checkpointer,
+          persistUsage: async () => {},
+        },
+      });
+
+      expect(outcome).toBe("stale");
+      const after = await channel(checkpointer, graphThreadId);
+      // The transfer ran inside the graph and this fence never could reverse it, so the record of it
+      // stays: erasing the turn would erase the only account of an act that really happened.
+      expect(after.some((m) => isNudgeTurn(m))).toBe(true);
+      expect(
+        after.some((m) => ((m as AIMessage).tool_calls?.length ?? 0) > 0),
+      ).toBe(true);
+    });
+
+    test("a turn that reached the customer stays in the history, where it belongs", async () => {
+      const contactInboxId = 7253;
+      await seedConv(9253, contactInboxId);
+      const graphThreadId = contactInboxThreadId(
+        tenantId,
+        instanceId,
+        contactInboxId,
+      );
+      const checkpointer = new MemorySaver();
+      await seedHistory(checkpointer, graphThreadId);
+      const s = stub();
+      const outcome = await runAgentNudge({
+        tenantId,
+        threadId: `${tenantId}:${instanceId}:9253`,
+        nudge: { source: "followup", kind: "inactivity", step: 1 },
+        stillWanted: async () => true,
+        base: appDb,
+        deps: {
+          makeModel: () =>
+            new RetiringModel(() => {}, "Oi, ainda precisa de ajuda?"),
+          makeClient: s.makeClient,
+          checkpointer,
+          persistUsage: async () => {},
+        },
+      });
+
+      expect(outcome).toBe("messaged");
+      expect(s.messages).toEqual([[9253, "Oi, ainda precisa de ajuda?"]]);
+      const after = await channel(checkpointer, graphThreadId);
+      expect(after.some((m) => isNudgeTurn(m))).toBe(true);
+      expect(after.map(textOf).join("\n")).toContain("ainda precisa de ajuda");
+    });
+  },
+);

--- a/tests/graph/refused-turn-callsites.test.ts
+++ b/tests/graph/refused-turn-callsites.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+// THE RULE THE ROLLBACK DEPENDS ON, AND THE ONE A PATCH CAN SILENTLY BREAK.
+//
+// `undoRefusedTurn` cannot be reached from inside `runAgentNudge`'s refusals unless each of them goes
+// out through `refuse`. There are eight of them today, spread over two hundred lines, and the ninth
+// will be written by someone adding a gate, copying the line above it, which is what a bare
+// `return "stale";` looks like. Nothing fails when they do: the send is still suppressed, the outcome
+// is still right, and the only symptom is the next turn answering about a message nobody received,
+// which is the defect issue #251 opened for.
+//
+// So the fence is on the SPELLING, at the position where it matters: below the point where a turn has
+// been generated, a refusal is not a `return`, it is a `refuse`.
+
+// The two outcomes a post-generation refusal can carry. "silent", "messaged", "noted" and the rest
+// are not refusals: the turn reached its end and something (a message, a note, a decision) stands.
+const REFUSAL_OUTCOMES = ["stale", "live-unavailable"] as const;
+
+const BARE = new RegExp(`return "(?:${REFUSAL_OUTCOMES.join("|")})";`, "g");
+
+// Everything above the closure is a refusal BEFORE the invoke, where there is no generated turn to
+// take back and `refuse` would be a checkpointer round trip for nothing.
+export function bareRefusalsAfterTheRollback(source: string): string[] {
+  const at = source.indexOf("const refuse = async (");
+  if (at === -1) return ["the `refuse` closure is gone"];
+  return (source.slice(at).match(BARE) ?? []).map((m) => m.trim());
+}
+
+describe("every post-generation refusal in runAgentNudge rolls the turn back", () => {
+  // The control: a sweep that finds nothing passes whether or not it is looking at anything, so the
+  // predicate is shown an offender first.
+  test("the predicate flags a bare refusal written below the closure", () => {
+    const withOffender = `
+  const refuse = async (outcome) => outcome;
+  if (!(await stillWanted())) return refuse("stale");
+  if (owned === "gone") return "live-unavailable";
+`;
+    expect(bareRefusalsAfterTheRollback(withOffender)).toEqual([
+      'return "live-unavailable";',
+    ]);
+  });
+
+  test("and says so when the closure itself was removed", () => {
+    expect(bareRefusalsAfterTheRollback("if (x) return 'stale';")).toEqual([
+      "the `refuse` closure is gone",
+    ]);
+  });
+
+  test("a refusal above the closure is not its business", () => {
+    const before = `
+  if (!(await stillWanted())) return "stale";
+  const refuse = async (outcome) => outcome;
+`;
+    expect(bareRefusalsAfterTheRollback(before)).toEqual([]);
+  });
+
+  test("nudge.ts has none", async () => {
+    const source = await Bun.file("src/graph/nudge.ts").text();
+    expect(bareRefusalsAfterTheRollback(source)).toEqual([]);
+    // …and the sweep is looking at something. A rule whose subject can become empty starts passing
+    // for the wrong reason the day the refusals are restructured.
+    const at = source.indexOf("const refuse = async (");
+    // A floor, not a census: more sites routed through `refuse` is a better state, never a worse one,
+    // so pinning the exact number would only cost a second edit to a PR that adds a gate correctly.
+    // What it guards is the subject going EMPTY, which is how a sweep starts passing blind.
+    const routed = source.slice(at).match(/return refuse\("/g) ?? [];
+    expect(routed.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/tests/graph/refused-turn.test.ts
+++ b/tests/graph/refused-turn.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AIMessage,
+  type BaseMessage,
+  HumanMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
+import { nudgeMessage } from "@/graph/markers";
+import { planTurnRollback, type RollbackPlan } from "@/graph/refused-turn";
+
+// The decision, as a table. `undoRefusedTurn` does the reading and the writing; everything that is a
+// JUDGEMENT is here, because the write is a checkpointer round trip and a rule proven through one
+// tells you the wiring works, not what the rule is.
+//
+// The question in every row: this invoke produced these messages and the channel currently holds
+// these ids. Which of them may be taken back out? Issue #251.
+
+function h(id: string, text: string): BaseMessage {
+  return new HumanMessage({ id, content: text });
+}
+function a(id: string, text: string): BaseMessage {
+  return new AIMessage({ id, content: text });
+}
+function calling(id: string, name: string): BaseMessage {
+  return new AIMessage({
+    id,
+    content: "",
+    tool_calls: [{ id: `${id}-c`, name, args: {} }],
+  });
+}
+function toolResult(id: string, text: string): BaseMessage {
+  return new ToolMessage({ id, content: text, tool_call_id: `${id}-c` });
+}
+function nudge(id: string): BaseMessage {
+  const m = nudgeMessage("An external system event just occurred…", 900);
+  m.id = id;
+  return m;
+}
+const allOf = (...ms: BaseMessage[]) => new Set(ms.map((m) => m.id as string));
+
+describe("planTurnRollback", () => {
+  const ROWS: Array<{
+    name: string;
+    produced: BaseMessage[];
+    present: ReadonlySet<string>;
+    expected: RollbackPlan;
+  }> = [
+    (() => {
+      const hist = [h("h1", "oi"), a("a1", "olá")];
+      return {
+        name: "a thread with no nudge in it has no proactive turn to take back",
+        produced: hist,
+        present: allOf(...hist),
+        expected: { action: "keep", reason: "no-turn-found" },
+      };
+    })(),
+    (() => {
+      const produced = [
+        h("h1", "oi"),
+        a("a1", "olá"),
+        nudge("n1"),
+        a("a2", "ainda precisa?"),
+      ];
+      return {
+        name: "the directive and the answer it produced, and nothing that came before them",
+        produced,
+        present: allOf(...produced),
+        expected: { action: "remove", ids: ["n1", "a2"] },
+      };
+    })(),
+    (() => {
+      // The transfer is the case that forces the rule: the tool handed the conversation to the human
+      // queue from inside the graph, and no removal here can undo that.
+      const produced = [
+        nudge("n1"),
+        calling("a1", "transfer_to_human"),
+        toolResult("t1", "ok"),
+        a("a2", "Vou te transferir."),
+      ];
+      return {
+        name: "a turn that ran a tool keeps its history, because the act it records really happened",
+        produced,
+        present: allOf(...produced),
+        expected: { action: "keep", reason: "tool-ran" },
+      };
+    })(),
+    (() => {
+      // A tool result with no matching call in the slice is the same answer: something ran.
+      const produced = [nudge("n1"), toolResult("t1", "ok"), a("a1", "pronto")];
+      return {
+        name: "a bare tool result answers the same question the same way",
+        produced,
+        present: allOf(...produced),
+        expected: { action: "keep", reason: "tool-ran" },
+      };
+    })(),
+    (() => {
+      // Two nudges on one thread: the earlier one ended silent and belongs to a turn nobody refused.
+      const produced = [
+        nudge("n1"),
+        a("a1", "[[SKIP]]"),
+        h("h1", "oi"),
+        nudge("n2"),
+        a("a2", "ainda precisa?"),
+      ];
+      return {
+        name: "only the LAST directive's turn, never an earlier nudge that already stood",
+        produced,
+        present: allOf(...produced),
+        expected: { action: "remove", ids: ["n2", "a2"] },
+      };
+    })(),
+    (() => {
+      const produced = [nudge("n1"), a("a1", "ainda precisa?")];
+      return {
+        name: "a channel another writer already rewrote is left exactly as it is",
+        produced,
+        present: new Set<string>(),
+        expected: { action: "keep", reason: "already-gone" },
+      };
+    })(),
+    (() => {
+      // The reducer THROWS on an id it cannot find, so a partially-surviving slice names only what
+      // survived. Half a rollback beats a thrown job on a refusal that already suppressed the send.
+      const produced = [nudge("n1"), a("a1", "ainda precisa?")];
+      return {
+        name: "half the turn still there names half the turn",
+        produced,
+        present: new Set(["a1"]),
+        expected: { action: "remove", ids: ["a1"] },
+      };
+    })(),
+    (() => {
+      // A message the reducer has not stamped yet has no id to name, and naming `undefined` is how a
+      // rollback becomes a throw.
+      const produced = [nudge("n1"), new AIMessage({ content: "sem id" })];
+      return {
+        name: "a message with no id is not nameable, so it is not named",
+        produced,
+        present: new Set(["n1"]),
+        expected: { action: "remove", ids: ["n1"] },
+      };
+    })(),
+  ];
+
+  for (const row of ROWS) {
+    test(row.name, () => {
+      expect(planTurnRollback(row.produced, row.present)).toEqual(row.expected);
+    });
+  }
+});

--- a/tests/graph/refused-turn.test.ts
+++ b/tests/graph/refused-turn.test.ts
@@ -5,7 +5,7 @@ import {
   HumanMessage,
   ToolMessage,
 } from "@langchain/core/messages";
-import { nudgeMessage } from "@/graph/markers";
+import { memoryHeadMessage, nudgeMessage } from "@/graph/markers";
 import { planTurnRollback, type RollbackPlan } from "@/graph/refused-turn";
 
 // The decision, as a table. `undoRefusedTurn` does the reading and the writing; everything that is a
@@ -36,13 +36,14 @@ function nudge(id: string): BaseMessage {
   m.id = id;
   return m;
 }
-const allOf = (...ms: BaseMessage[]) => new Set(ms.map((m) => m.id as string));
+const head = (id: string): BaseMessage =>
+  memoryHeadMessage("<atendimentos-anteriores>…</atendimentos-anteriores>", id);
 
 describe("planTurnRollback", () => {
   const ROWS: Array<{
     name: string;
     produced: BaseMessage[];
-    present: ReadonlySet<string>;
+    current: BaseMessage[];
     expected: RollbackPlan;
   }> = [
     (() => {
@@ -50,7 +51,7 @@ describe("planTurnRollback", () => {
       return {
         name: "a thread with no nudge in it has no proactive turn to take back",
         produced: hist,
-        present: allOf(...hist),
+        current: hist,
         expected: { action: "keep", reason: "no-turn-found" },
       };
     })(),
@@ -64,7 +65,7 @@ describe("planTurnRollback", () => {
       return {
         name: "the directive and the answer it produced, and nothing that came before them",
         produced,
-        present: allOf(...produced),
+        current: produced,
         expected: { action: "remove", ids: ["n1", "a2"] },
       };
     })(),
@@ -80,7 +81,7 @@ describe("planTurnRollback", () => {
       return {
         name: "a turn that ran a tool keeps its history, because the act it records really happened",
         produced,
-        present: allOf(...produced),
+        current: produced,
         expected: { action: "keep", reason: "tool-ran" },
       };
     })(),
@@ -90,7 +91,7 @@ describe("planTurnRollback", () => {
       return {
         name: "a bare tool result answers the same question the same way",
         produced,
-        present: allOf(...produced),
+        current: produced,
         expected: { action: "keep", reason: "tool-ran" },
       };
     })(),
@@ -106,7 +107,7 @@ describe("planTurnRollback", () => {
       return {
         name: "only the LAST directive's turn, never an earlier nudge that already stood",
         produced,
-        present: allOf(...produced),
+        current: produced,
         expected: { action: "remove", ids: ["n2", "a2"] },
       };
     })(),
@@ -115,7 +116,7 @@ describe("planTurnRollback", () => {
       return {
         name: "a channel another writer already rewrote is left exactly as it is",
         produced,
-        present: new Set<string>(),
+        current: [],
         expected: { action: "keep", reason: "already-gone" },
       };
     })(),
@@ -126,8 +127,30 @@ describe("planTurnRollback", () => {
       return {
         name: "half the turn still there names half the turn",
         produced,
-        present: new Set(["a1"]),
+        current: [produced[1] as BaseMessage],
         expected: { action: "remove", ids: ["a1"] },
+      };
+    })(),
+    (() => {
+      // The sharp one. Memory compaction REUSES the id of the first message it replaces for the
+      // rendered head, so a compaction landing between the invoke and this plan hands the refused
+      // directive's id to the head of an entire attendance. Removing by id alone would delete it.
+      const produced = [nudge("n1"), a("a1", "ainda precisa?")];
+      return {
+        name: "an id that memory compaction reused for its head is not the message we produced",
+        produced,
+        current: [head("n1")],
+        expected: { action: "keep", reason: "already-gone" } as RollbackPlan,
+      };
+    })(),
+    (() => {
+      // …and the half that IS still ours survives that same rewrite.
+      const produced = [nudge("n1"), a("a1", "ainda precisa?")];
+      return {
+        name: "the reply survives a rewrite that only took the directive's id",
+        produced,
+        current: [head("n1"), produced[1] as BaseMessage],
+        expected: { action: "remove", ids: ["a1"] } as RollbackPlan,
       };
     })(),
     (() => {
@@ -137,7 +160,7 @@ describe("planTurnRollback", () => {
       return {
         name: "a message with no id is not nameable, so it is not named",
         produced,
-        present: new Set(["n1"]),
+        current: [produced[0] as BaseMessage],
         expected: { action: "remove", ids: ["n1"] },
       };
     })(),
@@ -145,7 +168,7 @@ describe("planTurnRollback", () => {
 
   for (const row of ROWS) {
     test(row.name, () => {
-      expect(planTurnRollback(row.produced, row.present)).toEqual(row.expected);
+      expect(planTurnRollback(row.produced, row.current)).toEqual(row.expected);
     });
   }
 });


### PR DESCRIPTION
Fixes #251

## What was broken

`runAgentNudge` generates the proactive turn by invoking the graph, and the graph checkpoints as it
runs: the nudge directive and the assistant's answer are in the thread's history the moment `invoke`
returns. Eight refusals sit below that point, and every one of them suppresses the send and leaves
the pair there: an operator took the conversation, a `/reset` retired the job, the agent was
switched off mid-turn, the guardrail's ownership re-probe came back `not-ours`.

The next turn then reads an assistant message the customer never received, and answers as though they had seen it. Nothing in the thread says otherwise.

Measured against a real `PostgresSaver`, on `main`, with the job retired during generation and a prior
attendance already on the thread:

```
outcome: stale | sent to customer: []
channel read back from Postgres:
  [human] id=live-h1  bom dia
  [ai]    id=live-a1  Bom dia!
  [human] id=9e9afd21-…  An external system event just occurred for this conversation…
  [ai]    id=run-01a03a55-…  Oi, ainda precisa de ajuda?
```

The last two are the turn nobody received.

## What the issue got wrong

The issue weighed rolling the turn back against two alternatives and said the rollback "needs a
mechanism the repo does not have yet". It does not. Memory compaction already rewrites this exact
channel by naming ids: `RemoveMessage` through `graph.updateState` on `THREAD_STATE_NODE`
(`src/modules/memory/compact.ts`). Its own comment settles the concurrency question the issue raised
in the same breath: `REMOVE_ALL_MESSAGES` would erase a message that arrived from elsewhere, and
naming ids does not.

What the repo did not have was the DECISION, and that is what this PR adds.

## What changed

`src/graph/refused-turn.ts` answers one question as a pure function: this invoke produced these
messages and the channel currently holds these ids, so which of them may be taken back out?

| the turn | the answer |
| --- | --- |
| no nudge directive in it | `keep: no-turn-found` |
| directive + reply | `remove` both, and nothing that came before them |
| a tool ran | `keep: tool-ran` |
| its ids are already gone | `keep: already-gone` |
| half its ids survive | `remove` the half that survives |

Two of those rows are the ones that make it safe:

- **A tool call means the turn DID something**, to the outside world, that no removal here can undo.
  The transfer is the case that forces it: `handoff_to_human` hands the conversation to the human
  queue from inside the graph, and `runAgentNudge` already says so in its own words ("the transfer
  itself still stands: the tool ran inside the graph and this fence was never able to reverse it").
  Erasing the turn would erase the only record of it, so any tool call at all and the turn stays.
- **The reducer THROWS on an id it cannot find** (`Attempting to delete a message with an ID that
  doesn't exist`, `messagesStateReducer`), so the plan is computed against the channel as it reads at
  write time, not as the invoke returned it. Between those two moments sit the ownership probe and the
  guardrail judge, which are model calls and Chatwoot round trips.
- **An id is not an identity on this channel** (round 2 of review). Memory compaction REUSES the id of
  the first message it replaces for the rendered memory head, deliberately, so that the reducer keeps
  the head at the FRONT (`docs/graph.md`). A compaction landing in that same window can therefore hand
  the refused directive's id to the head of an entire attendance, and a plan that only asked "is the
  id still there?" would delete it. Losing a summary is worse than the residue this exists to clear,
  so the current message has to still BE the one this invoke produced, by type and content, not merely
  occupy its id.

`undoRefusedTurn` reads and writes under the same `ingest:<graphThreadId>` key the append and the
compaction rewrite take, and holds the in-flight claim for the length of it, so a compaction cannot
land between the read and the write.

That key is not enough on its own, and the in-flight COUNT is why (round 1 of review). A turn takes
the key to mark itself and releases it before the model runs, so an invoke in flight is not holding
anything this could queue behind. What it holds is a claim in `src/graph/inflight.ts`, and an invoke
is a read-modify-write of the whole channel: one that loaded the refused turn saves it back the
moment it finishes, undoing a removal written underneath it. So the count is read BEFORE this adds
its own claim, exactly as memory compaction does, and the rollback stands down with the reason named
(`another-invoke-is-reading`) and a `warn` line. Standing down leaves the refused turn in the
history, which is the honest outcome rather than a better one: writing a removal another invoke is
about to undo leaves the same history plus a checkpoint that says otherwise.

In `runAgentNudge`, the eight post-generation refusals go out through one `refuse` closure instead of
returning directly. It never decides whether to roll back; it hands the produced messages to
`undoRefusedTurn` and returns the outcome unchanged. A failed rollback is logged and swallowed: the
send was already suppressed, so the cost is the defect this closes, and throwing would turn a correct
refusal into a retried job.

The reactive turn (`runLoadedTurn`) has the same window and is NOT touched here. See below.

## Proving the red

Every rule was mutated one at a time, against the three new test files (15 tests):

| mutation | result |
| --- | --- |
| baseline | `15 pass 0 fail` |
| the removal never writes | `14 pass 1 fail` |
| drop the tool-ran guard | `12 pass 3 fail` |
| take the FIRST nudge instead of the last | `14 pass 1 fail` |
| drop the "still present" filter | `13 pass 2 fail` |
| turn one call site back into a bare `return "stale";` | the source fence fails |
| drop the in-flight check (round 1's fix) | `3 pass 1 fail` |
| compare ids only, not identity (round 2's fix) | `8 pass 2 fail` |

## Validation scope

**Proven by test.** `tests/graph/refused-turn.test.ts` is the decision table above (10 rows, two of
them the compaction id-reuse case: the head is never taken, and the reply that survived that same
rewrite still is).
`tests/graph/nudge-refused-rollback.test.ts` drives the real `runAgentNudge` against a real database
and asserts three ends: a turn retired during generation leaves the channel exactly as it found it
(the prior attendance intact, by id); a turn that transferred the conversation KEEPS its history,
tool call and all; a turn that reached the customer keeps its history too.
`tests/graph/refused-turn-callsites.test.ts` is the source fence that a ninth refusal cannot quietly
skip, with a positive control on a fixture that contains an offender.

**Proven live**, against a real `PostgresSaver` on a local Postgres, both halves:

```
### without the fix                        ### with the fix
outcome: stale | sent: []                  outcome: stale | sent: []
  [human] live-h1  bom dia                   [human] live-h1  bom dia
  [ai]    live-a1  Bom dia!                  [ai]    live-a1  Bom dia!
  [human] 9e9afd21-…  An external system…
  [ai]    run-01a03a55-…  Oi, ainda precisa de ajuda?
```

Same script, same seeded thread, same retirement position; the only difference is
`src/graph/nudge.ts`. This is the half `MemorySaver` cannot answer: it proves the removal survives
serialization by the checkpointer production actually runs.

**Not validated.** No Chatwoot round trip is involved in the rollback, so none was exercised: the
refusals themselves are already covered by `tests/graph/nudge.test.ts`, which this PR leaves passing
(109 tests across the four nudge suites).

The concurrent case is DETECTED and deferred, not closed. A refused turn that coincides with another
invoke on the same memory thread stays in the history, and the log line is the only trace. Closing it
would mean re-applying the removal after the other invoke finishes, which needs somewhere to defer to
and is the same redesign #203 is about.

And the detection is a count, not a gate, which round 3 pinned precisely: it excludes an invoke
already in flight, never one that starts a moment later, loads the refused turn and saves it back.
The window is widest on the fallback thread, where a conversation with no `contactInboxId` makes the
graph thread and the conversation thread the same key and `runLoadedTurn` marks that key before it
takes any lock. **The review finding asking for that to be closed is waived**, for a reason worth
having on the record rather than in a local ledger: closing it means holding a critical section
across another invoke, which is exactly the pool inversion #227 removed for issue #225 (a Prisma
transaction held open across the checkpointer's separate pool, draining the main one until unrelated
queries failed on `maxWait`). Losing that race costs precisely what happens today with no rollback at
all, so the rollback is best-effort against a concurrent invoke and never worse than not having run.

Full suite: `5465 pass, 0 fail`.

## Deliberately left out

`runLoadedTurn` has the same window: a reply generated and then refused by `shouldPost`, the assignee
re-check or the write-called-off gate stays in the channel the same way. Measured on `main`, on the
existing `issue #49` supersede test:

```
PROBE251-REACTIVE thread=2:2:970
   [human] oi
   [ai] Olá! Como posso ajudar?        ← sent === []
```

It is a different fix, not the same one applied twice: there the `[human]` message is the CUSTOMER's,
and `superseded` means the re-armed flush will answer the whole burst, so it must stay. Only the
assistant tail may go. Folding that into this PR would mean rewriting the reactive turn's exit paths
in the same change that introduces the mechanism. A follow-up issue carries the measurement.
