### PR TITLE
Read a refusal wherever it is written, not only where it is thrown

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -87,7 +87,10 @@ export class ConflictError extends AppError {
 // either: the refusal is the class. Without it every one of them answered English to a pt-BR caller
 // while `errors.tenantTargetRequired` sat in both catalogs, translated, with nothing pointing at it.
 export class TenantTargetRequiredError extends AppError {
-  constructor(message = "A target tenant is required for this operation") {
+  // The default is the catalog sentence VERBATIM, and the admin surface's `translate` default is the
+  // same string: three producers of one refusal, saying one thing. They did not, and nothing noticed
+  // until the reader learned to read a subclass's own default (issue #299).
+  constructor(message = "A target tenant is required") {
     super(message, 400, "errors.tenantTargetRequired");
   }
 }

--- a/src/modules/conversations/reengage.ts
+++ b/src/modules/conversations/reengage.ts
@@ -2,7 +2,11 @@ import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { loadAgentConfig } from "@/graph/prepare";
 import type { RunAgentTurnOutcome, RuntimeDeps } from "@/graph/runtime";
-import { AppError, NotFoundError } from "@/lib/errors";
+import {
+  AppError,
+  NotFoundError,
+  TenantTargetRequiredError,
+} from "@/lib/errors";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
   type ChatwootMessageRow,
@@ -33,7 +37,7 @@ function sysCtx(tenantId: bigint): TenantContext {
 
 function requireTenant(ctx: TenantContext): bigint {
   if (ctx.tenantId === null) {
-    throw new AppError("tenant required", 400, "errors.tenantTargetRequired");
+    throw new TenantTargetRequiredError();
   }
   return ctx.tenantId;
 }

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -3,7 +3,11 @@ import { broadcastConversationEvent } from "@/api/features/realtime/realtime.ser
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import { modelConfigSchema } from "@/graph/model-config";
-import { AppError, NotFoundError } from "@/lib/errors";
+import {
+  AppError,
+  NotFoundError,
+  TenantTargetRequiredError,
+} from "@/lib/errors";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
@@ -504,7 +508,7 @@ function normalizeMessages(raw: unknown): ConversationMessage[] {
 
 function requireTenant(ctx: TenantContext): bigint {
   if (ctx.tenantId === null) {
-    throw new AppError("tenant required", 400, "errors.tenantTargetRequired");
+    throw new TenantTargetRequiredError();
   }
   return ctx.tenantId;
 }

--- a/tests/api/error-catalog.test.ts
+++ b/tests/api/error-catalog.test.ts
@@ -308,6 +308,50 @@ async function throwSiteRes(): Promise<RegExp[]> {
   ];
 }
 
+// THE SIXTH PRODUCER, and the only one that cannot be a regex over the tree: a subclass that
+// hard-codes BOTH its sentence and its key, so neither is written at any call site.
+// `throw new ProEditionError()` names nothing for a sweep to find.
+//
+// The pair is split across two lines of the class — a `message = "…"` default in the constructor
+// signature, the key in the `super(...)` call — so the file is read class by class rather than by
+// one expression, which is also what keeps a default from pairing with the NEXT class's key. That
+// happened while writing this: a single greedy regex reported `ForbiddenError`'s "Forbidden" as the
+// sentence of `errors.proEdition`.
+//
+// Found by review on #304, and by the right question: the `tenantTargetRequired` fix in this same PR
+// moved two refusals ONTO one of these classes, which silenced the rule instead of satisfying it.
+// A producer the reader cannot see is not a producer that agrees.
+async function subclassDefaults(into: Map<string, Set<string>>): Promise<void> {
+  const src = await readFile("src/lib/errors.ts", "utf8");
+  const bodies = src.split(/\nexport class /).slice(1);
+  expect(bodies.length).toBeGreaterThan(5);
+  for (const body of bodies) {
+    const message = body.match(
+      /constructor\([^)]*?message\s*=\s*("(?:[^"\\]|\\.)*")/,
+    )?.[1];
+    const key = body
+      .match(/super\(([^;]*?)\)\s*;/s)?.[1]
+      ?.match(/"errors\.([A-Za-z0-9_]+)"/)?.[1];
+    if (!message || !key) continue;
+    const set = into.get(key) ?? new Set<string>();
+    set.add(message.slice(1, -1));
+    into.set(key, set);
+  }
+}
+
+// Every producer in the tree, in one place: the three tests below asked the same question with the
+// same loop, and a spelling added to one of them and not the others is the shape of blind spot this
+// whole file exists to close.
+async function allSites(): Promise<Map<string, Set<string>>> {
+  const res = await throwSiteRes();
+  const sites = new Map<string, Set<string>>();
+  for (const f of await sourceFiles("src")) {
+    throwSites(await readFile(f, "utf8"), sites, res);
+  }
+  await subclassDefaults(sites);
+  return sites;
+}
+
 function throwSites(
   body: string,
   into: Map<string, Set<string>>,
@@ -685,6 +729,23 @@ describe("both languages answer, and answer differently", () => {
     expect(into.has("d")).toBe(false);
   });
 
+  test("a subclass that hard-codes its own refusal is read from the class", async () => {
+    const into = new Map<string, Set<string>>();
+    await subclassDefaults(into);
+    // The live pairs, which is what makes this a positive control rather than a shape test: a reader
+    // that stopped pairing the default with the key would answer with an empty map and pass any
+    // assertion written about "no bad pairs".
+    expect(into.get("proEdition")).toEqual(
+      new Set(["This feature requires the Pro edition"]),
+    );
+    expect(into.get("tenantTargetRequired")).toEqual(
+      new Set(["A target tenant is required"]),
+    );
+    // A class whose key is a PARAMETER pairs its default with nothing: `new NotFoundError("…")` can
+    // carry any key, so its "Not found" is not the sentence of any one of them.
+    expect(into.has("tenantNotFound")).toBe(false);
+  });
+
   // The regression this derivation exists for: a subclass the alternation forgot is a whole family of
   // refusals the rule cannot see. `ConflictError` was that subclass.
   test("the reader covers every error class the module exports", async () => {
@@ -704,14 +765,9 @@ describe("both languages answer, and answer differently", () => {
   });
 
   test("no key answers with less than its call sites already said", async () => {
-    const sites = new Map<string, Set<string>>();
-    const res = await throwSiteRes();
-    for (const f of await sourceFiles("src")) {
-      throwSites(await readFile(f, "utf8"), sites, res);
-    }
     expect(
       keysThatSayLess(
-        sites,
+        await allSites(),
         apiEn.errors as Record<string, string>,
         SAY_LESS_GRANDFATHERED,
       ),
@@ -749,16 +805,15 @@ describe("both languages answer, and answer differently", () => {
     "invalidDocumentValues",
     "invalidIdempotencyKey",
     "unstorableText",
-    // A SUBCLASS THAT HARD-CODES ITS OWN REFUSAL AND TAKES NO MESSAGE. `new ProEditionError()` names
-    // nothing at the call site, so there is no site to read; the rule that covers this shape is
-    // "a subclass is a throw site with no arguments", further down this file.
-    "proEdition",
+    // A third group stood here until review asked the obvious question: a subclass that hard-codes
+    // its own refusal names nothing at the call site, and `errors.proEdition` was waived for it.
+    // "Nothing to read at the call site" is not "nothing to read": the sentence is in the class, and
+    // `subclassDefaults` now reads it there. The group is empty, so it is gone.
   ];
 
   test("every key the reader cannot see is named, with the reason it may stay invisible", async () => {
-    const res = await throwSiteRes();
     const named = new Set<string>();
-    const seen = new Map<string, Set<string>>();
+    const seen = await allSites();
     for (const f of await sourceFiles("src")) {
       const body = await readFile(f, "utf8");
       // A ledger comment declares a key, it does not produce one, and it is spelled in single
@@ -768,9 +823,10 @@ describe("both languages answer, and answer differently", () => {
         for (const m of line.matchAll(/"errors\.([A-Za-z0-9_]+)"/g))
           named.add(m[1] as string);
       }
-      throwSites(body, seen, res);
     }
-    const unseenGiven = (visible: Set<string>): string[] =>
+    // Takes anything that can answer "do you have this key": the sweep hands back a Map of
+    // key -> messages, and the blinded control below is an empty Set.
+    const unseenGiven = (visible: { has: (k: string) => boolean }): string[] =>
       [...named].filter((k) => !visible.has(k)).sort();
     // NO FLOOR ON EITHER COUNT, and that is the whole lesson of this assertion. The first version
     // pinned both above 150, which is true on THIS tree and false on the one the public CI runs:
@@ -789,11 +845,7 @@ describe("both languages answer, and answer differently", () => {
   });
 
   test("the grandfathered list only names keys that still offend", async () => {
-    const sites = new Map<string, Set<string>>();
-    const res = await throwSiteRes();
-    for (const f of await sourceFiles("src")) {
-      throwSites(await readFile(f, "utf8"), sites, res);
-    }
+    const sites = await allSites();
     const stillOffends = new Set(
       keysThatSayLess(sites, apiEn.errors as Record<string, string>, []),
     );

--- a/tests/api/error-catalog.test.ts
+++ b/tests/api/error-catalog.test.ts
@@ -770,13 +770,22 @@ describe("both languages answer, and answer differently", () => {
       }
       throwSites(body, seen, res);
     }
-    // Both halves are asserted, because a scan that stopped finding anything would satisfy the
-    // difference below with an empty set on either side.
-    expect(named.size).toBeGreaterThan(150);
-    expect(seen.size).toBeGreaterThan(150);
-    expect([...named].filter((k) => !seen.has(k)).sort()).toEqual(
+    const unseenGiven = (visible: Set<string>): string[] =>
+      [...named].filter((k) => !visible.has(k)).sort();
+    // NO FLOOR ON EITHER COUNT, and that is the whole lesson of this assertion. The first version
+    // pinned both above 150, which is true on THIS tree and false on the one the public CI runs:
+    // both totals shrink with the edition (166 named / 153 seen here, 161 / 148 in the Free
+    // projection, measured), while the ledger below is the same thirteen in every tree. A sentinel
+    // calibrated against a tree that the derivation reshapes is a red build in the derived repo and
+    // a green one here, which is the shape this file has been bitten by before.
+    //
+    // The comparison guards itself, so it needs no sentinel: a blinded reader reports every named
+    // key as unseen, and that is not this ledger. Proven rather than claimed, because "it would have
+    // failed" is exactly the kind of statement that turns out to be false.
+    expect(unseenGiven(new Set())).not.toEqual(
       [...UNSEEN_BY_THE_READER].sort(),
     );
+    expect(unseenGiven(seen)).toEqual([...UNSEEN_BY_THE_READER].sort());
   });
 
   test("the grandfathered list only names keys that still offend", async () => {

--- a/tests/api/error-catalog.test.ts
+++ b/tests/api/error-catalog.test.ts
@@ -254,11 +254,12 @@ function keysThatSayLess(
 // messages thrown with it. Literal messages only: a message built from a variable cannot be compared
 // to a catalog entry, and the rule is about what the two SAY.
 //
-// THREE SPELLINGS, because a refusal is written three ways here and the rule is about the refusal,
+// FIVE SPELLINGS, because a refusal is written five ways here and the rule is about the refusal,
 // not about the syntax. The class alternation is DERIVED from src/lib/errors.ts rather than spelled
 // out. A hard-coded list goes stale the day someone adds a subclass, and it did: `ConflictError`
 // was missing, so every refusal thrown through it (`chatwootDifferentDeployment` among them) was
-// invisible. The other two spellings were found the same way, one blind spot later:
+// invisible. Every spelling since was found the same way, one blind spot at a time, and each was
+// MEASURED before being added, because a widened reader is only worth what it newly sees:
 //
 //   1. `new AppError("…", 400, "errors.x")`, the direct throw;
 //   2. `super("…", 400, "errors.x")`, a subclass that hard-codes its own refusal. Sees three keys
@@ -268,16 +269,30 @@ function keysThatSayLess(
 //      shape `src/modules/documents/templates.ts` uses so a dry run and an apply can reach the same
 //      answer. This one was hiding a live offender: `invalidDocumentSlug` interpolates the rule the
 //      identifier broke (`slug: ${problem}.`) into a catalog entry that says only "This identifier
-//      is not valid", and issue #291 was written from a list that could not see it.
+//      is not valid", and issue #291 was written from a list that could not see it;
+//   4. `translate("errors.x", "…")` and 5. `translateWithLocale(locale, "errors.x", "…")`, which are
+//      not throws at all: the auth, admin and origin surfaces answer `set.status` plus a body, and
+//      the schema boundary renders its own. Twenty-one keys, and the whole of `features/auth` and
+//      `features/admin`, had never been read by this rule (issue #299).
+//
+// THE KEY COMES FIRST in 4 and 5 and second in 1 to 3, which is why the groups are NAMED. Written
+// positionally, the two orders are one transposition apart, and the transposed version still runs:
+// it reads a message as a key and reports offenders that do not exist.
+//
+// The `translate(` forms are anchored to the CALL and not to adjacency, and that is the whole
+// difference between this reader and a wrong one. Measured while writing it: a bare
+// `"errors.x"\s*,\s*"…"` also matches a key sitting next to its neighbour in an ARRAY of keys
+// (`src/graph/tools/documents.ts` holds one), and it reported `documentNotStored` and
+// `documentRevoked` as offenders whose "message" was the next key in the list.
 async function throwSiteRes(): Promise<RegExp[]> {
   const src = await readFile("src/lib/errors.ts", "utf8");
   const classes = [...src.matchAll(/export class (\w+)/g)].map(
     (m) => m[1] as string,
   );
   expect(classes.length).toBeGreaterThan(5);
-  const MESSAGE = '(`[^`]*`|"(?:[^"\\\\]|\\\\.)*")';
+  const MESSAGE = '(?<msg>`[^`]*`|"(?:[^"\\\\]|\\\\.)*")';
   const STATUS = "(?:\\d+\\s*,\\s*)?";
-  const KEY = '"errors\\.([A-Za-z0-9_]+)"';
+  const KEY = '"errors\\.(?<key>[A-Za-z0-9_]+)"';
   return [
     new RegExp(
       `new (?:${classes.join("|")})\\(\\s*${MESSAGE}\\s*,\\s*${STATUS}${KEY}`,
@@ -285,6 +300,11 @@ async function throwSiteRes(): Promise<RegExp[]> {
     ),
     new RegExp(`super\\(\\s*${MESSAGE}\\s*,\\s*${STATUS}${KEY}`, "gs"),
     new RegExp(`message:\\s*${MESSAGE}\\s*,\\s*key:\\s*${KEY}`, "gs"),
+    new RegExp(`\\btranslate\\(\\s*${KEY}\\s*,\\s*${MESSAGE}`, "gs"),
+    new RegExp(
+      `\\btranslateWithLocale\\(\\s*\\w+\\s*,\\s*${KEY}\\s*,\\s*${MESSAGE}`,
+      "gs",
+    ),
   ];
 }
 
@@ -295,10 +315,11 @@ function throwSites(
 ): void {
   for (const re of res) {
     for (const m of body.matchAll(re)) {
-      const key = m[2] as string;
-      const msg = (m[1] as string).slice(1, -1);
+      // Every reader above names both groups, so a match that is missing one is a broken reader and
+      // not a shape in the tree: let it throw here rather than skip the site quietly.
+      const { key, msg } = m.groups as { key: string; msg: string };
       const set = into.get(key) ?? new Set<string>();
-      set.add(msg);
+      set.add(msg.slice(1, -1));
       into.set(key, set);
     }
   }
@@ -319,6 +340,13 @@ const SAY_LESS_GRANDFATHERED: readonly string[] = [
   "googleOAuthNotConnected",
   "googleOAuthTokenExchangeFailed",
   "imageTooLarge",
+  // The one entry here that did NOT predate the rule: it predated the READER. Widening it to the
+  // `translate(key, "…")` producers (issue #299) put the admin surface's re-auth refusal beside the
+  // four `AppError` ones, and the two spell the same fact differently: "password verification
+  // failed" is the log line, "Incorrect password" is the sentence, and the catalog already answers
+  // both with the second. Two phrasings of one fact is what #292 exists to judge; rewording either
+  // side to satisfy the count would be pretending the rule caught something.
+  "invalidPassword",
   "invalidVaultValue",
   "mcpOAuthDiscoveryFailed",
   "mcpOAuthNotConnected",
@@ -618,16 +646,32 @@ describe("both languages answer, and answer differently", () => {
         'throw new NotFoundError("no status arg", "errors.c");',
         'throw new AppError("second message", 400, "errors.a");',
         'throw new AppError(someVariable, 400, "errors.d");',
-        // The two spellings the reader was blind to. Both are POSITIVE controls: a reader that
-        // stopped matching them would go green here and quietly stop covering a whole family, which
-        // is what it did to `invalidDocumentSlug` for four releases.
+        // The spellings the reader was blind to, each of which cost a release. All POSITIVE
+        // controls: a reader that stopped matching one would go green here and quietly stop
+        // covering a whole family, which is what it did to `invalidDocumentSlug` for four releases.
         'super("from a subclass", 400, "errors.e");',
         'return { message: "built, thrown elsewhere", key: "errors.f", params: {} };',
+        // KEY FIRST in these two, and the message second. The auth and admin surfaces answer with a
+        // body instead of throwing, and the schema boundary renders its own.
+        'return { error: translate("errors.g", "answered, not thrown") };',
+        'error: translateWithLocale(locale, "errors.h", "rendered at the boundary"),',
+        // NEGATIVE, and it is the false positive this reader was measured against: a key sitting
+        // beside its neighbour in an ARRAY of keys is not a key beside its message. Read by
+        // adjacency instead of by call, this line reports `i` as a refusal whose sentence is `j`.
+        'const DOCUMENT_KEYS = ["errors.i", "errors.j"];',
       ].join("\n"),
       into,
       await throwSiteRes(),
     );
-    expect([...into.keys()].sort()).toEqual(["a", "b", "c", "e", "f"]);
+    expect([...into.keys()].sort()).toEqual([
+      "a",
+      "b",
+      "c",
+      "e",
+      "f",
+      "g",
+      "h",
+    ]);
     // The captured MESSAGE, not just the key: what feeds the rule above is whether the message
     // interpolates, so a reader that stripped the `${…}` on the way out would silence it.
     //
@@ -672,6 +716,67 @@ describe("both languages answer, and answer differently", () => {
         SAY_LESS_GRANDFATHERED,
       ),
     ).toEqual([]);
+  });
+
+  // WHAT THE READER STILL CANNOT SEE, and why each one is allowed to stay invisible.
+  //
+  // A rule that never RUNS on a key is worse than one that runs and waives it: the waiver is a
+  // decision someone wrote down, and the blind spot is a number nobody knows. Issue #291 was drafted
+  // from a list this reader produced while blind to one of its own spellings, so the list was short
+  // by a key and wrong about another. This is the ledger that makes the blind spot a decision.
+  //
+  // NOT subtracted from the sweep, COMPARED to it, which is the difference that keeps it honest and
+  // is why it needs no size pin (issue #293): appending a key that the reader CAN see fails this
+  // test just as loudly as forgetting one it cannot. There is no direction to cheat in.
+  const UNSEEN_BY_THE_READER: readonly string[] = [
+    // NO MESSAGE AT ALL. A map from a reason enum to a key (src/lib/embedding-block.ts). The
+    // sentence is chosen by whoever renders it, so there is nothing here for any reader to compare.
+    "embeddingEmpty",
+    "embeddingNotConfigured",
+    "embeddingPending",
+    // A MESSAGE BUILT FROM A VARIABLE. The reader takes literals only, because a computed string
+    // cannot be compared to a catalog entry. That is right about the comparison and it is NOT a
+    // clean bill of health: a message that varies is exactly what an entry with no placeholder
+    // cannot carry, and four of these drop or contradict the reason that fired. Issue #302 holds
+    // the measurement and the fix; five of the nine already interpolate, which is the same answer
+    // arrived at one key at a time.
+    "invalidBusinessHoursDate",
+    "invalidCompanyField",
+    "invalidDocumentNumberPrefix",
+    "invalidDocumentTemplateDescription",
+    "invalidDocumentTemplateName",
+    "invalidDocumentTemplateReason",
+    "invalidDocumentValues",
+    "invalidIdempotencyKey",
+    "unstorableText",
+    // A SUBCLASS THAT HARD-CODES ITS OWN REFUSAL AND TAKES NO MESSAGE. `new ProEditionError()` names
+    // nothing at the call site, so there is no site to read; the rule that covers this shape is
+    // "a subclass is a throw site with no arguments", further down this file.
+    "proEdition",
+  ];
+
+  test("every key the reader cannot see is named, with the reason it may stay invisible", async () => {
+    const res = await throwSiteRes();
+    const named = new Set<string>();
+    const seen = new Map<string, Set<string>>();
+    for (const f of await sourceFiles("src")) {
+      const body = await readFile(f, "utf8");
+      // A ledger comment declares a key, it does not produce one, and it is spelled in single
+      // quotes. Skipping comment lines keeps this honest even if that ever changes.
+      for (const line of body.split("\n")) {
+        if (line.trimStart().startsWith("//")) continue;
+        for (const m of line.matchAll(/"errors\.([A-Za-z0-9_]+)"/g))
+          named.add(m[1] as string);
+      }
+      throwSites(body, seen, res);
+    }
+    // Both halves are asserted, because a scan that stopped finding anything would satisfy the
+    // difference below with an empty set on either side.
+    expect(named.size).toBeGreaterThan(150);
+    expect(seen.size).toBeGreaterThan(150);
+    expect([...named].filter((k) => !seen.has(k)).sort()).toEqual(
+      [...UNSEEN_BY_THE_READER].sort(),
+    );
   });
 
   test("the grandfathered list only names keys that still offend", async () => {
@@ -789,7 +894,10 @@ describe("both languages answer, and answer differently", () => {
     expectWaiverLedger(
       "SAY_LESS_GRANDFATHERED",
       SAY_LESS_GRANDFATHERED,
-      hasProOnlyKeys ? 14 : 13,
+      // GREW by one, which a ledger pinned to shrink has to explain out loud: a reader that sees
+      // more finds more, and the entry it found is named above with why it is a waiver and not a
+      // fix. This is the only direction of growth that is not an append papering over a defect.
+      hasProOnlyKeys ? 15 : 14,
     );
   });
 });


### PR DESCRIPTION
Fixes #299.

## What was wrong

`keysThatSayLess` is the rule that stops a catalog entry from answering with less than the call site
already knew. It reads the tree through a set of shapes, and a key produced any other way is not
merely unflagged: **the rule never runs on it.** #300 taught the reader two shapes it was blind to;
this is the third and largest family, and the accounting for what is left.

`translate("errors.x", "…")` and `translateWithLocale(locale, "errors.x", "…")` are not throws at
all. The auth, admin and origin surfaces answer with `set.status` plus a body, and the schema
boundary renders its own. Twenty-one keys, including the whole of `features/auth` and
`features/admin`, had never been read by this rule.

| | keys the reader sees | invisible |
| --- | --- | --- |
| when #299 was written | 127 | 40 |
| after #300 | 132 | 34 |
| this PR | 154 | 12 |

(re-derivable, and it holds in both trees: 166 named / 154 seen here, 161 / 149 in the Free
projection. The twelve are the same twelve in every edition.)

## What the widened reader found, and what was done with it

Two keys, and they are answered differently on purpose:

- **`errors.tenantTargetRequired` is fixed.** Two `requireTenant` helpers
  (`src/modules/conversations/{service,reengage}.ts`) hand-rolled
  `new AppError("tenant required", 400, "errors.tenantTargetRequired")` while
  `TenantTargetRequiredError` exists for exactly this refusal, and its header says why it exists: the
  key was being missed at twenty call sites. These two were the twenty-first and twenty-second.

  Review then asked the question that matters about that fix: moving a refusal ONTO one of these
  classes **silenced** the rule rather than satisfying it, because the class names neither a message
  nor a key at any call site. So the reader gained a sixth producer, read from the class itself, and
  it put that key's two remaining sentences side by side for the first time. They disagreed: the
  class answered `A target tenant is required for this operation` and every other producer answered
  the catalog sentence, `A target tenant is required`. The class default is now that sentence
  verbatim. `errors.proEdition` stops being invisible with the same change, and the third group of
  the unseen ledger is gone with it.
- **`errors.invalidPassword` is waived, with the reason written in the ledger.** The four `AppError`
  sites say "password verification failed" and the admin surface's `translate` says "Incorrect
  password": one is the log line, the other is the sentence, and the catalog already answers both
  with the second. Two phrasings of one fact is what #292 exists to judge. Rewording either side to
  satisfy the count would be pretending the rule caught something.

The ledger therefore GROWS by one, which a ledger pinned to shrink (#293) has to say out loud, so the
pin carries the reason: a reader that sees more finds more.

## What stays invisible, and why that is now a decision instead of a number

`UNSEEN_BY_THE_READER` names all twelve, grouped by the reason each is allowed to stay invisible: a
key with **no message at all** (a map from a reason enum to a key), and a message **built from a
variable**. A third group stood there for one round, for the subclasses, until review pointed out
that "nothing to read at the call site" is not "nothing to read": the sentence is in the class.

It is **compared** to the sweep, not subtracted from it, which is what keeps it honest without a size
pin: appending a key the reader CAN see fails the test just as loudly as forgetting one it cannot.
There is no direction to cheat in.

The middle group is not a clean bill of health, and #302 was opened for it: a message that varies is
exactly what an entry with no placeholder cannot carry, and four of those nine drop or **contradict**
the reason that fired. `errors.invalidDocumentTemplateName` answers "must be between 1 and 120
characters" to a five-character name holding an unprintable character.

## Validation scope

### Proven by test

- 35 tests in `tests/api/error-catalog.test.ts`. Eleven mutations, all killed: deleting any of the
  three new spellings, transposing the reader's anchor, blinding the class reader or unhooking it
  from the sweep, removing an entry from the unseen ledger, appending a VISIBLE key to it, undoing
  the `tenantTargetRequired` fix, un-aligning the class default, and removing the `invalidPassword`
  waiver.
- The three sweeps used to walk the tree with three copies of the same loop. They now share one
  collector, because a spelling added to one of them and not the others is the exact shape of blind
  spot this file exists to close.
- The negative control is the one that was measured before it was written: a bare
  `"errors.x"\s*,\s*"…"` also matches a key sitting next to its neighbour in an **array of keys**
  (`src/graph/tools/documents.ts` holds one), and it reported `documentNotStored` and
  `documentRevoked` as offenders whose "message" was the next key in the list. Anchoring both new
  readers to the CALL is what separates this reader from that one, and the fixture holds the array
  line so a future edit cannot quietly drop the anchor.
- The key comes FIRST in the two new spellings and second in the other three, so the groups are now
  NAMED. Positionally, the two orders are one transposition apart and the transposed version still
  runs: it reads a message as a key.

### Proven live

The one source change is meant to be invisible on the wire, so that is what was measured: two
servers, `:3392` on the merge base `7effe7db` and `:3391` on this branch, same throwaway database,
same SUPER_ADMIN session with no `X-Tenant-Id`.

| | base `7effe7db` | this branch |
| --- | --- | --- |
| `GET /v1/conversations/1` | `400 {"error":"É necessário informar um tenant de destino"}` | byte-identical |
| `POST /v1/conversations/1/reengage` | `400 {"error":"É necessário informar um tenant de destino"}` | byte-identical |
| server log, both routes | `tenant required` | `A target tenant is required` |

The log line is what proves the changed line is the one that answered: the body is the catalog
sentence either way, and only the class swap moves the log. Both changed sites were exercised. The
database was dropped afterwards.

### Not validated

- The size floors this PR removed were the first round's P1, caught by review and confirmed red on
  the public CI: `expect(seen.size).toBeGreaterThan(150)` is true in the master tree and false in the
  Free one, where both totals are five smaller. The test file now runs green in the actual public
  tree before each push, not only here.
- The twenty-one keys the reader newly sees are covered by the sweep, not by twenty-one live calls.
  What the sweep asserts about them is a source property (a key paired with a literal message), and
  the two it flagged were then read by hand.
- Rebased onto `4826b9f` (#298), which declares the tenant-selector refusal on the routes that can
  answer it. No file in common; `tests/modules/tenant-selector-entry-points.test.ts` was run
  alongside this change and passes, which is the one place the two could have met.
