### PR TITLE
Ask one agent whether a control command is active, not two

### DIFF
--- a/src/modules/chatwoot/normalize.ts
+++ b/src/modules/chatwoot/normalize.ts
@@ -88,6 +88,10 @@ export function normalizeChatwootEvent(
   const contactInbox =
     conv && isRecord(conv.contact_inbox) ? conv.contact_inbox : null;
 
+  // The message's own inbox object (Message#webhook_data → inbox: {id, name}); conversation events
+  // do not carry it. Read for both halves: the name, and the id when the conversation scalar is gone.
+  const inboxObj = isMessage && isRecord(payload.inbox) ? payload.inbox : null;
+
   const normalized: NormalizedChatwootEvent = {
     event,
     conversationId: conv ? num(conv.id) : null,
@@ -96,7 +100,13 @@ export function normalizeChatwootEvent(
       : conv
         ? num(conv.contact_inbox_id)
         : null,
-    inboxId: conv ? num(conv.inbox_id) : null,
+    // `conversation.inbox_id` first, then the message's own top-level `inbox` object. They name the
+    // same inbox and the fork sends both, but only the second survives a payload that carries the
+    // message without the conversation's scalar — and an inbox the payload named at either spot is
+    // an answer, so nothing downstream should go looking for an older one (issue #270).
+    inboxId:
+      (conv ? num(conv.inbox_id) : null) ??
+      (inboxObj ? num(inboxObj.id) : null),
     status: conv ? str(conv.status) : null,
     // NOTE: No meta ⇒ undefined ("said nothing", the mirror preserves); meta without an assignee ⇒
     // explicit null (a real unassign). Mirrors the attrs() sentinel above.
@@ -178,8 +188,6 @@ export function normalizeChatwootEvent(
     ? attrs(kanbanTask.custom_attributes)
     : undefined;
   if (taskAttrs) normalized.kanbanAttributes = taskAttrs;
-  // Inbox name only ships on message events (Message#webhook_data → inbox: {id, name}).
-  const inboxObj = isMessage && isRecord(payload.inbox) ? payload.inbox : null;
   normalized.inboxName = inboxObj ? str(inboxObj.name) : null;
   // `channel` (channel_type) is exposed by EventDataPresenter on conversation events.
   normalized.channel = conv ? str(conv.channel) : null;

--- a/src/modules/chatwoot/normalize.ts
+++ b/src/modules/chatwoot/normalize.ts
@@ -88,7 +88,7 @@ export function normalizeChatwootEvent(
   const contactInbox =
     conv && isRecord(conv.contact_inbox) ? conv.contact_inbox : null;
 
-  // The message's own inbox object (Message#webhook_data → inbox: {id, name}); conversation events
+  // NOTE: The message's own inbox object (Message#webhook_data → inbox: {id, name}); conversation events
   // do not carry it. Read for both halves: the name, and the id when the conversation scalar is gone.
   const inboxObj = isMessage && isRecord(payload.inbox) ? payload.inbox : null;
 
@@ -100,7 +100,7 @@ export function normalizeChatwootEvent(
       : conv
         ? num(conv.contact_inbox_id)
         : null,
-    // `conversation.inbox_id` first, then the message's own top-level `inbox` object. They name the
+    // NOTE: `conversation.inbox_id` first, then the message's own top-level `inbox` object. They name the
     // same inbox and the fork sends both, but only the second survives a payload that carries the
     // message without the conversation's scalar — and an inbox the payload named at either spot is
     // an answer, so nothing downstream should go looking for an older one (issue #270).

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2630,20 +2630,28 @@ export async function processChatwootDelivery(
   //
   // The payload stays PRIMARY, so an ordinary delivery is answered by exactly the query it always
   // was and pays for nothing extra. The stored row is consulted only when the payload names no
-  // agent at all AND a command was actually typed, which is the miss path that used to dead-end.
+  // INBOX at all AND a command was actually typed, which is the miss path that used to dead-end.
   // The fallback can only ever turn a dropped command into an honoured one; it can never make an
   // active command inactive, so no delivery that works today changes.
-  const commandMode =
-    command === null
-      ? null
-      : rt !== null
-        ? rt.mode
-        : await conversationAgentMode(
-            params.tenantId,
-            params.instanceId,
-            n.conversationId,
-            base,
-          );
+  let commandMode: string | null = null;
+  if (command !== null) {
+    if (rt !== null) {
+      commandMode = rt.mode;
+    } else if (n.inboxId == null) {
+      // ONLY when the payload named no inbox at all. An inbox it DID name that resolves to no agent
+      // is an answer, not a gap: falling back there would decide the command against whatever inbox
+      // the conversation pointed at BEFORE this event, and the mirror is about to move it to the one
+      // that just arrived. The command would then be active for an agent the delivery never reached,
+      // the route check would find no persona to match, and it would be consumed without running and
+      // without an acknowledgement — a worse silence than the one this fixes.
+      commandMode = await conversationAgentMode(
+        params.tenantId,
+        params.instanceId,
+        n.conversationId,
+        base,
+      );
+    }
+  }
   const commandActive = command !== null && commandMode === "test";
   // A command that will not run is otherwise indistinguishable from ordinary customer text, in the
   // logs and in the conversation alike — which is what left issue #270 undiagnosable from the

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -3025,8 +3025,11 @@ export async function processChatwootDelivery(
       // empty audio/image message. For a production agent this already ran before the gate; the call
       // is idempotent, so here it only does real work for a test-mode agent that just passed the gate
       // (activated with /teste). Best-effort — a failure leaves a "please send text" marker.
-      // `rt` is null only when no agent is bound to this inbox, and then no STT/vision config
-      // resolves and no line is written — so the nulls never reach a row.
+      // `rt` is null when nothing on the payload's inbox names an agent — either none is bound, or
+      // the payload named no inbox at all — and then no STT/vision config resolves and no line is
+      // written, so the nulls never reach a row. The second half of that reaches here only through
+      // a control command that the conversation's own agent made active (issue #270); the state
+      // itself is not new, since `act` never depended on `rt`.
       await runEagerMedia(params.tenantId, params.instanceId, n, base, {
         conversationId: mirror.conversationRowId,
         agentId: rt?.agentId ?? null,

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -213,19 +213,27 @@ async function inboxAgentRuntime(
   });
 }
 
-// The mode of the agent bound to a conversation's OWN (mirrored) inbox, or null when nothing
-// resolves. Deliberately keyed by the conversation rather than by a payload inbox id: it is the
-// reading `maybeConsumeCommandOrGate` already uses for the test-mode gate, and it exists so the
-// question "is this command active?" and the gate that silences the conversation cannot be answered
-// by two different rows (issue #270). Only ever called on the path where the payload resolved
-// nothing, so the common delivery pays for no extra query.
+// The mode of the agent bound to a conversation's OWN (mirrored) inbox — but ONLY when that agent is
+// also the persona whose route this delivery arrived on. Deliberately keyed by the conversation
+// rather than by a payload inbox id: it is the reading `maybeConsumeCommandOrGate` already uses for
+// the test-mode gate, and it exists so the question "is this command active?" and the gate that
+// silences the conversation cannot be answered by two different rows (issue #270).
+//
+// The route check is what keeps that safe. A payload that names no inbox leaves the mirrored row as
+// the only thing that can name an agent, and a mirrored row can be out of date — so without it a
+// command could go active for a persona this delivery never reached, fail the route fence
+// downstream, and be consumed without running and without an acknowledgement. Requiring the match
+// means the fallback either applies to this exact route or does not apply at all, which is the
+// behaviour that was there before it. Only ever called on the path where the payload named no inbox,
+// so the common delivery pays for no extra query.
 async function conversationAgentMode(
   tenantId: bigint,
   instanceId: bigint,
   chatwootConversationId: number | null,
+  agentBotId: number | null,
   base: PrismaClient,
 ): Promise<string | null> {
-  if (chatwootConversationId == null) return null;
+  if (chatwootConversationId == null || agentBotId == null) return null;
   return runScopedOn(base, sysCtx(tenantId), async (db) => {
     const conv = await db.conversation.findUnique({
       where: {
@@ -243,6 +251,17 @@ async function conversationAgentMode(
       select: { agentId: true },
     });
     if (!inbox?.agentId) return null;
+    const bot = await db.chatwootAgentBot.findUnique({
+      where: {
+        tenantId_chatwootInstanceId_agentId: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          agentId: inbox.agentId,
+        },
+      },
+      select: { chatwootAgentBotId: true },
+    });
+    if (bot?.chatwootAgentBotId !== agentBotId) return null;
     const agent = await db.agent.findUnique({
       where: { id: inbox.agentId },
       select: { mode: true },
@@ -2648,6 +2667,7 @@ export async function processChatwootDelivery(
         params.tenantId,
         params.instanceId,
         n.conversationId,
+        params.agentBotId,
         base,
       );
     }

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -213,27 +213,28 @@ async function inboxAgentRuntime(
   });
 }
 
-// The mode of the agent bound to a conversation's OWN (mirrored) inbox — but ONLY when that agent is
-// also the persona whose route this delivery arrived on. Deliberately keyed by the conversation
-// rather than by a payload inbox id: it is the reading `maybeConsumeCommandOrGate` already uses for
-// the test-mode gate, and it exists so the question "is this command active?" and the gate that
-// silences the conversation cannot be answered by two different rows (issue #270).
+// The mode of the agent bound to a conversation's OWN (mirrored) inbox, or null when nothing
+// resolves. Deliberately keyed by the conversation rather than by a payload inbox id: it is the
+// reading `maybeConsumeCommandOrGate` already uses for the test-mode gate, and it exists so the
+// question "is this command active?" and the gate that silences the conversation cannot be answered
+// by two different rows (issue #270).
 //
-// The route check is what keeps that safe. A payload that names no inbox leaves the mirrored row as
-// the only thing that can name an agent, and a mirrored row can be out of date — so without it a
-// command could go active for a persona this delivery never reached, fail the route fence
-// downstream, and be consumed without running and without an acknowledgement. Requiring the match
-// means the fallback either applies to this exact route or does not apply at all, which is the
-// behaviour that was there before it. Only ever called on the path where the payload named no inbox,
-// so the common delivery pays for no extra query.
+// It answers about the AGENT and says nothing about the route, which is the split that keeps this
+// safe. Chatwoot fans one command out to the inbox's persona and to the conversation's assigned bot,
+// so more than one delivery can reach here with the same command; `commandBelongsHere` downstream is
+// the single fence that picks which one runs it and consumes the rest. Answering the route question
+// here too would give the losing delivery `commandActive === false`, which does not defer to that
+// fence — it walks past it and hands the agent "/teste" as ordinary customer text.
+//
+// Only ever called on the path where the payload named no inbox, so the common delivery pays for no
+// extra query.
 async function conversationAgentMode(
   tenantId: bigint,
   instanceId: bigint,
   chatwootConversationId: number | null,
-  agentBotId: number | null,
   base: PrismaClient,
 ): Promise<string | null> {
-  if (chatwootConversationId == null || agentBotId == null) return null;
+  if (chatwootConversationId == null) return null;
   return runScopedOn(base, sysCtx(tenantId), async (db) => {
     const conv = await db.conversation.findUnique({
       where: {
@@ -251,17 +252,6 @@ async function conversationAgentMode(
       select: { agentId: true },
     });
     if (!inbox?.agentId) return null;
-    const bot = await db.chatwootAgentBot.findUnique({
-      where: {
-        tenantId_chatwootInstanceId_agentId: {
-          tenantId,
-          chatwootInstanceId: instanceId,
-          agentId: inbox.agentId,
-        },
-      },
-      select: { chatwootAgentBotId: true },
-    });
-    if (bot?.chatwootAgentBotId !== agentBotId) return null;
     const agent = await db.agent.findUnique({
       where: { id: inbox.agentId },
       select: { mode: true },
@@ -2640,7 +2630,7 @@ export async function processChatwootDelivery(
         )
       : null;
   const command = isNewIncoming ? controlCommand(n) : null;
-  // A control command is "active" only for a test-mode agent, and issue #270 is what happens when
+  // NOTE: A control command is "active" only for a test-mode agent, and issue #270 is what happens when
   // that question is answered by a different row than the one that acts on it: `rt` resolves the
   // agent from the inbox id the PAYLOAD carries, while the test-mode gate downstream resolves it
   // from the inbox id STORED on the mirrored conversation. Disagree, and the operator sends /teste
@@ -2657,7 +2647,7 @@ export async function processChatwootDelivery(
     if (rt !== null) {
       commandMode = rt.mode;
     } else if (n.inboxId == null) {
-      // ONLY when the payload named no inbox at all. An inbox it DID name that resolves to no agent
+      // NOTE: ONLY when the payload named no inbox at all. An inbox it DID name that resolves to no agent
       // is an answer, not a gap: falling back there would decide the command against whatever inbox
       // the conversation pointed at BEFORE this event, and the mirror is about to move it to the one
       // that just arrived. The command would then be active for an agent the delivery never reached,
@@ -2667,13 +2657,12 @@ export async function processChatwootDelivery(
         params.tenantId,
         params.instanceId,
         n.conversationId,
-        params.agentBotId,
         base,
       );
     }
   }
   const commandActive = command !== null && commandMode === "test";
-  // A command that will not run is otherwise indistinguishable from ordinary customer text, in the
+  // NOTE: A command that will not run is otherwise indistinguishable from ordinary customer text, in the
   // logs and in the conversation alike — which is what left issue #270 undiagnosable from the
   // outside. This is the only place that knows all three values the diagnosis needs, and past it
   // the command is simply gone: `isTeste`/`isReset` are both false, so every later line describes a

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -213,6 +213,44 @@ async function inboxAgentRuntime(
   });
 }
 
+// The mode of the agent bound to a conversation's OWN (mirrored) inbox, or null when nothing
+// resolves. Deliberately keyed by the conversation rather than by a payload inbox id: it is the
+// reading `maybeConsumeCommandOrGate` already uses for the test-mode gate, and it exists so the
+// question "is this command active?" and the gate that silences the conversation cannot be answered
+// by two different rows (issue #270). Only ever called on the path where the payload resolved
+// nothing, so the common delivery pays for no extra query.
+async function conversationAgentMode(
+  tenantId: bigint,
+  instanceId: bigint,
+  chatwootConversationId: number | null,
+  base: PrismaClient,
+): Promise<string | null> {
+  if (chatwootConversationId == null) return null;
+  return runScopedOn(base, sysCtx(tenantId), async (db) => {
+    const conv = await db.conversation.findUnique({
+      where: {
+        tenantId_chatwootInstanceId_chatwootConversationId: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootConversationId,
+        },
+      },
+      select: { inboxId: true },
+    });
+    if (conv?.inboxId == null) return null;
+    const inbox = await db.inbox.findUnique({
+      where: { id: conv.inboxId },
+      select: { agentId: true },
+    });
+    if (!inbox?.agentId) return null;
+    const agent = await db.agent.findUnique({
+      where: { id: inbox.agentId },
+      select: { mode: true },
+    });
+    return agent?.mode ?? null;
+  });
+}
+
 interface ResolvedChatwootBot {
   instanceId: bigint;
   tenantId: bigint;
@@ -2583,7 +2621,44 @@ export async function processChatwootDelivery(
         )
       : null;
   const command = isNewIncoming ? controlCommand(n) : null;
-  const commandActive = command !== null && rt?.mode === "test";
+  // A control command is "active" only for a test-mode agent, and issue #270 is what happens when
+  // that question is answered by a different row than the one that acts on it: `rt` resolves the
+  // agent from the inbox id the PAYLOAD carries, while the test-mode gate downstream resolves it
+  // from the inbox id STORED on the mirrored conversation. Disagree, and the operator sends /teste
+  // and gets back the private note asking them to send /teste — a dead end with no way out from
+  // inside the conversation, and nothing anywhere naming the command as the thing that was dropped.
+  //
+  // The payload stays PRIMARY, so an ordinary delivery is answered by exactly the query it always
+  // was and pays for nothing extra. The stored row is consulted only when the payload names no
+  // agent at all AND a command was actually typed, which is the miss path that used to dead-end.
+  // The fallback can only ever turn a dropped command into an honoured one; it can never make an
+  // active command inactive, so no delivery that works today changes.
+  const commandMode =
+    command === null
+      ? null
+      : rt !== null
+        ? rt.mode
+        : await conversationAgentMode(
+            params.tenantId,
+            params.instanceId,
+            n.conversationId,
+            base,
+          );
+  const commandActive = command !== null && commandMode === "test";
+  // A command that will not run is otherwise indistinguishable from ordinary customer text, in the
+  // logs and in the conversation alike — which is what left issue #270 undiagnosable from the
+  // outside. This is the only place that knows all three values the diagnosis needs, and past it
+  // the command is simply gone: `isTeste`/`isReset` are both false, so every later line describes a
+  // plain message. `mode=unresolved` means no inbox on either reading named an agent at all.
+  if (command !== null && !commandActive) {
+    logger.info(
+      "chatwoot: /%s not run (conv=%s) — control commands apply only to a test-mode agent (agent mode=%s, route bot=%s)",
+      command,
+      n.conversationId === null ? "?" : String(n.conversationId),
+      commandMode ?? "unresolved",
+      params.agentBotId === null ? "unknown" : String(params.agentBotId),
+    );
+  }
 
   // Mirror metadata (idempotent, monotonic, per-conversation locked) BEFORE the gate so the
   // runtime reads fresh state. Unconditional: applies to every event, not just actionable ones.

--- a/tests/modules/chatwoot-command-active-e2e.test.ts
+++ b/tests/modules/chatwoot-command-active-e2e.test.ts
@@ -406,4 +406,32 @@ describe.skipIf(!dbUp)("control commands: one reading of the agent", () => {
     expect(after.length).toBeGreaterThan(0);
     expect(after.every((p) => !p.content.includes("Envie /teste"))).toBe(true);
   });
+
+  test("a payload naming an UNKNOWN inbox does not borrow the conversation's previous agent", async () => {
+    // The conversation is mirrored on the bound entry inbox, so the fallback would find a test-mode
+    // agent — but the delivery arrived on an inbox that names no agent, and the mirror is about to
+    // move the conversation there. Deciding the command against the old inbox would activate it for
+    // an agent this delivery never reached, and the route check would then eat it without a word.
+    const id = await seedConv(6008, entryInboxId);
+    const info = spyOn(logger, "info");
+    let lines: unknown[][] = [];
+    try {
+      await deliver(6008, 999, "/teste", 9);
+      lines = info.mock.calls.map((c) => [...c]);
+    } finally {
+      info.mockRestore();
+    }
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    expect(row?.testActivatedAt).toBeNull();
+    const line = lines.find((c) => String(c[0]).includes("not run"));
+    expect(line?.slice(1)).toEqual([
+      "teste",
+      "6008",
+      "unresolved",
+      String(BOT),
+    ]);
+  });
 });

--- a/tests/modules/chatwoot-command-active-e2e.test.ts
+++ b/tests/modules/chatwoot-command-active-e2e.test.ts
@@ -457,12 +457,13 @@ describe.skipIf(!dbUp)("control commands: one reading of the agent", () => {
     ).toBeGreaterThan(0);
   });
 
-  test("the fallback does not fire on a route the conversation's own agent does not own", async () => {
+  test("a sparse command on the losing route defers to the fence, it does not become customer text", async () => {
     // The payload names no inbox, so the mirrored conversation is the only thing that can name an
-    // agent — and it names the entry inbox's persona (BOT). This delivery arrived on the OTHER
-    // persona's route (BOT+1), so the row does not describe where it landed. Firing there would make
-    // the command active for a persona this delivery never reached, and the route fence downstream
-    // would then eat it without running it and without a word. Not applying is what main did.
+    // agent — and Chatwoot fans one command out to the inbox's persona AND to the conversation's
+    // assigned bot, so two deliveries arrive carrying it. This is the losing one. It must reach
+    // `commandBelongsHere` and be consumed there; deciding the route any earlier leaves it
+    // `commandActive === false`, which walks past that fence and hands the agent "/teste" as
+    // ordinary customer text.
     const id = await seedConv(6010, entryInboxId);
     const info = spyOn(logger, "info");
     let lines: unknown[][] = [];
@@ -477,12 +478,10 @@ describe.skipIf(!dbUp)("control commands: one reading of the agent", () => {
       select: { testActivatedAt: true },
     });
     expect(row?.testActivatedAt).toBeNull();
-    const line = lines.find((c) => String(c[0]).includes("not run"));
-    expect(line?.slice(1)).toEqual([
-      "teste",
-      "6010",
-      "unresolved",
-      String(BOT + 1),
-    ]);
+    expect(posted.filter((p) => p.conversationId === 6010)).toEqual([]);
+    expect(
+      lines.some((c) => String(c[0]).includes("command not for this route")),
+    ).toBe(true);
+    expect(lines.some((c) => String(c[0]).includes("not run"))).toBe(false);
   });
 });

--- a/tests/modules/chatwoot-command-active-e2e.test.ts
+++ b/tests/modules/chatwoot-command-active-e2e.test.ts
@@ -105,6 +105,7 @@ async function deliver(
   content: string,
   seq: number,
   botId = BOT,
+  topLevelInboxId?: number,
 ) {
   const n = normalizeChatwootEvent({
     event: "message_created",
@@ -112,6 +113,9 @@ async function deliver(
     content,
     message_type: "incoming",
     private: false,
+    ...(topLevelInboxId === undefined
+      ? {}
+      : { inbox: { id: topLevelInboxId, name: "Top" } }),
     conversation: {
       id: convId,
       ...(chatwootInboxId === null ? {} : { inbox_id: chatwootInboxId }),
@@ -433,5 +437,23 @@ describe.skipIf(!dbUp)("control commands: one reading of the agent", () => {
       "unresolved",
       String(BOT),
     ]);
+  });
+
+  test("the message's own top-level inbox is honoured before the mirrored conversation", async () => {
+    // No `conversation.inbox_id`, but the message names its inbox at the top level. That is an
+    // answer, so the command must be decided against THAT inbox — never against whatever inbox the
+    // conversation happened to point at. Here the two disagree on purpose: the conversation sits on
+    // the redirect entry inbox (persona BOT) and the message names the plain one (persona BOT+1),
+    // so borrowing the conversation's agent would run the command on the wrong persona's route.
+    const id = await seedConv(6009, entryInboxId);
+    await deliver(6009, null, "/teste", 10, BOT + 1, PLAIN);
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    expect(row?.testActivatedAt).not.toBeNull();
+    expect(
+      posted.filter((p) => p.conversationId === 6009 && !p.private).length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/tests/modules/chatwoot-command-active-e2e.test.ts
+++ b/tests/modules/chatwoot-command-active-e2e.test.ts
@@ -1,0 +1,409 @@
+// A control command (`/teste`, `/reset`) is only honoured when the agent it lands on is in `test`
+// mode, and issue #270 is what happens when that question gets asked twice of two different rows.
+// `commandActive` resolves the agent from the inbox id IN THE PAYLOAD; the test-mode gate that
+// silences the conversation resolves it from the inbox id STORED on the mirrored conversation. When
+// those disagree the operator sends `/teste` and gets back the private note telling them to send
+// `/teste` — a dead end with no way out from inside the conversation.
+//
+// The reported diagnosis (the channel-redirect gate eating the command) is REFUTED here, on purpose
+// and by a passing test: with `channelRedirect.enabled` on the entry inbox, `/teste` activates and
+// acks exactly as it does without it. The redirect gate sits after the test-mode gate and is never
+// reached with a live command in hand.
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import logger from "@/api/lib/logger";
+import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
+import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const BASE_URL = "https://203.0.113.22:9";
+const ENTRY = 771;
+const WIDGET = 772;
+const PLAIN = 773;
+const BOT = 77;
+
+let tenantId = 0n;
+let instanceId = 0n;
+let entryInboxId = 0n;
+let plainInboxId = 0n;
+
+const posted: { conversationId: number; content: string; private: boolean }[] =
+  [];
+let realFetch: typeof globalThis.fetch;
+
+function installDouble(): void {
+  realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (b: unknown, s = 200) =>
+      new Response(JSON.stringify(b), {
+        status: s,
+        headers: { "content-type": "application/json" },
+      });
+    const m = url.match(/\/conversations\/(\d+)\/messages$/);
+    if (m && (init?.method ?? "GET") === "GET") return json({ payload: [] });
+    if (m && init?.method === "POST") {
+      const body = JSON.parse(String(init.body ?? "{}"));
+      posted.push({
+        conversationId: Number(m[1]),
+        content: String(body.content ?? ""),
+        private: body.private === true,
+      });
+      return json({ id: 1 });
+    }
+    if (/\/contacts\/\d+$/.test(url))
+      return json({ payload: { id: 1, identifier: null } });
+    return json({}, 404);
+  }) as typeof globalThis.fetch;
+}
+
+async function seedConv(convId: number, inbox: bigint): Promise<bigint> {
+  const row = await suDb.conversation.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      inboxId: inbox,
+      chatwootConversationId: convId,
+      status: "pending",
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      lastEventAt: new Date(Date.now() - 120_000),
+      lastInboundAt: new Date(Date.now() - 180_000),
+    },
+    select: { id: true },
+  });
+  return row.id;
+}
+
+async function deliver(
+  convId: number,
+  chatwootInboxId: number | null,
+  content: string,
+  seq: number,
+  botId = BOT,
+) {
+  const n = normalizeChatwootEvent({
+    event: "message_created",
+    id: 9000 + seq,
+    content,
+    message_type: "incoming",
+    private: false,
+    conversation: {
+      id: convId,
+      ...(chatwootInboxId === null ? {} : { inbox_id: chatwootInboxId }),
+      status: "pending",
+      contact_inbox: { id: 90_000 + convId },
+      meta: {
+        assignee_type: null,
+        assignee: null,
+        sender: { id: 801, name: "Lead", phone_number: "+5511977770000" },
+      },
+      channel: "Channel::Whatsapp",
+      last_activity_at: Math.floor(Date.now() / 1000),
+    },
+  });
+  if (!n) throw new Error("fixture");
+  const d = await suDb.chatwootWebhookDelivery.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      deliveryId: `r270-${process.pid}-${convId}-${seq}`,
+      event: "message_created",
+      status: "PENDING",
+    },
+    select: { id: true },
+  });
+  await processChatwootDelivery({
+    tenantId,
+    instanceId,
+    deliveryRowId: d.id,
+    agentBotId: botId,
+    normalized: n,
+    base: appDb,
+  });
+}
+
+describe.skipIf(!dbUp)("control commands: one reading of the agent", () => {
+  beforeAll(async () => {
+    installDouble();
+    const t = await suDb.tenant.create({
+      data: { name: "R270", slug: `r270-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 12,
+      baseUrl: BASE_URL,
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const key = await suDb.vaultEntry.create({
+      data: { tenantId, name: "k", secret: encryptJson("sk-test") },
+      select: { id: true },
+    });
+    const base = {
+      tenantId,
+      systemPrompt: "p",
+      mode: "test",
+      modelConfig: {
+        provider: "openai",
+        model: "gpt-4o-mini",
+        credentialRef: `vault:${key.id}`,
+      },
+    };
+    const redirectAgent = await suDb.agent.create({
+      data: {
+        ...base,
+        name: "Redirect ON",
+        settings: {
+          debounce: { enabled: false },
+          split: { enabled: false },
+          channelRedirect: {
+            enabled: true,
+            entryInboxId: ENTRY,
+            widgetInboxId: WIDGET,
+            redirectMessage: "Fale comigo aqui: {link}",
+          },
+        },
+      },
+      select: { id: true },
+    });
+    const plainAgent = await suDb.agent.create({
+      data: {
+        ...base,
+        name: "Redirect OFF",
+        settings: { debounce: { enabled: false }, split: { enabled: false } },
+      },
+      select: { id: true },
+    });
+    for (const [agentId, botId] of [
+      [redirectAgent.id, BOT],
+      [plainAgent.id, BOT + 1],
+    ] as const) {
+      await suDb.chatwootAgentBot.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          agentId,
+          chatwootAgentBotId: botId,
+          accessToken: encryptJson("BOT-TOKEN"),
+          webhookSecret: encryptJson("S"),
+          webhookRouteTokenHash: `h-${process.pid}-${agentId}`,
+          name: "bot",
+        },
+      });
+    }
+    const e = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: ENTRY,
+        name: "Entrada",
+        agentId: redirectAgent.id,
+        channelType: "Channel::Whatsapp",
+      },
+      select: { id: true },
+    });
+    entryInboxId = e.id;
+    const p = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: PLAIN,
+        name: "Simples",
+        agentId: plainAgent.id,
+        channelType: "Channel::Whatsapp",
+      },
+      select: { id: true },
+    });
+    plainInboxId = p.id;
+  });
+
+  afterAll(async () => {
+    globalThis.fetch = realFetch;
+    if (tenantId) {
+      for (const table of [
+        "chatwoot_webhook_deliveries",
+        "conversations",
+        "inboxes",
+        "chatwoot_agent_bots",
+        "agents",
+        "vault_entries",
+        "chatwoot_instances",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = $1`,
+          tenantId,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = $1`,
+        tenantId,
+      );
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  test("/teste activates on a plain bound inbox (control)", async () => {
+    const id = await seedConv(6001, plainInboxId);
+    await deliver(6001, PLAIN, "/teste", 1, BOT + 1);
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    expect(
+      posted.filter((p) => p.conversationId === 6001 && !p.private).length,
+    ).toBeGreaterThan(0);
+    expect(row?.testActivatedAt).not.toBeNull();
+  });
+
+  test("an inbox bound to no agent still says the command was dropped, and why", async () => {
+    const orphan = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: 774,
+        name: "Órfã",
+        channelType: "Channel::Whatsapp",
+      },
+      select: { id: true },
+    });
+    const id = await seedConv(6003, orphan.id);
+    // NOTE: `mockRestore` also clears `mock.calls` in Bun, so the lines are copied out first.
+    const info = spyOn(logger, "info");
+    let lines: unknown[][] = [];
+    try {
+      await deliver(6003, 774, "/teste", 3);
+      lines = info.mock.calls.map((c) => [...c]);
+    } finally {
+      info.mockRestore();
+    }
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    // No agent on either reading, so the command genuinely cannot run — but it must not vanish. The
+    // three values issue #270 asked for (the command, why it was inactive, the route it arrived on)
+    // are the whole point of the line: without them this delivery is indistinguishable from a
+    // customer who happened to type "/teste".
+    expect(row?.testActivatedAt).toBeNull();
+    expect(posted.filter((p) => p.conversationId === 6003)).toEqual([]);
+    const line = lines.find((c) => String(c[0]).includes("not run"));
+    expect(line).toBeDefined();
+    expect(String(line?.[0])).toContain("agent mode=%s");
+    expect(line?.slice(1)).toEqual([
+      "teste",
+      "6003",
+      "unresolved",
+      String(BOT),
+    ]);
+  });
+
+  test("a delivery on another persona's bot route leaves the command to the inbox's own persona", async () => {
+    const id = await seedConv(6004, entryInboxId);
+    // A entrega chega na rota do bot da OUTRA persona, como o Chatwoot faz quando a conversa está
+    // atribuída a ele: agentBotId != o bot da inbox.
+    await deliver(6004, ENTRY, "/teste", 4, BOT + 1);
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    expect(row?.testActivatedAt).toBeNull();
+    expect(posted.filter((p) => p.conversationId === 6004)).toEqual([]);
+  });
+
+  test("/teste still activates after the redirect link was already sent", async () => {
+    const id = await seedConv(6005, entryInboxId);
+    await suDb.conversation.update({
+      where: { id },
+      data: { redirectSentAt: new Date(Date.now() - 60_000), redirectCount: 1 },
+    });
+    await deliver(6005, ENTRY, "/teste", 5);
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    expect(row?.testActivatedAt).not.toBeNull();
+    expect(
+      posted.filter((p) => p.conversationId === 6005 && !p.private).length,
+    ).toBeGreaterThan(0);
+  });
+
+  test("/teste activates on a conversation assigned to another AgentBot (ack goes private)", async () => {
+    const id = await seedConv(6006, entryInboxId);
+    await suDb.conversation.update({
+      where: { id },
+      data: { assigneeType: "AgentBot", assigneeId: BOT + 1 },
+    });
+    await deliver(6006, ENTRY, "/teste", 6);
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    expect(row?.testActivatedAt).not.toBeNull();
+    expect(
+      posted.filter((p) => p.conversationId === 6006).every((p) => p.private),
+    ).toBe(true);
+  });
+
+  test("REFUTES #270: /teste activates on a redirect entry inbox with channelRedirect on", async () => {
+    const id = await seedConv(6002, entryInboxId);
+    await deliver(6002, ENTRY, "/teste", 2);
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true, redirectSentAt: true },
+    });
+    expect(
+      posted.filter((p) => p.conversationId === 6002 && !p.private).length,
+    ).toBeGreaterThan(0);
+    expect(row?.testActivatedAt).not.toBeNull();
+  });
+
+  test("REGRESSION #270: /teste is honoured when only the mirrored conversation can name the agent", async () => {
+    const id = await seedConv(6007, entryInboxId);
+    // First message WITH inbox_id: mirrors the conversation, so the row can name the agent.
+    await deliver(6007, ENTRY, "oi", 7);
+    // The /teste arrives with no inbox_id: `rt` resolves from n.inboxId and finds nothing, while the
+    // test-mode gate resolves from conv.inboxId and finds the test agent.
+    await deliver(6007, null, "/teste", 8);
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    // The payload could not name the agent, so the ONLY row that can is the mirrored conversation —
+    // the same row the test-mode gate reads. Before the fix the two disagreed and the operator got
+    // the "send /teste" private note back in reply to a /teste.
+    expect(row?.testActivatedAt).not.toBeNull();
+    // The private "send /teste" note from the pre-activation "oi" is legitimate and stays; what must
+    // NOT happen is the command itself being answered with that same instruction. The public ack is
+    // the positive signal that the command ran.
+    const after = posted.filter((p) => p.conversationId === 6007).slice(1);
+    expect(after.length).toBeGreaterThan(0);
+    expect(after.every((p) => !p.content.includes("Envie /teste"))).toBe(true);
+  });
+});

--- a/tests/modules/chatwoot-command-active-e2e.test.ts
+++ b/tests/modules/chatwoot-command-active-e2e.test.ts
@@ -456,4 +456,33 @@ describe.skipIf(!dbUp)("control commands: one reading of the agent", () => {
       posted.filter((p) => p.conversationId === 6009 && !p.private).length,
     ).toBeGreaterThan(0);
   });
+
+  test("the fallback does not fire on a route the conversation's own agent does not own", async () => {
+    // The payload names no inbox, so the mirrored conversation is the only thing that can name an
+    // agent — and it names the entry inbox's persona (BOT). This delivery arrived on the OTHER
+    // persona's route (BOT+1), so the row does not describe where it landed. Firing there would make
+    // the command active for a persona this delivery never reached, and the route fence downstream
+    // would then eat it without running it and without a word. Not applying is what main did.
+    const id = await seedConv(6010, entryInboxId);
+    const info = spyOn(logger, "info");
+    let lines: unknown[][] = [];
+    try {
+      await deliver(6010, null, "/teste", 11, BOT + 1);
+      lines = info.mock.calls.map((c) => [...c]);
+    } finally {
+      info.mockRestore();
+    }
+    const row = await suDb.conversation.findUnique({
+      where: { id },
+      select: { testActivatedAt: true },
+    });
+    expect(row?.testActivatedAt).toBeNull();
+    const line = lines.find((c) => String(c[0]).includes("not run"));
+    expect(line?.slice(1)).toEqual([
+      "teste",
+      "6010",
+      "unresolved",
+      String(BOT + 1),
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes #270.

Whether a control command (`/teste`, `/reset`) is *active* was asked twice, of two different rows.
`commandActive` resolved the agent from the inbox id **in the payload** (`inboxAgentRuntime`, before
the mirror); the test-mode gate that silences the conversation resolves it from the inbox id
**stored on the mirrored conversation** (`maybeConsumeCommandOrGate`, after the mirror). Agree, and
everything works. Disagree, and `/teste` degrades to ordinary customer text while the gate still
fires, so the operator sends `/teste` and gets back the private note asking them to send `/teste`,
with no way out from inside the conversation.

Two changes close that, and a third makes the next occurrence self-diagnosing.

**`normalize` now reads the inbox id the message carries at the top level.** It already read
`payload.inbox` for the *name* and threw the id away, so a message whose conversation object has no
`inbox_id` read as naming no inbox at all. An inbox the payload named at either spot is an answer,
and nothing downstream should go looking for an older one.

**The mirrored conversation answers only when the payload named no inbox.** The payload stays
primary, so an ordinary delivery is answered by exactly the query it always was and pays for nothing
extra. An inbox the payload *did* name that resolves to no agent is an answer too, not a gap: falling
back there would decide the command against whatever inbox the conversation pointed at before the
event, while the mirror is about to move it to the one that just arrived.

`conversationAgentMode` answers about the **agent** and says nothing about the route, and that split
is load-bearing. Chatwoot fans one command out to the inbox's persona and to the conversation's
assigned bot, so more than one delivery arrives carrying it; `commandBelongsHere` downstream is the
single fence that picks which one runs it and consumes the rest. Answering the route question here
too gives the losing delivery `commandActive === false`, which does not defer to that fence: it walks
past it and hands the agent `/teste` as ordinary customer text.

**A command that does not run now says so.** Past that point the command is simply gone: `isTeste`
and `isReset` are both false and every later line describes a plain message. So the one place that
knows all three values a diagnosis needs writes them down: the command, the mode that made it
inactive (`unresolved` when no inbox on either reading named an agent), and the bot the delivery
routed to.

## What the report got right, and what does not hold

The issue named `channelRedirect` as the suspected cause. It does not hold, and the test file says so
with a passing test rather than a comment: with `channelRedirect.enabled` on the entry inbox, `/teste`
activates and acks exactly as it does with the feature off. The redirect gate sits after the test-mode
gate and is never reached while a live command is in hand. The symptom the report described is real;
the mechanism is the two readings above, and it is not specific to the redirect.

Two other configurations consume `/teste` silently and are deliberately left alone, because neither is
this bug: an inbox bound to no agent has nothing that could answer (it now says so, and is #318), and
a delivery on another persona's route is *meant* to defer to the inbox's own persona, which receives
its own delivery.

The line this PR adds is a process log, which is not what an operator reads. Making a dropped command
visible in the console needs a `FLOW_STAGES` entry and its i18n, which is a second deliverable rather
than a bigger version of this one: #317.

## Validation scope

**Proven by test** (`tests/modules/chatwoot-command-active-e2e.test.ts`, DB-backed, real mirror and
gates, Chatwoot double): ten configurations of `/teste` on a test-mode agent. The regression case
fails on `main` (`test_activated_at` stays null, the "send /teste" note comes back) and passes here.
The refutation is pinned as its own test. The losing fan-out route is pinned too: it must be consumed
at the fence, never answered as customer text. The diagnostic line is asserted through a `logger`
spy, including its three argument values.

**Proven by mutation**: removing the fallback, widening it back to every unresolved inbox, dropping
the top-level inbox id, and inverting the mode comparison each turn the suite red (2, 1, 1 and 10
failures). No surviving mutant.

**Not validated**: which of the silent configurations the original report hit — the delivery was not
captured, and the log line this PR adds is what would have settled it. No live Chatwoot run: the fork
sends both `conversation.inbox_id` and the top-level `inbox`, so with the normalize change the
divergence is not reachable from a normal delivery on the current fork, and the remaining paths are
defence for payload shapes that omit them. A stale mirrored `conversation.inbox_id` (an inbox move
whose webhook was lost) is the same divergence by a second route and is not reproduced here; in that
state no route matches at the fence and the command is consumed everywhere, which is the fail-closed
behaviour `commandBelongsHere` already documents, now with a log line behind it.
