### PR TITLE
fix(google-calendar): a pinned slot grid is not the model's to change

### DIFF
--- a/src/client/lib/toolpackTools.ts
+++ b/src/client/lib/toolpackTools.ts
@@ -56,6 +56,18 @@ export function toolpackArgNote(
       "The agent only receives this argument when the integration allows several calendars; with a single one it is used automatically.",
     );
   }
+  // Same shape as calendarId: `slotDurationArgSchema` removes the argument whenever the appointment
+  // length is fixed, so the note is the only place the operator learns that "Let the AI choose" is
+  // what puts it back.
+  if (
+    argName === "slotDurationMinutes" &&
+    toolName === "calendar_check_availability"
+  ) {
+    return t(
+      "toolpackTools.argNote.slotDurationMinutes",
+      'The agent only receives this argument when the appointment length is set to "Let the AI choose"; a fixed length always applies and cannot be changed per conversation.',
+    );
+  }
   return null;
 }
 

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -2007,7 +2007,8 @@
   },
   "toolpackTools": {
     "argNote": {
-      "calendarId": "The agent only receives this argument when the integration allows several calendars; with a single one it is used automatically."
+      "calendarId": "The agent only receives this argument when the integration allows several calendars; with a single one it is used automatically.",
+      "slotDurationMinutes": "The agent only receives this argument when the appointment length is set to \"Let the AI choose\"; a fixed length always applies and cannot be changed per conversation."
     },
     "asaas_create_pix_charge": {
       "desc": "Open a PIX charge and return the copy-and-paste code plus the payment page.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -2015,7 +2015,8 @@
   },
   "toolpackTools": {
     "argNote": {
-      "calendarId": "O agente só recebe este argumento quando a integração permite vários calendários; com um só, ele é usado automaticamente."
+      "calendarId": "O agente só recebe este argumento quando a integração permite vários calendários; com um só, ele é usado automaticamente.",
+      "slotDurationMinutes": "O agente só recebe este argumento quando a duração do agendamento está em \"Deixar a IA escolher\"; uma duração fixa vale sempre e não muda por conversa."
     },
     "asaas_create_pix_charge": {
       "desc": "Abre uma cobrança PIX e retorna o código copia-e-cola e a página de pagamento.",

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -322,6 +322,17 @@ function resolveSlotDuration(
   );
 }
 
+// The operator-pinned spacing between candidate start times, or null when the integration leaves it
+// open. Mirrors configuredSlotDuration: a pinned grid is a business rule, not a per-request choice.
+function configuredSlotGranularity(
+  config: Record<string, unknown>,
+): number | null {
+  const v = config.slotGranularityMinutes;
+  return typeof v === "number" && Number.isFinite(v) && v > 0
+    ? Math.round(v)
+    : null;
+}
+
 function resolveSlotGranularity(
   config: Record<string, unknown>,
   override?: number,
@@ -581,7 +592,7 @@ const CHECK_AVAILABILITY_SCHEMA = z.object({
     .positive()
     .optional()
     .describe(
-      "Appointment length in minutes. Optional; defaults to the integration's setting (e.g. 30 or 60).",
+      "Appointment length in minutes. Only offered when the integration has NOT pinned one; when it is pinned this arg is absent and the pinned length always applies.",
     ),
   granularityMinutes: z
     .number()
@@ -589,7 +600,7 @@ const CHECK_AVAILABILITY_SCHEMA = z.object({
     .positive()
     .optional()
     .describe(
-      "Spacing between candidate start times, in minutes. Optional; defaults to the integration's setting (e.g. 15 ⇒ 09:00 and 09:15 are both offered).",
+      "Spacing between candidate start times, in minutes. Only offered when the integration has NOT pinned one; when it is pinned this arg is absent and the pinned spacing always applies.",
     ),
   calendarId: z.string().optional().describe(AVAILABILITY_CALENDAR_ID_DESC),
 });
@@ -730,6 +741,18 @@ function buildCheckAvailabilityTool(
   const businessHoursId = resolveBusinessHoursId(sel.config);
   const minLeadMinutes = resolveMinLead(sel.config);
   const blockingIds = resolveBlockingCalendarIds(sel.config);
+  // A pinned duration or spacing is the operator's business rule (a 1h visit offered on the half
+  // hour). Leaving the args on the schema let the model redefine that rule per call and offer a
+  // start time the business does not actually sell, so we drop them from what the model can send.
+  const pinnedDuration = configuredSlotDuration(sel.config);
+  const pinnedGranularity = configuredSlotGranularity(sel.config);
+  const pinnedArgs: { slotDurationMinutes?: true; granularityMinutes?: true } =
+    {};
+  if (pinnedDuration !== null) pinnedArgs.slotDurationMinutes = true;
+  if (pinnedGranularity !== null) pinnedArgs.granularityMinutes = true;
+  const schema = Object.keys(pinnedArgs).length
+    ? CHECK_AVAILABILITY_SCHEMA.omit(pinnedArgs)
+    : CHECK_AVAILABILITY_SCHEMA;
   return failableTool(
     async (input: {
       timeMin: string;
@@ -952,10 +975,14 @@ function buildCheckAvailabilityTool(
               .flatMap((b) => b.windows),
           ],
         })),
-        slotMinutes: resolveSlotDuration(sel.config, input.slotDurationMinutes),
+        // A pinned value wins over anything the model sent.
+        slotMinutes: resolveSlotDuration(
+          sel.config,
+          pinnedDuration === null ? input.slotDurationMinutes : undefined,
+        ),
         granularityMinutes: resolveSlotGranularity(
           sel.config,
-          input.granularityMinutes,
+          pinnedGranularity === null ? input.granularityMinutes : undefined,
         ),
         minLeadMinutes,
         // NOTE: Only when aggregating. The multiplication this bounds does not exist with one calendar,
@@ -977,11 +1004,11 @@ function buildCheckAvailabilityTool(
     {
       name: "calendar_check_availability",
       description: withCalendarContext(
-        `Return ALL bookable appointment start times within a range, already honoring the service hours, existing bookings and any operator-designated blocking calendars such as holidays or closures (no appointment details are exposed). Each slot has start, end, a human-readable label, and the calendarId (plus calendarLabel) that can actually take it. With several calendars configured, OMIT calendarId to search all of them at once and answer "who is available first?" in a single call; pass calendarId only to restrict the search to one. Offer these to the customer and confirm one before creating the appointment, then pass that slot's calendarId when booking. If \`unavailableCalendars\` comes back, those calendars could not be read and their slots are missing from the list. If \`coveredUntil\` comes back, the search stopped early and that timestamp is the FIRST start time it did not cover: the list is NOT the whole range, so never conclude that later times are unavailable, and call again with timeMin set to that value to continue. Pass ISO 8601 timestamps for the range, and search AT MOST 24 hours per call (one day at a time — call again for other days). The configured appointment length is shown in \`<slot_duration>\` below — when preset="false", choose it yourself per request and pass slotDurationMinutes (e.g. 30 for a standard appointment, 60 for a longer one); when preset="true", pass slotDurationMinutes only to override it.`,
+        `Return ALL bookable appointment start times within a range, already honoring the service hours, existing bookings and any operator-designated blocking calendars such as holidays or closures (no appointment details are exposed). Each slot has start, end, a human-readable label, and the calendarId (plus calendarLabel) that can actually take it. With several calendars configured, OMIT calendarId to search all of them at once and answer "who is available first?" in a single call; pass calendarId only to restrict the search to one. Offer these to the customer and confirm one before creating the appointment, then pass that slot's calendarId when booking. If \`unavailableCalendars\` comes back, those calendars could not be read and their slots are missing from the list. If \`coveredUntil\` comes back, the search stopped early and that timestamp is the FIRST start time it did not cover: the list is NOT the whole range, so never conclude that later times are unavailable, and call again with timeMin set to that value to continue. Pass ISO 8601 timestamps for the range, and search AT MOST 24 hours per call (one day at a time — call again for other days). The configured appointment length is shown in \`<slot_duration>\` below — when preset="false", choose it yourself per request and pass slotDurationMinutes (e.g. 30 for a standard appointment, 60 for a longer one); when preset="true" the length is fixed by the business and there is no arg to change it. Offer the returned start times EXACTLY as they come back: never round them, shift them or invent times in between.`,
         slotDurationXml(sel.config),
         calendarContextXml(allowed, labels),
       ),
-      schema: calendarArgSchema(CHECK_AVAILABILITY_SCHEMA, allowed),
+      schema: calendarArgSchema(schema, allowed),
     },
   );
 }

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -179,6 +179,21 @@ function calendarArgSchema(
   return pinnedCalendarId(allowed) ? schema.omit({ calendarId: true }) : schema;
 }
 
+// The appointment length as the MODEL sees it, the same shape calendarArgSchema gives calendarId.
+// Pinned ⇒ slotDurationMinutes is REMOVED: the console's "Let the AI choose" is what delegates the
+// length, so a fixed one is a business rule the model must not restate per call — a 1h school visit
+// was offered at 14:15 because the arg was still there to send. Zod strips a residual key from an
+// older turn before the body runs, so the pinned length is used either way. Not pinned ⇒ the arg
+// stays and the model chooses (a clinic whose appointments genuinely vary).
+function slotDurationArgSchema(
+  schema: z.ZodObject<z.ZodRawShape>,
+  config: Record<string, unknown>,
+): z.ZodObject<z.ZodRawShape> {
+  return configuredSlotDuration(config) === null
+    ? schema
+    : schema.omit({ slotDurationMinutes: true });
+}
+
 // The configured appointment length as an XML element for calendar_check_availability: preset="true"
 // with the pinned minutes when the operator fixed a duration, otherwise preset="false" (the model
 // chooses per request via the slotDurationMinutes arg). Always non-empty.
@@ -322,23 +337,14 @@ function resolveSlotDuration(
   );
 }
 
-// The operator-pinned spacing between candidate start times, or null when the integration leaves it
-// open. Mirrors configuredSlotDuration: a pinned grid is a business rule, not a per-request choice.
-function configuredSlotGranularity(
-  config: Record<string, unknown>,
-): number | null {
-  const v = config.slotGranularityMinutes;
-  return typeof v === "number" && Number.isFinite(v) && v > 0
-    ? Math.round(v)
-    : null;
-}
-
-function resolveSlotGranularity(
-  config: Record<string, unknown>,
-  override?: number,
-): number {
+// The spacing between candidate start times is the OPERATOR's, always: it takes no argument, because
+// unlike the duration there is no "let the AI choose" for it in the console — a config without the key
+// means the operator never made the choice, not that they delegated it. A grid the model redefines per
+// call offers a start time the business does not sell (a school running 1h visits on the half hour had
+// 14:15 offered, and honoured, because the model sent granularityMinutes: 15).
+function resolveSlotGranularity(config: Record<string, unknown>): number {
   return clampMinutes(
-    override ?? config.slotGranularityMinutes,
+    config.slotGranularityMinutes,
     MIN_GRAIN_MINUTES,
     MAX_GRANULARITY_MINUTES,
     DEFAULT_GRANULARITY_MINUTES,
@@ -592,15 +598,7 @@ const CHECK_AVAILABILITY_SCHEMA = z.object({
     .positive()
     .optional()
     .describe(
-      "Appointment length in minutes. Only offered when the integration has NOT pinned one; when it is pinned this arg is absent and the pinned length always applies.",
-    ),
-  granularityMinutes: z
-    .number()
-    .int()
-    .positive()
-    .optional()
-    .describe(
-      "Spacing between candidate start times, in minutes. Only offered when the integration has NOT pinned one; when it is pinned this arg is absent and the pinned spacing always applies.",
+      "Appointment length in minutes. Pick it per request (e.g. 30 for a standard appointment, 60 for a longer one).",
     ),
   calendarId: z.string().optional().describe(AVAILABILITY_CALENDAR_ID_DESC),
 });
@@ -741,24 +739,11 @@ function buildCheckAvailabilityTool(
   const businessHoursId = resolveBusinessHoursId(sel.config);
   const minLeadMinutes = resolveMinLead(sel.config);
   const blockingIds = resolveBlockingCalendarIds(sel.config);
-  // A pinned duration or spacing is the operator's business rule (a 1h visit offered on the half
-  // hour). Leaving the args on the schema let the model redefine that rule per call and offer a
-  // start time the business does not actually sell, so we drop them from what the model can send.
-  const pinnedDuration = configuredSlotDuration(sel.config);
-  const pinnedGranularity = configuredSlotGranularity(sel.config);
-  const pinnedArgs: { slotDurationMinutes?: true; granularityMinutes?: true } =
-    {};
-  if (pinnedDuration !== null) pinnedArgs.slotDurationMinutes = true;
-  if (pinnedGranularity !== null) pinnedArgs.granularityMinutes = true;
-  const schema = Object.keys(pinnedArgs).length
-    ? CHECK_AVAILABILITY_SCHEMA.omit(pinnedArgs)
-    : CHECK_AVAILABILITY_SCHEMA;
   return failableTool(
     async (input: {
       timeMin: string;
       timeMax: string;
       slotDurationMinutes?: number;
-      granularityMinutes?: number;
       calendarId?: string;
     }) => {
       const minMs = Date.parse(input.timeMin);
@@ -975,15 +960,8 @@ function buildCheckAvailabilityTool(
               .flatMap((b) => b.windows),
           ],
         })),
-        // A pinned value wins over anything the model sent.
-        slotMinutes: resolveSlotDuration(
-          sel.config,
-          pinnedDuration === null ? input.slotDurationMinutes : undefined,
-        ),
-        granularityMinutes: resolveSlotGranularity(
-          sel.config,
-          pinnedGranularity === null ? input.granularityMinutes : undefined,
-        ),
+        slotMinutes: resolveSlotDuration(sel.config, input.slotDurationMinutes),
+        granularityMinutes: resolveSlotGranularity(sel.config),
         minLeadMinutes,
         // NOTE: Only when aggregating. The multiplication this bounds does not exist with one calendar,
         // and what a single-calendar instance returns is not this change's to alter: capping it would
@@ -1008,7 +986,10 @@ function buildCheckAvailabilityTool(
         slotDurationXml(sel.config),
         calendarContextXml(allowed, labels),
       ),
-      schema: calendarArgSchema(schema, allowed),
+      schema: calendarArgSchema(
+        slotDurationArgSchema(CHECK_AVAILABILITY_SCHEMA, sel.config),
+        allowed,
+      ),
     },
   );
 }

--- a/tests/client/lib/toolpack-arg-notes.test.ts
+++ b/tests/client/lib/toolpack-arg-notes.test.ts
@@ -25,19 +25,66 @@ const CALENDAR_TOOLS = [
   "calendar_confirm_appointment",
 ];
 
+// The phrases that say WHEN an argument is offered. Any argument carrying one is paying model tokens
+// to state a condition its own presence already guarantees.
+const APPEARANCE_PHRASES = [
+  "only appears",
+  "only offered",
+  "integration allows",
+  "is absent",
+  "has not pinned",
+  "has NOT pinned",
+];
+
 describe("the calendarId argument's two audiences", () => {
   // NOTE: the tautology, stated as a property rather than as a string match on the old sentence: the
   // model can only ever READ this text in the case where the condition it describes is already true,
   // because calendarArgSchema removes the argument whenever the integration has one calendar.
-  test("no calendar tool's schema explains when the argument appears", () => {
+  // Asked of EVERY argument, not just calendarId: the second conditional schema (slotDurationArgSchema)
+  // arrived with the same sentence on a different argument, and a test naming one argument would have
+  // let it through.
+  test("no calendar tool's schema explains when an argument appears", () => {
     const views = getToolpackToolViews("GOOGLE_CALENDAR");
     expect(views.length).toBeGreaterThan(0);
     for (const view of views) {
-      const arg = view.args.find((a) => a.name === "calendarId");
-      if (!arg?.description) continue;
-      expect(arg.description).not.toContain("only appears");
-      expect(arg.description).not.toContain("integration allows");
+      for (const arg of view.args) {
+        if (!arg.description) continue;
+        for (const phrase of APPEARANCE_PHRASES) {
+          expect(arg.description).not.toContain(phrase);
+        }
+      }
     }
+  });
+
+  // The other half of #118: every argument a conditional schema can REMOVE needs the note, or the
+  // operator sees an argument in the console that their agent never receives and cannot find out why.
+  test("every argument a conditional schema removes carries an operator note", () => {
+    for (const [tool, arg] of [
+      ["calendar_check_availability", "calendarId"],
+      ["calendar_check_availability", "slotDurationMinutes"],
+    ] as const) {
+      expect(toolpackArgNote(tool, arg, t)).toBeTruthy();
+    }
+  });
+
+  test("the appointment length note names the console setting that puts the arg back", () => {
+    const note = toolpackArgNote(
+      "calendar_check_availability",
+      "slotDurationMinutes",
+      t,
+    );
+    expect(note).toContain("Let the AI choose");
+    // The spacing has no such setting, so it has no argument and needs no note.
+    expect(
+      toolpackArgNote("calendar_check_availability", "granularityMinutes", t),
+    ).toBeNull();
+    const views = getToolpackToolViews("GOOGLE_CALENDAR");
+    const availability = views.find(
+      (v) => v.name === "calendar_check_availability",
+    );
+    expect(availability?.args.map((a) => a.name)).not.toContain(
+      "granularityMinutes",
+    );
   });
 
   test("every calendar tool that takes the argument still tells the model how to fill it", () => {

--- a/tests/graph/calendar-pinned-calendar-turn.test.ts
+++ b/tests/graph/calendar-pinned-calendar-turn.test.ts
@@ -19,6 +19,11 @@ import { seedChatwootInstance } from "../utils/chatwoot";
 // be on the wire at all), and that a model which sends it anyway still gets slots and the customer
 // still gets an answer.
 //
+// Asked of EVERY argument a conditional schema removes, not just calendarId: the integration here also
+// pins the slot grid (1h visits on the half hour), which is the second instance of the same question —
+// a model sending granularityMinutes: 15 got 14:15 back, a real, bookable slot the business does not
+// sell. Same turn, same wire, one more pair of args.
+//
 // NOTE: the turn's SSRF guard is not injectable (prepare.ts builds the toolpack ctx without one), so
 // this test resolves www.googleapis.com for real. Every HTTP response is stubbed; only DNS is live.
 
@@ -101,6 +106,10 @@ function fakeHosts() {
                       timeMin: "2099-06-22T00:00:00-03:00",
                       timeMax: "2099-06-22T23:00:00-03:00",
                       calendarId: INVENTED,
+                      // The school's case: a grid the operator pinned, redefined per call. Sent
+                      // from a stale tool definition, since neither arg is on the wire any more.
+                      slotDurationMinutes: 15,
+                      granularityMinutes: 15,
                     }),
                   },
                 },
@@ -231,6 +240,9 @@ describe.skipIf(!dbUp)("a turn on an integration with one calendar", () => {
         config: {
           calendarIds: [PINNED],
           calendarLabels: { [PINNED]: "Clinic" },
+          // 1h appointments on the half hour, the configuration the report came from.
+          slotDurationMinutes: 60,
+          slotGranularityMinutes: 30,
         },
       },
       select: { id: true },
@@ -343,10 +355,29 @@ describe.skipIf(!dbUp)("a turn on an integration with one calendar", () => {
     // 3. The customer got the answer.
     expect(sent).toEqual([[801, REPLY]]);
 
-    // 4. And the arg the model filled in was never on the wire to begin with.
+    // 4. And no argument the operator's configuration decides was on the wire to begin with.
     const fn = toolOnTheWire(fake.llm[0]);
     expect(fn).not.toBeNull();
     const params = fn?.parameters as { properties?: Record<string, unknown> };
-    expect(Object.keys(params?.properties ?? {})).not.toContain("calendarId");
+    const onTheWire = Object.keys(params?.properties ?? {});
+    expect(onTheWire).not.toContain("calendarId");
+    expect(onTheWire).not.toContain("slotDurationMinutes");
+    expect(onTheWire).not.toContain("granularityMinutes");
+    expect(onTheWire).toContain("timeMin");
+
+    // 5. The observable effect, which is the whole point: the start times the model read back sit on
+    // the operator's grid, not on the 15-minute one it asked for. A `:15` here is the slot a family
+    // would have shown up for.
+    const slots = (
+      JSON.parse(String(toolReply?.content)) as {
+        slots: { start: string; end: string }[];
+      }
+    ).slots;
+    expect(slots.length).toBeGreaterThan(0);
+    for (const slot of slots) {
+      expect(new Date(slot.start).getUTCMinutes() % 30).toBe(0);
+      // 60 minutes long, the pinned duration — not the 15 the model sent.
+      expect(Date.parse(slot.end) - Date.parse(slot.start)).toBe(3_600_000);
+    }
   });
 });

--- a/tests/modules/toolpacks-google-calendar.test.ts
+++ b/tests/modules/toolpacks-google-calendar.test.ts
@@ -947,6 +947,69 @@ describe("google calendar toolpack — list + availability", () => {
     ]);
   });
 
+  // Regression: a pinned duration/spacing is the operator's business rule (a 1h school visit offered
+  // on the half hour). While granularityMinutes stayed on the schema, the model could send 15 and get
+  // back 14:15 — a real, bookable slot the school does not actually offer.
+  test("availability IGNORES a granularity the model sends when the operator pinned one", async () => {
+    const day = spWeekday("2099-06-22T14:00:00-03:00");
+    const { impl } = stubFetch(200, { calendars: { primary: { busy: [] } } });
+    const out = (await toolFor(
+      "calendar_check_availability",
+      {
+        businessHoursId: "5",
+        slotDurationMinutes: 60,
+        slotGranularityMinutes: 30,
+      },
+      baseCtx({
+        fetchImpl: impl,
+        resolveBusinessHours: async () => ({
+          windows: [{ day, start: "14:00", end: "16:00" }],
+          exceptions: [],
+          timezone: TZ,
+        }),
+      }),
+    )?.invoke({
+      timeMin: "2099-06-22T00:00:00-03:00",
+      timeMax: "2099-06-22T23:59:00-03:00",
+      // What the model actually sent in production. The pinned 30 must win.
+      granularityMinutes: 15,
+      slotDurationMinutes: 15,
+    })) as string;
+    const parsed = JSON.parse(out) as { slots: { start: string }[] };
+    expect(parsed.slots.map((s) => localHM(s.start))).toEqual([
+      "14:00",
+      "14:30",
+      "15:00",
+    ]);
+  });
+
+  test("availability hides the duration/spacing args when the operator pinned them", () => {
+    const keysFor = (config: Record<string, unknown>) => {
+      const tool = toolFor("calendar_check_availability", config, baseCtx({}));
+      if (!tool) throw new Error("calendar_check_availability was not built");
+      const { shape } = tool.schema as unknown as {
+        shape: Record<string, unknown>;
+      };
+      return Object.keys(shape);
+    };
+    // Pinned on both ⇒ neither arg exists, so the model cannot redefine the grid.
+    const pinned = keysFor({
+      slotDurationMinutes: 60,
+      slotGranularityMinutes: 30,
+    });
+    expect(pinned).not.toContain("slotDurationMinutes");
+    expect(pinned).not.toContain("granularityMinutes");
+    expect(pinned).toContain("timeMin");
+    // Left open ⇒ the model still chooses per request (a clinic with variable appointment lengths).
+    const open = keysFor({});
+    expect(open).toContain("slotDurationMinutes");
+    expect(open).toContain("granularityMinutes");
+    // Mixed: only the pinned one disappears.
+    const halfPinned = keysFor({ slotGranularityMinutes: 30 });
+    expect(halfPinned).toContain("slotDurationMinutes");
+    expect(halfPinned).not.toContain("granularityMinutes");
+  });
+
   test("availability with no schedule configured ⇒ no time-of-day filter (full grid)", async () => {
     const { impl } = stubFetch(200, { calendars: { primary: { busy: [] } } });
     const out = (await toolFor(

--- a/tests/modules/toolpacks-google-calendar.test.ts
+++ b/tests/modules/toolpacks-google-calendar.test.ts
@@ -947,10 +947,12 @@ describe("google calendar toolpack — list + availability", () => {
     ]);
   });
 
-  // Regression: a pinned duration/spacing is the operator's business rule (a 1h school visit offered
-  // on the half hour). While granularityMinutes stayed on the schema, the model could send 15 and get
-  // back 14:15 — a real, bookable slot the school does not actually offer.
-  test("availability IGNORES a granularity the model sends when the operator pinned one", async () => {
+  // Regression: the spacing between start times is the operator's business rule (a 1h school visit
+  // offered on the half hour). While granularityMinutes was on the schema, the model could send 15
+  // and get back 14:15 — a real, bookable slot the school does not actually offer. The arg is gone
+  // now, so this also pins the strip: a residual key from an older tool definition never reaches the
+  // body, which is why no handler guard is needed.
+  test("availability IGNORES a granularity the model sends", async () => {
     const day = spWeekday("2099-06-22T14:00:00-03:00");
     const { impl } = stubFetch(200, { calendars: { primary: { busy: [] } } });
     const out = (await toolFor(
@@ -983,7 +985,40 @@ describe("google calendar toolpack — list + availability", () => {
     ]);
   });
 
-  test("availability hides the duration/spacing args when the operator pinned them", () => {
+  // A config with no slotGranularityMinutes is the case the console cannot produce but the API can:
+  // there is no "let the AI choose" for spacing, so a missing key is an operator who never chose, not
+  // one who delegated. The runtime default must win over the model just the same.
+  test("availability IGNORES a granularity the model sends with NO spacing configured", async () => {
+    const day = spWeekday("2099-06-22T14:00:00-03:00");
+    const { impl } = stubFetch(200, { calendars: { primary: { busy: [] } } });
+    const out = (await toolFor(
+      "calendar_check_availability",
+      { businessHoursId: "5", slotDurationMinutes: 60 },
+      baseCtx({
+        fetchImpl: impl,
+        resolveBusinessHours: async () => ({
+          windows: [{ day, start: "14:00", end: "16:00" }],
+          exceptions: [],
+          timezone: TZ,
+        }),
+      }),
+    )?.invoke({
+      timeMin: "2099-06-22T00:00:00-03:00",
+      timeMax: "2099-06-22T23:59:00-03:00",
+      granularityMinutes: 5,
+    })) as string;
+    const parsed = JSON.parse(out) as { slots: { start: string }[] };
+    // The toolpack default (15), not the 5 the model asked for.
+    expect(parsed.slots.map((s) => localHM(s.start))).toEqual([
+      "14:00",
+      "14:15",
+      "14:30",
+      "14:45",
+      "15:00",
+    ]);
+  });
+
+  test("availability never offers granularityMinutes, and hides slotDurationMinutes when pinned", () => {
     const keysFor = (config: Record<string, unknown>) => {
       const tool = toolFor("calendar_check_availability", config, baseCtx({}));
       if (!tool) throw new Error("calendar_check_availability was not built");
@@ -992,22 +1027,26 @@ describe("google calendar toolpack — list + availability", () => {
       };
       return Object.keys(shape);
     };
-    // Pinned on both ⇒ neither arg exists, so the model cannot redefine the grid.
+    // The spacing is the operator's at every configuration, so the arg exists in none of them.
+    for (const config of [
+      { slotDurationMinutes: 60, slotGranularityMinutes: 30 },
+      { slotGranularityMinutes: 30 },
+      {},
+    ]) {
+      expect(keysFor(config)).not.toContain("granularityMinutes");
+    }
+    // Pinned length ⇒ the arg is gone, so the model cannot redefine the business rule per call.
     const pinned = keysFor({
       slotDurationMinutes: 60,
       slotGranularityMinutes: 30,
     });
     expect(pinned).not.toContain("slotDurationMinutes");
-    expect(pinned).not.toContain("granularityMinutes");
     expect(pinned).toContain("timeMin");
-    // Left open ⇒ the model still chooses per request (a clinic with variable appointment lengths).
-    const open = keysFor({});
-    expect(open).toContain("slotDurationMinutes");
-    expect(open).toContain("granularityMinutes");
-    // Mixed: only the pinned one disappears.
-    const halfPinned = keysFor({ slotGranularityMinutes: 30 });
-    expect(halfPinned).toContain("slotDurationMinutes");
-    expect(halfPinned).not.toContain("granularityMinutes");
+    // "Let the AI choose" ⇒ the arg stays and the model picks per request (a clinic whose
+    // appointments genuinely vary).
+    expect(keysFor({ slotGranularityMinutes: 30 })).toContain(
+      "slotDurationMinutes",
+    );
   });
 
   test("availability with no schedule configured ⇒ no time-of-day filter (full grid)", async () => {


### PR DESCRIPTION
## The bug

`calendar_check_availability` took `slotDurationMinutes` and `granularityMinutes` as optional args, and the resolvers let them win over the integration's config:

```ts
// src/modules/integrations/toolpacks/google-calendar.ts
return clampMinutes(override ?? config.slotGranularityMinutes, ...)
```

So whatever the model sent overrode what the operator configured. The arg description even suggested the value that causes the damage:

> Spacing between candidate start times, in minutes. Optional; defaults to the integration's setting (e.g. 15 ⇒ 09:00 and 09:15 are both offered).

## How it showed up in production

A school runs 1-hour visits on the half hour — `slotDurationMinutes: 60`, `slotGranularityMinutes: 30`. The agent offered a family:

> **14:00** · **14:15** · **14:30**

The first read was that the model had hallucinated `14:15`. It hadn't: it had sent `granularityMinutes: 15`, and the tool did exactly as told. The slot was real and bookable. A family would have shown up at 14:15 to a calendar built on one-hour blocks.

Across three runs the model sent 30 sometimes and 15 other times. That is the shape of the problem — the business rule lived somewhere the model could redefine per call, so it holds most of the time and quietly breaks the rest.

## The change

The two args are not the same kind of setting, so they do not get the same treatment.

**The spacing is the operator's, always.** `granularityMinutes` leaves the schema outright. The console has no "Let the AI choose" for spacing — only for the length — so a config *without* `slotGranularityMinutes` is an operator who never made the choice, not one who delegated it. Removing the arg only when a value happens to be pinned would leave the reported failure open for every integration created through the API: the model sends `granularityMinutes: 5` and gets a 5-minute grid over a 60-minute service.

**The length stays conditional**, via `slotDurationArgSchema` — pinned ⇒ the arg is removed, "Let the AI choose" ⇒ it stays and the model picks per request. That is the clinic case, where appointment length legitimately varies. It mirrors `calendarArgSchema`, which already does exactly this for `calendarId`, and sits next to it.

Dropping the arg from the schema is what fixes this; a description saying "don't do this" is still a request. No handler guard is needed alongside it: zod strips a residual key from an older tool definition before the body runs, which is why `calendarArgSchema` never needed one either. The regression test is what proves the strip.

The tool description stops suggesting a 15-minute grid, says the length is fixed when `preset="true"`, and tells the model to offer the returned start times exactly as they come back.

Per issue #118, the "when is this argument offered" half of the story lives in the console's operator note rather than in the model-facing `.describe()`: the model can only read that sentence in the case where it is already true, while the console — which lists args by `catalogType`, not by instance — is the audience that otherwise cannot tell why the agent never receives an argument it can see documented.

## Tests

Five regression tests, all failing against the previous behavior:

1. config pinned at 60/30, model sends `granularityMinutes: 15` → slots must be `14:00 · 14:30 · 15:00`. Before, five extra `:15` and `:45` slots came back.
2. **no** spacing configured, model sends `granularityMinutes: 5` → the runtime default (15) wins anyway. This is the case a conditional removal would have missed.
3. `granularityMinutes` is absent from the schema at every configuration; `slotDurationMinutes` is absent only when pinned.
4. every argument a conditional schema can remove carries an operator note.
5. the #118 tautology check now asks its question of **every** argument rather than of `calendarId` — the second conditional schema arrived carrying the same sentence on a different argument, and a test naming one argument would have let it through.

## Compatibility

- An integration that pinned a **spacing** is unaffected in practice: the model's override was never the operator's intent, and the pinned value is what applies now.
- An integration that pinned a **length** stops honoring a model-sent override. Switching the console's "Appointment length" to "Let the AI choose" restores per-request choice. Worth a line in the release notes.
