### PR TITLE
Record the two billed model calls that reached no ledger row

### DIFF
--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -891,6 +891,8 @@ export async function runAgentNudge(
       flow,
       systemPrompt: cfg.systemPrompt,
       makeModel: params.deps?.makeModel,
+      // Same sink as this turn's own callbacks (see the buildCallbacks call above).
+      persistUsage: params.deps?.persistUsage,
     })("output", text);
 
   // What the transfer promised the customer, delivered on the way OUT of the turn — whatever the way

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -615,6 +615,9 @@ export async function runLoadedTurn(
     // words would make it judge the reply against something nobody said.
     customerMessage: text,
     makeModel: params.deps?.makeModel,
+    // The same sink the turn's own callbacks use. A test that injects one and leaves guardrails on
+    // would otherwise capture the agent's row and send the guardrail's to the real database.
+    persistUsage: params.deps?.persistUsage,
   });
 
   // One piece of customer-facing text, delivered the way this agent delivers text: as audio when the

--- a/src/graph/usage.ts
+++ b/src/graph/usage.ts
@@ -4,6 +4,7 @@ import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import type { FlowContext } from "@/modules/flowlog/service";
 import { emitOutbound } from "@/modules/webhooks/outbound/service";
 
 // LLM usage capture AT THE SOURCE (not mirrored from Langfuse): a LangChain callback that
@@ -159,6 +160,68 @@ export function extractTokenUsage(output: LLMResult): TokenUsage {
     cachedReadTokens: 0,
     cacheCreationTokens: 0,
   };
+}
+
+// The attribution a SECONDARY billed call inherits from the turn it belongs to. A turn's own call
+// gets these from the loaded agent config; a call made beside it (the guardrail analysis, a vision
+// extraction) holds a FlowContext and nothing else, and that context already carries exactly the
+// five fields a row needs.
+//
+// Reading them from one place is what keeps the two apart from a third possibility, measured in
+// #316 and the reason this exists: a billed call attributed to NOTHING, because the code that made
+// it had no way to say where it came from and so wrote no row at all.
+export function usageAttribution(flow: FlowContext): {
+  tenantId: bigint;
+  agentId: bigint | null;
+  conversationId: bigint | null;
+  inboxId: bigint | null;
+  threadId: string | null;
+  source: UsageSource;
+  base?: PrismaClient;
+} {
+  return {
+    tenantId: flow.tenantId,
+    agentId: flow.agentId ?? null,
+    conversationId: flow.conversationId ?? null,
+    inboxId: flow.inboxId ?? null,
+    threadId: flow.threadId ?? null,
+    // FlowSource and UsageSource are the same two values ("inbox" | "playground") for the same
+    // reason: a row and a log line about one call must not disagree about which traffic it was.
+    source: flow.source,
+    base: flow.base,
+  };
+}
+
+// Records a billed call that did NOT go through LangChain, so no callback could have seen it: a
+// provider reached by raw fetch (vision). Best-effort, like the callback path — a ledger write
+// never breaks the call it is about.
+export async function recordDirectUsage(
+  flow: FlowContext,
+  row: {
+    model: string;
+    node: string;
+    promptTokens: number;
+    completionTokens: number;
+    cachedReadTokens?: number;
+    cacheCreationTokens?: number;
+  },
+  persist?: UsagePersist,
+): Promise<void> {
+  if (row.promptTokens === 0 && row.completionTokens === 0) return;
+  const attr = usageAttribution(flow);
+  try {
+    await (persist ?? defaultUsagePersist(attr.base))({
+      ...attr,
+      model: row.model,
+      node: row.node,
+      promptTokens: row.promptTokens,
+      completionTokens: row.completionTokens,
+      cachedReadTokens: row.cachedReadTokens ?? 0,
+      cacheCreationTokens: row.cacheCreationTokens ?? 0,
+    });
+  } catch (err) {
+    logger.warn({ err, node: row.node }, "usage: direct capture failed");
+  }
 }
 
 export interface UsageCaptureParams {

--- a/src/graph/usage.ts
+++ b/src/graph/usage.ts
@@ -35,6 +35,36 @@ export interface UsageRow {
 
 export type UsagePersist = (row: UsageRow) => Promise<void>;
 
+// Every `node` the ledger can carry, against the one question a reader asking about the AGENT has to
+// settle first: did the agent take the turn this call was billed for?
+//
+// "There is a billed call on this conversation" is not that question, and the two came apart the
+// moment the ledger got complete (#316). Vision runs on the incoming attachment BEFORE the
+// bot-ownership gate decides anything, so an image sent into a conversation a human owns bills the
+// tenant while the agent never speaks. Every other node is downstream of a turn that did run.
+//
+// The map is TOTAL on purpose, and the fence in tests/modules/billed-call-usage.test.ts keeps it
+// that way: a node value missing from it is a red test, never a silent default. Defaulting to true
+// inflates involvement exactly the way vision just did; defaulting to false deflates it as quietly.
+export const USAGE_NODE_IS_AGENT_TURN: Readonly<Record<string, boolean>> =
+  Object.freeze({
+    agent: true,
+    nudge: true,
+    guardrail: true,
+    tts_normalize: true,
+    memory_compact: true,
+    vision: false,
+  });
+
+// Consumed as an EXCLUSION, with `node: null` kept beside it: a row from before this column was
+// always written is an agent turn, because the agent path was the only one in the ledger then. An
+// inclusion list would drop those rows instead, and move every historical involvement number.
+export const NON_AGENT_TURN_NODES: readonly string[] = Object.freeze(
+  Object.entries(USAGE_NODE_IS_AGENT_TURN)
+    .filter(([, isTurn]) => !isTurn)
+    .map(([node]) => node),
+);
+
 function sysCtx(tenantId: bigint): TenantContext {
   return { tenantId, userId: null, role: "TENANT_ADMIN" };
 }

--- a/src/graph/usage.ts
+++ b/src/graph/usage.ts
@@ -205,12 +205,11 @@ export async function recordDirectUsage(
     cachedReadTokens?: number;
     cacheCreationTokens?: number;
   },
-  persist?: UsagePersist,
 ): Promise<void> {
   if (row.promptTokens === 0 && row.completionTokens === 0) return;
   const attr = usageAttribution(flow);
   try {
-    await (persist ?? defaultUsagePersist(attr.base))({
+    await defaultUsagePersist(attr.base)({
       ...attr,
       model: row.model,
       node: row.node,

--- a/src/modules/analytics/service.ts
+++ b/src/modules/analytics/service.ts
@@ -1,6 +1,6 @@
 import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
-import type { UsageSource } from "@/graph/usage";
+import { NON_AGENT_TURN_NODES, type UsageSource } from "@/graph/usage";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { classifyOutcome } from "@/modules/conversations/resolution-origin";
 
@@ -254,6 +254,14 @@ export async function getKpis(
         // mirror conversation (conversationId stays null), and source="inbox" makes that explicit.
         conversationId: { not: null },
         source: "inbox",
+        // A billed call is not the same claim as "the agent took this conversation", and this is
+        // the only reader that makes the second one. Vision runs on the incoming attachment before
+        // the bot-ownership gate decides anything, so an image sent into a conversation a human
+        // handled start to finish would otherwise land here as bot involvement.
+        //   The null arm is not a formality: Prisma renders `notIn` as plain SQL `NOT IN`, which
+        // drops NULL rows rather than keeping them (measured), and a legacy row with no node is an
+        // agent turn. Without it this filter would quietly shrink every historical figure.
+        OR: [{ node: null }, { node: { notIn: [...NON_AGENT_TURN_NODES] } }],
         ...(filter.since ? { createdAt: { gte: filter.since } } : {}),
       },
       select: { conversationId: true },

--- a/src/modules/guardrails/analyze.ts
+++ b/src/modules/guardrails/analyze.ts
@@ -1,3 +1,4 @@
+import type { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import {
   type BaseMessage,
@@ -152,10 +153,18 @@ export async function analyzeGuardrail(
   // (`acceptsConstrainedOutput`), and passed rather than inferred here: the same adapter serves an
   // endpoint we own and one we know nothing about, so the instance cannot answer this.
   mode: VerdictMode,
+  // The turn's usage sink. A guardrail analysis is a billed model call like any other, and without
+  // this it is spent money with no row (issue #316) — the same hole the speech normalizer had.
+  callbacks?: BaseCallbackHandler[],
 ): Promise<GuardrailVerdict> {
   const { policies, relevance } = splitAnalyses(params);
   if (relevance === null) {
-    const verdict = await runAnalysis(model, policies as AnalysisParams, mode);
+    const verdict = await runAnalysis(
+      model,
+      policies as AnalysisParams,
+      mode,
+      callbacks,
+    );
     // NOTE: The INPUT direction never delivers a replacement. There is no assistant reply to repair
     // there — the analyzed text is the CUSTOMER's message — so "write a safe replacement" has no
     // referent and the model composes one from an empty desk. Measured live against eight models
@@ -186,12 +195,14 @@ export async function analyzeGuardrail(
     return params.direction === "input" ? withoutReplacement(verdict) : verdict;
   }
   if (policies === null) {
-    return withoutReplacement(await runAnalysis(model, relevance, mode));
+    return withoutReplacement(
+      await runAnalysis(model, relevance, mode, callbacks),
+    );
   }
   // NOTE: In parallel: the operator is paying for a turn a customer is waiting on.
   const [byPolicy, byRelevance] = await Promise.all([
-    runAnalysis(model, policies, mode),
-    runAnalysis(model, relevance, mode).then(withoutReplacement),
+    runAnalysis(model, policies, mode, callbacks),
+    runAnalysis(model, relevance, mode, callbacks).then(withoutReplacement),
   ]);
   // NOTE: A rewrite from the policy half PRESERVES the substance of the reply and repairs its form, which
   // is the whole reason it is allowed to write one. When relevance also tripped, the substance is
@@ -228,10 +239,12 @@ async function invokeForVerdict(
   model: BaseChatModel,
   mode: VerdictMode,
   messages: BaseMessage[],
+  callbacks?: BaseCallbackHandler[],
 ): Promise<{ parsed: Record<string, unknown> | null; raw: string }> {
   const asProse = async () => {
     const res = await model.invoke(messages, {
       signal: AbortSignal.timeout(ANALYZE_TIMEOUT_MS),
+      callbacks,
     });
     return { parsed: null, raw: messageText(res.content).trim() };
   };
@@ -254,6 +267,7 @@ async function invokeForVerdict(
       })
       .invoke(messages, {
         signal: AbortSignal.timeout(ANALYZE_TIMEOUT_MS),
+        callbacks,
       })) as {
       raw: BaseMessage;
       parsed: Record<string, unknown> | null;
@@ -276,6 +290,7 @@ async function runAnalysis(
   model: BaseChatModel,
   params: AnalysisParams,
   mode: VerdictMode,
+  callbacks?: BaseCallbackHandler[],
 ): Promise<GuardrailVerdict> {
   const system = buildGuardrailSystemPrompt(params);
   // NOTE: The customer's message rides at USER level, fenced and named, never inside the system prompt:
@@ -287,7 +302,7 @@ async function runAnalysis(
   messages.push(new HumanMessage(params.text));
   try {
     const { parsed, raw } = await runModelCall(() =>
-      invokeForVerdict(model, mode, messages),
+      invokeForVerdict(model, mode, messages, callbacks),
     );
     return readVerdict(parsed, raw);
   } catch (err) {

--- a/src/modules/guardrails/gate.ts
+++ b/src/modules/guardrails/gate.ts
@@ -1,6 +1,11 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { verdictAskMode } from "@/graph/model-config";
 import { createChatModel } from "@/graph/models";
+import {
+  UsageCapture,
+  type UsagePersist,
+  usageAttribution,
+} from "@/graph/usage";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { emitFlowEvent, type FlowContext } from "@/modules/flowlog/service";
 import { analyzeGuardrail } from "./analyze";
@@ -126,10 +131,23 @@ export interface GuardrailGateParams {
   // check itself, structurally, the same way the input direction drops the replacement.
   customerMessage?: string;
   makeModel?: typeof createChatModel;
+  // Overrides the ledger sink. Tests inject; production takes the default, which writes the row.
+  persistUsage?: UsagePersist;
 }
 
 export function buildGuardrailGate(p: GuardrailGateParams): GuardrailGate {
   const gr = p.cfg;
+  // The analysis runs on the guardrails agent's OWN model, so the row has to name THAT model and
+  // not the agent's: a shared name would attribute this spend to the customer turn beside it. The
+  // rest of the attribution comes from the flow context, which is the only thing this gate holds
+  // that knows which conversation it is screening.
+  const usage = () =>
+    new UsageCapture({
+      ...usageAttribution(p.flow),
+      model: gr.model,
+      node: "guardrail",
+      persist: p.persistUsage,
+    });
   // Built on FIRST CALL, not here, and never twice: a gate is constructed for every turn and every
   // follow-up, while a direction that is switched off never reaches the model. `createChatModel`
   // throws synchronously on a configuration it cannot satisfy (an `openai-compatible` provider with
@@ -236,6 +254,7 @@ export function buildGuardrailGate(p: GuardrailGateParams): GuardrailGate {
       // OpenAI itself and whatever an operator points `openai-compatible` at (issue #131). Reaching
       // it through the gate is what puts the proactive path on the same footing as the reactive one.
       verdictAskMode(gr.provider),
+      [usage()],
     );
     // A guardrail that could not run reads exactly like one that ran and approved, so without this
     // line an expired credential is silent moderation for as long as nobody notices. The turn is

--- a/src/modules/vision/providers.ts
+++ b/src/modules/vision/providers.ts
@@ -17,12 +17,39 @@ export interface VisionRequest {
   fetchImpl: typeof fetch;
 }
 
+// What a vision call cost, in the provider's own numbers. Every one of the three endpoints below
+// returns this alongside the text; the contract used to be `Promise<string>`, which made it
+// unrepresentable, so it was parsed away and the spend reached no ledger (issue #316). Optional
+// because an endpoint may omit the block, and an absent count must not be recorded as zero spend.
+export interface VisionUsage {
+  promptTokens: number;
+  completionTokens: number;
+}
+
+export interface VisionResult {
+  text: string;
+  usage: VisionUsage | null;
+}
+
 export interface VisionProvider {
   defaultModel: string;
   // Whether the provider can extract from PDFs (all support images). OpenAI chat vision is
   // image-only; Gemini and Anthropic accept PDF documents inline.
   supportsDocuments: boolean;
-  extract(req: VisionRequest): Promise<string>;
+  extract(req: VisionRequest): Promise<VisionResult>;
+}
+
+function num(v: unknown): number {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+// A usage block is only reported when the endpoint actually sent counts. Returning zeros for a
+// missing block would write a row saying the call was free.
+function usageOf(prompt: unknown, completion: unknown): VisionUsage | null {
+  const p = num(prompt);
+  const c = num(completion);
+  return p === 0 && c === 0 ? null : { promptTokens: p, completionTokens: c };
 }
 
 export class VisionError extends Error {
@@ -47,7 +74,7 @@ async function chatCompletionsExtract(
   req: VisionRequest,
   providerName: string,
   defaultBase: string,
-): Promise<string> {
+): Promise<VisionResult> {
   const base = (req.baseURL ?? defaultBase).replace(/\/+$/, "");
   const dataUri = `data:${req.mimeType};base64,${base64(req.bytes)}`;
   const body = {
@@ -75,15 +102,19 @@ async function chatCompletionsExtract(
   if (!res.ok) throw new VisionError(providerName, res.status);
   const json = (await res.json()) as {
     choices?: Array<{ message?: { content?: string } }>;
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
   };
-  return (json.choices?.[0]?.message?.content ?? "").trim();
+  return {
+    text: (json.choices?.[0]?.message?.content ?? "").trim(),
+    usage: usageOf(json.usage?.prompt_tokens, json.usage?.completion_tokens),
+  };
 }
 
-async function openaiExtract(req: VisionRequest): Promise<string> {
+async function openaiExtract(req: VisionRequest): Promise<VisionResult> {
   return chatCompletionsExtract(req, "openai", "https://api.openai.com/v1");
 }
 
-async function openrouterExtract(req: VisionRequest): Promise<string> {
+async function openrouterExtract(req: VisionRequest): Promise<VisionResult> {
   return chatCompletionsExtract(
     req,
     "openrouter",
@@ -94,13 +125,15 @@ async function openrouterExtract(req: VisionRequest): Promise<string> {
 // Self-hosted / third-party OpenAI-compatible vision endpoint (e.g. a Qwen-VL server). The base URL is
 // REQUIRED (there is no canonical default); the model id is whatever the endpoint serves. Image-only
 // (chat-completions image_url), mirroring the stt `openai-compatible` provider.
-async function openaiCompatibleExtract(req: VisionRequest): Promise<string> {
+async function openaiCompatibleExtract(
+  req: VisionRequest,
+): Promise<VisionResult> {
   if (!req.baseURL) throw new VisionError("openai-compatible", 400);
   return chatCompletionsExtract(req, "openai-compatible", req.baseURL);
 }
 
 // Google Gemini generateContent with the file inlined as base64. Handles images AND PDFs.
-async function geminiExtract(req: VisionRequest): Promise<string> {
+async function geminiExtract(req: VisionRequest): Promise<VisionResult> {
   const base = (
     req.baseURL ?? "https://generativelanguage.googleapis.com/v1beta"
   ).replace(/\/+$/, "");
@@ -131,16 +164,26 @@ async function geminiExtract(req: VisionRequest): Promise<string> {
   if (!res.ok) throw new VisionError("gemini", res.status);
   const json = (await res.json()) as {
     candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+    usageMetadata?: {
+      promptTokenCount?: number;
+      candidatesTokenCount?: number;
+    };
   };
   const parts = json.candidates?.[0]?.content?.parts ?? [];
-  return parts
-    .map((p) => p.text ?? "")
-    .join("")
-    .trim();
+  return {
+    text: parts
+      .map((p) => p.text ?? "")
+      .join("")
+      .trim(),
+    usage: usageOf(
+      json.usageMetadata?.promptTokenCount,
+      json.usageMetadata?.candidatesTokenCount,
+    ),
+  };
 }
 
 // Anthropic messages API. Images use an `image` content block; PDFs use a `document` block.
-async function anthropicExtract(req: VisionRequest): Promise<string> {
+async function anthropicExtract(req: VisionRequest): Promise<VisionResult> {
   const base = (req.baseURL ?? "https://api.anthropic.com/v1").replace(
     /\/+$/,
     "",
@@ -178,11 +221,15 @@ async function anthropicExtract(req: VisionRequest): Promise<string> {
   if (!res.ok) throw new VisionError("anthropic", res.status);
   const json = (await res.json()) as {
     content?: Array<{ type?: string; text?: string }>;
+    usage?: { input_tokens?: number; output_tokens?: number };
   };
-  return (json.content ?? [])
-    .map((c) => (c.type === "text" ? (c.text ?? "") : ""))
-    .join("")
-    .trim();
+  return {
+    text: (json.content ?? [])
+      .map((c) => (c.type === "text" ? (c.text ?? "") : ""))
+      .join("")
+      .trim(),
+    usage: usageOf(json.usage?.input_tokens, json.usage?.output_tokens),
+  };
 }
 
 const PROVIDERS: Record<string, VisionProvider> = {

--- a/src/modules/vision/providers.ts
+++ b/src/modules/vision/providers.ts
@@ -24,6 +24,11 @@ export interface VisionRequest {
 export interface VisionUsage {
   promptTokens: number;
   completionTokens: number;
+  // Cached input: a discounted SUBSET of promptTokens, never additive. Same contract as
+  // `TokenUsage` in graph/usage.ts, because the two paths answer the same question and a reader
+  // summing both must not have to know which one wrote the row.
+  cachedReadTokens: number;
+  cacheCreationTokens: number;
 }
 
 export interface VisionResult {
@@ -46,10 +51,25 @@ function num(v: unknown): number {
 
 // A usage block is only reported when the endpoint actually sent counts. Returning zeros for a
 // missing block would write a row saying the call was free.
-function usageOf(prompt: unknown, completion: unknown): VisionUsage | null {
-  const p = num(prompt);
-  const c = num(completion);
-  return p === 0 && c === 0 ? null : { promptTokens: p, completionTokens: c };
+//
+// The cached counters are what separate "carried the pair" from "carried what was billed": a cached
+// prompt is charged at a discount, so a row that reports the whole prompt as fresh input overstates
+// the spend it exists to measure.
+function usageOf(u: {
+  prompt: unknown;
+  completion: unknown;
+  cachedRead?: unknown;
+  cacheCreation?: unknown;
+}): VisionUsage | null {
+  const promptTokens = num(u.prompt);
+  const completionTokens = num(u.completion);
+  if (promptTokens === 0 && completionTokens === 0) return null;
+  return {
+    promptTokens,
+    completionTokens,
+    cachedReadTokens: num(u.cachedRead),
+    cacheCreationTokens: num(u.cacheCreation),
+  };
 }
 
 export class VisionError extends Error {
@@ -102,11 +122,22 @@ async function chatCompletionsExtract(
   if (!res.ok) throw new VisionError(providerName, res.status);
   const json = (await res.json()) as {
     choices?: Array<{ message?: { content?: string } }>;
-    usage?: { prompt_tokens?: number; completion_tokens?: number };
+    usage?: {
+      prompt_tokens?: number;
+      completion_tokens?: number;
+      prompt_tokens_details?: { cached_tokens?: number };
+    };
   };
   return {
     text: (json.choices?.[0]?.message?.content ?? "").trim(),
-    usage: usageOf(json.usage?.prompt_tokens, json.usage?.completion_tokens),
+    usage: usageOf({
+      prompt: json.usage?.prompt_tokens,
+      completion: json.usage?.completion_tokens,
+      // NOTE: `completion_tokens_details.reasoning_tokens` is NOT read here on purpose: OpenAI
+      // counts reasoning INSIDE completion_tokens, so adding it would bill the same tokens twice.
+      // Gemini is the opposite case, and is handled as such below.
+      cachedRead: json.usage?.prompt_tokens_details?.cached_tokens,
+    }),
   };
 }
 
@@ -167,6 +198,8 @@ async function geminiExtract(req: VisionRequest): Promise<VisionResult> {
     usageMetadata?: {
       promptTokenCount?: number;
       candidatesTokenCount?: number;
+      thoughtsTokenCount?: number;
+      cachedContentTokenCount?: number;
     };
   };
   const parts = json.candidates?.[0]?.content?.parts ?? [];
@@ -175,10 +208,18 @@ async function geminiExtract(req: VisionRequest): Promise<VisionResult> {
       .map((p) => p.text ?? "")
       .join("")
       .trim(),
-    usage: usageOf(
-      json.usageMetadata?.promptTokenCount,
-      json.usageMetadata?.candidatesTokenCount,
-    ),
+    usage: usageOf({
+      prompt: json.usageMetadata?.promptTokenCount,
+      // Thinking tokens are billed output and are NOT part of candidatesTokenCount: the API
+      // reference defines totalTokenCount as "prompt + thoughts + response candidates", so a
+      // thinking model's reply would otherwise be recorded at a fraction of what it cost.
+      completion:
+        num(json.usageMetadata?.candidatesTokenCount) +
+        num(json.usageMetadata?.thoughtsTokenCount),
+      // promptTokenCount already INCLUDES the cached part ("the total effective prompt size"), so
+      // this is the discounted subset and never an addition.
+      cachedRead: json.usageMetadata?.cachedContentTokenCount,
+    }),
   };
 }
 
@@ -221,14 +262,24 @@ async function anthropicExtract(req: VisionRequest): Promise<VisionResult> {
   if (!res.ok) throw new VisionError("anthropic", res.status);
   const json = (await res.json()) as {
     content?: Array<{ type?: string; text?: string }>;
-    usage?: { input_tokens?: number; output_tokens?: number };
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
   };
   return {
     text: (json.content ?? [])
       .map((c) => (c.type === "text" ? (c.text ?? "") : ""))
       .join("")
       .trim(),
-    usage: usageOf(json.usage?.input_tokens, json.usage?.output_tokens),
+    usage: usageOf({
+      prompt: json.usage?.input_tokens,
+      completion: json.usage?.output_tokens,
+      cachedRead: json.usage?.cache_read_input_tokens,
+      cacheCreation: json.usage?.cache_creation_input_tokens,
+    }),
   };
 }
 

--- a/src/modules/vision/providers.ts
+++ b/src/modules/vision/providers.ts
@@ -60,15 +60,24 @@ function usageOf(u: {
   completion: unknown;
   cachedRead?: unknown;
   cacheCreation?: unknown;
+  // Whether `prompt` already contains the cached counts. OpenAI and Gemini report a prompt total
+  // that includes them; Anthropic reports only what fell outside the cache, and its own docs give
+  // the total as cache_read + cache_creation + input_tokens. Reading one like the other undercounts
+  // every cached call on that provider, and the row would carry subsets larger than the whole.
+  promptExcludesCached?: boolean;
 }): VisionUsage | null {
-  const promptTokens = num(u.prompt);
+  const cachedReadTokens = num(u.cachedRead);
+  const cacheCreationTokens = num(u.cacheCreation);
+  const promptTokens = u.promptExcludesCached
+    ? num(u.prompt) + cachedReadTokens + cacheCreationTokens
+    : num(u.prompt);
   const completionTokens = num(u.completion);
   if (promptTokens === 0 && completionTokens === 0) return null;
   return {
     promptTokens,
     completionTokens,
-    cachedReadTokens: num(u.cachedRead),
-    cacheCreationTokens: num(u.cacheCreation),
+    cachedReadTokens,
+    cacheCreationTokens,
   };
 }
 
@@ -279,6 +288,7 @@ async function anthropicExtract(req: VisionRequest): Promise<VisionResult> {
       completion: json.usage?.output_tokens,
       cachedRead: json.usage?.cache_read_input_tokens,
       cacheCreation: json.usage?.cache_creation_input_tokens,
+      promptExcludesCached: true,
     }),
   };
 }

--- a/src/modules/vision/service.ts
+++ b/src/modules/vision/service.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
+import { recordDirectUsage } from "@/graph/usage";
 import { AppError, NotFoundError } from "@/lib/errors";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { stashMediaAnnotation } from "@/modules/chatwoot/annotations";
@@ -15,6 +16,7 @@ import { tryResolveVaultEntry } from "@/modules/vault/service";
 import {
   getVisionProvider,
   type VisionKind,
+  type VisionResult,
   visionKindForMime,
 } from "./providers";
 import { readVisionConfig, type VisionConfig } from "./settings";
@@ -165,35 +167,33 @@ export async function extractInboundFile(
   if (kind === "document" && !provider.supportsDocuments)
     return skip("document_not_supported");
 
-  let text: string;
+  let extracted: VisionResult;
   try {
-    text = (
-      await withFlowStage(
-        params.flow,
-        "vision",
-        {
-          provider: cfg.provider,
+    extracted = await withFlowStage(
+      params.flow,
+      "vision",
+      {
+        provider: cfg.provider,
+        model: cfg.model || provider.defaultModel,
+        detail: { kind },
+        // Recovered (→ "couldn't extract" marker), so a failure reads as an advisory, not a red
+        // error — same contract as TTS.
+        errorLevel: "warn",
+      },
+      () =>
+        provider.extract({
+          bytes,
+          mimeType:
+            contentType ??
+            (kind === "image" ? "image/jpeg" : "application/pdf"),
+          kind,
+          prompt: cfg.extractionPrompt,
           model: cfg.model || provider.defaultModel,
-          detail: { kind },
-          // Recovered (→ "couldn't extract" marker), so a failure reads as an advisory, not a red
-          // error — same contract as TTS.
-          errorLevel: "warn",
-        },
-        () =>
-          provider.extract({
-            bytes,
-            mimeType:
-              contentType ??
-              (kind === "image" ? "image/jpeg" : "application/pdf"),
-            kind,
-            prompt: cfg.extractionPrompt,
-            model: cfg.model || provider.defaultModel,
-            apiKey: entry.secret,
-            baseURL: entry.baseUrl ?? cfg.baseURL,
-            fetchImpl: params.deps?.fetchImpl ?? fetch,
-          }),
-      )
-    ).trim();
+          apiKey: entry.secret,
+          baseURL: entry.baseUrl ?? cfg.baseURL,
+          fetchImpl: params.deps?.fetchImpl ?? fetch,
+        }),
+    );
   } catch (e) {
     // Best-effort: a provider error must not strand delivery. Log at error-level (ops alert channel)
     // and leave the attachment unextracted → the agent sees the "couldn't extract" marker.
@@ -208,6 +208,18 @@ export async function extractInboundFile(
       "inbound vision extraction failed; leaving attachment unextracted",
     );
     return null;
+  }
+  const text = extracted.text.trim();
+  // The row is written whether or not the extraction yielded text: a call that came back empty was
+  // billed exactly like one that came back full, and the early return below used to end the
+  // function before anything could record it.
+  if (params.flow && extracted.usage) {
+    await recordDirectUsage(params.flow, {
+      model: cfg.model || provider.defaultModel,
+      node: "vision",
+      promptTokens: extracted.usage.promptTokens,
+      completionTokens: extracted.usage.completionTokens,
+    });
   }
   if (!text) return null;
 
@@ -323,32 +335,38 @@ export async function extractPlaygroundFile(
   }
 
   try {
-    const text = (
-      await withFlowStage(
-        params.flow,
-        "vision",
-        {
-          provider: cfg.provider,
+    const extracted = await withFlowStage(
+      params.flow,
+      "vision",
+      {
+        provider: cfg.provider,
+        model: cfg.model || provider.defaultModel,
+        detail: { kind },
+        errorLevel: "warn",
+      },
+      () =>
+        provider.extract({
+          bytes: params.file,
+          mimeType:
+            params.mimeType ??
+            (kind === "image" ? "image/jpeg" : "application/pdf"),
+          kind,
+          prompt: cfg.extractionPrompt,
           model: cfg.model || provider.defaultModel,
-          detail: { kind },
-          errorLevel: "warn",
-        },
-        () =>
-          provider.extract({
-            bytes: params.file,
-            mimeType:
-              params.mimeType ??
-              (kind === "image" ? "image/jpeg" : "application/pdf"),
-            kind,
-            prompt: cfg.extractionPrompt,
-            model: cfg.model || provider.defaultModel,
-            apiKey: entry.secret,
-            baseURL: entry.baseUrl ?? cfg.baseURL,
-            fetchImpl: params.deps?.fetchImpl ?? fetch,
-          }),
-      )
-    ).trim();
-    return { kind, text };
+          apiKey: entry.secret,
+          baseURL: entry.baseUrl ?? cfg.baseURL,
+          fetchImpl: params.deps?.fetchImpl ?? fetch,
+        }),
+    );
+    if (params.flow && extracted.usage) {
+      await recordDirectUsage(params.flow, {
+        model: cfg.model || provider.defaultModel,
+        node: "vision",
+        promptTokens: extracted.usage.promptTokens,
+        completionTokens: extracted.usage.completionTokens,
+      });
+    }
+    return { kind, text: extracted.text.trim() };
   } catch (e) {
     // Provider error (bad file, model refusal, timeout) must NOT interrupt the turn: log at
     // error-level (the ops alert channel — no Sentry here) and degrade to the "couldn't extract"

--- a/src/modules/vision/service.ts
+++ b/src/modules/vision/service.ts
@@ -217,8 +217,7 @@ export async function extractInboundFile(
     await recordDirectUsage(params.flow, {
       model: cfg.model || provider.defaultModel,
       node: "vision",
-      promptTokens: extracted.usage.promptTokens,
-      completionTokens: extracted.usage.completionTokens,
+      ...extracted.usage,
     });
   }
   if (!text) return null;
@@ -362,8 +361,7 @@ export async function extractPlaygroundFile(
       await recordDirectUsage(params.flow, {
         model: cfg.model || provider.defaultModel,
         node: "vision",
-        promptTokens: extracted.usage.promptTokens,
-        completionTokens: extracted.usage.completionTokens,
+        ...extracted.usage,
       });
     }
     return { kind, text: extracted.text.trim() };

--- a/tests/modules/analytics-kpis.test.ts
+++ b/tests/modules/analytics-kpis.test.ts
@@ -91,6 +91,36 @@ async function seedClosedConversation(p: {
   }
 }
 
+// A conversation a human owned start to finish, on which the customer sent an image. Vision runs on
+// the incoming attachment BEFORE the bot-ownership gate, so the tenant was billed and the row exists
+// — but the agent never took the turn. Seeded with the node the real writer sets.
+async function seedVisionOnlyConversation(convId: number): Promise<void> {
+  const conv = await suDb.conversation.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      inboxId: inboxDbId,
+      chatwootConversationId: convId,
+      status: "open",
+      assigneeType: "User",
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      lastEventAt: new Date(),
+    },
+  });
+  await suDb.llmUsage.create({
+    data: {
+      tenantId,
+      inboxId: inboxDbId,
+      conversationId: conv.id,
+      source: "inbox",
+      model: "gpt-4o-mini",
+      node: "vision",
+      promptTokens: 273,
+      completionTokens: 1,
+    },
+  });
+}
+
 describe.skipIf(!dbUp)("getKpis: what counts as a resolution", () => {
   beforeAll(async () => {
     const t = await suDb.tenant.create({
@@ -202,6 +232,30 @@ describe.skipIf(!dbUp)("getKpis: what counts as a resolution", () => {
   test("a human takeover is still a handoff", async () => {
     const kpis = await getKpis(ctx(), {}, appDb);
     expect(kpis.handoff).toBe(1);
+  });
+
+  // Issue #316 completed the ledger, and completing it broke the proxy this KPI rested on: every
+  // billed call used to be an agent turn, because the calls that were not had no row. A vision-only
+  // conversation is the first one that is billed and never answered.
+  test("a call billed before the bot gate is not involvement", async () => {
+    const before = await getKpis(ctx(), {}, appDb);
+    await seedVisionOnlyConversation(30);
+    const after = await getKpis(ctx(), {}, appDb);
+    expect(after.involved).toBe(before.involved);
+    // The conversation is real and still counts in the denominator, so the rate must FALL: the
+    // funnel saw a customer it never engaged.
+    expect(after.totalConversations).toBe(before.totalConversations + 1);
+    expect(after.involvementRate).toBeLessThan(before.involvementRate);
+    // And the resolution rate, whose denominator is `involved`, must not move at all.
+    expect(after.resolutionRate).toBe(before.resolutionRate);
+  });
+
+  test("a legacy row with no node still counts as the agent turn it was", async () => {
+    // The eight conversations seeded above all carry `node: null`, which is what every row written
+    // before this column had a default looks like. `notIn` alone drops them (SQL NOT IN with NULL),
+    // so this is the assertion that catches the filter tightening past its own rule.
+    const kpis = await getKpis(ctx(), {}, appDb);
+    expect(kpis.involved).toBeGreaterThanOrEqual(8);
   });
 
   test("the rates derive from the recorded resolutions", async () => {

--- a/tests/modules/billed-call-usage.test.ts
+++ b/tests/modules/billed-call-usage.test.ts
@@ -293,6 +293,42 @@ describe.skipIf(!dbUp)("billed model calls reach the usage ledger", () => {
     expect(guard?.inboxId).toBe(inboxDbId);
   });
 
+  test("an injected sink receives the guardrail row too, and the database receives neither", async () => {
+    await seedConversation(9303);
+    const threadId = `${tenantId}:${instanceId}:9303`;
+    // The seam exists so a test can capture rows without a database. It only tells the truth if it
+    // covers every billed call in the turn: a sink that catches the agent's row and lets the
+    // guardrail's fall through to the real table is worse than no sink, because the capture looks
+    // complete.
+    const captured: { node: string | null; model: string }[] = [];
+    const agentModel = new UsageReportingModel(["Claro, posso agendar."]);
+    const guardModel = new UsageReportingModel([CLEAN_VERDICT]);
+    await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: { ...textEvent(9303), conversationId: 9303 },
+      base: appDb,
+      deps: {
+        makeModel: ((args: { model: string }) =>
+          args.model === GUARDRAIL_MODEL
+            ? guardModel
+            : agentModel) as unknown as never,
+        makeClient: makeStub({ text: [] }),
+        checkpointer: new MemorySaver(),
+        persistUsage: async (row) => {
+          captured.push({ node: row.node, model: row.model });
+        },
+      },
+    });
+    expect(captured.map((r) => r.node).sort()).toEqual(["agent", "guardrail"]);
+    expect(captured.find((r) => r.node === "guardrail")?.model).toBe(
+      GUARDRAIL_MODEL,
+    );
+    // Nothing leaked past the sink.
+    expect(await usageRows(threadId)).toEqual([]);
+  });
+
   test("an extracted image bills vision with the counts the provider returned", async () => {
     const convDbId = await seedConversation(9302);
     const threadId = `${tenantId}:${instanceId}:9302`;
@@ -469,7 +505,12 @@ const USAGE_SHAPES = [
     },
   },
   {
-    name: "anthropic: cache read and cache write are separate counters",
+    // Anthropic is the ODD ONE, and reading it like the other two undercounts every cached call:
+    // `input_tokens` is "the number of input tokens which were not read from or used to create a
+    // cache", so the doc's own formula is
+    // total_input = cache_read + cache_creation + input_tokens. On OpenAI and Gemini the cached
+    // count is a subset of a prompt total that already contains it.
+    name: "anthropic: the cache counters are ADDITIVE to input_tokens, not a subset",
     provider: "anthropic",
     body: {
       content: [{ type: "text", text: "ok" }],
@@ -481,7 +522,8 @@ const USAGE_SHAPES = [
       },
     },
     want: {
-      promptTokens: 100,
+      // 100 uncached + 40 read from cache + 7 written to cache.
+      promptTokens: 147,
       completionTokens: 10,
       cachedReadTokens: 40,
       cacheCreationTokens: 7,

--- a/tests/modules/billed-call-usage.test.ts
+++ b/tests/modules/billed-call-usage.test.ts
@@ -6,6 +6,7 @@ import { encryptJson } from "@/api/lib/crypto";
 import { runAgentTurn } from "@/graph/runtime";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
+import { getVisionProvider } from "@/modules/vision/providers";
 import { extractInboundFile } from "@/modules/vision/service";
 import { readVisionConfig } from "@/modules/vision/settings";
 import { seedChatwootInstance } from "../utils/chatwoot";
@@ -124,6 +125,7 @@ function usageRows(threadId: string) {
       promptTokens: true,
       completionTokens: true,
       source: true,
+      cachedReadTokens: true,
       conversationId: true,
       agentId: true,
       inboxId: true,
@@ -300,7 +302,11 @@ describe.skipIf(!dbUp)("billed model calls reach the usage ledger", () => {
       new Response(
         JSON.stringify({
           choices: [{ message: { content: "uma nota fiscal" } }],
-          usage: { prompt_tokens: 813, completion_tokens: 24 },
+          usage: {
+            prompt_tokens: 813,
+            completion_tokens: 24,
+            prompt_tokens_details: { cached_tokens: 512 },
+          },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       )) as unknown as typeof fetch;
@@ -340,6 +346,10 @@ describe.skipIf(!dbUp)("billed model calls reach the usage ledger", () => {
     // already.
     expect(usage[0]?.promptTokens).toBe(813);
     expect(usage[0]?.completionTokens).toBe(24);
+    // The discounted subset reaches the row too. The type could not catch this one: the cache
+    // counters are optional on `recordDirectUsage`, so a call site that forwarded only the pair
+    // still compiled.
+    expect(usage[0]?.cachedReadTokens).toBe(512);
     expect(usage[0]?.conversationId).toBe(convDbId);
     expect(usage[0]?.agentId).toBe(agentId);
   });
@@ -400,5 +410,116 @@ describe("every model invocation carries a usage sink", () => {
       }
     }
     expect(offenders).toEqual([]);
+  });
+});
+
+// The three vision branches parse three different usage shapes, and "carried the pair" is not the
+// same as "carried what was billed". Two of the counters are the ones a first pass drops: a cached
+// prompt is charged at a discount, and Gemini bills thinking as output that its candidates count
+// does NOT include (the API reference defines totalTokenCount as prompt + thoughts + candidates).
+//
+// A table rather than three tests: what is being pinned is one rule read three ways, and the shape
+// that hides a mistake is one provider quietly disagreeing with the others.
+const fetchReturning = (body: unknown) =>
+  (async () =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+
+const USAGE_SHAPES = [
+  {
+    name: "openai-compatible: cached prompt is a discounted subset",
+    provider: "openai",
+    body: {
+      choices: [{ message: { content: "ok" } }],
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 10,
+        prompt_tokens_details: { cached_tokens: 40 },
+        // Reasoning is counted INSIDE completion_tokens by OpenAI, so reading it would bill the
+        // same tokens twice. The expectation below is what pins that it is left alone.
+        completion_tokens_details: { reasoning_tokens: 6 },
+      },
+    },
+    want: {
+      promptTokens: 100,
+      completionTokens: 10,
+      cachedReadTokens: 40,
+      cacheCreationTokens: 0,
+    },
+  },
+  {
+    name: "gemini: thinking tokens are billed output on top of candidates",
+    provider: "gemini",
+    body: {
+      candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 10,
+        thoughtsTokenCount: 55,
+        cachedContentTokenCount: 40,
+      },
+    },
+    want: {
+      promptTokens: 100,
+      completionTokens: 65,
+      cachedReadTokens: 40,
+      cacheCreationTokens: 0,
+    },
+  },
+  {
+    name: "anthropic: cache read and cache write are separate counters",
+    provider: "anthropic",
+    body: {
+      content: [{ type: "text", text: "ok" }],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 10,
+        cache_read_input_tokens: 40,
+        cache_creation_input_tokens: 7,
+      },
+    },
+    want: {
+      promptTokens: 100,
+      completionTokens: 10,
+      cachedReadTokens: 40,
+      cacheCreationTokens: 7,
+    },
+  },
+] as const;
+
+describe("a vision provider carries every count it was billed for", () => {
+  for (const c of USAGE_SHAPES) {
+    test(c.name, async () => {
+      const out = await getVisionProvider(c.provider)?.extract({
+        bytes: new ArrayBuffer(4),
+        mimeType: "image/png",
+        kind: "image",
+        prompt: "Descreva.",
+        model: "m",
+        apiKey: "k",
+        baseURL: null,
+        fetchImpl: fetchReturning(c.body),
+      });
+      expect(out?.text).toBe("ok");
+      expect(out?.usage).toEqual(c.want);
+    });
+  }
+
+  // An endpoint that sent no counts must not be recorded as a free call: null is what keeps
+  // `recordDirectUsage` from writing a row that says this one cost nothing.
+  test("a response with no usage block reports null, never zeros", async () => {
+    const out = await getVisionProvider("openai")?.extract({
+      bytes: new ArrayBuffer(4),
+      mimeType: "image/png",
+      kind: "image",
+      prompt: "Descreva.",
+      model: "m",
+      apiKey: "k",
+      baseURL: null,
+      fetchImpl: fetchReturning({ choices: [{ message: { content: "ok" } }] }),
+    });
+    expect(out?.usage).toBeNull();
   });
 });

--- a/tests/modules/billed-call-usage.test.ts
+++ b/tests/modules/billed-call-usage.test.ts
@@ -1,0 +1,404 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { MemorySaver } from "@langchain/langgraph";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { runAgentTurn } from "@/graph/runtime";
+import type { ChatwootClient } from "@/modules/chatwoot/client";
+import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
+import { extractInboundFile } from "@/modules/vision/service";
+import { readVisionConfig } from "@/modules/vision/settings";
+import { seedChatwootInstance } from "../utils/chatwoot";
+import { UsageReportingModel } from "../utils/scripted-models";
+
+// `LlmUsage` is the only ledger of what an install spends on models, and a call reaches it only by
+// carrying the turn's usage callback. Two billed calls never did (issue #316): the guardrail
+// analysis, which invokes without callbacks, and vision, whose provider contract returned a bare
+// string and so could not carry the token counts the provider had already sent back.
+//
+// Every test here reads the row an operator would read, through the real call path. What is being
+// proved is not that a function returns a number: it is that the money spent leaves a trace.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let instanceId = 0n;
+let contactId = 0n;
+let agentId = 0n;
+let inboxDbId = 0n;
+
+// The guardrail runs on a model of its OWN, named differently from the agent's on purpose: the row
+// it writes has to be attributed to the model that was actually billed, and a shared name would let
+// a wrong attribution pass.
+const AGENT_MODEL = "gpt-4o-mini";
+const GUARDRAIL_MODEL = "guard-mini";
+const VISION_MODEL = "vision-mini";
+const CLEAN_VERDICT = JSON.stringify({
+  violated: false,
+  categories: [],
+  rationale: "",
+  suggestedReply: null,
+});
+
+function makeStub(rec: { text: string[] }) {
+  const client = {
+    sendMessage: async (_c: number, content: string) => {
+      rec.text.push(content);
+      return {};
+    },
+    downloadAttachment: async () => ({
+      bytes: new ArrayBuffer(8),
+      contentType: "image/png",
+    }),
+    updateAttachmentMeta: async () => ({}),
+  } as unknown as ChatwootClient;
+  return async () => client;
+}
+
+const textEvent = (convId: number): NormalizedChatwootEvent => ({
+  event: "message_created",
+  conversationId: convId,
+  contactInboxId: null,
+  inboxId: 7,
+  status: "pending",
+  assigneeType: null,
+  assigneeId: null,
+  assigneeName: null,
+  message: {
+    id: 1,
+    content: "quero agendar",
+    messageType: "incoming",
+    private: false,
+    attachments: [],
+  },
+});
+
+async function seedConversation(convId: number) {
+  const c = await suDb.conversation.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      chatwootConversationId: convId,
+      status: "pending",
+      assigneeType: null,
+      contactId,
+      // `loadAgentConfig` reads inboxDbId off the CONVERSATION's relation, not off the event, so a
+      // conversation seeded without it produces null-inbox rows for every node and would let a
+      // wrong attribution pass unnoticed.
+      inboxId: inboxDbId,
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      lastEventAt: new Date(),
+    },
+    select: { id: true },
+  });
+  return c.id;
+}
+
+function usageRows(threadId: string) {
+  return suDb.llmUsage.findMany({
+    where: { tenantId, threadId },
+    select: {
+      node: true,
+      model: true,
+      promptTokens: true,
+      completionTokens: true,
+      source: true,
+      conversationId: true,
+      agentId: true,
+      inboxId: true,
+    },
+    orderBy: { id: "asc" },
+  });
+}
+
+describe.skipIf(!dbUp)("billed model calls reach the usage ledger", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "USAGECOV", slug: `usagecov-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 9,
+      baseUrl: "https://chat.example.com",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const llmKey = await suDb.vaultEntry.create({
+      data: { tenantId, name: "llm-key", secret: encryptJson("sk-llm") },
+      select: { id: true },
+    });
+    const guardKey = await suDb.vaultEntry.create({
+      data: { tenantId, name: "guard-key", secret: encryptJson("sk-guard") },
+      select: { id: true },
+    });
+    const visionKey = await suDb.vaultEntry.create({
+      data: { tenantId, name: "vision-key", secret: encryptJson("sk-vision") },
+      select: { id: true },
+    });
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Atendente",
+        systemPrompt: "Você é prestativa.",
+        modelConfig: {
+          provider: "openai",
+          model: AGENT_MODEL,
+          credentialRef: `vault:${llmKey.id}`,
+        },
+        settings: {
+          split: { enabled: false },
+          // openai-compatible asks for the verdict in prose (verdictAskMode), which is the plain
+          // `model.invoke` path — the one that was missing its callbacks.
+          guardrails: {
+            enabled: true,
+            provider: "openai-compatible",
+            model: GUARDRAIL_MODEL,
+            credentialRef: `vault:${guardKey.id}`,
+            input: { enabled: true, action: "block" },
+            output: { enabled: false },
+          },
+          vision: {
+            enabled: true,
+            provider: "openai",
+            model: VISION_MODEL,
+            credentialRef: `vault:${visionKey.id}`,
+          },
+        },
+      },
+      select: { id: true },
+    });
+    agentId = agent.id;
+    await suDb.chatwootAgentBot.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        agentId: agent.id,
+        chatwootAgentBotId: 9,
+        accessToken: encryptJson("BOT"),
+        webhookSecret: encryptJson("S"),
+        webhookRouteTokenHash: `usagecov-route-${process.pid}`,
+        name: "Atendente",
+      },
+    });
+    const inbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: 7,
+        name: "Suporte",
+        agentId: agent.id,
+      },
+      select: { id: true },
+    });
+    inboxDbId = inbox.id;
+    const contact = await suDb.contact.create({
+      data: {
+        chatwootInstanceId: instanceId,
+        tenantId,
+        name: "Cliente",
+        chatwootContactId: 1,
+      },
+    });
+    contactId = contact.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const table of [
+        "execution_logs",
+        "llm_usage",
+        "conversations",
+        "inboxes",
+        "chatwoot_agent_bots",
+        "agents",
+        "contacts",
+        "vault_entries",
+        "chatwoot_instances",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  test("a screened turn bills the guardrail as its own row, on its own model", async () => {
+    await seedConversation(9301);
+    const rec = { text: [] as string[] };
+    // One factory, two models, told apart by the name the caller asked for — the same way the
+    // runtime tells them apart, and the only way a wrong attribution would be visible here.
+    const agentModel = new UsageReportingModel(["Claro, posso agendar."]);
+    const guardModel = new UsageReportingModel([CLEAN_VERDICT], {
+      input: 31,
+      output: 5,
+    });
+    const outcome = await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: textEvent(9301),
+      base: appDb,
+      deps: {
+        makeModel: ((args: { model: string }) =>
+          args.model === GUARDRAIL_MODEL
+            ? guardModel
+            : agentModel) as unknown as never,
+        makeClient: makeStub(rec),
+        checkpointer: new MemorySaver(),
+      },
+    });
+    expect(outcome).toBe("posted");
+    // The guardrail ran: without this the row's absence would prove nothing.
+    expect(guardModel.calls.length).toBeGreaterThan(0);
+
+    const usage = await usageRows(`${tenantId}:${instanceId}:9301`);
+    expect(usage.map((u) => u.node).sort()).toEqual(["agent", "guardrail"]);
+    const guard = usage.find((u) => u.node === "guardrail");
+    expect(guard?.model).toBe(GUARDRAIL_MODEL);
+    expect(guard?.promptTokens).toBe(31);
+    expect(guard?.completionTokens).toBe(5);
+    expect(guard?.source).toBe("inbox");
+    // Attribution, not just presence: a row nobody can trace to a conversation is a row the
+    // dashboard and any ceiling can only sum blindly.
+    expect(guard?.agentId).toBe(agentId);
+    expect(guard?.inboxId).toBe(inboxDbId);
+  });
+
+  test("an extracted image bills vision with the counts the provider returned", async () => {
+    const convDbId = await seedConversation(9302);
+    const threadId = `${tenantId}:${instanceId}:9302`;
+    // The provider answers the real shape: text AND the usage block every one of the three vision
+    // branches receives today and discards.
+    const visionFetch = (async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "uma nota fiscal" } }],
+          usage: { prompt_tokens: 813, completion_tokens: 24 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    const agentRow = await suDb.agent.findUniqueOrThrow({
+      where: { id: agentId },
+      select: { settings: true },
+    });
+    const cfg = readVisionConfig(agentRow.settings);
+    const out = await extractInboundFile({
+      tenantId,
+      instanceId,
+      conversationId: 9302,
+      messageId: 1,
+      attachmentId: 5,
+      dataUrl: "https://x/nota.png",
+      cfg: cfg as NonNullable<typeof cfg>,
+      base: appDb,
+      deps: { makeClient: makeStub({ text: [] }), fetchImpl: visionFetch },
+      flow: {
+        tenantId,
+        turnId: crypto.randomUUID(),
+        source: "inbox",
+        conversationId: convDbId,
+        agentId,
+        inboxId: inboxDbId,
+        threadId,
+        base: appDb,
+      },
+    });
+    expect(out?.text).toBe("uma nota fiscal");
+
+    const usage = await usageRows(threadId);
+    expect(usage.map((u) => u.node)).toEqual(["vision"]);
+    expect(usage[0]?.model).toBe(VISION_MODEL);
+    // The provider's own numbers, not an estimate: the whole point is that they were on the wire
+    // already.
+    expect(usage[0]?.promptTokens).toBe(813);
+    expect(usage[0]?.completionTokens).toBe(24);
+    expect(usage[0]?.conversationId).toBe(convDbId);
+    expect(usage[0]?.agentId).toBe(agentId);
+  });
+});
+
+// The fence. Fixing the two offenders above closes today's hole; this is what stops the next call
+// site from being born with it, and it is why this issue was one issue rather than two reports.
+//
+// The predicate is the offender's GRAMMAR, not its intention: an option bag handed to a model
+// invocation that names `signal` and not `callbacks`. Both guardrail sites read exactly that way,
+// and both sites that had already been fixed by hand (`tts/normalize.ts`, `memory/summarize.ts`)
+// carry `callbacks` right beside `signal`.
+//
+// Measured against the tree with the guardrail fix reverted, the sweep reports both sites; against
+// the tree as it stands, none.
+const INVOKE_OPTIONS = /\.invoke\([\s\S]{0,400}?\{([^{}]*signal:[^{}]*)\}/g;
+
+function sinkless(source: string): string[] {
+  const out: string[] = [];
+  for (const m of source.matchAll(INVOKE_OPTIONS)) {
+    if (!m[1]?.includes("callbacks")) out.push(m[1] ?? "");
+  }
+  return out;
+}
+
+async function tsFilesUnder(dir: string): Promise<string[]> {
+  const glob = new Bun.Glob("**/*.ts");
+  const out: string[] = [];
+  for await (const f of glob.scan({ cwd: dir, absolute: true })) out.push(f);
+  return out;
+}
+
+describe("every model invocation carries a usage sink", () => {
+  // A sweep that finds nothing passes whether the rule holds or the predicate is broken. This is
+  // what tells the two apart, and it is the shape the real offender had.
+  test("the predicate recognises an invocation with no sink", () => {
+    const offender = `
+      const res = await model.invoke(messages, {
+        signal: AbortSignal.timeout(15_000),
+      });`;
+    const fixed = `
+      const res = await model.invoke(messages, {
+        signal: AbortSignal.timeout(15_000),
+        callbacks,
+      });`;
+    expect(sinkless(offender).length).toBe(1);
+    expect(sinkless(fixed).length).toBe(0);
+  });
+
+  test("no billed call in src/ invokes a model without one", async () => {
+    const offenders: string[] = [];
+    for (const file of await tsFilesUnder(
+      new URL("../../src", import.meta.url).pathname,
+    )) {
+      const found = sinkless(await Bun.file(file).text());
+      for (const f of found) {
+        offenders.push(`${file.split("/src/")[1]}: ${f.trim().slice(0, 60)}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/modules/billed-call-usage.test.ts
+++ b/tests/modules/billed-call-usage.test.ts
@@ -4,6 +4,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import { runAgentTurn } from "@/graph/runtime";
+import { NON_AGENT_TURN_NODES, USAGE_NODE_IS_AGENT_TURN } from "@/graph/usage";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import { getVisionProvider } from "@/modules/vision/providers";
@@ -446,6 +447,59 @@ describe("every model invocation carries a usage sink", () => {
       }
     }
     expect(offenders).toEqual([]);
+  });
+});
+
+// A second sweep, over the other half of the same defect. Completing the ledger did not only add
+// rows: it added a KIND of row, and `getKpis` was reading "this conversation has a billed call" as
+// "the agent took this conversation". That held only while the calls the agent did not make had no
+// row. Vision is the first node that bills before the bot-ownership gate, and it will not be the
+// last, so the classification is total and this is what keeps it total.
+//
+// The predicate is the writer's grammar: a `node:` key resolving to a string literal, inside a file
+// that builds a ledger sink. Scoping it to sink files is what keeps unrelated `node:` keys (an n8n
+// workflow graph names its steps that way) out of the vocabulary.
+const SINK_FILE = /new UsageCapture\(|recordDirectUsage\(|buildCallbacks\(/;
+const NODE_LITERAL = /\bnode:\s*[^,\n}]*?"([a-z_]+)"/g;
+
+function nodesWritten(source: string): string[] {
+  if (!SINK_FILE.test(source)) return [];
+  return [...source.matchAll(NODE_LITERAL)].map((m) => m[1] as string);
+}
+
+describe("every node the ledger writes is classified for the involvement KPI", () => {
+  // Without this, a sweep that classifies nothing passes exactly like one that classifies
+  // everything. The fixture is the shape the next offender has: a new billed call, a new label.
+  test("the predicate finds a node a sink file writes, and ignores one it does not", () => {
+    const sink = `
+      await recordDirectUsage(params.flow, {
+        model: cfg.model,
+        node: "brand_new_node",
+      });`;
+    const notASink = `
+      const wf = { main: [[{ node: "HTTP Request", type: "main", index: 0 }]] };`;
+    expect(nodesWritten(sink)).toEqual(["brand_new_node"]);
+    expect(nodesWritten(notASink)).toEqual([]);
+    expect(USAGE_NODE_IS_AGENT_TURN.brand_new_node).toBeUndefined();
+  });
+
+  test("no node reaches a row without an answer to 'did the agent run'", async () => {
+    const found = new Set<string>();
+    for (const file of await tsFilesUnder(
+      new URL("../../src", import.meta.url).pathname,
+    )) {
+      for (const node of nodesWritten(await Bun.file(file).text())) {
+        found.add(node);
+      }
+    }
+    // Both directions. A node written but unclassified is the hole vision just opened; a node
+    // classified but no longer written is a rule about code that is gone, and the map is what a
+    // reader trusts to be the whole vocabulary.
+    expect([...found].sort()).toEqual(
+      Object.keys(USAGE_NODE_IS_AGENT_TURN).sort(),
+    );
+    // The claim the KPI actually rests on, spelled out where it can go red.
+    expect([...NON_AGENT_TURN_NODES].sort()).toEqual(["vision"]);
   });
 });
 

--- a/tests/modules/vision.test.ts
+++ b/tests/modules/vision.test.ts
@@ -56,7 +56,7 @@ describe("vision providers", () => {
       );
     }) as unknown as typeof fetch;
 
-    const text = await getVisionProvider("openrouter")?.extract({
+    const out = await getVisionProvider("openrouter")?.extract({
       bytes: new ArrayBuffer(4),
       mimeType: "image/png",
       kind: "image",
@@ -67,7 +67,7 @@ describe("vision providers", () => {
       fetchImpl,
     });
 
-    expect(text).toBe("um gato");
+    expect(out?.text).toBe("um gato");
     expect(calls[0]?.url).toBe("https://openrouter.ai/api/v1/chat/completions");
     const headers = calls[0]?.init.headers as Record<string, string>;
     expect(headers.authorization).toBe("Bearer sk-or");


### PR DESCRIPTION
`LlmUsage` is the only ledger of what an install spends on models, and it is written from exactly one place: `UsageCapture`, a LangChain callback built by `buildCallbacks`. A billed call lands in it only if it is a LangChain invocation *and* is handed those callbacks. Two calls were neither.

## What was not counted

Measured on `main` (`404677d0`), over every path that spends provider money:

| path | how it reaches the provider | wrote `LlmUsage` |
|---|---|---|
| agent turn, nudge, memory compaction, TTS normalize, playground | LangChain **with** callbacks | yes |
| attendance summary | LangChain, callbacks threaded | yes |
| **guardrails** | LangChain, **no callbacks** | **no** |
| **vision** | raw `fetch` | **no** |

**Guardrails** called `model.invoke(messages, { signal })` and `.withStructuredOutput(...).invoke(messages, { signal })`. Neither passed `callbacks`; `grep -n 'callbacks\|BaseCallbackHandler' src/modules/guardrails/*.ts` returned nothing, so the module had never had the concept. This is the hot path: input and output moderation run per reply, so a screened install spent one or two model calls **per customer turn** that no reader could see.

**Vision** received the counts and threw them away. `VisionProvider.extract` was typed `Promise<string>`, which made usage unrepresentable, and all three branches parsed the text only: the OpenAI-compatible one read `choices[0].message.content` past a sibling `usage`, Gemini read `candidates[].content.parts[].text` past `usageMetadata`, Anthropic read `content[].text` past `usage`.

## The fix

The attribution both needed was already in the `FlowContext` each of them holds, so it is read from one place (`usageAttribution`) rather than assembled twice:

- **Guardrails threads the callbacks**, the way `memory/summarize.ts` and `tts/normalize.ts` already did. The sink is built from the gate's own flow context and labelled with the **guardrail's** model, not the agent's — the analysis runs on a separately configured model, and a shared label would attribute this spend to the customer turn beside it.
- **`VisionProvider.extract` returns `{ text, usage }`.** The contract is what changed: the type now makes an unrecorded provider response fail to compile, and each branch parses the block its own endpoint sends. `usage` is `null` when the endpoint sent no counts, because writing zeros would record the call as free.
- **`recordDirectUsage`** writes the row for a provider reached by raw `fetch`, where no callback could ever have fired. Best-effort, like the callback path: a ledger write never breaks the call it is about.

The row is written even when the extraction came back empty: that call was billed exactly like a full one, and the early return used to end the function first.

## What completing the ledger broke

Adding vision added a **kind** of row, not just rows, and one reader rested on the kind never existing. `getKpis` counted a conversation as bot involvement whenever it had an inbox `LlmUsage` row — a proxy that held only while the calls the agent did not make had none. Vision runs on the incoming attachment at `webhook.ts:2885`, gated on `rt.enabled && isNewIncoming && mode === "production"` and **not** on `act`, so an image sent into a conversation a human owns is billed and answered by nobody.

Excluding `"vision"` by name would be right today and would guarantee the next pre-gate node is born wrong, so the vocabulary is classified once and **totally** (`USAGE_NODE_IS_AGENT_TURN`), with a fence asserting the set of `node:` literals written by sink files equals the map's keys in both directions. The other five nodes are downstream of a turn that ran — `memory_compact` included, which attributes to `segment?.id`, the closed attendance, not to the payload's conversation.

The filter keeps `node: null` explicitly: Prisma renders `notIn` as plain SQL `NOT IN`, which drops NULL rather than keeping it (seeded `[null, "vision", "agent"]`, `notIn: ["vision"]` returned `["agent"]`), and a legacy row with no node is an agent turn. Without that arm every historical involvement figure would shrink silently.

The five other `llmUsage` readers are about spend, where a vision call is real money on that conversation and belongs. `involvedRows` is the only one making the participation claim, and the only one that changed.

## The fence

Fixing two call sites closes today's hole; this is what stops the next one from being born with it. The predicate is the offender's grammar, not its intent: an option bag handed to a model invocation that names `signal` and not `callbacks`. It carries a **positive control**, because a sweep that finds nothing passes whether the rule holds or the regex is broken.

Measured with the guardrail fix reverted, the sweep reports both sites; against this branch, none.

## Validation scope

**Proved by test** (`tests/modules/billed-call-usage.test.ts`, DB-backed, through the real call paths):

- A screened turn writes `agent` **and** `guardrail` rows; the guardrail row carries its own model, its own token counts, and the conversation/agent/inbox it belongs to. Red before: `["agent"]`.
- An extracted image writes a `vision` row with the counts the provider returned. Red before: `[]`, while the extraction itself succeeded.
- A conversation whose only billed call is a pre-gate vision extraction does not move `involved`, and does move `totalConversations` — the funnel saw a customer it never engaged (`tests/modules/analytics-kpis.test.ts`).
- Both fences, each with its positive control.

Mutation run, one rule killed at a time: gate stops passing the sink → 1 fail; vision stops writing the row → 1 fail; sink fence predicate always empty → 1 fail; KPI filter removed → 1 fail; `notIn` without the null arm → 7 fail; `vision` classified as an agent turn → 2 fail; a node written under an unclassified label → 2 fail. No survivors.

**Proved live**, against the real OpenAI API, same script run on `main` and on this branch:

```
vision   base:  typeof extract() => string    carries usage? NO — the contract cannot express it
vision   fixed: typeof extract() => object    carries usage? {"promptTokens":273,"completionTokens":1}

guardrail fixed: decision {"kind":"replaced",...}
                 row node=guardrail model=gpt-4o-mini prompt=292 completion=31 source=inbox
```

The vision probe is a 1x1 PNG, so no customer content travelled. The guardrail probe is a toxicity input on `gpt-4o-mini`; the verdict came back `replaced`, which is the analysis actually running rather than failing open.

**Not validated.** Gemini and Anthropic vision were exercised by unit tests against their documented response shapes, not against a live endpoint — no credential for either on this machine. The OpenAI-compatible branch (which `openai` and `openrouter` share) is the one measured live above. STT and TTS remain outside the ledger deliberately: they are billed per audio-second and per character, and putting either in `promptTokens` would make every downstream reader sum two different units. #316 records that reasoning.

Fixes #316.
