### PR TITLE
Take a refused reactive turn back out of the conversation history too

### DIFF
--- a/src/graph/nudge.ts
+++ b/src/graph/nudge.ts
@@ -1163,6 +1163,7 @@ export async function runAgentNudge(
       checkpointer,
       graphThreadId,
       produced: result.messages,
+      kind: "proactive",
     }).catch((err) => {
       // NOTE: best-effort, and loudly. The send was already suppressed, so a failed rollback costs
       // the next turn a message the customer never saw, which is the defect this exists to close,

--- a/src/graph/refused-turn.ts
+++ b/src/graph/refused-turn.ts
@@ -102,6 +102,15 @@ export function planTurnRollback(
   if (start === -1) return { action: "keep", reason: "no-turn-found" };
   const slice = produced.slice(start);
   if (actedOnTheWorld(slice)) return { action: "keep", reason: "tool-ran" };
+  return nameWhatSurvived(slice, current);
+}
+
+// The last step of both plans, and the only one that reads the CURRENT channel: a slice is a
+// proposal, and this is what turns it into ids the reducer will accept.
+function nameWhatSurvived(
+  slice: readonly BaseMessage[],
+  current: readonly BaseMessage[],
+): RollbackPlan {
   const byId = new Map<string, BaseMessage>();
   for (const m of current) if (typeof m.id === "string") byId.set(m.id, m);
   const ids = slice
@@ -113,6 +122,50 @@ export function planTurnRollback(
     .map((m) => m.id as string);
   if (ids.length === 0) return { action: "keep", reason: "already-gone" };
   return { action: "remove", ids };
+}
+
+// WHAT A REACTIVE TURN LEAVES BEHIND, which is the same residue and NOT the same slice (issue #315).
+//
+// `runLoadedTurn` appends the customer's own message and then invokes, so the pair in the channel is
+// [their message][our answer] — and every refusal below the invoke suppresses only the second half.
+// The proactive plan above removes the directive together with the answer because this process wrote
+// the directive; doing that here would delete the customer's message, and on `superseded` it is
+// precisely the message the re-armed flush exists to answer.
+//
+// So the removable part is named directly rather than by a boundary: the trailing run of assistant
+// messages that neither called a tool nor are a tool result. It stops at the first message that is
+// anything else, which means it can never reach a HumanMessage of any kind — the customer's, a
+// divider, a memory head, a nudge, or an attendant's — and it needs no rule about where a turn
+// "starts".
+//
+// That also answers the tool case better than the proactive plan could. There, the directive and the
+// act are one slice, so any tool call keeps everything. Here the act sits OUTSIDE the trailing run by
+// construction: the tool call and its result stay, and only the sentence nobody read comes out. A
+// transfer that really happened keeps its record, and the closing line the customer never saw does
+// not go on to be read as something they were told.
+function saidSomethingAndNothingElse(m: BaseMessage): boolean {
+  return (
+    m.getType() === "ai" && ((m as AIMessage).tool_calls?.length ?? 0) === 0
+  );
+}
+
+export function planReactiveTurnRollback(
+  produced: readonly BaseMessage[],
+  current: readonly BaseMessage[],
+): RollbackPlan {
+  let start = produced.length;
+  while (start > 0) {
+    const m = produced[start - 1];
+    if (m === undefined || !saidSomethingAndNothingElse(m)) break;
+    start--;
+  }
+  // Nothing trailing (the turn ended on a tool, so it said nothing), or nothing but assistant
+  // messages, which is not a channel this invoke produced — the wall this rule leans on is missing,
+  // and guessing where the turn began is how a rollback eats history.
+  if (start === produced.length || start === 0) {
+    return { action: "keep", reason: "no-turn-found" };
+  }
+  return nameWhatSurvived(produced.slice(start), current);
 }
 
 // Reads the channel and writes the removal under the SAME key the append and the compaction rewrite
@@ -148,8 +201,15 @@ export async function undoRefusedTurn(params: {
   checkpointer: BaseCheckpointSaver;
   graphThreadId: string;
   produced: readonly BaseMessage[];
+  // WHICH turn was refused, because the two have different removable slices and neither plan is
+  // right for the other: a proactive one wrote its own `[human]` directive and takes it back with the
+  // answer, a reactive one is answering the CUSTOMER'S message and must leave it standing. Required
+  // rather than defaulted — a caller that has to name it cannot inherit the wrong one by omission.
+  kind: "proactive" | "reactive";
 }): Promise<RollbackPlan> {
-  const { checkpointer, graphThreadId, produced } = params;
+  const { checkpointer, graphThreadId, produced, kind } = params;
+  const plan =
+    kind === "reactive" ? planReactiveTurnRollback : planTurnRollback;
   const graph = buildThreadStateGraph(checkpointer);
   const threadCfg = { configurable: { thread_id: graphThreadId } };
   return withKeyedQueue(`ingest:${graphThreadId}`, async () => {
@@ -165,15 +225,15 @@ export async function undoRefusedTurn(params: {
           | { messages?: BaseMessage[] }
           | undefined
       )?.messages ?? []) as BaseMessage[];
-      const plan = planTurnRollback(produced, current);
-      if (plan.action === "remove") {
+      const decided = plan(produced, current);
+      if (decided.action === "remove") {
         await graph.updateState(
           threadCfg,
-          { messages: plan.ids.map((id) => new RemoveMessage({ id })) },
+          { messages: decided.ids.map((id) => new RemoveMessage({ id })) },
           THREAD_STATE_NODE,
         );
       }
-      return plan;
+      return decided;
     } finally {
       clearTurnInFlight(graphThreadId);
     }

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -74,6 +74,7 @@ import {
   buildToolset,
   loadAgentConfig,
 } from "./prepare";
+import { undoRefusedTurn } from "./refused-turn";
 import { AgentStatusReporter } from "./status";
 import { buildThreadStateGraph, THREAD_STATE_NODE } from "./thread-state";
 import { ToolFlowLogger } from "./tool-flowlog";
@@ -1076,6 +1077,56 @@ export async function runLoadedTurn(
       await deliverHandoffPromise();
       throw e;
     });
+    // EVERY REFUSAL FROM HERE DOWN GOES OUT THROUGH THIS, and the fence in
+    // tests/graph/refused-turn-callsites.test.ts is what keeps that true.
+    //
+    // The invoke above checkpointed as it ran, so the customer's message and the assistant's answer
+    // are in the thread's history the moment it returned. Everything below suppresses the SEND and
+    // nothing removes what was written: an operator took the conversation, a newer message arrived
+    // mid-turn, a `/reset` retired the run, the output guardrail replaced the reply with nothing. The
+    // customer never received it and the next turn reads it as something they were told — on
+    // `superseded` that next turn is guaranteed, because the re-armed flush answers the whole burst
+    // with the abandoned reply already in its context (issue #315).
+    //
+    // It never decides WHETHER to roll back: `undoRefusedTurn` reads the channel and answers that,
+    // so a refusal is one word here and the judgement lives in one place.
+    const refuse = async (
+      outcome: RunAgentTurnOutcome,
+    ): Promise<RunAgentTurnOutcome> => {
+      const plan = await undoRefusedTurn({
+        checkpointer: params.deps?.checkpointer ?? (await getCheckpointer()),
+        graphThreadId,
+        produced: result.messages,
+        kind: "reactive",
+      }).catch((err) => {
+        // NOTE: best-effort, and loudly. The send was already suppressed, so a failed rollback costs
+        // the next turn a message the customer never saw — the defect this exists to close, and
+        // nothing more. Throwing would turn a correct refusal into a retried turn.
+        logger.warn(
+          { err, conversationId: String(conversationId) },
+          "turn: could not roll back the refused turn",
+        );
+        return null;
+      });
+      if (plan?.action === "remove") {
+        logger.info(
+          "turn rolled back a refused turn: conv=%s outcome=%s messages=%d",
+          String(conversationId),
+          outcome,
+          plan.ids.length,
+        );
+      } else if (plan?.reason === "another-invoke-is-reading") {
+        // NOTE: the one keep that is a MISS rather than a decision about this turn. The history still
+        // holds a message the customer never received. Logged at warn so the case has a name instead
+        // of looking like a rollback that ran.
+        logger.warn(
+          "turn could not roll back a refused turn, another invoke holds the thread: conv=%s outcome=%s",
+          String(conversationId),
+          outcome,
+        );
+      }
+      return outcome;
+    };
     let reply = lastAssistantText(result.messages).trim();
 
     // The deferred resolve falls with the TRANSFER, not with the suppression of the final text: a
@@ -1163,13 +1214,13 @@ export async function runLoadedTurn(
           status: recheck.observed.status,
         }),
       });
-      return "taken-over";
+      return refuse("taken-over");
     }
 
     // Last-moment supersede gate (debounce): a newer message arrived mid-turn → drop this reply
     // AND any deferred resolve intent (the re-armed flush re-decides over the full burst).
     const blocked = await postBlocked();
-    if (blocked) return blocked;
+    if (blocked) return refuse(blocked);
 
     // OUTPUT guardrail: screen the model's reply BEFORE delivery. On a violation, replace it with the
     // template / a guardrails-generated safe reply, or suppress the send entirely ("silent"). A
@@ -1190,11 +1241,11 @@ export async function runLoadedTurn(
     const outGuard = screened ? await runGuardrail("output", screened) : null;
     // Same wait, same reason: `postBlocked` answered before this model call, and the suppressed
     // branch below returns "blocked" without passing any later ask.
-    if (await writeCalledOff()) return "stale";
+    if (await writeCalledOff()) return refuse("stale");
     if (outGuard && guardrailTripped(outGuard)) {
       turnState.pendingAttachments.length = 0;
       const replacement = screenedText(outGuard, screened);
-      if (replacement === null) return "blocked";
+      if (replacement === null) return refuse("blocked");
       reply = replacement;
     }
 
@@ -1208,7 +1259,7 @@ export async function runLoadedTurn(
     // reported "empty" would leave a stale turn error on a conversation that was just answered.
     if (!reply) {
       // Nothing has left this turn yet on this branch, so the whole thing stands down.
-      if (await writeCalledOff()) return "stale";
+      if (await writeCalledOff()) return refuse("stale");
       const queued = turnState.pendingAttachments.length;
       const {
         sent,
@@ -1226,7 +1277,7 @@ export async function runLoadedTurn(
       // customer, and "stale" would leave the watermark where it is — handing the same burst to the
       // next flush, which would send that attachment again. What was delivered decides the word, the
       // same rule the reply below follows.
-      if (attachmentsCalledOff && !sent) return "stale";
+      if (attachmentsCalledOff && !sent) return refuse("stale");
       // NOTE: The attachments WERE the turn and none of them reached the customer. That is a failed
       // turn, not a silent one: returning "empty" here would let the deferred resolve close a
       // conversation nobody answered, and the callers only record a turn error (private note,
@@ -1264,7 +1315,7 @@ export async function runLoadedTurn(
 
     // The image lands before the text that talks about it, and before the TTS branch: an audio
     // reply must not swallow the attachment.
-    if (await writeCalledOff()) return "stale";
+    if (await writeCalledOff()) return refuse("stale");
     const attachments = await deliverPendingAttachments(
       client,
       conversationId,
@@ -1276,7 +1327,8 @@ export async function runLoadedTurn(
     // Called off mid-batch with something already out: the text below would stand down anyway, and
     // returning "stale" from there would replay a burst whose attachment the customer has. The turn
     // reports what it delivered and stops here.
-    if (attachments.calledOff) return attachments.sent ? "posted" : "stale";
+    if (attachments.calledOff)
+      return attachments.sent ? "posted" : refuse("stale");
 
     const delivered = await deliverText(reply, recheck.voiceReply);
     // Zero is the split loop standing down on its FIRST balloon: nothing reached the customer, so
@@ -1288,7 +1340,7 @@ export async function runLoadedTurn(
     // command landing in the text send leaves a customer holding part of the answer. "stale" would
     // hand the burst back to the next flush, which sends that attachment again.
     if (delivered === "stale" || delivered === 0) {
-      return attachments.sent ? "posted" : "stale";
+      return attachments.sent ? "posted" : refuse("stale");
     }
     deliveredBalloons = delivered;
     // Same rule as the branch above: the reply is out, the resolve is a separate write.

--- a/tests/graph/refused-turn-callsites.test.ts
+++ b/tests/graph/refused-turn-callsites.test.ts
@@ -2,31 +2,57 @@ import { describe, expect, test } from "bun:test";
 
 // THE RULE THE ROLLBACK DEPENDS ON, AND THE ONE A PATCH CAN SILENTLY BREAK.
 //
-// `undoRefusedTurn` cannot be reached from inside `runAgentNudge`'s refusals unless each of them goes
-// out through `refuse`. There are eight of them today, spread over two hundred lines, and the ninth
-// will be written by someone adding a gate, copying the line above it, which is what a bare
-// `return "stale";` looks like. Nothing fails when they do: the send is still suppressed, the outcome
-// is still right, and the only symptom is the next turn answering about a message nobody received,
-// which is the defect issue #251 opened for.
+// `undoRefusedTurn` cannot be reached from inside a turn's refusals unless each of them goes out
+// through `refuse`. There are eight in `runAgentNudge` and nine in `runLoadedTurn`, spread over
+// hundreds of lines, and the next one will be written by someone adding a gate and copying the line
+// above it — which is what a bare `return "stale";` looks like. Nothing fails when they do: the send
+// is still suppressed, the outcome is still right, and the only symptom is the next turn answering
+// about a message nobody received, which is the defect issues #251 and #315 opened for.
 //
 // So the fence is on the SPELLING, at the position where it matters: below the point where a turn has
 // been generated, a refusal is not a `return`, it is a `refuse`.
+//
+// TWO SPELLINGS, and the second is why this predicate does not just look for `return "x";`. A refusal
+// can also ride a ternary — `return attachments.sent ? "posted" : "stale";` — and `runLoadedTurn` has
+// two of those. A sweep written against the first spelling passes over them without a word, which is
+// the shape of every scan that reports zero because it was looking for the wrong thing.
 
-// The two outcomes a post-generation refusal can carry. "silent", "messaged", "noted" and the rest
-// are not refusals: the turn reached its end and something (a message, a note, a decision) stands.
-const REFUSAL_OUTCOMES = ["stale", "live-unavailable"] as const;
-
-const BARE = new RegExp(`return "(?:${REFUSAL_OUTCOMES.join("|")})";`, "g");
+// The outcomes that mean "the turn was generated and the customer got none of it". Everything else a
+// turn can return ("posted", "empty", "silent", "messaged", "noted", …) is not a refusal: something
+// stands at the end of it.
+const NUDGE_REFUSALS = ["stale", "live-unavailable"] as const;
+const TURN_REFUSALS = ["stale", "superseded", "blocked", "taken-over"] as const;
 
 // Everything above the closure is a refusal BEFORE the invoke, where there is no generated turn to
 // take back and `refuse` would be a checkpointer round trip for nothing.
-export function bareRefusalsAfterTheRollback(source: string): string[] {
+export function bareRefusalsAfterTheRollback(
+  source: string,
+  outcomes: readonly string[],
+): string[] {
   const at = source.indexOf("const refuse = async (");
   if (at === -1) return ["the `refuse` closure is gone"];
-  return (source.slice(at).match(BARE) ?? []).map((m) => m.trim());
+  const any = outcomes.join("|");
+  // What is already routed stops being a candidate, so what the match reports is the spelling that
+  // was left behind rather than a count of anything.
+  const below = source
+    .slice(at)
+    // COMMENTS FIRST, and this is not tidiness. Collapsing whitespace below makes a statement one
+    // string, and prose has no `;` in it — so the word "returning" in a NOTE two paragraphs above a
+    // routed refusal pairs with that refusal's literal and reports a site that does not exist. This
+    // file's comments are long and quote the outcomes by name, so that is the normal case, not a
+    // corner one. (`[^:]` keeps a `https://` out of it.)
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1")
+    .replace(new RegExp(`refuse\\("(?:${any})"\\)`, "g"), "refuse(ROUTED)")
+    // Collapsed so a statement is one string no matter how the formatter broke it: `[^;]` is what
+    // bounds a match to a single statement, and a `return` split across lines would otherwise be
+    // invisible to a line-bounded pattern for no reason other than its width.
+    .replace(/\s+/g, " ");
+  const pattern = new RegExp(`return[^;]*"(?:${any})"[^;]*;`, "g");
+  return below.match(pattern) ?? [];
 }
 
-describe("every post-generation refusal in runAgentNudge rolls the turn back", () => {
+describe("every post-generation refusal rolls the turn back", () => {
   // The control: a sweep that finds nothing passes whether or not it is looking at anything, so the
   // predicate is shown an offender first.
   test("the predicate flags a bare refusal written below the closure", () => {
@@ -35,15 +61,56 @@ describe("every post-generation refusal in runAgentNudge rolls the turn back", (
   if (!(await stillWanted())) return refuse("stale");
   if (owned === "gone") return "live-unavailable";
 `;
-    expect(bareRefusalsAfterTheRollback(withOffender)).toEqual([
+    expect(bareRefusalsAfterTheRollback(withOffender, NUDGE_REFUSALS)).toEqual([
       'return "live-unavailable";',
     ]);
   });
 
-  test("and says so when the closure itself was removed", () => {
-    expect(bareRefusalsAfterTheRollback("if (x) return 'stale';")).toEqual([
-      "the `refuse` closure is gone",
+  // The second spelling, and the one the first version of this predicate could not see. A refusal
+  // that shares a return with a non-refusal is still a refusal on the branch that takes it.
+  test("and flags one hiding on the losing side of a ternary", () => {
+    const withTernary = `
+  const refuse = async (outcome) => outcome;
+  if (attachments.calledOff) return attachments.sent ? "posted" : "stale";
+`;
+    expect(bareRefusalsAfterTheRollback(withTernary, TURN_REFUSALS)).toEqual([
+      'return attachments.sent ? "posted" : "stale";',
     ]);
+  });
+
+  // …and does not flag the same line once it is routed.
+  test("a routed ternary is not an offender", () => {
+    const routed = `
+  const refuse = async (outcome) => outcome;
+  if (attachments.calledOff) return attachments.sent ? "posted" : refuse("stale");
+`;
+    expect(bareRefusalsAfterTheRollback(routed, TURN_REFUSALS)).toEqual([]);
+  });
+
+  // A comparison is not a return, and flagging one would make the fence unfixable.
+  test("a refusal outcome that is only being COMPARED is not a return", () => {
+    const comparing = `
+  const refuse = async (outcome) => outcome;
+  if (delivered === "stale" || delivered === 0) return refuse("stale");
+`;
+    expect(bareRefusalsAfterTheRollback(comparing, TURN_REFUSALS)).toEqual([]);
+  });
+
+  // The trap the comment stripping exists for, kept as a row because it produced two phantom sites
+  // the first time this ran against runtime.ts.
+  test("prose above a routed refusal does not invent an offender", () => {
+    const prosey = `
+  const refuse = async (outcome) => outcome;
+  // …returning "stale" from there would replay a burst the customer already has.
+  if (attachments.calledOff) return attachments.sent ? "posted" : refuse("stale");
+`;
+    expect(bareRefusalsAfterTheRollback(prosey, TURN_REFUSALS)).toEqual([]);
+  });
+
+  test("and says so when the closure itself was removed", () => {
+    expect(
+      bareRefusalsAfterTheRollback("if (x) return 'stale';", NUDGE_REFUSALS),
+    ).toEqual(["the `refuse` closure is gone"]);
   });
 
   test("a refusal above the closure is not its business", () => {
@@ -51,19 +118,30 @@ describe("every post-generation refusal in runAgentNudge rolls the turn back", (
   if (!(await stillWanted())) return "stale";
   const refuse = async (outcome) => outcome;
 `;
-    expect(bareRefusalsAfterTheRollback(before)).toEqual([]);
+    expect(bareRefusalsAfterTheRollback(before, NUDGE_REFUSALS)).toEqual([]);
   });
+
+  // A floor, not a census: more sites routed through `refuse` is a better state, never a worse one,
+  // so pinning the exact number would only cost a second edit to a PR that adds a gate correctly.
+  // What it guards is the subject going EMPTY, which is how a sweep starts passing blind.
+  const routedCount = (source: string) => {
+    const at = source.indexOf("const refuse = async (");
+    return (source.slice(at).match(/refuse\(/g) ?? []).length;
+  };
 
   test("nudge.ts has none", async () => {
     const source = await Bun.file("src/graph/nudge.ts").text();
-    expect(bareRefusalsAfterTheRollback(source)).toEqual([]);
-    // …and the sweep is looking at something. A rule whose subject can become empty starts passing
-    // for the wrong reason the day the refusals are restructured.
-    const at = source.indexOf("const refuse = async (");
-    // A floor, not a census: more sites routed through `refuse` is a better state, never a worse one,
-    // so pinning the exact number would only cost a second edit to a PR that adds a gate correctly.
-    // What it guards is the subject going EMPTY, which is how a sweep starts passing blind.
-    const routed = source.slice(at).match(/return refuse\("/g) ?? [];
-    expect(routed.length).toBeGreaterThanOrEqual(8);
+    expect(bareRefusalsAfterTheRollback(source, NUDGE_REFUSALS)).toEqual([]);
+    expect(routedCount(source)).toBeGreaterThanOrEqual(8);
+  });
+
+  // NOTE: one refusal in `runLoadedTurn` reaches `refuse` through a VARIABLE — `postBlocked()`
+  // answers "stale" or "superseded" from above the invoke, and its caller writes
+  // `if (blocked) return refuse(blocked);`. No spelling rule can see that the variable holds a
+  // refusal, so that one site is held by the supersede e2e in runtime.test.ts instead.
+  test("runtime.ts has none", async () => {
+    const source = await Bun.file("src/graph/runtime.ts").text();
+    expect(bareRefusalsAfterTheRollback(source, TURN_REFUSALS)).toEqual([]);
+    expect(routedCount(source)).toBeGreaterThanOrEqual(8);
   });
 });

--- a/tests/graph/refused-turn.test.ts
+++ b/tests/graph/refused-turn.test.ts
@@ -6,7 +6,11 @@ import {
   ToolMessage,
 } from "@langchain/core/messages";
 import { memoryHeadMessage, nudgeMessage } from "@/graph/markers";
-import { planTurnRollback, type RollbackPlan } from "@/graph/refused-turn";
+import {
+  planReactiveTurnRollback,
+  planTurnRollback,
+  type RollbackPlan,
+} from "@/graph/refused-turn";
 
 // The decision, as a table. `undoRefusedTurn` does the reading and the writing; everything that is a
 // JUDGEMENT is here, because the write is a checkpointer round trip and a rule proven through one
@@ -169,6 +173,175 @@ describe("planTurnRollback", () => {
   for (const row of ROWS) {
     test(row.name, () => {
       expect(planTurnRollback(row.produced, row.current)).toEqual(row.expected);
+    });
+  }
+});
+
+// The same question asked of a REACTIVE turn, and the answer is a different shape (issue #315).
+//
+// Two things separate it from the proactive table above, and both come from one fact: the `[human]`
+// message here is the CUSTOMER'S OWN. The proactive planner removes the directive together with the
+// answer because this process wrote the directive; removing the customer's message would lose it,
+// and on `superseded` it is exactly the message the re-armed flush exists to answer.
+//
+// So the removable part is named directly instead of by a boundary: the trailing run of assistant
+// messages that neither called a tool nor are a tool result. That is the text the customer never saw,
+// it stops at the first message that is anything else, and it can never reach a HumanMessage of any
+// kind — the customer's, a divider, a memory head, a nudge, or an attendant's.
+//
+// It also gives the tool case a better answer than the proactive one could have. There, a turn that
+// ran a tool keeps EVERYTHING, because the directive and the act are one slice. Here the act stays
+// (the tool call and its result are outside the trailing run) and only the unsent sentence goes.
+describe("planReactiveTurnRollback", () => {
+  const ROWS: Array<{
+    name: string;
+    produced: BaseMessage[];
+    current: BaseMessage[];
+    expected: RollbackPlan;
+  }> = [
+    (() => {
+      const produced = [h("h1", "oi"), a("a1", "Olá! Como posso ajudar?")];
+      return {
+        name: "the reply the customer never received, and not the message that asked for it",
+        produced,
+        current: produced,
+        expected: { action: "remove", ids: ["a1"] },
+      };
+    })(),
+    (() => {
+      const produced = [
+        h("h0", "bom dia"),
+        a("a0", "bom dia!"),
+        h("h1", "oi"),
+        a("a1", "Olá! Como posso ajudar?"),
+      ];
+      return {
+        name: "nothing from a turn that already stood",
+        produced,
+        current: produced,
+        expected: { action: "remove", ids: ["a1"] },
+      };
+    })(),
+    (() => {
+      // The row the proactive table answers the other way. The transfer really happened and no
+      // removal undoes it, so its record stays — but the closing line was never sent, and keeping it
+      // is the whole defect.
+      const produced = [
+        h("h1", "quero falar com alguém"),
+        calling("a1", "transfer_to_human"),
+        toolResult("t1", "ok"),
+        a("a2", "Vou te transferir."),
+      ];
+      return {
+        name: "a turn that ran a tool keeps the act and loses only the sentence nobody read",
+        produced,
+        current: produced,
+        expected: { action: "remove", ids: ["a2"] },
+      };
+    })(),
+    (() => {
+      const produced = [
+        h("h1", "quero falar com alguém"),
+        calling("a1", "transfer_to_human"),
+        toolResult("t1", "ok"),
+      ];
+      return {
+        name: "a turn that ended on the tool said nothing, so there is nothing to take back",
+        produced,
+        current: produced,
+        expected: { action: "keep", reason: "no-turn-found" },
+      };
+    })(),
+    (() => {
+      // The other half of "and nothing else", and the row without which that clause is untested: a
+      // turn whose LAST message is a request to act. Nothing was said to the customer, and a tool
+      // call is the module's own evidence of acting (`actedOnTheWorld` reads the same two things),
+      // so it is not part of the run either.
+      const produced = [
+        h("h1", "quero agendar"),
+        calling("a1", "create_appointment"),
+      ];
+      return {
+        name: "a turn that ended asking to act said nothing, so nothing comes out",
+        produced,
+        current: produced,
+        expected: { action: "keep", reason: "no-turn-found" },
+      };
+    })(),
+    (() => {
+      // A split reply is several assistant messages in a row, and none of them was sent.
+      const produced = [
+        h("h1", "oi"),
+        a("a1", "Olá!"),
+        a("a2", "Como posso ajudar?"),
+      ];
+      return {
+        name: "every message of a split reply, because the send was suppressed once for all of them",
+        produced,
+        current: produced,
+        expected: { action: "remove", ids: ["a1", "a2"] },
+      };
+    })(),
+    (() => {
+      // The wall this rule depends on is a message that is not an assistant's. A channel that is
+      // nothing but assistant messages is not one this invoke produced, and guessing where the turn
+      // starts there is how a rollback eats history.
+      const produced = [a("a1", "Olá!")];
+      return {
+        name: "a channel with no turn boundary in it is left alone",
+        produced,
+        current: produced,
+        expected: { action: "keep", reason: "no-turn-found" },
+      };
+    })(),
+    (() => {
+      const produced = [h("h1", "oi"), a("a1", "Olá!")];
+      return {
+        name: "a channel another writer already rewrote is left exactly as it is",
+        produced,
+        current: [],
+        expected: { action: "keep", reason: "already-gone" },
+      };
+    })(),
+    (() => {
+      // Same compaction hazard as the proactive table: an id can survive while the message it named
+      // does not.
+      const produced = [h("h1", "oi"), a("a1", "Olá!")];
+      return {
+        name: "an id that memory compaction reused for its head is not the message we produced",
+        produced,
+        current: [head("a1")],
+        expected: { action: "keep", reason: "already-gone" },
+      };
+    })(),
+    (() => {
+      const produced = [h("h1", "oi"), new AIMessage({ content: "sem id" })];
+      return {
+        name: "a message with no id is not nameable, so it is not named",
+        produced,
+        current: [produced[0] as BaseMessage],
+        expected: { action: "keep", reason: "already-gone" },
+      };
+    })(),
+    (() => {
+      // A nudge directive is a HumanMessage, so it walls this rule the same way the customer's does.
+      // The two planners are different questions and this is where that shows: the proactive one
+      // takes the directive with the answer, this one never could.
+      const produced = [nudge("n1"), a("a1", "ainda precisa?")];
+      return {
+        name: "a nudge directive walls the run like any other human message",
+        produced,
+        current: produced,
+        expected: { action: "remove", ids: ["a1"] },
+      };
+    })(),
+  ];
+
+  for (const row of ROWS) {
+    test(row.name, () => {
+      expect(planReactiveTurnRollback(row.produced, row.current)).toEqual(
+        row.expected,
+      );
     });
   }
 });

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -20,6 +20,7 @@ import { armIngest } from "@/graph/ingest-job";
 import { isConversationDivider, stampedConversationId } from "@/graph/markers";
 import type { ResolvedModelConfig } from "@/graph/models";
 import { runAgentTurn } from "@/graph/runtime";
+import { buildThreadStateGraph } from "@/graph/thread-state";
 import type { TenantContext } from "@/lib/tenancy";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
@@ -224,6 +225,30 @@ async function mirroredStatus(convId: number) {
     select: { status: true },
   });
   return row?.status ?? null;
+}
+
+// What the graph memory thread HOLDS after a turn, which is a different question from what the
+// customer received and the only one that shows a refused turn's residue (issues #251, #315). Read
+// through the same one-node graph the rollback writes with, so the test sees what the next invoke
+// will load.
+async function threadChannel(
+  checkpointer: MemorySaver,
+  convId: number,
+  // The guardrail suite runs on a tenant of its own, so the thread key cannot be taken from the
+  // module's; defaulted rather than passed everywhere, since every other caller is on this one.
+  scope?: { tenantId: bigint; instanceId: bigint },
+): Promise<Array<[string, string]>> {
+  const t = scope?.tenantId ?? tenantId;
+  const i = scope?.instanceId ?? instanceId;
+  const state = await buildThreadStateGraph(checkpointer).getState({
+    configurable: { thread_id: `${t}:${i}:${convId}` },
+  });
+  const messages = ((state.values as { messages?: BaseMessage[] })?.messages ??
+    []) as BaseMessage[];
+  return messages.map((m) => [
+    m.getType(),
+    typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+  ]);
 }
 
 async function seedConversation(
@@ -3034,6 +3059,163 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     expect(sent).toEqual([]);
   });
 
+  // ── issue #315: what a refusal below the invoke leaves in the thread ──
+  //
+  // The invoke checkpoints as it runs, so by the time any of these gates answers, the customer's
+  // message and the assistant's reply are both in the history. The send is suppressed and the reply
+  // stays — and on `superseded` the next flush is guaranteed to read it, because that outcome exists
+  // precisely so the re-armed flush answers the whole burst. It then has the abandoned sentence in
+  // its context and can write "as I said" about something nobody was shown.
+  //
+  // What each of these asserts is the CHANNEL, not the outcome: the outcome was already right before
+  // the rollback existed, which is why the defect was invisible.
+  describe("a refused reactive turn leaves the thread as the customer saw it", () => {
+    // The customer's own message SURVIVES, and that is the half that separates this from the
+    // proactive rollback: `superseded` hands the burst to the next flush, so removing it would lose
+    // the message the whole outcome exists to answer.
+    test("superseded: the reply goes, the message that asked for it stays", async () => {
+      await seedConversation(93151, null);
+      const checkpointer = new MemorySaver();
+      const sent: Array<[number, string]> = [];
+      const client = {
+        getMessages: async () => ({
+          payload: [
+            { id: 1, content: "oi", message_type: 0, private: false },
+            {
+              id: 2,
+              content: "na verdade, esquece",
+              message_type: 0,
+              private: false,
+            },
+          ],
+        }),
+        sendMessage: async (conversationId: number, content: string) => {
+          sent.push([conversationId, content]);
+          return {};
+        },
+      } as unknown as ChatwootClient;
+      const outcome = await runAgentTurn({
+        tenantId,
+        instanceId,
+        agentBotId: 9,
+        event: incoming({ conversationId: 93151 }),
+        base: appDb,
+        deps: {
+          makeModel: fakeModel,
+          makeClient: async () => client,
+          checkpointer,
+        },
+      });
+      expect(outcome).toBe("superseded");
+      expect(sent).toEqual([]);
+      expect(await threadChannel(checkpointer, 93151)).toEqual([
+        ["human", "oi"],
+      ]);
+    });
+
+    test("taken-over: a human owning the conversation leaves no reply behind either", async () => {
+      await seedConversation(93152, "User", 3);
+      const checkpointer = new MemorySaver();
+      const sent: Array<[number, string]> = [];
+      const outcome = await runAgentTurn({
+        tenantId,
+        instanceId,
+        agentBotId: 9,
+        event: incoming({ conversationId: 93152 }),
+        base: appDb,
+        deps: {
+          makeModel: fakeModel,
+          makeClient: makeStubClient(sent),
+          checkpointer,
+        },
+      });
+      expect(outcome).toBe("taken-over");
+      expect(sent).toEqual([]);
+      expect(await threadChannel(checkpointer, 93152)).toEqual([
+        ["human", "oi"],
+      ]);
+    });
+
+    // The row the PROACTIVE rollback answers the other way, and the reason the reactive plan is not
+    // the same function. `transfer_to_human` really handed the conversation over from inside the
+    // graph and no removal here undoes it, so its record stays — while the closing line, which the
+    // customer never received, does not go on to be read as something they were told.
+    test("a tool that acted keeps its record, and only the unsent sentence comes out", async () => {
+      await seedConversation(93153, null);
+      const checkpointer = new MemorySaver();
+      const sent: Array<[number, string]> = [];
+      const client = {
+        getMessages: async () => ({
+          payload: [
+            { id: 1, content: "oi", message_type: 0, private: false },
+            { id: 2, content: "deixa", message_type: 0, private: false },
+          ],
+        }),
+        sendMessage: async (conversationId: number, content: string) => {
+          sent.push([conversationId, content]);
+          return {};
+        },
+        assignToAgent: async () => ({}),
+        toggleStatus: async () => ({}),
+        unassignConversation: async () => ({}),
+        getConversation: async () => ({
+          id: 93153,
+          status: "pending",
+          meta: { assignee_type: null, assignee: null },
+        }),
+      } as unknown as ChatwootClient;
+      const outcome = await runAgentTurn({
+        tenantId,
+        instanceId,
+        agentBotId: 9,
+        event: incoming({ conversationId: 93153 }),
+        base: appDb,
+        deps: {
+          makeModel: () =>
+            new HandoffThenReplyModel(
+              "Vou te transferir.",
+              "cliente quer atendente",
+            ) as unknown as BaseChatModel,
+          makeClient: async () => client,
+          checkpointer,
+        },
+      });
+      expect(outcome).toBe("superseded");
+      // The transfer's own message DID reach the customer — that is the act the rollback must not
+      // erase the record of. The turn's closing line did not, and is the part that comes out.
+      expect(sent).toEqual([[93153, "cliente quer atendente"]]);
+      const channel = await threadChannel(checkpointer, 93153);
+      expect(channel.map(([type]) => type)).toEqual(["human", "ai", "tool"]);
+      expect(JSON.stringify(channel)).not.toContain("Vou te transferir");
+    });
+
+    // The control the three above cannot give: a turn that was NOT refused keeps its reply, so the
+    // rollback is proven to be about refusals rather than about running on every turn.
+    test("a turn that was delivered keeps its reply in the thread", async () => {
+      await seedConversation(93154, null);
+      const checkpointer = new MemorySaver();
+      const sent: Array<[number, string]> = [];
+      const outcome = await runAgentTurn({
+        tenantId,
+        instanceId,
+        agentBotId: 9,
+        event: incoming({ conversationId: 93154 }),
+        base: appDb,
+        deps: {
+          makeModel: fakeModel,
+          makeClient: makeStubClient(sent),
+          checkpointer,
+        },
+      });
+      expect(outcome).toBe("posted");
+      expect(sent).toEqual([[93154, REPLY]]);
+      expect(await threadChannel(checkpointer, 93154)).toEqual([
+        ["human", "oi"],
+        ["ai", REPLY],
+      ]);
+    });
+  });
+
   test("issue #49 guard: a clean direct turn still posts and lands the watermark", async () => {
     await seedConversation(972, null);
     const sent: Array<[number, string]> = [];
@@ -3478,6 +3660,65 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       expect(outcome).toBe("blocked");
       expect(attachments).toEqual([]);
       expect(sent).toEqual([]);
+    });
+
+    // Issue #315, the fourth refusal. A suppressed reply is the one case where keeping the text has
+    // an argument — the operator gets a private note either way, so the record is not lost. It still
+    // comes out: the note is where the record belongs, and the thread is where the model READS. Left
+    // in, the sentence a judge just refused to let out travels in every prompt of this attendance,
+    // and the next turn treats it as something the customer was told.
+    test("output 'silent': the suppressed reply is not left in the thread", async () => {
+      await setGuardrails({
+        enabled: true,
+        provider: "openai",
+        model: GUARD_MODEL,
+        credentialRef: gVaultRef,
+        input: { enabled: false },
+        output: {
+          enabled: true,
+          action: "silent",
+          checks: {
+            toxicity: true,
+            unsafeContent: false,
+            competitorMentions: false,
+            promptAdherence: false,
+          },
+        },
+      });
+      await seedConv(93155);
+      const checkpointer = new MemorySaver();
+      const sent: Array<[number, string]> = [];
+      const notes: Array<[number, string]> = [];
+      const verdict = JSON.stringify({
+        violated: true,
+        categories: ["toxicity"],
+        rationale: "reply",
+      });
+      const outcome = await runAgentTurn({
+        tenantId: gTenantId,
+        instanceId: gInstanceId,
+        agentBotId: G_BOT,
+        event: incoming({ conversationId: 93155, inboxId: G_INBOX }),
+        base: appDb,
+        deps: {
+          makeModel: (cfg: ResolvedModelConfig): BaseChatModel =>
+            cfg.model === GUARD_MODEL
+              ? guardrailModel(async () => ({ content: verdict }))
+              : fakeModel(),
+          makeClient: guardStub(sent, notes, [], []),
+          checkpointer,
+        },
+      });
+      expect(outcome).toBe("blocked");
+      expect(sent).toEqual([]);
+      // The operator's copy survives the removal — the record is in the note, not in the channel.
+      expect(notes.length).toBeGreaterThan(0);
+      expect(
+        await threadChannel(checkpointer, 93155, {
+          tenantId: gTenantId,
+          instanceId: gInstanceId,
+        }),
+      ).toEqual([["human", "oi"]]);
     });
 
     // On the INPUT direction there is no assistant reply to rewrite — the analyzed text is the


### PR DESCRIPTION
`runLoadedTurn` invokes the graph, and the graph checkpoints as it runs: the customer's message and the assistant's reply are in the thread's history the moment `invoke` returns. Nine refusals sit below that point and suppress only the **send** — a newer message arrived mid-turn (`superseded`), an operator took the conversation (`taken-over`), a `/reset` retired the run (`stale`), the output guardrail replaced the reply with nothing (`blocked`).

The reply stays in the channel, and the next turn reads it as something the customer was told. On `superseded` that next turn is *guaranteed*: the outcome exists so the re-armed flush answers the whole burst, and it does so with the abandoned sentence already in its context.

#251 fixed the same window for the proactive turn (#303) and deliberately split this one out, because the fix is not the same one applied twice. There the `[human]` message is a synthetic nudge this process wrote, and it comes out with the answer. Here it is the customer's own, and `superseded` exists precisely so the next flush answers it — removing it would lose the message.

## The rule

The removable part is named directly instead of by a boundary: **the trailing run of assistant messages that neither called a tool nor are a tool result.** It stops at the first message that is anything else, which means it can never reach a `HumanMessage` of any kind — the customer's, a divider, a memory head, a nudge, or an attendant's — and it needs no rule for where a turn "starts".

That also answers the tool case better than the proactive plan could. There, the directive and the act are one slice, so any tool call keeps everything. Here the act sits **outside** the trailing run by construction: the tool call and its result stay, and only the sentence nobody read comes out. A transfer that really happened keeps its record, and its closing line does not go on to be read as something the customer was told.

## The measurement

Both arms, against the real `PostgresSaver` (not the in-memory one — the removal is written through `graph.updateState`, and the reducer is the thing that could differ):

| | channel after the refusal |
| --- | --- |
| before, `superseded` | `[human] oi` · `[ai] Olá! Como posso ajudar?` |
| before, `superseded` + tool | `[human] oi` · `[ai] tool_calls` · `[tool] Handed off…` · `[ai] Vou te transferir.` |
| after, `superseded` | `[human] oi` |
| after, `superseded` + tool | `[human] oi` · `[ai] tool_calls` · `[tool] Handed off…` |

## What the issue asked to check rather than assume

**`blocked` is in the set.** The argument for keeping it is real — a guardrail that suppressed a reply already wrote its own private note, so the operator has the record either way. It still comes out: the note is where the *record* belongs, and the thread is where the model *reads*. Left in, a sentence a judge just refused to let out travels in every prompt of that attendance. The test asserts both halves — the channel holds only the customer's message, and the note is still there.

**The concurrent-writer hazard is unchanged and still open**, in both issues. `src/graph/inflight.ts` documents it: an invoke saves the channel it loaded plus its own messages, so two turns on one thread already race. Naming ids does not make that worse and does not fix it. `undoRefusedTurn` stands down when another invoke is already in flight, and logs at warn when it does.

## The fence, and a spelling it could not see

`tests/graph/refused-turn-callsites.test.ts` grew a `runtime.ts` arm. Writing it turned up a second spelling the predicate was blind to: a refusal riding the losing side of a ternary — `return attachments.sent ? "posted" : "stale";` — which `runLoadedTurn` has twice. A sweep written against `return "x";` passes over both without a word.

It also needed comment stripping. Collapsing whitespace makes a statement one string, and prose has no `;` in it, so the word "returning" in a NOTE two paragraphs above a routed refusal paired with that refusal's literal and reported two sites that do not exist. Both are rows in the table now.

## Validation scope

**Proved by test:**
- `planReactiveTurnRollback` as a decision table, 11 rows: the plain pair, an earlier turn left alone, the tool row (act kept, sentence removed), a turn that ended on a tool result, a turn that ended asking to act, a split reply, a channel with no boundary, a rewritten channel, memory compaction reusing an id, an unnameable message, and a nudge directive walling the run like any other human message;
- four e2e paths in `runtime.test.ts` reading the channel back — `superseded`, `taken-over`, `blocked`, and the tool case — plus a **control**: a turn that was delivered keeps its reply, so the rollback is proven to be about refusals rather than about running every turn;
- the call-site fence, with a positive control for each spelling it must catch and each it must not.

**Mutation-tested**, 7 mutations, 0 survivors: ignoring `kind` and planning proactively (4 fail), dropping the `tool_calls` exclusion (1), each of the two `start` guards (1 and 2), one call site back to a bare return (2), the ternary back to a bare return (1), and `postBlocked`'s result bypassing `refuse` (2). The last one is the site no spelling rule can hold — its refusal reaches `refuse` through a variable — and it is held by the supersede e2e instead.

**Not validated**: no Chatwoot round trip is involved. The defect is entirely inside the graph memory thread and every one of these refusals has already suppressed the send by the time it is reached, so the client is a stub in all of it. The claim stops at the channel the next invoke will load.

Full suite green (5587 pass / 0 fail) and `bun check` clean.

Fixes #315
