### PR TITLE
Render a refusal at the input it names, instead of only in a toast

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -21,6 +21,21 @@ Added alongside the existing Button/Input/Card/Badge/Modal/Toast/Tooltip: **Sele
 
 **Loading states are skeletons, not spinners** (see CLAUDE.md → UX). `DataBoundary` is the chokepoint: its `loading` branch renders a generic row-skeleton by default, or a caller-supplied `skeleton={<…/>}` for distinctive layouts (Dashboard, Conversations list, Channels, the Agent editor); it owns the `role="status"` + sr-only `common.loading` announcement, so a bespoke skeleton is purely visual. Pages outside `DataBoundary` (admin tables, Approvals, the conversation message thread) compose `<Skeleton>` inline with their own `role="status"` wrapper. Spinners survive only for `<Button loading>` and the boot/auth/invite-token splash. Skeleton bars are `bg-bg-tertiary`, so don't nest them inside a `bg-bg-tertiary` shell (zero contrast) — drop the shell's bg and let the bars read against the card.
 
+## Where a server refusal goes
+
+The API answers a refusal as `{ error, field? }` (`src/api/lib/refusal.ts`): the sentence, already localized for the request's `Accept-Language`, and — when the refusal is about one input — the server's own name for that input, identical in every language. `field` is a column (`systemPrompt`), a key of a patch (`document`), or a dotted path into a bag the server owns (`guardrails.output.templateMessage`); it is **absent**, never null, whenever the refusal is not about one input, which is most of them.
+
+Two client pieces read it, and which one a call site wants depends on whether it is a form:
+
+- **`apiErrorMessage(e)`** (`lib/apiError.ts`) → the sentence, or `null` for a transport failure with no server behind it. For actions that are not a form (a delete, a retry, a connection test), where a toast is the answer either way.
+- **`useFieldRefusal(fields)`** (`hooks/useFieldRefusal.ts`) for a form. The form **declares** the server names it can render (`useFieldRefusal(COMPANY_FIELDS)`), passes `error={refusal.at(name)}` to each `<FormField>`, and its submit handler does `const toast = refusal.capture(error, fallback); if (toast) showToast(toast, "error")`.
+
+The rule the mechanism holds is that the two channels are **exclusive and exhaustive**: a refusal about a declared input renders at that control and raises no toast; a refusal about anything else — another screen's field, no field at all, or no server at all — is a toast. Silence is the outcome that must never happen, and a message shown at the control *and* in a toast is the noise that teaches people to dismiss toasts unread. `placeRefusal` (`lib/fieldRefusal.ts`) is that decision as a pure function, with the table in `tests/client/field-refusal.test.ts`.
+
+Declared rather than discovered, because the submit handler needs the answer *before* the next render; matched exactly rather than by prefix, so a form rendering a parent path does not claim every leaf under it. The state is per form instance: a modal over the panel that opened it has its own, and both have a `name`.
+
+Reference wiring: `pages/resources/documents/CompanyProfileCard.tsx`. The 106 remaining call sites are the sweep in issue #233.
+
 ## i18n gotchas
 
 - `t("key", "Default")` everywhere; `bun i18n:extract` auto-adds keys to `en.json` AND `pt-BR.json` (copying the English default into pt-BR — **new pt-BR keys must then be translated**). Run `bun check` (which runs the extractor) after adding strings.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -28,9 +28,13 @@ The API answers a refusal as `{ error, field? }` (`src/api/lib/refusal.ts`): the
 Two client pieces read it, and which one a call site wants depends on whether it is a form:
 
 - **`apiErrorMessage(e)`** (`lib/apiError.ts`) → the sentence, or `null` for a transport failure with no server behind it. For actions that are not a form (a delete, a retry, a connection test), where a toast is the answer either way.
-- **`useFieldRefusal(fields)`** (`hooks/useFieldRefusal.ts`) for a form. The form **declares** the server names it can render (`useFieldRefusal(COMPANY_FIELDS)`), passes `error={refusal.at(name)}` to each `<FormField>`, and its submit handler does `const toast = refusal.capture(error, fallback); if (toast) showToast(toast, "error")`.
+- **`useFieldRefusal(fields)`** (`hooks/useFieldRefusal.ts`) for a form. The form **declares** the server names it can render (`useFieldRefusal(COMPANY_FIELDS)`), passes `error={refusal.at(name, draft[name])}` to each `<FormField>`, and its submit handler does `const toast = refusal.capture(error, fallback, sent, current); if (toast) showToast(toast, "error")` — `sent` being what the request carried and `current` what the inputs hold now.
 
 The rule the mechanism holds is that the two channels are **exclusive and exhaustive**: a refusal about a declared input renders at that control and raises no toast; a refusal about anything else — another screen's field, no field at all, or no server at all — is a toast. Silence is the outcome that must never happen, and a message shown at the control *and* in a toast is the noise that teaches people to dismiss toasts unread. `placeRefusal` (`lib/fieldRefusal.ts`) is that decision as a pure function, with the table in `tests/client/field-refusal.test.ts`.
+
+The decision is about whether the operator will actually **read** the message, not merely whether the field was declared, and three cases separate those. The form may have unmounted while its own save was out (a modal body does this), in which case the mark goes to state nobody renders. The operator may have corrected the value while the request was out, in which case marking the box blames a value the server never saw. And a refusal about a field the request never carried is about what is *stored*, so there is nothing to be stale against and the mark stands. All three are rows in the same table.
+
+The mark then expires **by value**: `at(field, value)` shows the message only while the input still holds what was refused, so an edit takes it off with no `onChange` line to forget. `clear()` exists for the save that goes through, which the value key cannot recognise on its own.
 
 Declared rather than discovered, because the submit handler needs the answer *before* the next render; matched exactly rather than by prefix, so a form rendering a parent path does not claim every leaf under it. The state is per form instance: a modal over the panel that opened it has its own, and both have a `name`.
 

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -79,7 +79,7 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
         });
         return null;
       }
-      // Written even when nothing is placed, and that is the whole of "the capture is also the
+      // NOTE: written even when nothing is placed, and that is the whole of "the capture is also the
       // clear": a mark left over from a refusal the server has stopped making would sit on a control
       // while the toast says something else.
       setHeld(null);

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -1,30 +1,35 @@
-import { useCallback, useMemo, useState } from "react";
-import {
-  placeRefusal,
-  type Refusal,
-  readRefusal,
-} from "@/client/lib/fieldRefusal";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { placeRefusal, readRefusal } from "@/client/lib/fieldRefusal";
 
-// A form's held refusal: which input the server refused, and what it said about it.
+// A form's held refusal: which input the server refused, what it said about it, and the value it was
+// about.
 //
 // PER FORM, not per page and not in a context. Two forms are on screen together all the time here — a
 // modal over the panel that opened it — and both have a `name`. A shared store would mark the page
 // behind the modal, and a store that outlives the form would still be holding a refusal when the
 // operator closes a modal and opens it again.
 export interface FieldRefusal {
-  // The message to render at `field`, or null when this input is not the one refused. Goes straight
-  // into `<FormField error={...}>`, which already has the slot.
-  at: (field: string) => string | null;
-  // Take a failed call. Returns the sentence the caller must TOAST, or null when it landed on an
-  // input and the toast must stay silent. One line at the call site, because the sweep that follows
-  // (#233) applies it a hundred times and a two-line idiom is one that gets applied unevenly.
-  capture: (e: unknown, fallback: string) => string | null;
-  // Drop the mark: one input (the operator edited it) or all of them (the save went through).
+  // The message to render at `field`, or null when this input is not the one refused — or no longer
+  // holds the value that was.
   //
-  // A refused resubmit needs no clear — `capture` is the only writer of this state and always
-  // replaces it, so the refusal on screen is always the one the server last answered. Two marks
-  // would claim it refused twice.
-  clear: (field?: string) => void;
+  // Keyed by VALUE rather than cleared by a call: an edit takes the mark off because the box stops
+  // holding what the server refused, so there is no `onChange` line to forget. Forgetting the
+  // argument is a type error; forgetting a `clear(field)` was invisible.
+  at: (field: string, value: unknown) => string | null;
+  // Take a failed call. Returns the sentence the caller must TOAST, or null when it landed on an
+  // input and the toast must stay silent. `sent` is what this request carried and `current` is what
+  // the inputs hold now — the placement is refused when they disagree about the refused field, or
+  // when this form is already gone, because both render the mark unreadable.
+  capture: (
+    e: unknown,
+    fallback: string,
+    sent: Record<string, unknown>,
+    current: Record<string, unknown>,
+  ) => string | null;
+  // Drop the mark. Needed for the save that GOES THROUGH: the operator can resubmit the same value
+  // after the server changes its mind (a duplicate name freed, a cap raised), and the value key
+  // cannot tell that apart from the refusal still standing.
+  clear: () => void;
   // The input currently marked, for a caller that has to go somewhere to show it: the agent editor's
   // fields live behind tabs, and a mark on a tab nobody is looking at is not yet visible. Nothing
   // here navigates — which tab holds which path is the screen's knowledge, not this hook's.
@@ -32,7 +37,22 @@ export interface FieldRefusal {
 }
 
 export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
-  const [held, setHeld] = useState<Required<Refusal> | null>(null);
+  const [held, setHeld] = useState<{
+    field: string;
+    message: string;
+    value: unknown;
+  } | null>(null);
+  // Read from inside a request that may outlive the form. A ref and not state: the answer is needed
+  // in a callback that runs after the unmount, where a state read would be the value from the last
+  // render this component ever had — which is `true`.
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
   // The declared list is a literal at almost every call site (`COMPANY_FIELDS`), but a caller that
   // builds it inline would otherwise hand `capture` a new identity on every render.
   const key = rendered.join(" ");
@@ -40,10 +60,23 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
   const fields = useMemo(() => rendered.slice(), [key]);
 
   const capture = useCallback(
-    (e: unknown, fallback: string) => {
-      const placed = placeRefusal(readRefusal(e), fields, fallback);
+    (
+      e: unknown,
+      fallback: string,
+      sent: Record<string, unknown>,
+      current: Record<string, unknown>,
+    ) => {
+      const placed = placeRefusal(readRefusal(e), fields, fallback, {
+        mounted: mounted.current,
+        sent,
+        current,
+      });
       if (placed.at !== undefined) {
-        setHeld({ field: placed.at, message: placed.message });
+        setHeld({
+          field: placed.at,
+          message: placed.message,
+          value: placed.value,
+        });
         return null;
       }
       // Written even when nothing is placed, and that is the whole of "the capture is also the
@@ -55,16 +88,11 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
     [fields],
   );
 
-  const clear = useCallback((field?: string) => {
-    setHeld((current) =>
-      !current || field === undefined || current.field === field
-        ? null
-        : current,
-    );
-  }, []);
+  const clear = useCallback(() => setHeld(null), []);
 
   const at = useCallback(
-    (field: string) => (held?.field === field ? held.message : null),
+    (field: string, value: unknown) =>
+      held?.field === field && held.value === value ? held.message : null,
     [held],
   );
 

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -1,0 +1,72 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  placeRefusal,
+  type Refusal,
+  readRefusal,
+} from "@/client/lib/fieldRefusal";
+
+// A form's held refusal: which input the server refused, and what it said about it.
+//
+// PER FORM, not per page and not in a context. Two forms are on screen together all the time here — a
+// modal over the panel that opened it — and both have a `name`. A shared store would mark the page
+// behind the modal, and a store that outlives the form would still be holding a refusal when the
+// operator closes a modal and opens it again.
+export interface FieldRefusal {
+  // The message to render at `field`, or null when this input is not the one refused. Goes straight
+  // into `<FormField error={...}>`, which already has the slot.
+  at: (field: string) => string | null;
+  // Take a failed call. Returns the sentence the caller must TOAST, or null when it landed on an
+  // input and the toast must stay silent. One line at the call site, because the sweep that follows
+  // (#233) applies it a hundred times and a two-line idiom is one that gets applied unevenly.
+  capture: (e: unknown, fallback: string) => string | null;
+  // Drop the mark: one input (the operator edited it) or all of them (the save went through).
+  //
+  // A refused resubmit needs no clear — `capture` is the only writer of this state and always
+  // replaces it, so the refusal on screen is always the one the server last answered. Two marks
+  // would claim it refused twice.
+  clear: (field?: string) => void;
+  // The input currently marked, for a caller that has to go somewhere to show it: the agent editor's
+  // fields live behind tabs, and a mark on a tab nobody is looking at is not yet visible. Nothing
+  // here navigates — which tab holds which path is the screen's knowledge, not this hook's.
+  field: string | null;
+}
+
+export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
+  const [held, setHeld] = useState<Required<Refusal> | null>(null);
+  // The declared list is a literal at almost every call site (`COMPANY_FIELDS`), but a caller that
+  // builds it inline would otherwise hand `capture` a new identity on every render.
+  const key = rendered.join(" ");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `key` IS `rendered`, by value.
+  const fields = useMemo(() => rendered.slice(), [key]);
+
+  const capture = useCallback(
+    (e: unknown, fallback: string) => {
+      const placed = placeRefusal(readRefusal(e), fields, fallback);
+      if (placed.at !== undefined) {
+        setHeld({ field: placed.at, message: placed.message });
+        return null;
+      }
+      // Written even when nothing is placed, and that is the whole of "the capture is also the
+      // clear": a mark left over from a refusal the server has stopped making would sit on a control
+      // while the toast says something else.
+      setHeld(null);
+      return placed.toast;
+    },
+    [fields],
+  );
+
+  const clear = useCallback((field?: string) => {
+    setHeld((current) =>
+      !current || field === undefined || current.field === field
+        ? null
+        : current,
+    );
+  }, []);
+
+  const at = useCallback(
+    (field: string) => (held?.field === field ? held.message : null),
+    [held],
+  );
+
+  return { at, capture, clear, field: held?.field ?? null };
+}

--- a/src/client/lib/apiError.ts
+++ b/src/client/lib/apiError.ts
@@ -1,4 +1,4 @@
-import type { ApiErrorPayload } from "@/client/lib/types";
+import { readRefusal } from "@/client/lib/fieldRefusal";
 
 // The backend's own message for a failed call, when it sent one.
 //
@@ -10,9 +10,13 @@ import type { ApiErrorPayload } from "@/client/lib/types";
 //
 // Returns null for a transport failure (no body, or a body without `error`), where the generic toast
 // is the honest thing to show.
+//
+// The half of the same body that names the refused INPUT is read by `readRefusal`, and this delegates
+// to it rather than parsing the body a second time: two readers of one wire shape is how the sweep in
+// #233 would end up with call sites that show the sentence and call sites that place it, disagreeing
+// about what counts as a message at all. Callers that can render a refusal at the control it is about
+// want `useFieldRefusal`; this one stays for the actions that are not a form (a delete, a retry, a
+// connection test), where a toast is the answer either way.
 export function apiErrorMessage(e: unknown): string | null {
-  if (!e || typeof e !== "object" || !("value" in e)) return null;
-  const value = (e as { value?: ApiErrorPayload }).value;
-  const msg = value?.error;
-  return typeof msg === "string" && msg.trim() ? msg : null;
+  return readRefusal(e)?.message ?? null;
 }

--- a/src/client/lib/fieldRefusal.ts
+++ b/src/client/lib/fieldRefusal.ts
@@ -37,9 +37,28 @@ export function readRefusal(e: unknown): Refusal | null {
 // that holds every refusal at an input holds the ones it has no input for as well, and the operator
 // gets a save button that does nothing. And a message rendered at the control AND repeated in a
 // toast is the noise that trains people to dismiss toasts without reading them.
+//
+// `value` travels with a placement because the mark expires by VALUE and not by a call: `at` shows
+// it only while the input still holds what was refused (see the hook).
 export type RefusalPlacement =
-  | { at: string; message: string }
+  | { at: string; message: string; value: unknown }
   | { at?: undefined; toast: string };
+
+// What the form was doing when the answer landed. The first round of review on #313 found three ways
+// a placement can be held and never read, and they are all this: the question is not "is this input
+// one the form declared" but "will the operator actually read this".
+export interface FormAtAnswer {
+  // False once the form is gone. A modal body can unmount while its own save is in flight — this
+  // card's own comments record that the operator does exactly that — and a mark written to state
+  // nobody renders is silence, with `capture` having already reported "it is on the control".
+  mounted: boolean;
+  // What the request carried. A refusal is about the value that was SENT.
+  sent: Record<string, unknown>;
+  // What the inputs hold now. If they no longer hold what was sent, the operator changed it while
+  // the request was out, and marking the box would put "this is not valid" under a value the server
+  // never saw.
+  current: Record<string, unknown>;
+}
 
 // `rendered` is what the FORM declares it can show, by the server's names.
 //
@@ -55,10 +74,17 @@ export function placeRefusal(
   refusal: Refusal | null,
   rendered: readonly string[],
   fallback: string,
+  form: FormAtAnswer,
 ): RefusalPlacement {
   if (!refusal) return { toast: fallback };
-  if (refusal.field && rendered.includes(refusal.field)) {
-    return { at: refusal.field, message: refusal.message };
+  const { field, message } = refusal;
+  if (!field || !rendered.includes(field)) return { toast: message };
+  if (!form.mounted) return { toast: message };
+  // Only when the request carried this field. A refusal about a value this write did not change is
+  // about what is stored, and the input has not moved relative to it, so there is nothing stale.
+  const carried = Object.hasOwn(form.sent, field);
+  if (carried && form.sent[field] !== form.current[field]) {
+    return { toast: message };
   }
-  return { toast: refusal.message };
+  return { at: field, message, value: form.current[field] };
 }

--- a/src/client/lib/fieldRefusal.ts
+++ b/src/client/lib/fieldRefusal.ts
@@ -1,0 +1,64 @@
+import type { ApiErrorPayload } from "@/client/lib/types";
+
+// WHERE A REFUSAL GOES, decided once instead of at every call site.
+//
+// Since #231 the API answers a refusal as `{ error, field? }`: the sentence, localized for whoever is
+// reading, and — when the refusal is about one input — the server's own name for that input, which
+// reads the same in every language (see src/api/lib/refusal.ts). Measured before this module existed,
+// the console read `field` in zero of the thirteen places that already destructure that body.
+//
+// The decision is small and it is the whole mechanism, so it lives here as a pure function rather
+// than inside a hook: a component cannot be asked what it would have done, and this is a rule about
+// what the operator ends up seeing.
+export interface Refusal {
+  message: string;
+  // Absent, never empty: the wire omits the key entirely when the refusal is not about one input,
+  // and a blank name would be a second spelling of "nothing here" for every reader to handle.
+  field?: string;
+}
+
+// The backend's own refusal for a failed call, when it sent one.
+//
+// Eden rejects with an object carrying the parsed body on `value`. Returns null for a transport
+// failure (no body, or a body without `error`), where there is nothing the server said.
+export function readRefusal(e: unknown): Refusal | null {
+  if (!e || typeof e !== "object" || !("value" in e)) return null;
+  const value = (e as { value?: ApiErrorPayload }).value;
+  const message = value?.error;
+  if (typeof message !== "string" || !message.trim()) return null;
+  const field = typeof value?.field === "string" ? value.field.trim() : "";
+  return field ? { message, field } : { message };
+}
+
+// The two channels a refusal can reach the operator through, as an EITHER: exactly one of them
+// fires, always.
+//
+// Both halves of that are load-bearing. Silence is what a mechanism like this breaks first — a form
+// that holds every refusal at an input holds the ones it has no input for as well, and the operator
+// gets a save button that does nothing. And a message rendered at the control AND repeated in a
+// toast is the noise that trains people to dismiss toasts without reading them.
+export type RefusalPlacement =
+  | { at: string; message: string }
+  | { at?: undefined; toast: string };
+
+// `rendered` is what the FORM declares it can show, by the server's names.
+//
+// Declared and not discovered, because of WHEN the answer is needed: the submit handler has to know,
+// before React renders again, whether it must raise a toast. A registry that filled itself while
+// rendering would answer for the previous render — the one before the refusal existed.
+//
+// Matched exactly, never by prefix. The server's names are dotted paths into bags it owns
+// (`guardrails.output.templateMessage`), and a form that wants to catch a subtree can say so by
+// listing what it renders. Guessing that a form showing `guardrails` also shows every leaf under it
+// is how a refusal ends up marked on a control that is not about it.
+export function placeRefusal(
+  refusal: Refusal | null,
+  rendered: readonly string[],
+  fallback: string,
+): RefusalPlacement {
+  if (!refusal) return { toast: fallback };
+  if (refusal.field && rendered.includes(refusal.field)) {
+    return { at: refusal.field, message: refusal.message };
+  }
+  return { toast: refusal.message };
+}

--- a/src/client/pages/resources/documents/CompanyProfileCard.tsx
+++ b/src/client/pages/resources/documents/CompanyProfileCard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Card, FormField, Input, useToast } from "@/client/components";
 import { useNavGuard } from "@/client/contexts/NavGuardContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import {
@@ -67,6 +68,11 @@ export function CompanyProfileCard({
   // an unsaved edit and a click on another tab — or a tenant switch, which is a full reload. The
   // same `companyChanges` the save sends is what "unsaved" means here, so the two cannot disagree.
   const dirty = Object.keys(companyChanges(form)).length > 0;
+  // The six patch keys ARE the six names the server refuses by: `updateCompanySettings` names the key
+  // of the patch it rejected, and that key was chosen to be this form's input name. Declared from the
+  // same constant the inputs are rendered from, so a seventh field cannot be added to one and not the
+  // other.
+  const refusal = useFieldRefusal(FIELDS);
   useNavGuard(dirty);
   useEffect(() => {
     onDirtyChange?.(dirty);
@@ -127,14 +133,19 @@ export function CompanyProfileCard({
       if (error || !data) {
         // The server's own words when it sent any: a letterhead field is refused for a character the
         // document fonts cannot print, and the refusal NAMES the field and the character. Six inputs
-        // and a generic sentence leave the operator hunting for which one.
-        showToast(
-          apiErrorMessage(error) ||
-            t("documents.company.saveError", "Could not save."),
-          "error",
+        // and a generic sentence leave the operator hunting for which one — and a toast that names
+        // the field still makes them count down the form to find it.
+        //
+        // A sentence back means the refusal is about nothing this form renders (or there was no
+        // server at all); null means it is already on the control and repeating it would be noise.
+        const toast = refusal.capture(
+          error,
+          t("documents.company.saveError", "Could not save."),
         );
+        if (toast) showToast(toast, "error");
         return;
       }
+      refusal.clear();
       // The text is now stored, so it becomes the baseline — see afterCompanySave. Anything typed
       // while the request was in flight stays, and stays unsaved.
       // Computed from the ref, not from the closed-over `form`: the operator can type during the
@@ -246,15 +257,19 @@ export function CompanyProfileCard({
           they all get the short one's width. */}
       <div className="grid gap-3">
         {FIELDS.map((field) => (
-          <FormField key={field} label={label[field]}>
+          <FormField key={field} label={label[field]} error={refusal.at(field)}>
             <Input
               value={draft[field]}
-              onChange={(e) =>
+              onChange={(e) => {
+                // The operator has acted on what the message asked for, so the mark comes off before
+                // the next save answers. Leaving it would keep a refusal on screen about a value the
+                // server has not seen.
+                refusal.clear(field);
                 setForm((current) => ({
                   ...current,
                   draft: { ...current.draft, [field]: e.target.value },
-                }))
-              }
+                }));
+              }}
             />
           </FormField>
         ))}

--- a/src/client/pages/resources/documents/CompanyProfileCard.tsx
+++ b/src/client/pages/resources/documents/CompanyProfileCard.tsx
@@ -138,9 +138,15 @@ export function CompanyProfileCard({
         //
         // A sentence back means the refusal is about nothing this form renders (or there was no
         // server at all); null means it is already on the control and repeating it would be noise.
+        //
+        // `sent` against the CURRENT draft, read from the ref: the operator can type during the
+        // request, and a refusal about a value they have already replaced belongs in a toast rather
+        // than under a box that no longer holds it.
         const toast = refusal.capture(
           error,
           t("documents.company.saveError", "Could not save."),
+          sent,
+          formRef.current.draft,
         );
         if (toast) showToast(toast, "error");
         return;
@@ -163,11 +169,25 @@ export function CompanyProfileCard({
       // `session` as captured when the request STARTED: it is the opening this save belongs to, and
       // the parent decides whether that opening is still the one on screen.
       if (clean) onSaved?.(session);
-    } catch {
+    } catch (e) {
       // Eden RESOLVES an HTTP error as `{ error }` and REJECTS on a transport failure — offline, a
       // reset connection. Only the first half was handled, so the second left the operator with a
       // button that did nothing and an unhandled rejection in the console.
-      showToast(t("documents.company.saveError", "Could not save."), "error");
+      //
+      // Through `capture` as well, so it stays the only writer of the held refusal. Measured: an
+      // offline save on this route RESOLVES here (the branch above runs and already clears), so this
+      // is not a path a mark was observed surviving — it is a path that could bypass the single
+      // writer, and routing it costs one argument.
+      const toast = refusal.capture(
+        e,
+        t("documents.company.saveError", "Could not save."),
+        sent,
+        formRef.current.draft,
+      );
+      showToast(
+        toast ?? t("documents.company.saveError", "Could not save."),
+        "error",
+      );
     } finally {
       setBusy(null);
     }
@@ -257,19 +277,21 @@ export function CompanyProfileCard({
           they all get the short one's width. */}
       <div className="grid gap-3">
         {FIELDS.map((field) => (
-          <FormField key={field} label={label[field]} error={refusal.at(field)}>
+          <FormField
+            key={field}
+            label={label[field]}
+            // The value the mark is keyed on: the message shows while this box still holds what the
+            // server refused, and stops the keystroke it changes. No `onChange` line to forget.
+            error={refusal.at(field, draft[field])}
+          >
             <Input
               value={draft[field]}
-              onChange={(e) => {
-                // The operator has acted on what the message asked for, so the mark comes off before
-                // the next save answers. Leaving it would keep a refusal on screen about a value the
-                // server has not seen.
-                refusal.clear(field);
+              onChange={(e) =>
                 setForm((current) => ({
                   ...current,
                   draft: { ...current.draft, [field]: e.target.value },
-                }));
-              }}
+                }))
+              }
             />
           </FormField>
         ))}

--- a/tests/client/field-refusal-at-input.test.tsx
+++ b/tests/client/field-refusal-at-input.test.tsx
@@ -309,3 +309,91 @@ test("a save that goes through takes the mark off", async () => {
     expect(shownAnywhere(reason)).toBe(0);
   });
 });
+
+// ── The three ways a mark can be held and never seen ──────────────────────────────────────────
+//
+// `capture` answers "is this input one the form declared", and the invariant needs "will the
+// operator actually read this". The three below are where those diverge, all found by review on the
+// first round of #313 and all the same defect: a placement that renders nothing is silence, and
+// silence is the one outcome this mechanism may not produce.
+
+// A `fetch` whose answer is released by hand, so the test can act between the click and the reply.
+function deferredPut(body: { error: string; field?: string }) {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if ((init?.method ?? "GET").toUpperCase() !== "PUT") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    await gate;
+    return new Response(JSON.stringify(body), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return () => release();
+}
+
+// The modal case, mounted the way it really is: the card goes away and the ToastProvider does NOT.
+// Unmounting the whole tree instead would take the toast viewport with it and the test could only
+// ever observe zero, whatever the code did.
+function DismissableCompany({ gone }: { gone: boolean }) {
+  return (
+    <MemoryRouter>
+      <NavGuardProvider>
+        <ToastProvider>
+          {gone ? null : (
+            <CompanyProfileCard
+              company={COMPANY as never}
+              onChanged={() => undefined}
+              session={1}
+            />
+          )}
+        </ToastProvider>
+      </NavGuardProvider>
+    </MemoryRouter>
+  );
+}
+
+test("a refusal that arrives after the form is gone still reaches the operator", async () => {
+  // This card is a modal body, and the file already records that a save is slow enough for the
+  // operator to close the modal while the request is out. Closing it unmounts the hook, so the mark
+  // is written to state nobody renders — and `capture` had already reported "it is on the control".
+  const reason =
+    "document contains a character the document fonts cannot print";
+  const release = deferredPut({ error: reason, field: "document" });
+  const view = render(<DismissableCompany gone={false} />);
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345" } });
+  save();
+  view.rerender(<DismissableCompany gone={true} />);
+  release();
+
+  await waitFor(() => {
+    expect(toastCount()).toBe(1);
+  });
+});
+
+test("a refusal about a value the operator has already changed is a toast, not a mark", async () => {
+  // Marking the input would put "this is not valid" under a value the server never saw. The refusal
+  // is about what was SENT, and what was sent is no longer in the box.
+  const reason =
+    "document contains a character the document fonts cannot print";
+  const release = deferredPut({ error: reason, field: "document" });
+  mountCompany();
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345 x" } });
+  save();
+  fireEvent.change(inputFor("document"), { target: { value: "12.345" } });
+  release();
+
+  await waitFor(() => {
+    expect(toastCount()).toBe(1);
+  });
+  expect(shownInsideFieldOf("document", reason)).toBe(0);
+});

--- a/tests/client/field-refusal-at-input.test.tsx
+++ b/tests/client/field-refusal-at-input.test.tsx
@@ -1,0 +1,311 @@
+/// <reference lib="dom" />
+
+import { afterEach, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+// THE REFUSAL THAT LANDS ON THE INPUT IT IS ABOUT, AND THE ONE THAT CANNOT.
+//
+// #231 put the refused field on the wire: `{ error, field }`, where `field` is the server's own name
+// for the value it refused and reads the same in every language. Measured before this change, the
+// console read it in ZERO of the thirteen places that already destructure that body — the sentence
+// went to a toast, and the operator of a six-input form still had to work out which input to fix.
+//
+// A toast is also the wrong container for it twice over: it is far from the control, and it scrolls
+// away carrying the only copy of the reason.
+//
+// The rule this file holds is not "always render at the input" — it is that the two channels are
+// EXCLUSIVE and one of them always fires. A refusal about an input this form renders goes to that
+// input and the toast stays silent; a refusal about anything else (a field on another screen, a
+// refusal about no input at all, a transport failure with no server behind it) goes to the toast.
+// Silence is the one outcome that must never happen, and showing it twice is its own kind of noise.
+
+const { CompanyProfileCard } = await import(
+  "@/client/pages/resources/documents/CompanyProfileCard"
+);
+const { ToastProvider } = await import("@/client/components");
+const { NavGuardProvider } = await import("@/client/contexts/NavGuardContext");
+
+const realFetch = globalThis.fetch;
+
+const COMPANY = {
+  name: "ACME Ltda",
+  document: "",
+  address: "",
+  phone: "",
+  email: "",
+  website: "",
+  logoKey: null,
+  logoVersion: 0,
+};
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+});
+
+// The body an AppError answers with since #231: the localized sentence, and the field it is about
+// when the refusal is about one. `field` is absent — not null — whenever it is not.
+function refusingPut(body: { error: string; field?: string }) {
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if ((init?.method ?? "GET").toUpperCase() !== "PUT") {
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify(body), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function mountCompany() {
+  return render(
+    <MemoryRouter>
+      <NavGuardProvider>
+        <ToastProvider>
+          <CompanyProfileCard
+            company={COMPANY as never}
+            onChanged={() => undefined}
+            session={1}
+          />
+        </ToastProvider>
+      </NavGuardProvider>
+    </MemoryRouter>,
+  );
+}
+
+// The six inputs are rendered in `COMPANY_FIELDS` order, which is the order the card maps over.
+const ORDER = ["name", "document", "address", "phone", "email", "website"];
+
+function inputFor(field: string): HTMLInputElement {
+  return screen.getAllByRole("textbox")[
+    ORDER.indexOf(field)
+  ] as HTMLInputElement;
+}
+
+function save() {
+  fireEvent.click(screen.getByRole("button", { name: /^(save|salvar)$/i }));
+}
+
+// Reduced to a COUNT before it leaves this function, never a node: an expectation that fails while
+// holding a happy-dom element serializes a cyclic tree and hangs the runner.
+function shownInsideFieldOf(field: string, message: string): number {
+  const control = inputFor(field);
+  const box = control.closest("label") ?? control.parentElement;
+  return Array.from(box?.querySelectorAll("*") ?? []).filter(
+    (el) => el.textContent === message && el.children.length === 0,
+  ).length;
+}
+
+function shownAnywhere(message: string): number {
+  return screen.queryAllByText(message).length;
+}
+
+// How many toasts are on screen, whatever they say. Counting the reason's occurrences is not the
+// same question: a toast raised with the GENERIC sentence beside a message already on the control is
+// still the duplicate this rule bars, and it shares no text with the one at the input.
+//
+// Radix renders each toast as an `<li>` in its viewport, and this card renders no list of its own.
+function toastCount(): number {
+  return document.querySelectorAll("li[data-state]").length;
+}
+
+test("a refusal that names an input this form renders lands on that input, once", async () => {
+  // Worded the way `updateCompanySettings` words it (tenant-settings/service.ts): the sentence names
+  // the character, and `field` names the patch key — which is the same string this form uses for the
+  // input, because the console's company form is what that name was chosen for.
+  const reason =
+    'document contains a character the document fonts cannot print: "😀"';
+  refusingPut({ error: reason, field: "document" });
+  mountCompany();
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345 😀" } });
+  save();
+
+  await waitFor(() => {
+    expect(shownInsideFieldOf("document", reason)).toBe(1);
+  });
+  // And nowhere else: the toast does not repeat what is already on the control.
+  expect(shownAnywhere(reason)).toBe(1);
+  // Nor does it fire with the generic sentence instead, which is the same interruption carrying less
+  // than the control already says.
+  expect(toastCount()).toBe(0);
+});
+
+test("a refusal about an input this form does not render still reaches the operator", async () => {
+  // `logoKey` is a column of the same block and has no text input on this card. Holding the refusal
+  // for an input that is not on screen would be silence, which is the one outcome barred here.
+  const reason = "the stored logo is no longer readable";
+  refusingPut({ error: reason, field: "logoKey" });
+  mountCompany();
+
+  fireEvent.change(inputFor("name"), { target: { value: "ACME Nova" } });
+  save();
+
+  await waitFor(() => {
+    expect(shownAnywhere(reason)).toBeGreaterThan(0);
+  });
+  for (const field of ORDER) {
+    expect(shownInsideFieldOf(field, reason)).toBe(0);
+  }
+  // The positive control for the counter the test above reads as zero: a toast DOES register here,
+  // so a counter that had stopped counting would fail on this line instead of passing on that one.
+  expect(toastCount()).toBe(1);
+});
+
+test("a refusal about no input at all is still a toast", async () => {
+  // Most refusals are not about one input (a 403, a 404, a conflict) and answer with no `field` at
+  // all. They must keep behaving exactly as they did before this mechanism existed.
+  const reason = "this tenant is not allowed to change the letterhead";
+  refusingPut({ error: reason });
+  mountCompany();
+
+  fireEvent.change(inputFor("name"), { target: { value: "ACME Nova" } });
+  save();
+
+  await waitFor(() => {
+    expect(shownAnywhere(reason)).toBeGreaterThan(0);
+  });
+  for (const field of ORDER) {
+    expect(shownInsideFieldOf(field, reason)).toBe(0);
+  }
+});
+
+test("editing the refused input takes the refusal off it", async () => {
+  // The operator has acted on the thing the message asked them to fix. Leaving it there marks a value
+  // the server never saw, and the next save answers for the new one.
+  const reason =
+    'document contains a character the document fonts cannot print: "😀"';
+  refusingPut({ error: reason, field: "document" });
+  mountCompany();
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345 😀" } });
+  save();
+  await waitFor(() => {
+    expect(shownInsideFieldOf("document", reason)).toBe(1);
+  });
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345" } });
+  expect(shownInsideFieldOf("document", reason)).toBe(0);
+});
+
+test("a second refusal about another input does not leave the first one marked", async () => {
+  // The capture is also the clear: one refusal is what the server answers, so two marks on screen
+  // would claim the server refused twice. Only the second one is a fact.
+  const first =
+    'document contains a character the document fonts cannot print: "😀"';
+  refusingPut({ error: first, field: "document" });
+  mountCompany();
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345 😀" } });
+  save();
+  await waitFor(() => {
+    expect(shownInsideFieldOf("document", first)).toBe(1);
+  });
+
+  const second =
+    'website contains a character the document fonts cannot print: "🙃"';
+  refusingPut({ error: second, field: "website" });
+  fireEvent.change(inputFor("website"), { target: { value: "acme.com 🙃" } });
+  save();
+
+  await waitFor(() => {
+    expect(shownInsideFieldOf("website", second)).toBe(1);
+  });
+  expect(shownAnywhere(first)).toBe(0);
+});
+
+test("a save with no server behind it still says something", async () => {
+  // Eden REJECTS on a transport failure rather than answering a body, so there is no message and no
+  // field. The generic sentence is the honest thing, and it is a toast: there is no input to blame.
+  globalThis.fetch = (async () => {
+    throw new Error("offline");
+  }) as unknown as typeof fetch;
+  mountCompany();
+
+  fireEvent.change(inputFor("name"), { target: { value: "ACME Nova" } });
+  save();
+
+  await waitFor(() => {
+    expect(
+      screen.queryAllByText(/não foi possível salvar|could not save/i).length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+test("editing another input leaves the mark where the server put it", async () => {
+  // `clear(field)` answers for ONE input. An operator who reads "fix the tax id" and goes on typing
+  // their address has not fixed anything, and a mark that came off would take the reason with it.
+  const reason =
+    "document contains a character the document fonts cannot print";
+  refusingPut({ error: reason, field: "document" });
+  mountCompany();
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345" } });
+  save();
+  await waitFor(() => {
+    expect(shownInsideFieldOf("document", reason)).toBe(1);
+  });
+
+  fireEvent.change(inputFor("address"), { target: { value: "Rua Um, 2" } });
+  expect(shownInsideFieldOf("document", reason)).toBe(1);
+});
+
+test("a later refusal about no input takes the earlier mark off", async () => {
+  // The capture is the only writer, and it always writes. Otherwise the mark from a refusal the
+  // server has stopped making sits on a control while a toast says something else entirely.
+  const first = "document contains a character the document fonts cannot print";
+  refusingPut({ error: first, field: "document" });
+  mountCompany();
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345" } });
+  save();
+  await waitFor(() => {
+    expect(shownInsideFieldOf("document", first)).toBe(1);
+  });
+
+  const second = "this tenant is not allowed to change the letterhead";
+  refusingPut({ error: second });
+  save();
+
+  await waitFor(() => {
+    expect(shownAnywhere(second)).toBeGreaterThan(0);
+  });
+  expect(shownAnywhere(first)).toBe(0);
+});
+
+test("a save that goes through takes the mark off", async () => {
+  // The refusal was about the value the server rejected; it accepted this one. Nothing on screen may
+  // still say otherwise.
+  const reason =
+    "document contains a character the document fonts cannot print";
+  refusingPut({ error: reason, field: "document" });
+  mountCompany();
+
+  fireEvent.change(inputFor("document"), { target: { value: "12.345" } });
+  save();
+  await waitFor(() => {
+    expect(shownInsideFieldOf("document", reason)).toBe(1);
+  });
+
+  // The save route answers with the whole company block; nothing here reads it beyond `data.company`.
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ company: COMPANY }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+  save();
+
+  await waitFor(() => {
+    expect(shownAnywhere(reason)).toBe(0);
+  });
+});

--- a/tests/client/field-refusal.test.ts
+++ b/tests/client/field-refusal.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import {
+  placeRefusal,
+  type Refusal,
+  type RefusalPlacement,
+  readRefusal,
+} from "@/client/lib/fieldRefusal";
+
+// THE DECISION, ON ITS OWN.
+//
+// `useFieldRefusal` is state around these two functions and nothing else, so the rule is provable
+// without mounting anything: what the wire said, what the form declared it renders, and which of the
+// two channels the operator ends up reading it in.
+//
+// The invariant the table is really checking is that the channels are EXCLUSIVE and one always
+// fires. Every row below answers exactly one of `at` and `toast`, and no row answers neither.
+
+// The Eden rejection shape: the parsed body on `value`.
+const eden = (value: unknown) => ({ value });
+
+describe("readRefusal", () => {
+  const cases: Array<{ name: string; input: unknown; want: Refusal | null }> = [
+    {
+      name: "a refusal that names an input carries both halves",
+      input: eden({ error: "too long", field: "systemPrompt" }),
+      want: { message: "too long", field: "systemPrompt" },
+    },
+    {
+      name: "a refusal about no input carries only the sentence",
+      input: eden({ error: "forbidden" }),
+      want: { message: "forbidden" },
+    },
+    {
+      // The wire never sends this (`refusalBody` drops a blank name before answering), and a client
+      // that matched on it would mark whichever control declared the empty string.
+      name: "a blank field is not a name",
+      input: eden({ error: "nope", field: "   " }),
+      want: { message: "nope" },
+    },
+    {
+      // Trimmed on the way in for the same reason the server trims on the way out: `" name "` and
+      // `"name"` must not be two different inputs.
+      name: "a padded field is the same name",
+      input: eden({ error: "nope", field: " name " }),
+      want: { message: "nope", field: "name" },
+    },
+    {
+      name: "a field that is not a string is not a name",
+      input: eden({ error: "nope", field: 7 }),
+      want: { message: "nope" },
+    },
+    {
+      // A transport failure: Eden rejects with no parsed body at all.
+      name: "no body at all is not a refusal",
+      input: new Error("offline"),
+      want: null,
+    },
+    {
+      name: "a body with no sentence is not a refusal",
+      input: eden({ field: "name" }),
+      want: null,
+    },
+    {
+      // Whitespace is not a sentence. Showing it would be a toast the operator sees as empty.
+      name: "a blank sentence is not a refusal",
+      input: eden({ error: "   ", field: "name" }),
+      want: null,
+    },
+    { name: "null is not a refusal", input: null, want: null },
+    { name: "a string is not a refusal", input: "boom", want: null },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(readRefusal(c.input)).toEqual(c.want as Refusal);
+    });
+  }
+});
+
+describe("placeRefusal", () => {
+  const RENDERED = ["name", "document", "guardrails.output.templateMessage"];
+  const FALLBACK = "Could not save.";
+
+  const cases: Array<{
+    name: string;
+    refusal: Refusal | null;
+    rendered?: readonly string[];
+    want: RefusalPlacement;
+  }> = [
+    {
+      name: "an input this form renders takes the message",
+      refusal: { message: "bad character", field: "document" },
+      want: { at: "document", message: "bad character" },
+    },
+    {
+      // A dotted path is a name like any other. Nothing here parses it.
+      name: "a dotted path this form renders takes it too",
+      refusal: {
+        message: "too long",
+        field: "guardrails.output.templateMessage",
+      },
+      want: {
+        at: "guardrails.output.templateMessage",
+        message: "too long",
+      },
+    },
+    {
+      // The silence case, and the one the mechanism breaks first: an input this form has no control
+      // for must not swallow the refusal.
+      name: "an input this form does not render falls back to the toast",
+      refusal: { message: "logo unreadable", field: "logoKey" },
+      want: { toast: "logo unreadable" },
+    },
+    {
+      // Exact match only. A form that renders the parent path has not said it renders the leaf, and
+      // marking the parent control would point at an input the refusal is not about.
+      name: "a child of a rendered path is not a rendered path",
+      refusal: {
+        message: "too long",
+        field: "guardrails.output.templateMessage.extra",
+      },
+      want: { toast: "too long" },
+    },
+    {
+      name: "a parent of a rendered path is not a rendered path either",
+      refusal: { message: "too long", field: "guardrails.output" },
+      want: { toast: "too long" },
+    },
+    {
+      name: "a refusal about no input is a toast, in the server's words",
+      refusal: { message: "forbidden" },
+      want: { toast: "forbidden" },
+    },
+    {
+      // The only row where the caller's own sentence is the answer: there was no server to word it.
+      name: "no refusal at all is the caller's fallback",
+      refusal: null,
+      want: { toast: FALLBACK },
+    },
+    {
+      name: "a form that renders nothing toasts everything",
+      refusal: { message: "bad character", field: "document" },
+      rendered: [],
+      want: { toast: "bad character" },
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(placeRefusal(c.refusal, c.rendered ?? RENDERED, FALLBACK)).toEqual(
+        c.want,
+      );
+    });
+  }
+
+  // The property the rows are individually asserting, stated once over all of them: never both, and
+  // never neither. A future row that answered `{ at, toast }` would read as correct in its own line.
+  test("exactly one channel fires, on every row", () => {
+    for (const c of cases) {
+      const placed = placeRefusal(c.refusal, c.rendered ?? RENDERED, FALLBACK);
+      const at = "at" in placed && placed.at !== undefined;
+      const toast = "toast" in placed;
+      expect([c.name, at !== toast]).toEqual([c.name, true]);
+    }
+  });
+});

--- a/tests/client/field-refusal.test.ts
+++ b/tests/client/field-refusal.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  type FormAtAnswer,
   placeRefusal,
   type Refusal,
   type RefusalPlacement,
@@ -81,16 +82,25 @@ describe("placeRefusal", () => {
   const RENDERED = ["name", "document", "guardrails.output.templateMessage"];
   const FALLBACK = "Could not save.";
 
+  // A form that is on screen and whose inputs still hold exactly what the request carried: the
+  // ordinary case, so the rows that are about WHERE a refusal goes are not also about staleness.
+  const STEADY: FormAtAnswer = {
+    mounted: true,
+    sent: { document: "12.345", name: "ACME" },
+    current: { document: "12.345", name: "ACME" },
+  };
+
   const cases: Array<{
     name: string;
     refusal: Refusal | null;
     rendered?: readonly string[];
+    form?: FormAtAnswer;
     want: RefusalPlacement;
   }> = [
     {
       name: "an input this form renders takes the message",
       refusal: { message: "bad character", field: "document" },
-      want: { at: "document", message: "bad character" },
+      want: { at: "document", message: "bad character", value: "12.345" },
     },
     {
       // A dotted path is a name like any other. Nothing here parses it.
@@ -99,9 +109,12 @@ describe("placeRefusal", () => {
         message: "too long",
         field: "guardrails.output.templateMessage",
       },
+      // The request did not carry this field, so there is nothing to compare it against and nothing
+      // stale: the refusal is about what is STORED, not about a value this write changed.
       want: {
         at: "guardrails.output.templateMessage",
         message: "too long",
+        value: undefined,
       },
     },
     {
@@ -143,13 +156,64 @@ describe("placeRefusal", () => {
       rendered: [],
       want: { toast: "bad character" },
     },
+    {
+      // A modal body can unmount while its own save is out. The mark would be written to state
+      // nobody renders, and `capture` would have reported "it is on the control" — silence.
+      name: "a form that is gone renders nothing, so the message is a toast",
+      refusal: { message: "bad character", field: "document" },
+      form: { ...STEADY, mounted: false },
+      want: { toast: "bad character" },
+    },
+    {
+      // The operator corrected the value while the request was out. The refusal is about what was
+      // SENT, and marking the box would blame a value the server never saw.
+      name: "a value the operator has already replaced is a toast",
+      refusal: { message: "bad character", field: "document" },
+      form: {
+        ...STEADY,
+        current: { document: "12.345", name: "ACME" },
+        sent: { document: "12.345 x" },
+      },
+      want: { toast: "bad character" },
+    },
+    {
+      // The guard on the comparison, and it needs a row of its own: a refusal about a field this
+      // write never carried is about what is STORED, so there is no submitted value to be stale
+      // against. Comparing anyway reads `undefined` out of `sent`, finds it different from what the
+      // input holds, and toasts every one of them.
+      name: "a field the request never carried is not stale, it is just not sent",
+      refusal: { message: "too long", field: "name" },
+      form: {
+        mounted: true,
+        sent: { document: "12.345" },
+        current: { document: "12.345", name: "ACME" },
+      },
+      want: { at: "name", message: "too long", value: "ACME" },
+    },
+    {
+      // The same comparison the other way: unchanged since the request went out, so the mark is
+      // about the value in the box.
+      name: "a value still in the box takes the mark",
+      refusal: { message: "bad character", field: "document" },
+      form: {
+        mounted: true,
+        sent: { document: "12.345 x" },
+        current: { document: "12.345 x" },
+      },
+      want: { at: "document", message: "bad character", value: "12.345 x" },
+    },
   ];
 
   for (const c of cases) {
     test(c.name, () => {
-      expect(placeRefusal(c.refusal, c.rendered ?? RENDERED, FALLBACK)).toEqual(
-        c.want,
-      );
+      expect(
+        placeRefusal(
+          c.refusal,
+          c.rendered ?? RENDERED,
+          FALLBACK,
+          c.form ?? STEADY,
+        ),
+      ).toEqual(c.want);
     });
   }
 
@@ -157,7 +221,12 @@ describe("placeRefusal", () => {
   // never neither. A future row that answered `{ at, toast }` would read as correct in its own line.
   test("exactly one channel fires, on every row", () => {
     for (const c of cases) {
-      const placed = placeRefusal(c.refusal, c.rendered ?? RENDERED, FALLBACK);
+      const placed = placeRefusal(
+        c.refusal,
+        c.rendered ?? RENDERED,
+        FALLBACK,
+        c.form ?? STEADY,
+      );
       const at = "at" in placed && placed.at !== undefined;
       const toast = "toast" in placed;
       expect([c.name, at !== toast]).toEqual([c.name, true]);


### PR DESCRIPTION
Fixes #232

## What is missing

#231 put the refused field on the wire. `AppError` carries a `field`, `refusalBody` answers `{ error, field }`, and the name is the server's own — a column (`systemPrompt`), a key of a patch (`document`), or a dotted path into a bag it owns (`guardrails.output.templateMessage`) — identical in every language, so a client can match on it.

Measured on `main`: **the console reads it in zero of the thirteen places that already destructure that body.** `grep -rn "ApiErrorPayload" src/client` returns 13 call sites and every one of them reads `.error`; `apiErrorMessage` (`lib/apiError.ts`) drops `field` on the floor. So the half that shipped is the half nothing consumes, and a refusal about one input still arrives as prose in a toast: far from the control, and it scrolls away carrying the only copy of the reason.

There was also nowhere to put it. `FormField` has had an `error` slot all along; what did not exist was any state that knows *which* input the server refused.

## The change

`placeRefusal` (`lib/fieldRefusal.ts`), a pure function, plus `useFieldRefusal` (`hooks/useFieldRefusal.ts`), which is state around it and nothing else.

A form declares the server names it can render and passes the message down:

```tsx
const refusal = useFieldRefusal(COMPANY_FIELDS);
…
const toast = refusal.capture(error, fallback, sent, formRef.current.draft);
if (toast) showToast(toast, "error");
…
<FormField error={refusal.at(field, draft[field])}>
```

The rule is **not** "always render at the input". It is that the two channels are exclusive and one always fires:

| the refusal is about | goes to |
| --- | --- |
| an input this form declared, still holding the value that was sent | that control; no toast |
| an input on another screen | the toast, in the server's words |
| no input at all (a 403, a 404, a conflict) | the toast, exactly as before |
| nothing — a transport failure | the toast, the caller's own sentence |

Silence is what a mechanism like this breaks first: a form that holds every refusal at an input holds the ones it has no input for as well, and the operator gets a save button that does nothing. Showing the message at the control *and* in a toast is the other failure, and it is the one that teaches people to dismiss toasts unread.

### The placement is about whether it will be READ, not about the declared list

The first version asked only "is this input one the form declared", and review found three ways a placement can then be held and never seen. They are one defect, so they are one table rather than three guards:

- **The form is gone.** This card is a modal body, and its own comments already record that a save is slow enough for the operator to close the modal while the request is out. The mark would be written to state nobody renders, with `capture` having already reported "it is on the control".
- **The value moved.** The operator corrected the input while the request was out. The refusal is about what was **sent**; marking the box would put "this is not valid" under a value the server never saw.
- **The request never carried the field.** Then there is nothing to be stale against — the refusal is about what is *stored* — and the mark stands. This is the guard on the comparison above, and it needs to exist: without it, `sent[field]` reads `undefined`, differs from what the input holds, and every such refusal becomes a toast.

The mark then expires **by value**: `at(field, value)` shows the message only while the input still holds what was refused. That removed the `refusal.clear(field)` call from `onChange` — forgetting that line was invisible, forgetting the argument is a type error. `clear()` survives for the save that goes through, which the value key cannot recognise on its own.

`apiErrorMessage` now delegates to `readRefusal` rather than parsing the body a second time, so there is one reader of the wire shape. It stays as the answer for actions that are not a form (a delete, a retry, a connection test), where a toast is right either way.

### The four questions #232 left open

- **Where the state lives**: per form instance. A modal over the panel that opened it is the normal case here and both have a `name`; a shared store would mark the page behind the modal, and one that outlives the form would still be holding a refusal when the operator closes a modal and reopens it.
- **How it clears**: by value on edit, and by the next `capture`, which is the only writer and always writes. Two marks can never be on screen at once — the server refuses one thing, and claiming it refused two would be a lie the UI invented.
- **A field that is not on screen**: the form *declares* what it renders, and anything else falls back to the toast. Declared rather than discovered because the submit handler needs the answer before the next render; a registry that filled itself while rendering would answer for the render before the refusal existed. `refusal.field` is exposed for a screen that has somewhere to navigate to (the agent editor's tabs) — the hook itself navigates nothing, because which tab holds which path is the screen's knowledge.
- **Does the toast still fire**: no, when the message is at the control. That is the table above.

Matched exactly, never by prefix: a form rendering `guardrails.output` has not said it renders every leaf under it, and marking the parent control would point at an input the refusal is not about.

## Scope

One screen is wired as the reference (`CompanyProfileCard`), because its six patch keys *are* the six names the server refuses by. The remaining 105 call sites are #233, which this unblocks and which explicitly depends on the mechanism existing first.

## Validation scope

### Proven live

Against the real server and a real browser, on a throwaway database, with the A/B run **in one worktree by checking the four source files back and forth** so the only variable is the code.

The server's refusal, measured (`PUT /api/v1/tenant-settings/company`, `{"document":"12.345 😀"}`):

```
Accept-Language: pt-BR
{"error":"Este campo do perfil da empresa não é válido: document contains characters this document cannot print (😀) …","field":"document"}

Accept-Language: en
{"error":"This company profile field is not valid: document contains characters this document cannot print (😀) …","field":"document"}
```

The sentence changes with the language and the field does not, which is the property the client matches on.

In the browser, same scenario both times, counting toasts with a 30 ms observer armed **before** the click (a single read after the fact cannot tell "no toast" from "the toast already expired" — the first attempt at this measurement read zero toasts on the base code for exactly that reason):

| | base | with the change |
| --- | --- | --- |
| toasts observed | 1, carrying the sentence | **0** |
| fields marked | **0** | 1 — `CNPJ/CPF`, carrying the sentence |

And editing the refused input clears the mark, observed on the live form: `markedAfterEdit: []`.

### Proven by test

`tests/client/field-refusal.test.ts` — a decision table over `readRefusal` and `placeRefusal`, plus the property the rows are individually asserting, stated once over all of them: exactly one channel fires, never both and never neither.

`tests/client/field-refusal-at-input.test.tsx` — the real card driven through a stubbed `fetch`. Written **before** the change and run against `main`: **3 pass, 6 fail** — the three that passed are the toast fallbacks, which are today's behaviour and must not regress. The three cases review added were also written first and run against the then-current code: two failed, and the third did not (below).

Mutation battery, one mutation at a time, restored between runs. All fifteen are killed:

```
1  place: drop the no-refusal guard                          3 fail
2  place: stop asking what the form renders                  5 fail
3  place: match by prefix instead of exactly                 1 fail
4  place: mark even when the form is gone                    2 fail
5  place: mark a value the operator already replaced         2 fail
6  place: compare even a field the request never carried     1 fail
7  read: stop trimming the field                             2 fail
8  read: accept a blank sentence                             1 fail
9  hook: report the form as mounted, always                  1 fail
10 hook: stop clearing when nothing is placed                1 fail
11 hook: stop keying the mark on the value                   1 fail
12 card: no clear after a save that went through             1 fail
13 card: toast even when it is on the control                1 fail
14 card: never render the refusal at the control             6 fail
15 card: compare against the pre-request snapshot            1 fail
```

Two of them survived a first run, and both were tests passing for the wrong reason rather than rules that did not matter:

- **13** survived because the assertion counted occurrences of the reason, so a toast raised with the *generic* sentence beside the message already on the control shared no text with it and went unseen. The rule "the toast stays silent" had no test at all until a toast **counter** replaced it, with a positive control on the row where a toast is expected so a counter that stopped counting fails there instead of passing where zero is the answer.
- **6** survived because no row exercised the guard: the one dotted-path row had the field absent from both `sent` and `current`, so `undefined === undefined` placed it either way.

A third test was **removed**: the one for "a save that dies in transit takes an earlier mark off". Measured, Eden surfaces an offline save on this route as a *resolved* `error`, so it already flows through `capture` and the mark already clears — the test passed on the base code and after, and could discriminate nothing. The `catch` is still routed through `capture`, as a simplification that keeps it the only writer, not as a fix for an observed defect.

`bun check`: **5561 pass / 0 fail**.

### Not validated

- **The other 105 call sites** are untouched and behave exactly as before. That sweep is #233.
- **A refusal whose field is on a collapsed section or another tab** is held and rendered, but the operator may not be looking at it. `refusal.field` exists so a screen can navigate; nothing here does, and the editor's tab routing (`TEXT_CAP_TARGETS`, `lib/configHealth.ts`) is not wired to it. It belongs to whichever screen #233 reaches first.
- **Screen readers.** The message renders in `FormField`'s existing error slot, which is the same slot every current `error` prop uses; no `aria-describedby`/`aria-invalid` wiring was added or measured, and adding it would change the slot for all 46 existing users of it.
- **A form whose two inputs hold equal values** and a refusal that moves between them is distinguished by field name, not by value, so this is fine — but the value key does mean a refusal re-arriving for a value the operator restored by hand will show again. That is the intended reading of "the box holds what was refused" and it has no test.
