### PR TITLE
Answer a service's own schema refusal as the caller's, instead of as a server fault

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11069,15 +11069,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name",
+                  "label",
+                  "urlTemplate",
+                  "allowedHosts"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Tool name the agent sees when selecting tools.",
-                    "type": "string"
-                  },
-                  "label": {
-                    "description": "Human-friendly display name; the identifier (name) is derived from it.",
-                    "type": "string"
-                  },
                   "description": {
                     "description": "Tool description shown to the agent, or null to clear it.",
                     "anyOf": [
@@ -11098,17 +11096,6 @@
                       "PATCH",
                       "DELETE"
                     ]
-                  },
-                  "urlTemplate": {
-                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
-                    "type": "string"
-                  },
-                  "allowedHosts": {
-                    "description": "Hostnames the tool is permitted to call (SSRF allowlist).",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
                   },
                   "headers": {
                     "description": "Static request headers; values may contain {{secret}} placeholders.",
@@ -11190,6 +11177,25 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "name": {
+                    "description": "Tool name the agent sees when selecting tools.",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Human-friendly display name; the identifier (name) is derived from it.",
+                    "type": "string"
+                  },
+                  "urlTemplate": {
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "type": "string"
+                  },
+                  "allowedHosts": {
+                    "description": "Hostnames the tool is permitted to call (SSRF allowlist).",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -11197,15 +11203,13 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name",
+                  "label",
+                  "urlTemplate",
+                  "allowedHosts"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Tool name the agent sees when selecting tools.",
-                    "type": "string"
-                  },
-                  "label": {
-                    "description": "Human-friendly display name; the identifier (name) is derived from it.",
-                    "type": "string"
-                  },
                   "description": {
                     "description": "Tool description shown to the agent, or null to clear it.",
                     "anyOf": [
@@ -11226,17 +11230,6 @@
                       "PATCH",
                       "DELETE"
                     ]
-                  },
-                  "urlTemplate": {
-                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
-                    "type": "string"
-                  },
-                  "allowedHosts": {
-                    "description": "Hostnames the tool is permitted to call (SSRF allowlist).",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
                   },
                   "headers": {
                     "description": "Static request headers; values may contain {{secret}} placeholders.",
@@ -11318,6 +11311,25 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "name": {
+                    "description": "Tool name the agent sees when selecting tools.",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Human-friendly display name; the identifier (name) is derived from it.",
+                    "type": "string"
+                  },
+                  "urlTemplate": {
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "type": "string"
+                  },
+                  "allowedHosts": {
+                    "description": "Hostnames the tool is permitted to call (SSRF allowlist).",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -11325,15 +11337,13 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name",
+                  "label",
+                  "urlTemplate",
+                  "allowedHosts"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Tool name the agent sees when selecting tools.",
-                    "type": "string"
-                  },
-                  "label": {
-                    "description": "Human-friendly display name; the identifier (name) is derived from it.",
-                    "type": "string"
-                  },
                   "description": {
                     "description": "Tool description shown to the agent, or null to clear it.",
                     "anyOf": [
@@ -11354,17 +11364,6 @@
                       "PATCH",
                       "DELETE"
                     ]
-                  },
-                  "urlTemplate": {
-                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
-                    "type": "string"
-                  },
-                  "allowedHosts": {
-                    "description": "Hostnames the tool is permitted to call (SSRF allowlist).",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
                   },
                   "headers": {
                     "description": "Static request headers; values may contain {{secret}} placeholders.",
@@ -11446,6 +11445,25 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "name": {
+                    "description": "Tool name the agent sees when selecting tools.",
+                    "type": "string"
+                  },
+                  "label": {
+                    "description": "Human-friendly display name; the identifier (name) is derived from it.",
+                    "type": "string"
+                  },
+                  "urlTemplate": {
+                    "description": "Request URL template; {{param}}, {{context}} and {{secret}} placeholders are interpolated at call time. Single-brace {param} is accepted and normalized when it matches a declared input field or context variable.",
+                    "type": "string"
+                  },
+                  "allowedHosts": {
+                    "description": "Hostnames the tool is permitted to call (SSRF allowlist).",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -12577,19 +12595,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name",
+                  "transport"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Display name for the MCP server connection.",
-                    "type": "string"
-                  },
-                  "transport": {
-                    "type": "string",
-                    "enum": [
-                      "streamableHttp",
-                      "sse",
-                      "stdio"
-                    ]
-                  },
                   "url": {
                     "description": "Server URL for the streamableHttp and sse transports; null for stdio.",
                     "anyOf": [
@@ -12626,6 +12636,18 @@
                   "enabled": {
                     "description": "Whether the connection is active.",
                     "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Display name for the MCP server connection.",
+                    "type": "string"
+                  },
+                  "transport": {
+                    "type": "string",
+                    "enum": [
+                      "streamableHttp",
+                      "sse",
+                      "stdio"
+                    ]
                   }
                 }
               }
@@ -12633,19 +12655,11 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name",
+                  "transport"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Display name for the MCP server connection.",
-                    "type": "string"
-                  },
-                  "transport": {
-                    "type": "string",
-                    "enum": [
-                      "streamableHttp",
-                      "sse",
-                      "stdio"
-                    ]
-                  },
                   "url": {
                     "description": "Server URL for the streamableHttp and sse transports; null for stdio.",
                     "anyOf": [
@@ -12682,6 +12696,18 @@
                   "enabled": {
                     "description": "Whether the connection is active.",
                     "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Display name for the MCP server connection.",
+                    "type": "string"
+                  },
+                  "transport": {
+                    "type": "string",
+                    "enum": [
+                      "streamableHttp",
+                      "sse",
+                      "stdio"
+                    ]
                   }
                 }
               }
@@ -12689,19 +12715,11 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name",
+                  "transport"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Display name for the MCP server connection.",
-                    "type": "string"
-                  },
-                  "transport": {
-                    "type": "string",
-                    "enum": [
-                      "streamableHttp",
-                      "sse",
-                      "stdio"
-                    ]
-                  },
                   "url": {
                     "description": "Server URL for the streamableHttp and sse transports; null for stdio.",
                     "anyOf": [
@@ -12738,6 +12756,18 @@
                   "enabled": {
                     "description": "Whether the connection is active.",
                     "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Display name for the MCP server connection.",
+                    "type": "string"
+                  },
+                  "transport": {
+                    "type": "string",
+                    "enum": [
+                      "streamableHttp",
+                      "sse",
+                      "stdio"
+                    ]
                   }
                 }
               }
@@ -13709,11 +13739,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Human-readable name of the schedule.",
-                    "type": "string"
-                  },
                   "timezone": {
                     "description": "IANA timezone (e.g. America/Sao_Paulo) the windows are evaluated in.",
                     "type": "string"
@@ -13807,6 +13836,10 @@
                         }
                       }
                     }
+                  },
+                  "name": {
+                    "description": "Human-readable name of the schedule.",
+                    "type": "string"
                   }
                 }
               }
@@ -13814,11 +13847,10 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Human-readable name of the schedule.",
-                    "type": "string"
-                  },
                   "timezone": {
                     "description": "IANA timezone (e.g. America/Sao_Paulo) the windows are evaluated in.",
                     "type": "string"
@@ -13912,6 +13944,10 @@
                         }
                       }
                     }
+                  },
+                  "name": {
+                    "description": "Human-readable name of the schedule.",
+                    "type": "string"
                   }
                 }
               }
@@ -13919,11 +13955,10 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
+                "required": [
+                  "name"
+                ],
                 "properties": {
-                  "name": {
-                    "description": "Human-readable name of the schedule.",
-                    "type": "string"
-                  },
                   "timezone": {
                     "description": "IANA timezone (e.g. America/Sao_Paulo) the windows are evaluated in.",
                     "type": "string"
@@ -14017,6 +14052,10 @@
                         }
                       }
                     }
+                  },
+                  "name": {
+                    "description": "Human-readable name of the schedule.",
+                    "type": "string"
                   }
                 }
               }

--- a/src/api/v1/business-hours.controller.ts
+++ b/src/api/v1/business-hours.controller.ts
@@ -113,6 +113,22 @@ const writeBody = t.Object({
   ),
 });
 
+// The CREATE route's own body. `writeBody` above describes what a PATCH accepts, where every field
+// being optional is correct, and a POST that borrows it lets a request missing a required field
+// through the transport: the refusal then comes from the service's zod schema, whose `ZodError`
+// src/app.ts has no branch for, so the caller is told the server broke about a field they own
+// (issue #301, measured: `POST` with `{}` answered 500 `Something went wrong`).
+//
+// Composed rather than written out, so the descriptions and the field list stay in one place and a
+// field added to `writeBody` cannot be missing here. WHICH fields are required is not written twice
+// either: tests/api/v1/write-body-required.test.ts derives that set from the service's create schema
+// and fails if the two drift.
+const CREATE_REQUIRED = ["name"] as const;
+const createBody = t.Composite([
+  t.Omit(writeBody, CREATE_REQUIRED),
+  t.Required(t.Pick(writeBody, CREATE_REQUIRED)),
+]);
+
 export const businessHoursController = new Elysia({
   prefix: "/v1/business-hours",
   tags: ["Resources"],
@@ -172,7 +188,7 @@ export const businessHoursController = new Elysia({
         "Create a new business-hours schedule for the current tenant.",
       ),
       response: errors(400, 401, 403, 404),
-      body: writeBody,
+      body: createBody,
     },
   )
   .patch(

--- a/src/api/v1/mcp-connections.controller.ts
+++ b/src/api/v1/mcp-connections.controller.ts
@@ -79,6 +79,22 @@ const writeBody = t.Object({
   ),
 });
 
+// The CREATE route's own body. `writeBody` above describes what a PATCH accepts, where every field
+// being optional is correct, and a POST that borrows it lets a request missing a required field
+// through the transport: the refusal then comes from the service's zod schema, whose `ZodError`
+// src/app.ts has no branch for, so the caller is told the server broke about a field they own
+// (issue #301, measured: `POST` with `{}` answered 500 `Something went wrong`).
+//
+// Composed rather than written out, so the descriptions and the field list stay in one place and a
+// field added to `writeBody` cannot be missing here. WHICH fields are required is not written twice
+// either: tests/api/v1/write-body-required.test.ts derives that set from the service's create schema
+// and fails if the two drift.
+const CREATE_REQUIRED = ["name", "transport"] as const;
+const createBody = t.Composite([
+  t.Omit(writeBody, CREATE_REQUIRED),
+  t.Required(t.Pick(writeBody, CREATE_REQUIRED)),
+]);
+
 export const mcpConnectionsController = new Elysia({
   prefix: "/v1/mcp-connections",
   tags: ["MCP"],
@@ -152,7 +168,7 @@ export const mcpConnectionsController = new Elysia({
         "Create MCP connection",
         "Registers a new consumed MCP server connection for the tenant.",
       ),
-      body: writeBody,
+      body: createBody,
       response: errors(400, 401, 403, 404),
     },
   )

--- a/src/api/v1/tools.controller.ts
+++ b/src/api/v1/tools.controller.ts
@@ -137,6 +137,27 @@ export const writeBody = t.Object({
   ),
 });
 
+// The CREATE route's own body. `writeBody` above describes what a PATCH accepts, where every field
+// being optional is correct, and a POST that borrows it lets a request missing a required field
+// through the transport: the refusal then comes from the service's zod schema, whose `ZodError`
+// src/app.ts has no branch for, so the caller is told the server broke about a field they own
+// (issue #301, measured: `POST` with `{}` answered 500 `Something went wrong`).
+//
+// Composed rather than written out, so the descriptions and the field list stay in one place and a
+// field added to `writeBody` cannot be missing here. WHICH fields are required is not written twice
+// either: tests/api/v1/write-body-required.test.ts derives that set from the service's create schema
+// and fails if the two drift.
+const CREATE_REQUIRED = [
+  "name",
+  "label",
+  "urlTemplate",
+  "allowedHosts",
+] as const;
+const createBody = t.Composite([
+  t.Omit(writeBody, CREATE_REQUIRED),
+  t.Required(t.Pick(writeBody, CREATE_REQUIRED)),
+]);
+
 export const toolsController = new Elysia({
   prefix: "/v1/tools",
   tags: ["Resources"],
@@ -219,7 +240,7 @@ export const toolsController = new Elysia({
         "Create a custom HTTP tool definition for the current tenant.",
       ),
       response: errors(400, 401, 403, 404, 409),
-      body: writeBody,
+      body: createBody,
     },
   )
   .patch(

--- a/src/lib/parse-input.ts
+++ b/src/lib/parse-input.ts
@@ -1,0 +1,48 @@
+import type { ZodType } from "zod";
+import { AppError } from "@/lib/errors";
+
+// Parse what a CALLER sent, and refuse it as the caller's fault.
+//
+// The one place a zod refusal becomes an HTTP status. Every service that validates a create/update
+// payload goes through here instead of calling `schema.parse` itself, because the difference between
+// "the caller sent a bad value" and "something else failed to validate" is not visible in a
+// `ZodError`: the MCP SDK rejects with one when a remote server answers a malformed result, and a
+// global "ZodError means 422" branch in the error handler answered that as the operator's mistake.
+//
+// The field is the issue's path, spelled the way #245 spells a path on the wire (`windows.0.day`).
+// Nothing else from the issue crosses: not zod's message, which quotes the caller's own key for
+// `unrecognized_keys`, and never the submitted value — the same rule api/lib/schema-refusal.ts
+// follows for the transport's refusal, and for the same reason.
+//
+// A path segment is a name the SERVER chose only while no zod record in this repo constrains its
+// value type (a `z.record(z.string(), z.unknown())` cannot fail below itself), which
+// tests/api/v1/write-body-required.test.ts checks rather than leaves as a reading.
+// `at` is the caller's name for the value being parsed, and it is REQUIRED whenever the value is not
+// the whole payload: zod's path is relative to what was handed to it, so parsing `params.variants`
+// reports `0.weight`, and parsing a lone token reports nothing at all. Either one puts a name on the
+// wire that no input on the caller's side answers to — the field exists so a client can point at the
+// input, and a relative path points at nothing. Found by review on PR #309.
+export function parseInput<T>(
+  schema: ZodType<T>,
+  value: unknown,
+  at?: string,
+): T {
+  const parsed = schema.safeParse(value);
+  if (parsed.success) return parsed.data;
+  const first = parsed.error.issues[0];
+  const path = first?.path.map(String).join(".") ?? "";
+  const field = [at, path].filter(Boolean).join(".");
+  // Built HERE rather than in a subclass of AppError, so the message, the key, the interpolation and
+  // the field sit at one call site: tests/api/lib/refusal-callsites.test.ts and the catalog rule in
+  // tests/api/error-catalog.test.ts both read the call site, and a class that decides its own key
+  // with a ternary is a refusal neither of them can read (the lesson #299 wrote down).
+  throw field
+    ? new AppError(
+        `The value sent in ${field} is not valid.`,
+        422,
+        "errors.invalidRequestValue",
+        { field },
+        field,
+      )
+    : new AppError("The request is not valid.", 422, "errors.invalidRequest");
+}

--- a/src/modules/agents/service.ts
+++ b/src/modules/agents/service.ts
@@ -12,6 +12,7 @@ import {
   NotFoundError,
   TenantTargetRequiredError,
 } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import { collectCredentialRefWrites } from "@/modules/agents/credential-paths";
 import { collectOversizedTextChanges } from "@/modules/agents/text-caps";
@@ -359,7 +360,7 @@ export async function updateAgent(
   opts: { expectedUpdatedAt?: Date } = {},
 ): Promise<AgentDto> {
   assertPromptSize(patch.systemPrompt);
-  const data = agentUpdateSchema.parse(patch);
+  const data = parseInput(agentUpdateSchema, patch);
   validateModelConfigForWrite(data.modelConfig);
   const { businessHoursId, followUpHoursId, ...rest } = data;
   const hasBh = businessHoursId !== undefined;
@@ -574,7 +575,7 @@ export async function createAgent(
   const tenantId = requireTenant(ctx);
   assertPromptSize(input.systemPrompt);
   assertSettingsTextSizes(input.settings, undefined);
-  const data = agentCreateSchema.parse(input);
+  const data = parseInput(agentCreateSchema, input);
   validateModelConfigForWrite(data.modelConfig);
   const bhId =
     data.businessHoursId != null ? BigInt(data.businessHoursId) : null;

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -1490,6 +1490,7 @@ async function createMissingComponents(
     //
     // Asked AFTER the validity gate, and the order is the message: a bundle carrying a template that
     // is both unreadable and named like an existing one is more usefully told about the first.
+    // not-caller-input: a name read off the template being imported, not a value from this request
     const approvedName = templateNameSchema.parse(tpl.name);
     const nameHolder = await db.documentTemplate.findFirst({
       where: { name: approvedName },

--- a/src/modules/api-keys/service.ts
+++ b/src/modules/api-keys/service.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { PrismaClient, UserRole } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { recordAudit } from "@/modules/audit/service";
 import { generateApiKey } from "./verify";
@@ -88,7 +89,7 @@ export async function createApiKey(
 ): Promise<CreatedApiKey> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const parsed = apiKeyCreateSchema.parse(input);
+  const parsed = parseInput(apiKeyCreateSchema, input);
   const gen = generateApiKey();
   const row = await runScopedOn(base, ctx, async (db) => {
     const created = await db.apiKey.create({

--- a/src/modules/business-hours/service.ts
+++ b/src/modules/business-hours/service.ts
@@ -3,6 +3,7 @@ import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { parseDbId } from "@/lib/db-id";
 import { AppError, NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
   isRangeOrdered,
@@ -199,7 +200,7 @@ export async function createBusinessHours(
 ): Promise<BusinessHoursDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const data = businessHoursCreateSchema.parse(input);
+  const data = parseInput(businessHoursCreateSchema, input);
   if (data.timezone) assertValidTimezone(data.timezone);
   if (data.windows) assertValidWindows(data.windows);
   if (data.exceptions) assertValidExceptions(data.exceptions);
@@ -225,7 +226,7 @@ export async function updateBusinessHours(
   patch: BusinessHoursUpdate,
   base: PrismaClient = basePrisma,
 ): Promise<BusinessHoursDto> {
-  const data = businessHoursUpdateSchema.parse(patch);
+  const data = parseInput(businessHoursUpdateSchema, patch);
   if (data.timezone) assertValidTimezone(data.timezone);
   if (data.windows) assertValidWindows(data.windows);
   if (data.exceptions) assertValidExceptions(data.exceptions);

--- a/src/modules/chatwoot/management.ts
+++ b/src/modules/chatwoot/management.ts
@@ -3,6 +3,7 @@ import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import { decryptJson, encryptJson } from "@/api/lib/crypto";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, ConflictError, NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
@@ -222,7 +223,7 @@ export async function connectChatwootDeployment(
 }> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const data = chatwootDeploymentConnectSchema.parse(input);
+  const data = parseInput(chatwootDeploymentConnectSchema, input);
   data.baseUrl = normalizeChatwootBaseUrl(data.baseUrl);
   await assertSafeOutboundUrl(data.baseUrl); // DNS lookup OUTSIDE the tx
   // Validate the credentials (and discover accounts) before persisting anything.
@@ -271,7 +272,11 @@ export async function rotateChatwootDeploymentToken(
   deps: ListAccountsDeps = {},
   base: PrismaClient = basePrisma,
 ): Promise<ChatwootDeploymentDto> {
-  const token = z.string().min(1).max(2000).parse(adminToken);
+  const token = parseInput(
+    z.string().min(1).max(2000),
+    adminToken,
+    "adminToken",
+  );
   const dep = await runScopedOn(base, ctx, (db) =>
     db.chatwootDeployment.findFirst({ select: { id: true, baseUrl: true } }),
   );
@@ -1413,7 +1418,7 @@ export async function listChatwootAccounts(
   input: ChatwootAccountsProbeInput,
   deps: ListAccountsDeps = {},
 ): Promise<ChatwootAccountSummary[]> {
-  const data = chatwootAccountsProbeSchema.parse(input);
+  const data = parseInput(chatwootAccountsProbeSchema, input);
   const fetchProfile = deps.fetchProfile ?? fetchChatwootProfile;
   let raw: unknown;
   try {

--- a/src/modules/documents/templates.ts
+++ b/src/modules/documents/templates.ts
@@ -280,6 +280,7 @@ export async function documentTemplateWriteProblem(
   const metadata = templateMetadataProblem(input);
   if (metadata) return metadata;
   const name =
+    // not-caller-input: wrapped by invalidDocumentTemplate, which names the rule that broke
     input.name !== undefined ? templateNameSchema.parse(input.name) : undefined;
   // Only CREATE derives a slug from the name; a rename keeps the slug it already has, because the
   // slug is a tool name an agent may already be granted. Deriving here on an update would refuse a
@@ -465,6 +466,7 @@ function parseNumberPrefix(value: unknown): string | null {
   if (problem) {
     throw new AppError(problem, 400, "errors.invalidDocumentNumberPrefix");
   }
+  // not-caller-input: wrapped by invalidDocumentTemplate, which names the rule that broke
   return templateNumberPrefixSchema.parse(value ?? null);
 }
 
@@ -477,6 +479,7 @@ function parseTemplateDescription(value: unknown): string | null {
       "errors.invalidDocumentTemplateDescription",
     );
   }
+  // not-caller-input: wrapped by invalidDocumentTemplate, which names the rule that broke
   return templateDescriptionSchema.parse(value ?? null);
 }
 
@@ -485,6 +488,7 @@ function parseTemplateName(value: unknown): string {
   if (problem) {
     throw new AppError(problem, 400, "errors.invalidDocumentTemplateName");
   }
+  // not-caller-input: wrapped by invalidDocumentTemplate, which names the rule that broke
   return templateNameSchema.parse(value);
 }
 

--- a/src/modules/documents/validate.ts
+++ b/src/modules/documents/validate.ts
@@ -722,6 +722,7 @@ export function parseDocumentValues(
       field.type === "lineItems"
         ? (z
             .array(lineItemValueSchema)
+            // not-caller-input: inside a validator whose contract is { ok: false, reason }, not a throw
             .parse(value)
             .map((item) => ({
               ...item,

--- a/src/modules/experiments/service.ts
+++ b/src/modules/experiments/service.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 
 // Prompt A/B experiments. A thread is bucketed to a variant DETERMINISTICALLY (so re-resolution is
@@ -112,7 +113,11 @@ export async function createExperiment(params: {
   base?: PrismaClient;
 }): Promise<{ id: bigint }> {
   const base = params.base ?? basePrisma;
-  const variants = z.array(variantSchema).parse(params.variants);
+  const variants = parseInput(
+    z.array(variantSchema),
+    params.variants,
+    "variants",
+  );
   return runScopedOn(base, params.ctx, async (db) => {
     const exp = await db.experiment.create({
       data: {
@@ -167,7 +172,7 @@ export async function updateExperiment(params: {
   const base = params.base ?? basePrisma;
   const variants =
     params.variants !== undefined
-      ? z.array(variantSchema).parse(params.variants)
+      ? parseInput(z.array(variantSchema), params.variants, "variants")
       : undefined;
   return runScopedOn(base, params.ctx, async (db) => {
     const current = await db.experiment.findUnique({

--- a/src/modules/flowlog/channels.ts
+++ b/src/modules/flowlog/channels.ts
@@ -3,6 +3,7 @@ import type { PrismaClient } from "@/../generated/prisma/client";
 import { decryptJson, encryptJson } from "@/api/lib/crypto";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { requireVaultRef } from "@/modules/vault/service";
@@ -139,7 +140,7 @@ export async function createAlertChannel(
 ): Promise<AlertChannelDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const parsed = alertChannelCreateSchema.parse(input);
+  const parsed = parseInput(alertChannelCreateSchema, input);
   await assertSafeOutboundUrl(parsed.url);
   const stages = assertStages(parsed.stages ?? []);
   const row = await runScopedOn(base, ctx, async (db) => {
@@ -183,7 +184,7 @@ export async function updateAlertChannel(
   patch: AlertChannelUpdate,
   base: PrismaClient = basePrisma,
 ): Promise<AlertChannelDto> {
-  const parsed = alertChannelUpdateSchema.parse(patch);
+  const parsed = parseInput(alertChannelUpdateSchema, patch);
   const data: Record<string, unknown> = {};
   if (parsed.name !== undefined) data.name = parsed.name;
   if (parsed.type !== undefined) data.type = parsed.type;

--- a/src/modules/mcp-connections/service.ts
+++ b/src/modules/mcp-connections/service.ts
@@ -11,6 +11,7 @@ import {
   MCP_STDIO_LAUNCHERS,
   stdioCommandLauncher,
 } from "@/lib/mcp-launchers";
+import { parseInput } from "@/lib/parse-input";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import { ensureFreshGoogleAccessToken } from "@/modules/vault/google-oauth";
@@ -189,7 +190,7 @@ export async function createMcpConnection(
 ): Promise<McpConnectionDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const data = mcpConnectionCreateSchema.parse(input);
+  const data = parseInput(mcpConnectionCreateSchema, input);
   await assertTransportValid(data);
   return runScopedOn(base, ctx, async (db) => {
     await assertNameFree(db, data.name);
@@ -218,7 +219,7 @@ export async function updateMcpConnection(
   patch: McpConnectionUpdate,
   base: PrismaClient = basePrisma,
 ): Promise<McpConnectionDto> {
-  const data = mcpConnectionUpdateSchema.parse(patch);
+  const data = parseInput(mcpConnectionUpdateSchema, patch);
   const current = await runScopedOn(base, ctx, (db) =>
     db.mcpServerConnection.findUnique({
       where: { id },

--- a/src/modules/tenant-settings/service.ts
+++ b/src/modules/tenant-settings/service.ts
@@ -228,6 +228,7 @@ export async function updateEmbeddingSettings(
     // feature ships (configurable dimension + provider registry). Only the
     // credential is honored; provider/model/baseURL from the patch are ignored. Unlocking = restore
     // the `{ ...current, ...patch }` merge.
+    // not-caller-input: the STORED block merged with the patch, so a failure here is not necessarily the caller's
     return embeddingSettingsSchema.parse({
       ...EMBEDDING_DEFAULTS,
       credentialRef:
@@ -296,6 +297,7 @@ export async function updateLangfuse(
 
   return patchBlock(ctx, base, "langfuse", (raw) => {
     const live = parseLangfuseSettings(raw);
+    // not-caller-input: the STORED block merged with the patch, so a failure here is not necessarily the caller's
     return langfuseSettingsSchema.parse({
       enabled: input.enabled ?? live.enabled,
       // The live value when this request did not mention one, like every other field here.
@@ -337,6 +339,7 @@ export async function updateCompanySettings(
       );
   }
   return patchBlock(ctx, base, "company", (raw) =>
+    // not-caller-input: the STORED block merged with the patch; the patch's own fields are refused above with errors.invalidCompanyField
     companySettingsSchema.parse({ ...parseCompanySettings(raw), ...patch }),
   );
 }
@@ -376,6 +379,7 @@ export async function setCompanyLogoKey(
   return patchBlock(ctx, base, "company", async (raw) => {
     const current = parseCompanySettings(raw);
     await publish?.(current);
+    // not-caller-input: the STORED block merged with the patch, so a failure here is not necessarily the caller's
     return companySettingsSchema.parse({
       ...current,
       logoKey,

--- a/src/modules/tool-definitions/service.ts
+++ b/src/modules/tool-definitions/service.ts
@@ -3,6 +3,7 @@ import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { normalizeExpectedStatuses } from "@/graph/tools/http-status";
 import { AppError, ConflictError, NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import { requireVaultRef } from "@/modules/vault/service";
 import { unsupportedBodyShape } from "./body-shape";
@@ -197,7 +198,7 @@ export async function createToolDefinition(
     throw new AppError("tenant required", 400);
   }
   const tenantId = ctx.tenantId;
-  const data = toolDefinitionCreateSchema.parse(input);
+  const data = parseInput(toolDefinitionCreateSchema, input);
   assertSupportedBody(data.body);
   // NOTE: canonicalize programmatic authoring shapes (JSON-Schema inputSchema, single-brace
   // {var}) so storage always holds what the runtime executes.
@@ -245,7 +246,7 @@ export async function updateToolDefinition(
   patch: ToolDefinitionUpdate,
   base: PrismaClient = basePrisma,
 ): Promise<ToolDefinitionDto> {
-  const data = toolDefinitionUpdateSchema.parse(patch);
+  const data = parseInput(toolDefinitionUpdateSchema, patch);
   // NOTE: an absent body is not judged, so a row stored before this check stays editable — only a
   // write that sets the body is refused.
   assertSupportedBody(data.body);

--- a/src/modules/webhooks/outbound/subscriptions.ts
+++ b/src/modules/webhooks/outbound/subscriptions.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { requireVaultRef } from "@/modules/vault/service";
@@ -113,7 +114,7 @@ export async function createWebhookSubscription(
 ): Promise<WebhookSubscriptionDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const parsed = webhookSubscriptionCreateSchema.parse(input);
+  const parsed = parseInput(webhookSubscriptionCreateSchema, input);
   const events = assertKnownEvents(parsed.events);
   await assertUrlSafe(parsed.url);
   const row = await runScopedOn(base, ctx, async (db) => {
@@ -155,7 +156,7 @@ export async function updateWebhookSubscription(
   patch: WebhookSubscriptionUpdate,
   base: PrismaClient = basePrisma,
 ): Promise<WebhookSubscriptionDto> {
-  const parsed = webhookSubscriptionUpdateSchema.parse(patch);
+  const parsed = parseInput(webhookSubscriptionUpdateSchema, patch);
   const data: Record<string, unknown> = {};
   if (parsed.url !== undefined) {
     await assertUrlSafe(parsed.url);

--- a/tests/api/v1/upstream-zod-error.test.ts
+++ b/tests/api/v1/upstream-zod-error.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+import { z } from "zod";
+import { authPlugin } from "@/api/lib/auth";
+import {
+  mockFindUnique,
+  mockUser,
+  setupPrismaMock,
+} from "@/tests/utils/prisma-mock";
+
+// The half of issue #301 that a global "a ZodError means the caller sent something wrong" branch got
+// backwards, found by review on PR #309.
+//
+// `discoverMcpTools` calls `MultiServerMCPClient.getTools()`, and the MCP SDK validates the REMOTE
+// server's JSON-RPC results with the same zod package this repo depends on
+// (@modelcontextprotocol/sdk, shared/protocol.js: `safeParse(resultSchema, response.result)` then
+// `reject(parseResult.error)`; zod 4.4.3 is deduped, so that error IS `instanceof ZodError` here).
+// A malformed answer from someone else's server is not the operator's input being wrong, and
+// answering it 422 with `field` would name a value the caller never sent, while logging a server
+// fault as a warning.
+//
+// So the refusal is raised where the input is KNOWN to be the caller's — `parseInput` — and a bare
+// ZodError keeps the 500 it deserves. That is what this file pins.
+const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
+setupPrismaMock();
+
+const mcpService = await import("@/modules/mcp-connections/service");
+// A ZodError produced the way the SDK produces one: a schema THIS request never chose, over a value
+// the caller never sent.
+const upstream = z.object({ tools: z.array(z.object({ name: z.string() })) });
+mock.module("@/modules/mcp-connections/service", () => ({
+  ...mcpService,
+  discoverMcpTools: async () => {
+    upstream.parse({ tools: [{ name: 42 }] });
+    return { instructions: null, tools: [] };
+  },
+}));
+
+const app = (await import("@/app")).default;
+
+// `mock.module` is GLOBAL to the process and outlives this file for every other test in the same
+// worker, so put the module back.
+afterAll(() => {
+  mock.module("@/modules/mcp-connections/service", () => mcpService);
+});
+
+const admin = { ...mockUser, tenantId: 1n, role: "TENANT_ADMIN" as const };
+mockFindUnique.mockImplementation(() => Promise.resolve(admin));
+const tokenApp = new Elysia()
+  .use(authPlugin)
+  .post("/mint", async ({ setAuthCookie }) => ({
+    token: await setAuthCookie(admin),
+  }));
+const { token } = (await (
+  await tokenApp.handle(
+    new Request("http://localhost/mint", { method: "POST" }),
+  )
+).json()) as { token: string };
+
+describe("a ZodError raised by something other than this request's input", () => {
+  test("is a server fault, not the caller's", async () => {
+    const res = await app.handle(
+      new BunRequest("http://localhost/api/v1/mcp-connections/1/discover", {
+        method: "POST",
+        headers: { cookie: `fazerai_auth_token=${token}` },
+      }),
+    );
+    const text = await res.text();
+    expect(res.status).toBe(500);
+    // …and it does not name a field, which is the half that would have been actively misleading:
+    // `tools.0.name` is a path into someone else's answer.
+    expect(text).not.toContain("tools.0.name");
+  });
+});

--- a/tests/api/v1/write-body-required.test.ts
+++ b/tests/api/v1/write-body-required.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { authPlugin } from "@/api/lib/auth";
+import { businessHoursCreateSchema } from "@/modules/business-hours/service";
+import { mcpConnectionCreateSchema } from "@/modules/mcp-connections/service";
+import { toolDefinitionCreateSchema } from "@/modules/tool-definitions/service";
+import {
+  mockFindUnique,
+  mockUser,
+  setupPrismaMock,
+} from "@/tests/utils/prisma-mock";
+
+// Issue #301. Three create routes declared the body schema their PATCH sibling uses, where every
+// field being optional is correct. A request missing a required field therefore passed the transport
+// and was refused by the service's zod schema instead, and src/app.ts had no branch for a `ZodError`:
+// it fell to the generic 500, so the caller was told the server broke about a field they own, and
+// the zod issue array — submitted values included — went to the error log.
+//
+// Measured on main before this change, body `{}`: 500 `Something went wrong` on all three, while the
+// ten other v1 write routes (which declare their required fields at the transport) answered 422. The
+// same 500 answered a value the service refuses but the transport accepts: `POST /v1/tools` with a
+// name carrying a space, `POST /v1/business-hours` with `name: ""`.
+const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
+setupPrismaMock();
+const app = (await import("@/app")).default;
+
+const admin = { ...mockUser, tenantId: 1n, role: "TENANT_ADMIN" as const };
+mockFindUnique.mockImplementation(() => Promise.resolve(admin));
+const tokenApp = new Elysia()
+  .use(authPlugin)
+  .post("/mint", async ({ setAuthCookie }) => ({
+    token: await setAuthCookie(admin),
+  }));
+const { token } = (await (
+  await tokenApp.handle(
+    new Request("http://localhost/mint", { method: "POST" }),
+  )
+).json()) as { token: string };
+
+async function post(path: string, payload: unknown): Promise<Response> {
+  return app.handle(
+    new BunRequest(`http://localhost/api${path}`, {
+      method: "POST",
+      headers: {
+        cookie: `fazerai_auth_token=${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    }),
+  );
+}
+
+// The schema the ROUTE declares, read off the built app rather than off the exported const: what the
+// defect was is that a route pointed at the wrong one of two schemas, and an assertion about the
+// const cannot see which one a route uses.
+function routeBody(
+  method: string,
+  path: string,
+): { required?: string[]; properties: Record<string, unknown> } | undefined {
+  const routes = (
+    app as unknown as {
+      routes: Array<{
+        method: string;
+        path: string;
+        hooks?: { body?: unknown };
+      }>;
+    }
+  ).routes;
+  const found = routes.find((r) => r.method === method && r.path === path);
+  return found?.hooks?.body as
+    | { required?: string[]; properties: Record<string, unknown> }
+    | undefined;
+}
+
+function requiredInZod(schema: {
+  shape: Record<string, { safeParse: (v: unknown) => { success: boolean } }>;
+}): string[] {
+  return Object.entries(schema.shape)
+    .filter(([, field]) => !field.safeParse(undefined).success)
+    .map(([key]) => key)
+    .sort();
+}
+
+const CONTROLLERS: Array<{
+  name: string;
+  path: string;
+  routePath: string;
+  patchPath: string;
+  schema: unknown;
+}> = [
+  {
+    name: "tools",
+    path: "/v1/tools",
+    routePath: "/api/v1/tools/",
+    patchPath: "/api/v1/tools/:id",
+    schema: toolDefinitionCreateSchema,
+  },
+  {
+    name: "business-hours",
+    path: "/v1/business-hours",
+    routePath: "/api/v1/business-hours/",
+    patchPath: "/api/v1/business-hours/:id",
+    schema: businessHoursCreateSchema,
+  },
+  {
+    name: "mcp-connections",
+    path: "/v1/mcp-connections",
+    routePath: "/api/v1/mcp-connections/",
+    patchPath: "/api/v1/mcp-connections/:id",
+    schema: mcpConnectionCreateSchema,
+  },
+];
+
+describe("a create route whose body is missing a required field", () => {
+  for (const { name, path } of CONTROLLERS) {
+    test(`${name} refuses it, naming the field`, async () => {
+      const res = await post(path, {});
+      const body = (await res.json()) as { error?: string; field?: string };
+      expect({ name, status: res.status }).toEqual({ name, status: 422 });
+      expect(typeof body.field).toBe("string");
+    });
+  }
+});
+
+// The same user error, one layer later: a value the transport accepts and the service's zod schema
+// refuses. It has to answer the same status as the row above — one mistake answering 422 or 500
+// depending on which layer noticed it is the thing being removed.
+describe("a create route carrying a value the service refuses", () => {
+  const rows: Array<[string, unknown, string]> = [
+    [
+      "/v1/tools",
+      {
+        name: "has space",
+        label: "L",
+        urlTemplate: "https://x.test/a",
+        allowedHosts: ["x.test"],
+      },
+      "name",
+    ],
+    // A nested path survives the crossing, which is what lets a console point at the input rather
+    // than at the form: `allowedHosts` is `t.Array(t.String())` at the transport and
+    // `z.string().min(1)` in the service, so an empty host reaches zod and comes back named.
+    [
+      "/v1/tools",
+      {
+        name: "probe_tool",
+        label: "L",
+        urlTemplate: "https://x.test/a",
+        allowedHosts: [""],
+      },
+      "allowedHosts.0",
+    ],
+    ["/v1/business-hours", { name: "" }, "name"],
+  ];
+
+  for (const [path, payload, field] of rows) {
+    test(`${path} (${field})`, async () => {
+      const res = await post(path, payload);
+      const body = (await res.json()) as { error?: string; field?: string };
+      expect({ status: res.status, field: body.field }).toEqual({
+        status: 422,
+        field,
+      });
+    });
+  }
+});
+
+// Why the routes were split rather than left to the `ZodError` branch alone, which already answers
+// 422 for both rows above: the PUBLISHED contract said every field of a create body was optional,
+// which is not true of any of the three, and a generated client reading it has no way to know.
+describe("the create route declares exactly what the service requires", () => {
+  for (const { name, routePath, patchPath, schema } of CONTROLLERS) {
+    test(name, () => {
+      const create = routeBody("POST", routePath);
+      const patch = routeBody("PATCH", patchPath);
+      expect([name, create?.required?.slice().sort()]).toEqual([
+        name,
+        requiredInZod(schema as never),
+      ]);
+      // …and the PATCH keeps the all-optional schema, which is what made sharing one object with the
+      // POST look right in the first place.
+      expect([name, patch?.required]).toEqual([name, undefined]);
+      // Composing the create body cannot lose a field: Elysia's `normalize` silently strips what the
+      // schema does not declare, which is the regression the drift guard in tools-controller.test.ts
+      // exists for.
+      expect([name, Object.keys(create?.properties ?? {}).sort()]).toEqual([
+        name,
+        Object.keys(patch?.properties ?? {}).sort(),
+      ]);
+    });
+  }
+
+  test("the comparison can see a required set that drifted", () => {
+    expect(["name"]).not.toEqual(
+      requiredInZod(toolDefinitionCreateSchema as never),
+    );
+  });
+});
+
+// The field a sub-value refusal names, which review on PR #309 caught the first spelling getting
+// wrong: zod's path is relative to what was handed to the parse, so a service that parses one member
+// of the request reported `0.weight` for a bad variant, and a lone token reported no field at all.
+// Both name something no input on the caller's side answers to.
+
+// The argument text of a call, read by matching parentheses so a nested call cannot end it early.
+function balancedArgs(source: string, openParen: number): string {
+  let depth = 0;
+  for (let i = openParen; i < source.length; i++) {
+    const c = source[i];
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return source.slice(openParen + 1, i);
+    }
+  }
+  return "";
+}
+
+describe("a refusal about a value inside the request names the whole path", () => {
+  test("the prefix and the issue path are joined", async () => {
+    const { parseInput } = await import("@/lib/parse-input");
+    const { z } = await import("zod");
+    const variants = z.array(z.object({ weight: z.number().nonnegative() }));
+    const err = (() => {
+      try {
+        parseInput(variants, [{ weight: -1 }], "variants");
+      } catch (e) {
+        return e as { field?: string; statusCode?: number };
+      }
+    })();
+    expect([err?.statusCode, err?.field]).toEqual([422, "variants.0.weight"]);
+  });
+
+  test("a scalar parsed on its own is named by the prefix alone", async () => {
+    const { parseInput } = await import("@/lib/parse-input");
+    const { z } = await import("zod");
+    const err = (() => {
+      try {
+        parseInput(z.string().min(1), "", "adminToken");
+      } catch (e) {
+        return e as { field?: string };
+      }
+    })();
+    // Without the prefix zod reports an empty path here, so the wire would carry no field at all.
+    expect(err?.field).toBe("adminToken");
+  });
+
+  // The call sites, read from the source with the whitespace taken out so the assertion is about the
+  // arguments and not about how the formatter broke the line.
+  test("the two call sites that parse a sub-value pass one", async () => {
+    // EVERY call that parses that sub-value, not "the file mentions one somewhere": experiments
+    // parses `params.variants` at two call sites, and a per-file assertion is satisfied by whichever
+    // one still carries the prefix — the same shape of hole #258 measured.
+    for (const [file, value] of [
+      ["src/modules/experiments/service.ts", "params.variants"],
+      ["src/modules/chatwoot/management.ts", "adminToken"],
+    ] as const) {
+      const dense = (await Bun.file(file).text()).replace(/\s+/g, "");
+      const calls = [...dense.matchAll(/parseInput\(/g)].map((m) =>
+        balancedArgs(dense, (m.index ?? 0) + "parseInput(".length - 1),
+      );
+      const subValue = calls.filter((c) => c.includes(`,${value}`));
+      expect([file, subValue.length > 0]).toEqual([file, true]);
+      for (const c of subValue) {
+        expect([file, c, /,"[^"]+",?$/.test(c)]).toEqual([file, c, true]);
+      }
+    }
+  });
+});
+
+// The issue path goes on the wire, and a path segment is a name the SERVER chose only, and a path segment is a name the SERVER chose only
+// while no zod record constrains its value type: a `z.record(z.string(), z.unknown())` cannot fail
+// below itself, so no issue can carry a key the caller wrote. That holds for every record in src/
+// today, and it is the same hazard the transport's own refusal walks the schema to avoid
+// (api/lib/schema-refusal.ts), so it is pinned rather than left as a reading.
+export function recordConstrainsItsValues(source: string): boolean {
+  // Written as "read the value expression and compare it" rather than as a negative lookahead: with
+  // `\s*` before the lookahead the regex backtracks over the whitespace and matches anyway, which is
+  // what the control below caught the first time this was written.
+  for (const m of source.matchAll(
+    /z\.record\(\s*z\.string\(\)\s*,([\s\S]{0,24})/g,
+  )) {
+    if (!(m[1] ?? "").trimStart().startsWith("z.unknown()")) return true;
+  }
+  return false;
+}
+
+describe("no zod record can put a caller's key in a refusal", () => {
+  test("the predicate separates a constrained record from a free-form one", () => {
+    expect(recordConstrainsItsValues("z.record(z.string(), z.string())")).toBe(
+      true,
+    );
+    expect(recordConstrainsItsValues("z.record(z.string(), z.unknown())")).toBe(
+      false,
+    );
+    expect(
+      recordConstrainsItsValues(
+        "z.record(\n    z.string(),\n    z.number(),\n  )",
+      ),
+    ).toBe(true);
+  });
+
+  test("no file under src declares one", async () => {
+    const { Glob } = await import("bun");
+    const offenders: string[] = [];
+    for await (const rel of new Glob("**/*.ts").scan("src")) {
+      if (recordConstrainsItsValues(await Bun.file(`src/${rel}`).text())) {
+        offenders.push(rel);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+// Where the refusal is RAISED, which is the half review found on PR #309: a global "a ZodError means
+// the caller sent something wrong" branch also caught a ZodError the MCP SDK rejects with when a
+// remote server answers a malformed result (tests/api/v1/upstream-zod-error.test.ts pins that one).
+// So the 422 is raised where the input is known to be the caller's — `parseInput` — and every other
+// zod parse in service code has to say, at the call site, why it is not that.
+//
+// Keyed on the CALL SITE and not on the file: an exemption attached to a file adopts the next parse
+// written into it, which is the exact failure #258 measured.
+export function unmarkedServiceParse(source: string): string[] {
+  const lines = source.split("\n");
+  const offenders: string[] = [];
+  for (const [i, line] of lines.entries()) {
+    // Keyed on `.parse(` itself and not on what precedes it: a chained schema
+    // (`z.string().min(1).parse(x)`) and a multiline chain whose line begins with `.parse(` both put
+    // a `)` or a line start there, and the first spelling of this predicate matched neither — so the
+    // sweep reported a clean tree while the exact shape this PR converted could be written back in.
+    // Found by review on PR #309.
+    if (!line.includes(".parse(")) continue;
+    if (
+      /JSON\.parse|Number\.parse|Date\.parse|\.parseAsync|safeParse/.test(line)
+    ) {
+      continue;
+    }
+    const marked =
+      /not-caller-input:/.test(line) ||
+      /not-caller-input:/.test(lines[i - 1] ?? "");
+    if (!marked) offenders.push(line.trim());
+  }
+  return offenders;
+}
+
+describe("a zod parse of caller input goes through parseInput", () => {
+  test("the predicate sees an unmarked parse and not a marked one", () => {
+    expect(
+      unmarkedServiceParse("  const d = someSchema.parse(input);"),
+    ).toEqual(["const d = someSchema.parse(input);"]);
+    expect(
+      unmarkedServiceParse(
+        "  // not-caller-input: a stored row\n  const d = someSchema.parse(row);",
+      ),
+    ).toEqual([]);
+    // The two shapes the first spelling of this predicate missed, and the reason they are controls
+    // rather than a sentence: in both the character before `.parse` is a `)` or a line start, so a
+    // predicate anchored on the identifier before it reported a clean tree while the exact call this
+    // PR converted (`z.string().min(1).max(2000).parse(adminToken)`) could be written straight back.
+    expect(
+      unmarkedServiceParse("  const t = z.string().min(1).parse(token);"),
+    ).toEqual(["const t = z.string().min(1).parse(token);"]);
+    expect(
+      unmarkedServiceParse(
+        "  const v = z\n    .array(itemSchema)\n    .parse(value);",
+      ),
+    ).toEqual([".parse(value);"]);
+    // The shapes that are not a zod parse at all, and the helper itself.
+    expect(unmarkedServiceParse("  const x = JSON.parse(raw);")).toEqual([]);
+    expect(
+      unmarkedServiceParse("  const d = parseInput(someSchema, input);"),
+    ).toEqual([]);
+    expect(
+      unmarkedServiceParse("  const d = someSchema.safeParse(input);"),
+    ).toEqual([]);
+  });
+
+  test("no service file parses caller input outside it", async () => {
+    const { Glob } = await import("bun");
+    const offenders: string[] = [];
+    let scanned = 0;
+    for (const dir of ["src/modules", "src/api"]) {
+      for await (const rel of new Glob("**/*.ts").scan(dir)) {
+        const file = `${dir}/${rel}`;
+        if (file === "src/lib/parse-input.ts") continue;
+        scanned++;
+        for (const line of unmarkedServiceParse(await Bun.file(file).text())) {
+          offenders.push(`${file}: ${line}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+    // …and the sweep is looking at something.
+    expect(scanned).toBeGreaterThanOrEqual(50);
+  });
+});


### PR DESCRIPTION
Fixes #301.

## What breaks

`POST /v1/tools`, `POST /v1/business-hours` and `POST /v1/mcp-connections` answered **500
`Something went wrong`** for a body the caller got wrong, and wrote the zod issue array — submitted
values included — to the `error` log.

Two causes, one symptom:

1. **The create route borrowed the PATCH's body schema.** `writeBody` has every field optional,
   which is correct for a PATCH, so a create request missing a required field passed the transport
   and reached the service's zod schema.
2. **`src/app.ts` had no branch for a `ZodError`.** It answers `AppError` and Elysia's own
   `ValidationError` (the schema refusal from #255/#263); a zod refusal is neither, so it fell to the
   generic 500 branch, which also logs the whole error at `error` level.

The second cause is the wider one: it also swallowed a value the transport accepts and the service
refuses. Measured on `main`, every required field present: `POST /v1/tools` with `name: "has space"`
(the service's `regex`) and `POST /v1/business-hours` with `name: ""` (`min(1)`) both answered 500.
So the same user error answered 422 or 500 depending on which layer noticed it.

## The change

- **`parseInput` (`src/lib/parse-input.ts`), and the service call sites through it.** A service that
  validates a caller's payload now parses it there instead of calling `schema.parse` itself, and a
  failure is raised as a 422 `AppError` naming the field — the same two sentences the transport's own
  schema refusal answers, because it is the same user error one layer later.
- **The three create routes declare their own body**, composed from `writeBody` so no field can be
  lost, with the required set the service's schema requires. This is the half the refusal cannot do:
  the published contract said every field of a create body was optional, and a generated client had
  no way to know otherwise.
- `openapi.json` regenerated: three operations change (`post /v1/tools`, `post /v1/business-hours`,
  `post /v1/mcp-connections`), each gaining the `required` array; no other route is touched.

**Where the refusal is raised is the design, and the first version got it wrong.** A global "a
`ZodError` means the caller sent something wrong" branch in the error handler was written first, on a
sweep showing that every `.parse()` in `src/` parses caller input. Review on this PR found what the
sweep could not see: the MCP SDK validates a REMOTE server's JSON-RPC results with the same zod
package (`@modelcontextprotocol/sdk`, `shared/protocol.js`: `safeParse(resultSchema, response.result)`
then `reject(parseResult.error)`; zod is deduped, so that error is `instanceof ZodError` here), and
`discoverMcpTools` lets it propagate. That branch answered a malformed answer from someone else's
server as the operator's input being wrong, named a field they never sent, and logged a server fault
as a warning. Measured, and now pinned red-first in `tests/api/v1/upstream-zod-error.test.ts`.

Review then found two more, both of them mine and both about the refusal naming the wrong thing or
the fence not seeing it:

- **A sub-value refusal named a relative path.** zod's path is relative to what was handed to the
  parse, so an experiment with a negative variant weight reported `0.weight` instead of
  `variants.0.weight`, and an overlong Chatwoot admin token reported no field at all. `parseInput`
  now takes the caller's name for the value (`at`), and the two call sites that parse one member of
  the request pass it.
- **The fence could not see a chained parse.** Its predicate was anchored on the identifier before
  `.parse(`, so `z.string().min(1).parse(x)` — the exact shape this PR converted — and a multiline
  chain whose line starts with `.parse(` both slipped past it. Broadened, with both shapes as
  controls.

So the refusal is raised where the input is KNOWN to be the caller's, and a bare `ZodError` keeps the
500 it deserves. The ten zod parses that stay outside `parseInput` each say why at the call site
(`// not-caller-input: …`): four merge the STORED settings block with a patch, four are already
wrapped by `invalidDocumentTemplate`, one reads a name off the template being imported, one lives
inside a validator whose contract is `{ ok: false, reason }` rather than a throw.

## Validation scope

**Proved by test**, driven through the real app over HTTP with an authenticated `TENANT_ADMIN`
(`tests/api/v1/write-body-required.test.ts`, 14 pass; `tests/api/v1/upstream-zod-error.test.ts`, 1):

- red first on the pre-change tree: all three create routes answered 500 for `{}` (the body is not
  even JSON, so the test fails on the parse), and the value-refused rows answered 500 too;
- red first for the review finding as well: with the global branch in place, a `ZodError` raised the
  way the MCP SDK raises one was answered **422** on `POST /v1/mcp-connections/:id/discover`;
  it is 500 now, and the response does not carry the upstream path as a `field`;
- both halves of the caller's error now answer 422 naming the field, including a nested path
  (`allowedHosts.0`), which is what lets a console point at the input rather than at the form;
- the create route's declared body — read off the **built app's route table**, not off the exported
  const, so the assertion is about which schema the route uses — requires exactly what the service's
  zod schema requires, while the PATCH still requires nothing and both declare the same fields;
- a fence keyed on the CALL SITE (not the file, per #258): every zod parse under `src/modules` and
  `src/api` either goes through `parseInput` or carries `// not-caller-input:` on its own line, with
  the chained and multiline shapes as controls; ten parses are marked, twenty go through the helper;
- the two sub-value call sites are asserted per CALL, not per file: experiments parses
  `params.variants` twice, and a per-file assertion is satisfied by whichever one still carries the
  prefix — measured, because that mutation survived the first spelling of this test;
- a fence proving no zod record in `src/` constrains its value type, which is what makes an issue
  path a name the SERVER chose. Its positive control caught a real bug in the predicate's first
  spelling, where a negative lookahead backtracked over the whitespace and matched everything.

**Mutation**, one at a time: `parseInput` rethrowing the raw `ZodError` (3 fail), the field reduced to
the first path segment (1), the prefix ignored (2), each of the three sub-value call sites dropping
its prefix (1 each), the fence predicate back to its narrow spelling (1), one call site back to
`schema.parse` (2), the refusal at 400 instead of 422 (3), a field dropped from the create-required
set (1), the POST pointed back at `writeBody` (1).

**Base**: rebased onto #304, which widened `keysThatSayLess` to read `translate` and
`translateWithLocale` — the spelling this PR's refusal used. That widened rule and
`refusal-callsites` both flagged the first shape of the fix (a subclass deciding its own key with a
ternary is a refusal neither reader can see), which is why the refusal is now built at the call site
with its message, key, params and field in one place.

**Editions**: `src/api/v1/tenants.admin.service.ts` is a paired file — the Free edition swaps in a
stub that raises `ProEditionError` and parses nothing — so its two call sites are converted in the
master tree only and are not part of this PR. Nothing else in the change is edition-specific.

**Not validated**: nothing about how the console renders the new `field` — the recovery that reads it
is unchanged and no client code is touched here. The upstream-`ZodError` case is exercised through a
stub that raises the same value the SDK raises, not against a live MCP server answering malformed
JSON-RPC. The 422 itself stays undeclared in the routes' response maps, which is the repo's existing
state rather than something this PR introduces (#314).
