### PR TITLE
Show the reason the server sent, wherever a handler already has it

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -38,7 +38,11 @@ The mark then expires **by value**: `at(field, value)` shows the message only wh
 
 Declared rather than discovered, because the submit handler needs the answer *before* the next render; matched exactly rather than by prefix, so a form rendering a parent path does not claim every leaf under it. The state is per form instance: a modal over the panel that opened it has its own, and both have a `name`.
 
-Reference wiring: `pages/resources/documents/CompanyProfileCard.tsx`. The 106 remaining call sites are the sweep in issue #233.
+Reference wiring: `pages/resources/documents/CompanyProfileCard.tsx`.
+
+**Where the console actually stands**, because the two paragraphs above describe the destination and not today. Every error toast now shows the server's sentence when there is one — `tests/client/error-toast-reason.test.ts` holds that as a rule, and a handler that discards an error it has fails the suite. Rendering the refusal **at the input** it names is wired on that one card and nowhere else: `AdvancedPanel`, the vault picker, Channels and the admin surfaces all receive a `field` today (`requireVaultRef` names `embedding.credentialRef`, `SettingsTextTooLongError` names the settings path) and all of them still show it in a toast. Issue #320 tracks that, per screen, and it is deliberately separate: declaring the server's names for a form's inputs has to be read screen by screen, and doing it inside the sentence sweep would have meant editing the same handlers twice.
+
+Refusals rendered into **local error state** rather than a toast are a third population, unswept and unfenced: issue #329.
 
 ## i18n gotchas
 

--- a/src/client/components/BusinessHoursForm.tsx
+++ b/src/client/components/BusinessHoursForm.tsx
@@ -9,6 +9,7 @@ import { Select } from "@/client/components/Select";
 import { TimezonePicker } from "@/client/components/TimezonePicker";
 import { useToast } from "@/client/components/Toast";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 
 type HoursData = Awaited<
   ReturnType<(typeof api.api.v1)["business-hours"]["get"]>
@@ -226,9 +227,10 @@ export function BusinessHoursForm({
         showToast(t("hours.saved", "Business hours saved."), "success");
         onSaved(data.businessHours.id, data.businessHours.name);
       }
-    } catch {
+    } catch (e) {
       showToast(
-        t("hours.saveError", "Could not save (check the timezone)."),
+        apiErrorMessage(e) ||
+          t("hours.saveError", "Could not save (check the timezone)."),
         "error",
       );
     } finally {

--- a/src/client/components/GoogleOAuthSection.tsx
+++ b/src/client/components/GoogleOAuthSection.tsx
@@ -9,6 +9,7 @@ import { useModalController } from "@/client/components/Modal";
 import { useToast } from "@/client/components/Toast";
 import { Tooltip } from "@/client/components/Tooltip";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { watchOAuthPopup } from "@/client/lib/oauthPopup";
 
 // Derived from the treaty response; never hand-mirrored (see docs/eden-treaty.md).
@@ -361,10 +362,11 @@ export function GoogleOAuthSection({
         .oauth.google.authorize.post({ scopes });
       if (err || !data) {
         showToast(
-          t(
-            "vault.googleOAuth.connectError",
-            "Could not start the authorization flow.",
-          ),
+          apiErrorMessage(err) ||
+            t(
+              "vault.googleOAuth.connectError",
+              "Could not start the authorization flow.",
+            ),
           "error",
         );
         setConnecting(false);

--- a/src/client/components/McpOAuthSection.tsx
+++ b/src/client/components/McpOAuthSection.tsx
@@ -9,6 +9,7 @@ import { useModalController } from "@/client/components/Modal";
 import { useToast } from "@/client/components/Toast";
 import { Tooltip } from "@/client/components/Tooltip";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { watchOAuthPopup } from "@/client/lib/oauthPopup";
 
 // Derived from the treaty response; never hand-mirrored (see docs/eden-treaty.md).
@@ -109,10 +110,11 @@ export function McpOAuthSection({ entryId }: McpOAuthSectionProps) {
         .oauth.mcp.authorize.post();
       if (err || !data) {
         showToast(
-          t(
-            "vault.mcpOAuth.connectError",
-            "Could not start the authorization flow.",
-          ),
+          apiErrorMessage(err) ||
+            t(
+              "vault.mcpOAuth.connectError",
+              "Could not start the authorization flow.",
+            ),
           "error",
         );
         setConnecting(false);

--- a/src/client/components/alerts/AlertChannelsSection.tsx
+++ b/src/client/components/alerts/AlertChannelsSection.tsx
@@ -21,6 +21,7 @@ import {
   useToast,
 } from "@/client/components";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { flowStageLabel } from "@/client/lib/flowLabels";
 import type { ApiErrorPayload } from "@/client/lib/types";
 import { cn, formatDate } from "@/client/lib/utils";
@@ -396,7 +397,11 @@ export function AlertChannelsSection() {
       setChannels((prev) =>
         prev.map((c) => (c.id === ch.id ? { ...c, enabled: ch.enabled } : c)),
       );
-      showToast(t("alerts.saveFailed", "Could not save the channel"), "error");
+      showToast(
+        apiErrorMessage(err) ||
+          t("alerts.saveFailed", "Could not save the channel"),
+        "error",
+      );
     }
   };
 
@@ -415,7 +420,8 @@ export function AlertChannelsSection() {
         }).delete();
         if (err) {
           showToast(
-            t("alerts.deleteFailed", "Could not delete the channel"),
+            apiErrorMessage(err) ||
+              t("alerts.deleteFailed", "Could not delete the channel"),
             "error",
           );
           throw new Error("delete failed");

--- a/src/client/pages/AgentsPage.tsx
+++ b/src/client/pages/AgentsPage.tsx
@@ -28,6 +28,7 @@ import {
   useToast,
 } from "@/client/components";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { providerLabel } from "@/client/lib/providerLabels";
 import { formatDateTime, formatRelativeTime } from "@/client/lib/utils";
 
@@ -154,9 +155,10 @@ export function AgentsPage() {
           ? { importWarnings: data.warnings }
           : undefined,
       });
-    } catch {
+    } catch (e) {
       showToast(
-        t("agents.importError", "Could not import (invalid file?)."),
+        apiErrorMessage(e) ||
+          t("agents.importError", "Could not import (invalid file?)."),
         "error",
       );
     } finally {
@@ -174,9 +176,10 @@ export function AgentsPage() {
       if (err || !data) throw err ?? new Error("no data");
       createModal.close();
       navigate(`/agents/${data.agent.id}`);
-    } catch {
+    } catch (e) {
       showToast(
-        t("agents.createError", "Could not create the agent."),
+        apiErrorMessage(e) ||
+          t("agents.createError", "Could not create the agent."),
         "error",
       );
     } finally {

--- a/src/client/pages/ApiKeysPage.tsx
+++ b/src/client/pages/ApiKeysPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/client/components";
 import { CreateApiKeyModal } from "@/client/components/api-keys/CreateApiKeyModal";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { formatDate } from "@/client/lib/utils";
 
 // Derived from the treaty response; never hand-mirrored (see docs/eden-treaty.md).
@@ -71,7 +72,8 @@ export function ApiKeysPage() {
         }).delete();
         if (err) {
           showToast(
-            t("apiKeys.revokeFailed", "Could not revoke the key"),
+            apiErrorMessage(err) ||
+              t("apiKeys.revokeFailed", "Could not revoke the key"),
             "error",
           );
           throw new Error("revoke failed");

--- a/src/client/pages/ChannelsPage.tsx
+++ b/src/client/pages/ChannelsPage.tsx
@@ -38,6 +38,7 @@ import {
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { useAuth } from "@/client/contexts/AuthContext";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { chatwootInboxNewUrl } from "@/client/lib/chatwootLinks";
 import { cn } from "@/client/lib/utils";
 import { isValidHttpUrl } from "@/client/lib/validation";
@@ -432,15 +433,16 @@ export function ChannelsPage() {
             ? (err as { status?: number }).status
             : undefined;
         showToast(
-          status === 409
-            ? t(
-                "channels.connectDifferent",
-                "This tenant is already connected to a different Chatwoot. Disconnect it first to switch servers.",
-              )
-            : t(
-                "channels.connectError",
-                "Could not connect. Check the URL and token.",
-              ),
+          apiErrorMessage(err) ||
+            (status === 409
+              ? t(
+                  "channels.connectDifferent",
+                  "This tenant is already connected to a different Chatwoot. Disconnect it first to switch servers.",
+                )
+              : t(
+                  "channels.connectError",
+                  "Could not connect. Check the URL and token.",
+                )),
           "error",
         );
         return;
@@ -477,12 +479,13 @@ export function ChannelsPage() {
         t("channels.accountsResynced", "Account list updated."),
         "success",
       );
-    } catch {
+    } catch (e) {
       showToast(
-        t(
-          "channels.accountsError",
-          "Could not list accounts. Check the URL and token.",
-        ),
+        apiErrorMessage(e) ||
+          t(
+            "channels.accountsError",
+            "Could not list accounts. Check the URL and token.",
+          ),
         "error",
       );
     } finally {
@@ -528,9 +531,10 @@ export function ChannelsPage() {
       manageModal.close();
       setSelected(new Set());
       showToast(t("channels.accountsEnabled", "Accounts updated."), "success");
-    } catch {
+    } catch (e) {
       showToast(
-        t("channels.accountsSaveError", "Could not update the accounts."),
+        apiErrorMessage(e) ||
+          t("channels.accountsSaveError", "Could not update the accounts."),
         "error",
       );
     } finally {
@@ -554,9 +558,13 @@ export function ChannelsPage() {
       showToast(t("channels.tokenSaved", "Token updated."), "success");
       tokenModal.close();
       void load();
-    } catch {
+    } catch (e) {
       showToast(
-        t("channels.tokenSaveError", "Could not update the token (check it)."),
+        apiErrorMessage(e) ||
+          t(
+            "channels.tokenSaveError",
+            "Could not update the token (check it).",
+          ),
         "error",
       );
     } finally {
@@ -590,10 +598,11 @@ export function ChannelsPage() {
         });
         if (err) {
           showToast(
-            t(
-              "channels.teardownError",
-              "Could not disconnect. Check your password and try again.",
-            ),
+            apiErrorMessage(err) ||
+              t(
+                "channels.teardownError",
+                "Could not disconnect. Check your password and try again.",
+              ),
             "error",
           );
           throw err; // keep the dialog open
@@ -638,10 +647,11 @@ export function ChannelsPage() {
           .remove.post({ confirmName: phrase, password });
         if (err) {
           showToast(
-            t(
-              "channels.removeAccountError",
-              "Could not remove the account. Check your password and try again.",
-            ),
+            apiErrorMessage(err) ||
+              t(
+                "channels.removeAccountError",
+                "Could not remove the account. Check your password and try again.",
+              ),
             "error",
           );
           throw err; // keep the dialog open
@@ -672,8 +682,12 @@ export function ChannelsPage() {
         "success",
       );
       await refreshInboxes();
-    } catch {
-      showToast(t("channels.syncError", "Could not sync inboxes."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) ||
+          t("channels.syncError", "Could not sync inboxes."),
+        "error",
+      );
     } finally {
       syncInFlight.current.delete(account.id);
       setBusy(false);
@@ -689,7 +703,8 @@ export function ChannelsPage() {
       .patch({ agentId });
     if (err) {
       showToast(
-        t("channels.bindError", "Could not update the inbox."),
+        apiErrorMessage(err) ||
+          t("channels.bindError", "Could not update the inbox."),
         "error",
       );
       throw err;
@@ -715,9 +730,10 @@ export function ChannelsPage() {
       if (err) throw err;
       setBotStatus((prev) => ({ ...prev, [inboxId]: "active" }));
       showToast(t("channels.reconnected", "Bot reconnected."), "success");
-    } catch {
+    } catch (e) {
       showToast(
-        t("channels.reconnectError", "Could not reconnect the bot."),
+        apiErrorMessage(e) ||
+          t("channels.reconnectError", "Could not reconnect the bot."),
         "error",
       );
     } finally {

--- a/src/client/pages/ConversationDetailPage.tsx
+++ b/src/client/pages/ConversationDetailPage.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/client/components";
 import { useTenantEvents } from "@/client/hooks/useTenantEvents";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { cn, formatRelativeTime } from "@/client/lib/utils";
 
 // Eden-derived types for the dynamic /conversations/:id routes (metadata shell + the separate
@@ -1428,8 +1429,11 @@ export function ConversationDetailPage() {
       showToast(successMsg, "success");
       void loadMeta({ background: true });
       void loadMessages({ background: true });
-    } catch {
-      showToast(t("conversation.opError", "Action failed."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) || t("conversation.opError", "Action failed."),
+        "error",
+      );
     } finally {
       setBusy(false);
     }
@@ -1467,8 +1471,11 @@ export function ConversationDetailPage() {
       }
       void loadMeta();
       void loadMessages();
-    } catch {
-      showToast(t("conversation.opError", "Action failed."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) || t("conversation.opError", "Action failed."),
+        "error",
+      );
     } finally {
       setBusy(false);
     }
@@ -1519,8 +1526,12 @@ export function ConversationDetailPage() {
       }
       void loadMeta({ background: true });
       void loadMessages({ background: true });
-    } catch {
-      showToast(t("conversation.reengage.error", "Re-engage failed."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) ||
+          t("conversation.reengage.error", "Re-engage failed."),
+        "error",
+      );
     } finally {
       setBusy(false);
     }

--- a/src/client/pages/LogsExportModal.tsx
+++ b/src/client/pages/LogsExportModal.tsx
@@ -11,6 +11,7 @@ import {
   useToast,
 } from "@/client/components";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import type { LogExportFormat } from "@/modules/flowlog/export";
 
 // Export flow for the Logs page. Picks a time range (a bounded export is the default; exporting the
@@ -109,8 +110,12 @@ export function LogsExportModal({
         );
       }
       modal.close();
-    } catch {
-      showToast(t("logs.exportError", "Could not export the logs."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) ||
+          t("logs.exportError", "Could not export the logs."),
+        "error",
+      );
     } finally {
       setBusy(false);
     }

--- a/src/client/pages/McpPage.tsx
+++ b/src/client/pages/McpPage.tsx
@@ -16,6 +16,7 @@ import {
 import { McpInstall } from "@/client/components/mcp/McpInstall";
 import { useAuth } from "@/client/contexts/AuthContext";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { isAdminRole } from "@/client/lib/roles";
 import { formatDate } from "@/client/lib/utils";
 import { McpAdminSections } from "@/client/pages/mcp/McpAdminSections";
@@ -92,7 +93,8 @@ export function McpPage() {
           .delete();
         if (err) {
           showToast(
-            t("mcp.my.disconnectFailed", "Could not disconnect the app"),
+            apiErrorMessage(err) ||
+              t("mcp.my.disconnectFailed", "Could not disconnect the app"),
             "error",
           );
           throw new Error("disconnect failed");

--- a/src/client/pages/WebhooksPage.tsx
+++ b/src/client/pages/WebhooksPage.tsx
@@ -110,11 +110,13 @@ export function WebhooksPage() {
           "success",
         );
       } else {
+        // A 200 carrying the TARGET's rejection, not a refusal of ours: `err` is null by the guard
+        // above, and `result.error` is the reason the endpoint gave. Reading `err` here would be the
+        // sweep's own idiom applied where it can only ever answer null.
         showToast(
-          apiErrorMessage(err) ||
-            t("webhooks.testFailedReason", "Test failed: {{reason}}", {
-              reason: result.error ?? String(result.status ?? "unknown"),
-            }),
+          t("webhooks.testFailedReason", "Test failed: {{reason}}", {
+            reason: result.error ?? String(result.status ?? "unknown"),
+          }),
           "error",
         );
       }

--- a/src/client/pages/WebhooksPage.tsx
+++ b/src/client/pages/WebhooksPage.tsx
@@ -22,6 +22,7 @@ import {
   WebhookSubscriptionModal,
 } from "@/client/components/webhooks/WebhookSubscriptionModal";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { formatDate } from "@/client/lib/utils";
 import { webhookEventLabel } from "@/client/lib/webhookEvents";
 
@@ -79,7 +80,8 @@ export function WebhooksPage() {
         prev.map((s) => (s.id === sub.id ? { ...s, enabled: sub.enabled } : s)),
       );
       showToast(
-        t("webhooks.saveFailed", "Could not save the subscription"),
+        apiErrorMessage(err) ||
+          t("webhooks.saveFailed", "Could not save the subscription"),
         "error",
       );
     }
@@ -93,7 +95,11 @@ export function WebhooksPage() {
         .test.post();
       const result = data?.result;
       if (err || !result) {
-        showToast(t("webhooks.testFailed", "Test delivery failed"), "error");
+        showToast(
+          apiErrorMessage(err) ||
+            t("webhooks.testFailed", "Test delivery failed"),
+          "error",
+        );
         return;
       }
       if (result.ok) {
@@ -105,9 +111,10 @@ export function WebhooksPage() {
         );
       } else {
         showToast(
-          t("webhooks.testFailedReason", "Test failed: {{reason}}", {
-            reason: result.error ?? String(result.status ?? "unknown"),
-          }),
+          apiErrorMessage(err) ||
+            t("webhooks.testFailedReason", "Test failed: {{reason}}", {
+              reason: result.error ?? String(result.status ?? "unknown"),
+            }),
           "error",
         );
       }
@@ -133,7 +140,8 @@ export function WebhooksPage() {
           .delete();
         if (err) {
           showToast(
-            t("webhooks.deleteFailed", "Could not delete the subscription"),
+            apiErrorMessage(err) ||
+              t("webhooks.deleteFailed", "Could not delete the subscription"),
             "error",
           );
           throw new Error("delete failed");

--- a/src/client/pages/admin/AdminUsersPage.tsx
+++ b/src/client/pages/admin/AdminUsersPage.tsx
@@ -17,6 +17,7 @@ import { PendingInvitesCard } from "@/client/components/admin/PendingInvitesCard
 import { Tooltip } from "@/client/components/Tooltip";
 import { useAuth } from "@/client/contexts/AuthContext";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { isAdminRole } from "@/client/lib/roles";
 import { cn, formatDate } from "@/client/lib/utils";
 
@@ -175,7 +176,11 @@ export function AdminUsersPage() {
       });
 
     if (error) {
-      showToast(t("admin.roleUpdateFailed", "Failed to update role"), "error");
+      showToast(
+        apiErrorMessage(error) ||
+          t("admin.roleUpdateFailed", "Failed to update role"),
+        "error",
+      );
       return;
     }
 
@@ -215,9 +220,9 @@ export function AdminUsersPage() {
           .users({ id: user.id })
           .delete({ password });
         if (error) {
-          const msg = (error.value as { error?: string } | undefined)?.error;
           showToast(
-            msg || t("admin.deleteUserError", "Could not delete the user."),
+            apiErrorMessage(error) ||
+              t("admin.deleteUserError", "Could not delete the user."),
             "error",
           );
           throw error;

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -2435,8 +2435,11 @@ function AgentEditor() {
       a.download = `agents-agent-${slugify(data.export.agent.name) || "agent"}.json`;
       a.click();
       URL.revokeObjectURL(url);
-    } catch {
-      showToast(t("editor.exportError", "Could not export."), "error");
+    } catch (caught) {
+      showToast(
+        apiErrorMessage(caught) || t("editor.exportError", "Could not export."),
+        "error",
+      );
     }
   }
 
@@ -2500,10 +2503,11 @@ function AgentEditor() {
           .delete({ confirmName, password });
         if (err) {
           showToast(
-            t(
-              "editor.deleteError",
-              "Could not delete. Check your password and try again.",
-            ),
+            apiErrorMessage(err) ||
+              t(
+                "editor.deleteError",
+                "Could not delete. Check your password and try again.",
+              ),
             "error",
           );
           throw err; // keep the dialog open

--- a/src/client/pages/agents/ChannelsTab.tsx
+++ b/src/client/pages/agents/ChannelsTab.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/client/components";
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 
 type DeploymentData = Awaited<
   ReturnType<typeof api.api.v1.chatwoot.deployment.get>
@@ -123,9 +124,10 @@ export function ChannelsTab({
       });
       showToast(t("channels.bound", "Inbox updated."), "success");
       onBindingChanged?.();
-    } catch {
+    } catch (e) {
       showToast(
-        t("channels.bindError", "Could not update the inbox."),
+        apiErrorMessage(e) ||
+          t("channels.bindError", "Could not update the inbox."),
         "error",
       );
     } finally {
@@ -167,9 +169,10 @@ export function ChannelsTab({
       if (err) throw err;
       setBotStatus((prev) => ({ ...prev, [inboxId]: "active" }));
       showToast(t("channels.reconnected", "Bot reconnected."), "success");
-    } catch {
+    } catch (e) {
       showToast(
-        t("channels.reconnectError", "Could not reconnect the bot."),
+        apiErrorMessage(e) ||
+          t("channels.reconnectError", "Could not reconnect the bot."),
         "error",
       );
     } finally {

--- a/src/client/pages/agents/ToolGrantsEditor.tsx
+++ b/src/client/pages/agents/ToolGrantsEditor.tsx
@@ -33,6 +33,7 @@ import {
   McpToolArgs,
 } from "@/client/components/mcp/DiscoveredMcpTools";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { nativeToolMeta } from "@/client/lib/nativeTools";
 import {
   toolpackToolMeta,
@@ -714,7 +715,11 @@ export function ToolGrantsEditor({
       if (session !== documentSession.current) return;
       if (err || !data) {
         showToast(
-          t("editor.tools.documentOpenError", "Could not open this template."),
+          apiErrorMessage(err) ||
+            t(
+              "editor.tools.documentOpenError",
+              "Could not open this template.",
+            ),
           "error",
         );
         return;
@@ -771,7 +776,8 @@ export function ToolGrantsEditor({
       }).discover.post();
       if (error || !data) {
         showToast(
-          t("mcp.discoverError", "Could not reach the server."),
+          apiErrorMessage(error) ||
+            t("mcp.discoverError", "Could not reach the server."),
           "error",
         );
         return;

--- a/src/client/pages/mcp/McpAdminSections.tsx
+++ b/src/client/pages/mcp/McpAdminSections.tsx
@@ -19,6 +19,7 @@ import {
   RegisterMcpClientModal,
 } from "@/client/components/mcp/RegisterMcpClientModal";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { formatDate } from "@/client/lib/utils";
 
 // Admin management of OUR MCP server (third transport): OAuth clients, active tokens and
@@ -124,7 +125,8 @@ export function McpAdminSections() {
           .delete();
         if (err) {
           showToast(
-            t("mcp.admin.clientDeleteFailed", "Could not delete the client"),
+            apiErrorMessage(err) ||
+              t("mcp.admin.clientDeleteFailed", "Could not delete the client"),
             "error",
           );
           throw new Error("delete failed");
@@ -151,7 +153,8 @@ export function McpAdminSections() {
           .delete();
         if (err) {
           showToast(
-            t("mcp.admin.revokeFailed", "Could not revoke the token"),
+            apiErrorMessage(err) ||
+              t("mcp.admin.revokeFailed", "Could not revoke the token"),
             "error",
           );
           throw new Error("revoke failed");
@@ -177,10 +180,11 @@ export function McpAdminSections() {
           .delete();
         if (err) {
           showToast(
-            t(
-              "mcp.admin.revokeApprovalFailed",
-              "Could not revoke the approval",
-            ),
+            apiErrorMessage(err) ||
+              t(
+                "mcp.admin.revokeApprovalFailed",
+                "Could not revoke the approval",
+              ),
             "error",
           );
           throw new Error("revoke failed");

--- a/src/client/pages/resources/AdvancedPanel.tsx
+++ b/src/client/pages/resources/AdvancedPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/client/components";
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 
 type Settings = NonNullable<
   Awaited<ReturnType<(typeof api.api.v1)["tenant-settings"]["get"]>>["data"]
@@ -79,9 +80,13 @@ export function AdvancedPanel() {
         t("advanced.embedding.saved", "Embedding settings saved."),
         "success",
       );
-    } catch {
+    } catch (e) {
       showToast(
-        t("advanced.embedding.saveError", "Could not save embedding settings."),
+        apiErrorMessage(e) ||
+          t(
+            "advanced.embedding.saveError",
+            "Could not save embedding settings.",
+          ),
         "error",
       );
     } finally {
@@ -106,12 +111,13 @@ export function AdvancedPanel() {
         t("advanced.observability.saved", "Observability settings saved."),
         "success",
       );
-    } catch {
+    } catch (e) {
       showToast(
-        t(
-          "advanced.observability.saveError",
-          "Could not save observability settings.",
-        ),
+        apiErrorMessage(e) ||
+          t(
+            "advanced.observability.saveError",
+            "Could not save observability settings.",
+          ),
         "error",
       );
     } finally {

--- a/src/client/pages/resources/BusinessHoursPanel.tsx
+++ b/src/client/pages/resources/BusinessHoursPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/client/components";
 import { BusinessHoursForm } from "@/client/components/BusinessHoursForm";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { formatTimezoneLabel } from "@/client/lib/timezones";
 import { formatWindowsSummary } from "@/modules/business-hours/announce";
 
@@ -79,7 +80,10 @@ export function BusinessHoursPanel() {
           id: h.id,
         }).delete();
         if (err) {
-          showToast(t("hours.deleteError", "Could not delete."), "error");
+          showToast(
+            apiErrorMessage(err) || t("hours.deleteError", "Could not delete."),
+            "error",
+          );
           throw err;
         }
         showToast(t("hours.deleted", "Deleted."), "success");

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/client/components";
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { credentialCompat } from "@/client/lib/credentialCompat";
 import {
   toolpackToolMeta,
@@ -809,8 +810,11 @@ export function IntegrationEditModal({
           });
         }
       }
-    } catch {
-      showToast(t("integrations.saveError", "Could not save."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) || t("integrations.saveError", "Could not save."),
+        "error",
+      );
     } finally {
       setSaving(false);
     }
@@ -856,7 +860,8 @@ export function IntegrationEditModal({
           tokenModal.open({ url: inboundUrl(data.routeToken) });
         } catch (e) {
           showToast(
-            t("integrations.webhook.rotateError", "Could not generate."),
+            apiErrorMessage(e) ||
+              t("integrations.webhook.rotateError", "Could not generate."),
             "error",
           );
           // NOTE: Rethrow — ConfirmDialog's contract is that a throwing onConfirm keeps the dialog

--- a/src/client/pages/resources/IntegrationsPanel.tsx
+++ b/src/client/pages/resources/IntegrationsPanel.tsx
@@ -13,6 +13,7 @@ import {
   useToast,
 } from "@/client/components";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { IntegrationEditModal } from "./IntegrationEditModal";
 
 type CatalogData = Awaited<
@@ -119,7 +120,8 @@ export function IntegrationsPanel() {
           .delete();
         if (err) {
           showToast(
-            t("integrations.deleteError", "Could not delete."),
+            apiErrorMessage(err) ||
+              t("integrations.deleteError", "Could not delete."),
             "error",
           );
           throw err;

--- a/src/client/pages/resources/KnowledgeApprovals.tsx
+++ b/src/client/pages/resources/KnowledgeApprovals.tsx
@@ -20,6 +20,7 @@ import {
   useToast,
 } from "@/client/components";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { approvalEditPatch } from "@/client/lib/approvalEdit";
 
 // Types derived from the Eden treaty — never hand-declared (see docs/eden-treaty.md).
@@ -130,7 +131,8 @@ export function KnowledgeApprovals({
         .patch(patch);
       if (err) {
         showToast(
-          t("approvals.editError", "Could not save the edit."),
+          apiErrorMessage(err) ||
+            t("approvals.editError", "Could not save the edit."),
           "error",
         );
         return;

--- a/src/client/pages/resources/KnowledgeApprovals.tsx
+++ b/src/client/pages/resources/KnowledgeApprovals.tsx
@@ -87,7 +87,10 @@ export function KnowledgeApprovals({
           ? await endpoint.approve.post()
           : await endpoint.reject.post();
       if (err) {
-        showToast(t("approvals.actionError", "Action failed."), "error");
+        showToast(
+          apiErrorMessage(err) || t("approvals.actionError", "Action failed."),
+          "error",
+        );
         return;
       }
       setApprovals((prev) => {

--- a/src/client/pages/resources/McpPanel.tsx
+++ b/src/client/pages/resources/McpPanel.tsx
@@ -19,6 +19,7 @@ import {
   McpToolArgs,
 } from "@/client/components/mcp/DiscoveredMcpTools";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { McpEditModal } from "./McpEditModal";
 
 type McpData = Awaited<
@@ -87,7 +88,8 @@ export function McpPanel() {
       }).discover.post();
       if (err || !data) {
         showToast(
-          t("mcp.discoverError", "Could not reach the server."),
+          apiErrorMessage(err) ||
+            t("mcp.discoverError", "Could not reach the server."),
           "error",
         );
         return;
@@ -132,7 +134,10 @@ export function McpPanel() {
         id,
       }).delete();
       if (err) {
-        showToast(t("mcp.deleteError", "Could not delete."), "error");
+        showToast(
+          apiErrorMessage(err) || t("mcp.deleteError", "Could not delete."),
+          "error",
+        );
         return;
       }
       showToast(t("mcp.deleted", "Deleted."), "success");

--- a/src/client/pages/resources/ToolsPanel.tsx
+++ b/src/client/pages/resources/ToolsPanel.tsx
@@ -14,6 +14,7 @@ import {
   useToast,
 } from "@/client/components";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { nativeToolMeta } from "@/client/lib/nativeTools";
 import { NATIVE_TOOL_CATEGORY, NATIVE_TOOL_NAMES } from "@/graph/tools/catalog";
 import { type Tool, ToolEditModal } from "./ToolEditModal";
@@ -79,7 +80,10 @@ export function ToolsPanel() {
     try {
       const { error: err } = await api.api.v1.tools({ id }).delete();
       if (err) {
-        showToast(t("tools.deleteError", "Could not delete."), "error");
+        showToast(
+          apiErrorMessage(err) || t("tools.deleteError", "Could not delete."),
+          "error",
+        );
         return;
       }
       showToast(t("tools.deleted", "Tool deleted."), "success");

--- a/src/client/pages/resources/VaultPanel.tsx
+++ b/src/client/pages/resources/VaultPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/client/components";
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 import { secretTypeService } from "@/client/lib/secretTypes";
 import { cn } from "@/client/lib/utils";
 import { invalidateVault } from "@/client/lib/vaultCache";
@@ -191,7 +192,10 @@ export function VaultPanel() {
     try {
       const { error: err } = await api.api.v1.vault({ id }).delete();
       if (err) {
-        showToast(t("vault.deleteError", "Could not delete."), "error");
+        showToast(
+          apiErrorMessage(err) || t("vault.deleteError", "Could not delete."),
+          "error",
+        );
         return;
       }
       showToast(t("vault.deleted", "Secret deleted."), "success");

--- a/src/client/pages/resources/documents/CompanyProfileCard.tsx
+++ b/src/client/pages/resources/documents/CompanyProfileCard.tsx
@@ -240,7 +240,11 @@ export function CompanyProfileCard({
         await api.api.v1["tenant-settings"].company.logo.delete();
       if (error || !data) {
         showToast(
-          t("documents.company.logoRemoveError", "Could not remove the logo."),
+          apiErrorMessage(error) ||
+            t(
+              "documents.company.logoRemoveError",
+              "Could not remove the logo.",
+            ),
           "error",
         );
         return;

--- a/src/client/pages/resources/documents/DocumentsPanel.tsx
+++ b/src/client/pages/resources/documents/DocumentsPanel.tsx
@@ -304,7 +304,11 @@ export function DocumentsPanel() {
         id,
       }).delete();
       if (err) {
-        showToast(t("documents.deleteError", "Could not delete."), "error");
+        showToast(
+          apiErrorMessage(err) ||
+            t("documents.deleteError", "Could not delete."),
+          "error",
+        );
         return;
       }
       showToast(t("documents.deleted", "Deleted."), "success");
@@ -385,7 +389,10 @@ export function DocumentsPanel() {
         .revoke.post();
       if (err) throw err;
     } catch (e) {
-      showToast(t("documents.revokeError", "Could not revoke."), "error");
+      showToast(
+        apiErrorMessage(e) || t("documents.revokeError", "Could not revoke."),
+        "error",
+      );
       // Rethrown so the confirm dialog stays OPEN on failure, per its own contract: a revoke worth
       // asking about is worth retrying without hunting the row down in the list again. Eden
       // RESOLVES an HTTP error as `{ error }` and REJECTS on a transport failure, so both halves

--- a/src/client/pages/resources/documents/DocumentsPanel.tsx
+++ b/src/client/pages/resources/documents/DocumentsPanel.tsx
@@ -150,16 +150,25 @@ export function DocumentsPanel() {
   // Where a failed load is reported, which depends entirely on whether there is anything on screen
   // to lose. With nothing loaded, the retry card is the only thing that can say the panel is empty
   // because a request failed rather than because the account is.
-  const failed = useCallback(() => {
-    if (loadedOnce.current) {
-      showToast(
-        t("documents.refreshError", "Could not refresh this page."),
-        "error",
-      );
-      return;
-    }
-    setError(true);
-  }, [showToast, t]);
+  //
+  // `reason` is the response that failed, and it is passed rather than read here because the caller
+  // is the only one that knows WHICH of the four requests refused. Absent from the `catch` on
+  // purpose: Eden resolves a transport failure, so that one holds a fault of ours, with no sentence
+  // of the server's in it.
+  const failed = useCallback(
+    (reason?: unknown) => {
+      if (loadedOnce.current) {
+        showToast(
+          apiErrorMessage(reason) ||
+            t("documents.refreshError", "Could not refresh this page."),
+          "error",
+        );
+        return;
+      }
+      setError(true);
+    },
+    [showToast, t],
+  );
   const load = useCallback(async () => {
     const seq = ++loadSeq.current;
     const writes = companyWrites.current;
@@ -183,7 +192,7 @@ export function DocumentsPanel() {
       // be writing an answer to a question nobody is asking any more.
       if (!current()) return;
       if (list.error || !list.data || settings.error) {
-        failed();
+        failed(list.error ?? settings.error);
         return;
       }
       setTemplates([...list.data.templates]);

--- a/src/client/pages/resources/useKnowledgeManager.tsx
+++ b/src/client/pages/resources/useKnowledgeManager.tsx
@@ -452,8 +452,11 @@ export function useKnowledgeManager(opts: {
       createModal.close();
       void onChanged();
       opts.onCreated?.({ id: data.base.id, name: name.trim() });
-    } catch {
-      showToast(t("knowledge.createError", "Could not create."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) || t("knowledge.createError", "Could not create."),
+        "error",
+      );
     } finally {
       setBusy(false);
     }
@@ -477,8 +480,11 @@ export function useKnowledgeManager(opts: {
       showToast(t("knowledge.updated", "Knowledge base updated."), "success");
       editModal.close();
       void onChanged();
-    } catch {
-      showToast(t("knowledge.updateError", "Could not update."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) || t("knowledge.updateError", "Could not update."),
+        "error",
+      );
     } finally {
       setBusy(false);
     }
@@ -676,9 +682,10 @@ export function useKnowledgeManager(opts: {
       docEditModal.close();
       if (docsModal.payload) await reloadDocs(docsModal.payload.id);
       void onChanged();
-    } catch {
+    } catch (e) {
       showToast(
-        t("knowledge.docUpdateError", "Could not update the document."),
+        apiErrorMessage(e) ||
+          t("knowledge.docUpdateError", "Could not update the document."),
         "error",
       );
     } finally {
@@ -695,8 +702,12 @@ export function useKnowledgeManager(opts: {
       const base = data.bases.find((b) => b.id === id);
       if (!base) throw new Error("not found");
       editModal.open(base);
-    } catch {
-      showToast(t("knowledge.loadError", "Could not load this base."), "error");
+    } catch (e) {
+      showToast(
+        apiErrorMessage(e) ||
+          t("knowledge.loadError", "Could not load this base."),
+        "error",
+      );
     }
   }
 
@@ -720,13 +731,16 @@ export function useKnowledgeManager(opts: {
       // (e.g. the editor's "documents need indexing" banner) clear immediately.
       void onChanged();
       showToast(t("knowledge.retried", "Retrying..."), "success");
-    } catch {
+    } catch (e) {
       setDocs((prev) =>
         prev
           ? prev.map((d) => (d.id === doc.id ? { ...d, status: original } : d))
           : null,
       );
-      showToast(t("knowledge.retryError", "Could not retry."), "error");
+      showToast(
+        apiErrorMessage(e) || t("knowledge.retryError", "Could not retry."),
+        "error",
+      );
     }
   }
 
@@ -781,10 +795,11 @@ export function useKnowledgeManager(opts: {
       // (e.g. the editor's "documents need indexing" banner) clear immediately.
       void onChanged();
       showToast(t("knowledge.indexing", "Indexing…"), "success");
-    } catch {
+    } catch (e) {
       revert();
       showToast(
-        t("knowledge.indexAllError", "Could not start indexing."),
+        apiErrorMessage(e) ||
+          t("knowledge.indexAllError", "Could not start indexing."),
         "error",
       );
     }
@@ -804,7 +819,8 @@ export function useKnowledgeManager(opts: {
           .delete();
         if (err) {
           showToast(
-            t("knowledge.docDeleteError", "Could not delete document."),
+            apiErrorMessage(err) ||
+              t("knowledge.docDeleteError", "Could not delete document."),
             "error",
           );
           throw err;
@@ -831,7 +847,11 @@ export function useKnowledgeManager(opts: {
           .bases({ id: b.id })
           .delete();
         if (err) {
-          showToast(t("knowledge.deleteError", "Could not delete."), "error");
+          showToast(
+            apiErrorMessage(err) ||
+              t("knowledge.deleteError", "Could not delete."),
+            "error",
+          );
           throw err;
         }
         showToast(t("knowledge.deleted", "Deleted."), "success");

--- a/tests/client/document-refresh-error.test.tsx
+++ b/tests/client/document-refresh-error.test.tsx
@@ -44,6 +44,9 @@ const json = (body: unknown) =>
 
 // Which GET the NEXT load should fail. The first load always succeeds: this is about a refresh.
 let failSettings = false;
+// What the server says when it does. A sentence no catalogue in this tree contains, so finding it on
+// screen can only mean it travelled from the response.
+let settingsRefusal = "boom";
 
 globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   const url = new URL(
@@ -65,7 +68,9 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   }
   if (url.pathname.endsWith("/tenant-settings")) {
     if (failSettings) {
-      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+      return new Response(JSON.stringify({ error: settingsRefusal }), {
+        status: 500,
+      });
     }
     return json({
       company: {
@@ -85,6 +90,7 @@ globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 
 beforeEach(() => {
   failSettings = false;
+  settingsRefusal = "boom";
 });
 afterEach(cleanup);
 const startingLanguage = i18n.language;
@@ -148,4 +154,43 @@ test("a failed FIRST load still shows the retry card", async () => {
   await waitFor(() => {
     expect(screen.queryAllByText(/Retry/).length).toBeGreaterThan(0);
   });
+});
+
+// #233. A failed refresh keeps the screen (above) AND says what the server said. The toast lives in
+// `failed`, a callback that awaits nothing — `load` is the one that knows WHICH of the four requests
+// refused, so the response travels to it as an argument. That wiring is what this proves: the static
+// fence judges the SHAPE of the call, not that the reason arrives.
+test("a failed refresh shows the reason the server sent", async () => {
+  await i18n.changeLanguage("en");
+  settingsRefusal = "Your plan does not include letterheads.";
+  render(
+    <MemoryRouter initialEntries={["/recursos/documentos"]}>
+      <ToastProvider>
+        <DocumentsPanel />
+      </ToastProvider>
+    </MemoryRouter>,
+  );
+  await screen.findByRole("button", { name: /^(edit|fill in)$/i });
+
+  failSettings = true;
+  await act(async () => {
+    await i18n.changeLanguage("pt-BR");
+  });
+
+  // Both sentences are searched for, in both languages: the refresh that fires here is the one the
+  // language switch caused, so the fallback would come out in pt-BR. Searching only for the English
+  // one would fail by TIMEOUT instead of by showing what was on screen, which is a worse failure —
+  // it cannot tell "the wrong sentence" from "no toast at all".
+  const anyToast = /letterheads|Could not refresh|atualizar esta página/;
+  // Reduced to a string before the expectation: a failing assertion holding a happy-dom node
+  // serializes a cyclic tree and stalls the runner.
+  await waitFor(() => {
+    expect(screen.queryAllByText(anyToast).length).toBeGreaterThan(0);
+  });
+  const shown = screen
+    .queryAllByText(anyToast)
+    .map((n) => n.textContent ?? "")
+    .join(" | ");
+  expect(shown).toContain("Your plan does not include letterheads.");
+  expect(shown).not.toContain("atualizar esta página");
 });

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -364,6 +364,21 @@ function blockEnd(code: string, start: number): number {
   return -1;
 }
 
+// Would `name` being truthy, on its own, have entered this condition? True for `err` and for
+// `err || anything`; false for `err && anything`, whose exit says nothing about `err`.
+function entersOnItsOwn(condition: string, name: string): boolean {
+  let depth = 0;
+  for (let i = 0; i < condition.length; i++) {
+    const c = condition[i];
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") depth--;
+    else if (depth === 0 && c === "|" && condition[i + 1] === "|")
+      return condition.slice(0, i).trim() === name;
+    else if (depth === 0 && c === "&" && condition[i + 1] === "&") return false;
+  }
+  return condition.trim() === name;
+}
+
 // Is `name` provably falsy where this toast is raised?
 //
 // `apiErrorMessage(err)` reads as compliance, and the fence took it as such — from the ARGUMENT TEXT,
@@ -391,6 +406,11 @@ function bindingIsDead(body: string, name: string): boolean {
       }
     }
     if (close < 0) continue;
+    // Leaving proves the binding falsy only when the binding ALONE would have entered: `if (err)` and
+    // `if (err || !data)` do, `if (err && err.status === 409)` does not — its exit is compatible with
+    // a truthy `err`, and the read below it is real. One such guard on this tree
+    // (`AgentEditorPage.handleConflict`), so this is a rule about correctness, not a count.
+    if (!entersOnItsOwn(body.slice(paren + 1, close), name)) continue;
     let i = close + 1;
     while (i < body.length && /\s/.test(body[i] as string)) i++;
     if (body[i] === "{") {
@@ -907,6 +927,26 @@ describe("an error toast shows what the server said", () => {
         }
       }`;
     expect(deadReads(live)).toEqual([]);
+  });
+
+  test("a guard with a second condition proves nothing", () => {
+    // `if (err && err.status === 409) return;` exits on ONE kind of error and leaves every other kind
+    // truthy below it. A rule that matched any condition starting with the binding called that read
+    // dead and would have refused correct code — the direction that shouts instead of going quiet,
+    // and the only one of this predicate's bugs to point that way. The shape is real:
+    // `AgentEditorPage.handleConflict` is exactly it.
+    const partial = `
+      async function save() {
+        const { data, error: err } = await api.api.v1.things.post(body);
+        if (err && err.status === 409) {
+          setStale(true);
+          return;
+        }
+        if (err || !data) {
+          showToast(apiErrorMessage(err) || t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(deadReads(partial)).toEqual([]);
   });
 
   test("a guard that does not leave keeps the binding live", () => {

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -1,0 +1,492 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
+
+// THE GUARD AGAINST THE NEXT HANDLER THAT ASKS THE SERVER AND THEN INVENTS ITS OWN SENTENCE.
+//
+// The API answers a refusal with a sentence already localized for the request's Accept-Language, and
+// since #231 with the field it is about. A handler that catches that and shows "could not save"
+// throws away the only part the operator can act on — and a fixed sentence that sounds SPECIFIC is
+// worse than one that does not: `hours.saveError` said "Could not save (check the timezone)" for
+// every refusal the business-hours write can answer, duplicate name included.
+//
+// Measured before this sweep: 112 error toasts, 10 of them reading the server's sentence.
+//
+// What counts as an offender is a rule and not a list, because the two legitimate reasons to show a
+// fixed sentence are both derivable from the source:
+//
+//   - the toast fires BEFORE the handler has talked to the server, so it is a client-side check
+//     (an empty name, an unparseable file) and there is no server sentence in existence yet;
+//   - the toast is in a bare `catch {}` that no `throw` of the request's error can reach. Measured:
+//     Eden does NOT reject on a transport failure, it resolves with `{ status: 503, value: { message,
+//     line, column, sourceURL } }` — a `value` with no `error` key. So such a catch sees only a fault
+//     in our own handler, and there is nothing of the server's to show.
+//
+// Everything else is an offender, including the shape that reads as if it were the second case and is
+// not: `catch {}` sitting under `if (err || !data) throw err`, which receives the Eden error object
+// and discards it at the binding.
+
+const ROOT = "src/client";
+
+function sources(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) out.push(...sources(path));
+    else if (/\.tsx?$/.test(path)) out.push(path);
+  }
+  return out;
+}
+
+// The argument list of one call, from the source, without the commas that belong to something nested.
+function callArgs(src: string, openParen: number): string {
+  let depth = 1;
+  let i = openParen + 1;
+  let quote: string | null = null;
+  while (i < src.length && depth > 0) {
+    const c = src[i] as string;
+    if (quote) {
+      if (c === "\\") i++;
+      else if (c === quote) quote = null;
+    } else if (c === '"' || c === "'" || c === "`") quote = c;
+    else if (c === "(" || c === "{" || c === "[") depth++;
+    else if (c === ")" || c === "}" || c === "]") depth--;
+    i++;
+  }
+  return src.slice(openParen + 1, i - 1);
+}
+
+// The source with every comment and every string body blanked to spaces, offsets preserved.
+//
+// Counting braces on the raw text drifts, and it drifts SILENTLY: this tree's comments are prose
+// about the code and full of `{ error }`, `{{placeholder}}` and `${…}`. One unbalanced brace inside
+// one comment shifts every block boundary after it, and the scan then answers about the wrong
+// function for the rest of the file. Measured: on the raw text the scan found 28 offenders and
+// missed `BusinessHoursForm.tsx:230`, which is a bare `catch {}` under `throw err` read by hand.
+export function codeSkeleton(src: string): string {
+  const out = src.split("");
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== "\n") out[k] = " ";
+    }
+  };
+  while (i < src.length) {
+    const two = src.slice(i, i + 2);
+    if (two === "//") {
+      const end = src.indexOf("\n", i);
+      blank(i, end < 0 ? src.length : end);
+      i = end < 0 ? src.length : end;
+    } else if (two === "/*") {
+      const end = src.indexOf("*/", i + 2);
+      blank(i, end < 0 ? src.length : end + 2);
+      i = end < 0 ? src.length : end + 2;
+    } else if (src[i] === '"' || src[i] === "'" || src[i] === "`") {
+      const quote = src[i] as string;
+      let k = i + 1;
+      while (k < src.length) {
+        if (src[k] === "\\") k += 2;
+        else if (src[k] === quote) break;
+        else k++;
+      }
+      blank(i + 1, k);
+      i = k + 1;
+    } else i++;
+  }
+  return out.join("");
+}
+
+// Every `{` still open at `at`, innermost last. Brace-matched rather than indentation-matched: this
+// tree formats at two spaces and at four, and a JSX handler nests.
+//
+// The CHAIN and not just the innermost, and the positive control below is what forced that: a toast
+// inside `if (error || !data) { … }` sits in a block that contains no `await` at all, so an innermost
+// reading answers "this handler never talked to the server" about the single commonest shape there
+// is. The question is about the HANDLER, so it has to be asked of the handler.
+export function openBlocks(code: string, at: number): number[] {
+  const opens: number[] = [];
+  for (let i = 0; i < at; i++) {
+    if (code[i] === "{") opens.push(i);
+    else if (code[i] === "}") opens.pop();
+  }
+  return opens;
+}
+
+// Anything whose head ends in a parameter list: a declaration, a method, an arrow. The annotation
+// between the `)` and the `{` is why this cannot exclude parens — `function ensureSavedForConnect():
+// Promise<string | null> {` was read as "no function here", the search fell back to the whole
+// component body, and two client-side preflights were accused because something ELSE in the
+// component awaited.
+const FUNCTION_HEAD = /\)\s*(?::[^={}]*)?(?:=>)?\s*\{$/;
+// `\w+(args) {` is also how every control statement reads, and treating `if (error || !data) {` as
+// the handler is what the positive control caught: the search for the request stopped one brace too
+// early and answered "this handler never talked to the server" about the commonest shape there is.
+const CONTROL_HEAD =
+  /\b(if|else|for|while|switch|catch|do|try)\s*(\([^()]*\))?\s*\{$/;
+
+// The block that IS the handler: the innermost enclosing block whose head reads as a function, so a
+// `try`, an `if` or a loop in between does not truncate the search for the request.
+function enclosingHandler(
+  src: string,
+  chain: number[],
+): { body: string; start: number } | null {
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const start = chain[i] as number;
+    const head = src.slice(Math.max(0, start - 200), start + 1);
+    if (CONTROL_HEAD.test(head)) continue;
+    if (FUNCTION_HEAD.test(head)) {
+      return {
+        body: src.slice(start, chain[chain.length - 1] as number),
+        start,
+      };
+    }
+  }
+  // No enclosing function found. Unknown is not "offender": falling back to the outermost block asks
+  // the question of the whole COMPONENT, which awaits somewhere for sure, and every preflight in it
+  // becomes an accusation.
+  return null;
+}
+
+// Does a `catch` block reach the error of the request its `try` made?
+//
+// Two ways: the catch binds it itself, or the try re-threw it. `throw err` is the idiom in this tree
+// (`if (err || !data) throw err`), and it is the one that reads like there is nothing to show.
+function catchSeesTheError(src: string, blockStart: number): boolean {
+  const head = src.slice(Math.max(0, blockStart - 40), blockStart + 1);
+  const bound = /catch\s*\(\s*\w+\s*\)\s*\{$/.test(head);
+  if (bound) return true;
+  if (!/catch\s*\{$/.test(head)) return false;
+  // The `try` this catch belongs to: the block that ends where the catch begins.
+  const before = src.slice(0, blockStart);
+  const tryEnd = before.lastIndexOf("}");
+  if (tryEnd < 0) return false;
+  return /\bthrow\s+(err|error|e)\b/.test(
+    before.slice(Math.max(0, tryEnd - 3000), tryEnd),
+  );
+}
+
+export interface Offender {
+  file: string;
+  line: number;
+  shown: string;
+}
+
+export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
+  const out: Offender[] = [];
+  // Structure is read off the skeleton and TEXT off the source: the braces have to be real code, and
+  // the sentence being shown is exactly the part the skeleton blanks.
+  const code = codeSkeleton(src);
+  for (const m of code.matchAll(/showToast\(/g)) {
+    const open = m.index + m[0].length - 1;
+    const args = callArgs(src, open);
+    // The trailing comma is not optional to allow for: biome writes one on every multi-line call, and
+    // requiring the quote to be last silently skipped every toast the formatter had wrapped — which
+    // is most of the long ones, and they are the ones with a sentence worth replacing.
+    if (!/["']error["'],?$/.test(args.trim())) continue;
+    // `.value.error` is the same read by hand, and one screen does it on purpose: `mapSaveError`
+    // (CredentialForm) answers a LOCALIZED sentence for 409 and the server's own for 400, which is a
+    // policy, not an oversight. A fence that only knows the helper's name calls that an offender and
+    // the sweep then overrides the 409 branch.
+    if (/apiErrorMessage|refusal\.|\.value\??\.error/.test(args)) continue;
+    // The sentence can be computed a few lines up and shown by name — `const toast =
+    // refusal.capture(…)` then `showToast(toast, "error")`. Reading only the argument list calls that
+    // handler an offender while it is the reference implementation of the rule.
+    const named = args.trim().match(/^(\w+)\s*(?:\?\?[^,]*)?,/);
+    if (named) {
+      const chainForName = openBlocks(code, m.index);
+      const from = chainForName[0] ?? 0;
+      const assigned = new RegExp(
+        `\\b${named[1]}\\b\\s*=[^;]*(?:apiErrorMessage|refusal\\.)`,
+      );
+      if (assigned.test(src.slice(from, m.index))) continue;
+    }
+
+    const chain = openBlocks(code, m.index);
+    if (!chain.length) continue;
+
+    // The innermost enclosing `catch`, if the toast is in one at all.
+    const catchStart = chain.findLast((start) =>
+      /catch\s*(\(\s*\w+\s*\))?\s*\{$/.test(
+        code.slice(Math.max(0, start - 40), start + 1),
+      ),
+    );
+
+    if (catchStart !== undefined) {
+      // A catch nothing of the request's can reach. See the header: Eden resolves transport failures,
+      // so this one only ever holds a fault in our own handler.
+      if (!catchSeesTheError(code, catchStart)) continue;
+    } else {
+      // A client-side check: the handler has not asked the server BEFORE this line, so no sentence
+      // of its exists yet. Asked of the handler, not of the `if` the toast happens to sit in.
+      const handler = enclosingHandler(code, chain);
+      // NOTE: unreachable on this tree and on every fixture here — every toast sits inside some
+      // function — and kept anyway, deliberately: a source scanner that meets a shape it does not
+      // understand must answer "I cannot tell", not throw a null dereference in the middle of the
+      // suite. Mutation-surviving on purpose; the alternative is a crash instead of an abstention.
+      if (!handler) continue;
+      if (!/await\s+api\./.test(code.slice(handler.start, m.index))) continue;
+    }
+
+    out.push({
+      file,
+      line: src.slice(0, m.index).split("\n").length,
+      shown: args.replace(/\s+/g, " ").slice(0, 70),
+    });
+  }
+  return out;
+}
+
+// `a || b ? c : d` is `(a || b) ? c : d`, and that is how the sweep for this issue broke the one
+// call site whose fallback was a ternary: `apiErrorMessage(err) || status === 409 ? <409 sentence> :
+// <generic>` answered the 409 sentence for EVERY refusal that carried a message. It is the defect
+// this whole issue is about — a fixed sentence that sounds specific — reintroduced by the fix for it.
+//
+// Neither the compiler nor the fence above can see it: both branches are strings, and
+// `apiErrorMessage` is right there in the argument. So it gets its own rule.
+export function unparenthesisedFallback(
+  src: string,
+  file = "<memory>",
+): string[] {
+  const out: string[] = [];
+  for (const m of codeSkeleton(src).matchAll(
+    /apiErrorMessage\(\w+\)\s*\|\|\s*/g,
+  )) {
+    const tail = src.slice(m.index + m[0].length);
+    let depth = 0;
+    for (let i = 0; i < tail.length && i < 600; i++) {
+      const c = tail[i] as string;
+      if ("([{".includes(c)) depth++;
+      else if (")]}".includes(c)) {
+        if (depth === 0) break;
+        depth--;
+      } else if (depth === 0 && c === ",") break;
+      // `?.` and `??` both start with the character a ternary does, and `??` has to be excluded on
+      // BOTH sides: skipping only the first of the pair leaves the second one reading as a ternary.
+      else if (
+        depth === 0 &&
+        c === "?" &&
+        tail[i + 1] !== "." &&
+        tail[i + 1] !== "?" &&
+        tail[i - 1] !== "?"
+      ) {
+        out.push(`${file}:${src.slice(0, m.index).split("\n").length}`);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+// The judgement calls: a toast raised AFTER the handler has talked to the server that is still
+// correctly a fixed sentence, for a reason the source cannot state. Each one is named with why.
+//
+// Not a place to put a handler you did not get to. Every entry here is a toast about something the
+// server did NOT refuse.
+//
+// Keyed by the SENTENCE and not by the line. A line number is a fact about the rest of the file:
+// adding one import to `GoogleOAuthSection` moved four waivers by two lines each and un-waived all of
+// them at once. The sentence is what the waiver is actually about, and when someone rewrites it the
+// waiver SHOULD come back for review — a key that rots on an unrelated edit is noise, one that rots
+// when the subject changes is the point.
+const WAIVED: Record<string, string> = {
+  "pages/agents/AgentEditorPage.tsx :: toolsText":
+    "settingsTextError is OUR OWN preflight over the bag, run after a re-read of the stored settings. There is no refusal: the request it would have made was never sent.",
+  "pages/resources/KnowledgeApprovals.tsx :: approvals.editGone":
+    "A lost race reported INSIDE a 200: another reviewer got there first. The server did not refuse anything, so there is no sentence of its to show.",
+  "components/GoogleOAuthSection.tsx :: vault.googleOAuth.popupBlocked":
+    "The browser refused to open the popup. Nothing was sent, so there is no answer to quote.",
+  "components/GoogleOAuthSection.tsx :: vault.googleOAuth.authFailed":
+    "The popup's own outcome (closed, denied), which never reached our API. `outcome` is the window's, not a response.",
+  "components/McpOAuthSection.tsx :: vault.mcpOAuth.popupBlocked":
+    "Same as the Google section: the browser blocked the popup before any request.",
+  "components/McpOAuthSection.tsx :: vault.mcpOAuth.authFailed":
+    "Same as the Google section: the popup outcome, decided in the browser.",
+};
+
+// The subject of a waiver: the file, and the first translation key or bare identifier the toast
+// shows. Both spellings appear — `t("k", "…")` and a variable computed above.
+export function waiverKey(o: Offender): string {
+  const named =
+    o.shown.match(/t\(\s*["']([\w.]+)["']/)?.[1] ??
+    o.shown.match(/^(\w+)\s*,/)?.[1];
+  return `${o.file.replace(`${ROOT}/`, "")} :: ${named ?? o.shown}`;
+}
+
+describe("an error toast shows what the server said", () => {
+  test("the predicate flags a handler that discards the error it has", () => {
+    // The positive control, and the reason it is written out rather than trusted to the tree: after
+    // this sweep the real scan finds nothing, and a predicate that matched NOTHING would pass that
+    // assertion exactly as well as one that works.
+    const offending = `
+      async function save() {
+        const { data, error } = await api.api.v1.things.post(body);
+        if (error || !data) {
+          showToast(t("x.saveError", "Could not save."), "error");
+          return;
+        }
+      }`;
+    expect(unreadRefusals(offending).length).toBe(1);
+  });
+
+  test("the predicate flags a bare catch that a throw reaches", () => {
+    // The shape that reads as if there were nothing to show. There is: `throw err` put the Eden
+    // error object into the catch, and the binding is where it was dropped.
+    const rethrown = `
+      async function save() {
+        try {
+          const { data, error: err } = await api.api.v1.things.post(body);
+          if (err || !data) throw err;
+        } catch {
+          showToast(t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(unreadRefusals(rethrown).length).toBe(1);
+  });
+
+  test("a bare catch with nothing thrown into it is not an offender", () => {
+    // Measured: Eden resolves a transport failure rather than rejecting, so this catch holds only a
+    // fault in our own handler, and `apiErrorMessage` would answer null for it anyway.
+    const ownFault = `
+      async function save() {
+        try {
+          const { data } = await api.api.v1.things.post(body);
+          render(data);
+        } catch {
+          showToast(t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(unreadRefusals(ownFault)).toEqual([]);
+  });
+
+  test("a check that runs before the request is not an offender", () => {
+    const preflight = `
+      async function save() {
+        if (!name.trim()) {
+          showToast(t("x.nameRequired", "Name is required."), "error");
+          return;
+        }
+        const { data } = await api.api.v1.things.post(body);
+        render(data);
+      }`;
+    expect(unreadRefusals(preflight)).toEqual([]);
+  });
+
+  test("a toast the formatter wrapped is still read", () => {
+    // biome writes a trailing comma on every multi-line call, so requiring the `"error"` to be LAST
+    // skipped every long toast — and the long ones are the ones with a sentence worth replacing.
+    // Measured: that alone hid 50 of the 67.
+    const wrapped = `
+      async function save() {
+        const { data, error } = await api.api.v1.things.post(body);
+        if (error || !data) {
+          showToast(
+            t("x.saveError", "Could not save."),
+            "error",
+          );
+        }
+      }`;
+    expect(unreadRefusals(wrapped).length).toBe(1);
+  });
+
+  test("a comment full of braces does not move the block boundaries", () => {
+    // This tree's comments are prose about code: `{ error }`, `{{placeholder}}`, `${…}`. Counting
+    // braces on the raw text lets ONE unbalanced comment shift every boundary after it, and the scan
+    // then answers about the wrong function for the rest of the file, silently.
+    const commented = `
+      async function save() {
+        // The body is \`{ data, error }\` and the catch takes what the throw put in it: }
+        const { data, error } = await api.api.v1.things.post(body);
+        if (error || !data) {
+          showToast(t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(unreadRefusals(commented).length).toBe(1);
+  });
+
+  test("a return annotation does not hide the function", () => {
+    // `function f(): Promise<string | null> {` has parens in its head, so a pattern that excluded
+    // them read "no function here", fell back to the whole component, and accused two preflights
+    // because something ELSE in that component awaited.
+    const annotated = `
+      async function ensureSaved(): Promise<string | null> {
+        if (!name) {
+          showToast(t("x.nameRequired", "Name is required."), "error");
+          return null;
+        }
+        const { data } = await api.api.v1.things.post(body);
+        return data.id;
+      }`;
+    expect(unreadRefusals(annotated)).toEqual([]);
+  });
+
+  test("a handler that reads the sentence is not an offender", () => {
+    const reads = `
+      async function save() {
+        const { data, error } = await api.api.v1.things.post(body);
+        if (error || !data) {
+          showToast(apiErrorMessage(error) || t("x.saveError", "Could not save."), "error");
+          return;
+        }
+      }`;
+    expect(unreadRefusals(reads)).toEqual([]);
+  });
+
+  test("every error toast the server could have worded reads what it said", () => {
+    const offenders = sources(ROOT)
+      .flatMap((f) => unreadRefusals(readFileSync(f, "utf8"), f))
+      .filter((o) => !(waiverKey(o) in WAIVED));
+    expect(
+      offenders.map((o) => `${o.file}:${o.line}  ${o.shown}`),
+      "these raise a fixed sentence where the server sent one: pass it through apiErrorMessage",
+    ).toEqual([]);
+  });
+
+  test("a ternary fallback without parentheses is flagged", () => {
+    // The positive control for the rule below, and the shape it is about, verbatim from the sweep.
+    const broken = `showToast(
+      apiErrorMessage(err) || status === 409 ? t("a", "A") : t("b", "B"),
+      "error",
+    );`;
+    expect(unparenthesisedFallback(broken).length).toBe(1);
+  });
+
+  test("the same fallback with parentheses is not", () => {
+    const fixed = `showToast(
+      apiErrorMessage(err) || (status === 409 ? t("a", "A") : t("b", "B")),
+      "error",
+    );`;
+    expect(unparenthesisedFallback(fixed)).toEqual([]);
+  });
+
+  test("optional chaining and nullish coalescing are not ternaries", () => {
+    // `||` cannot be mixed with `??` without parentheses at all, so the pair under test is the one
+    // that does occur: optional chaining on the left, another `||` after it.
+    const fine = `showToast(apiErrorMessage(err) || other?.msg || t("b", "B"), "error");`;
+    expect(unparenthesisedFallback(fine)).toEqual([]);
+  });
+
+  test("a ternary after the call is not this call's fallback", () => {
+    // The scan stops at the argument's own comma. Without that it runs on into the NEXT argument and
+    // reports its ternary as this fallback's — and a `?` after a top-level comma is still inside the
+    // call, so no closing paren stops it first.
+    const later = `showToast(apiErrorMessage(err) || t("b", "B"), tone ? "error" : "info");`;
+    expect(unparenthesisedFallback(later)).toEqual([]);
+  });
+
+  test("no fallback swallows its own ternary", () => {
+    const offenders = sources(ROOT).flatMap((f) =>
+      unparenthesisedFallback(readFileSync(f, "utf8"), f),
+    );
+    expect(
+      offenders,
+      "`a || b ? c : d` binds as `(a || b) ? c : d`: wrap the fallback ternary in parentheses",
+    ).toEqual([]);
+  });
+
+  // The ledger may only shrink, and its size is the anchor the tree cannot supply: appending a name
+  // silences a new offender AND satisfies every other rule here.
+  test("the waiver ledger is pinned to its size", () => {
+    expectWaiverLedger("WAIVED", WAIVED, 6);
+  });
+});

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -119,25 +119,61 @@ export function openBlocks(code: string, at: number): number[] {
 // component body, and two client-side preflights were accused because something ELSE in the
 // component awaited.
 const FUNCTION_HEAD = /\)\s*(?::[^={}]*)?(?:=>)?\s*\{$/;
+// The keyword that opens the block starting at `brace`, or "" when its head is not `<word>(…) {`.
+//
 // `\w+(args) {` is also how every control statement reads, and treating `if (error || !data) {` as
-// the handler is what the positive control caught: the search for the request stopped one brace too
-// early and answered "this handler never talked to the server" about the commonest shape there is.
-const CONTROL_HEAD =
-  /\b(if|else|for|while|switch|catch|do|try)\s*(\([^()]*\))?\s*\{$/;
+// the handler is what the first positive control caught: the search for the request stopped one brace
+// too early and answered "this handler never talked to the server" about the commonest shape there
+// is.
+//
+// Matched by PARENS and not by a regex over the head, because `[^()]*` cannot cross a nested call:
+// `if (error && isKnown(error)) {` failed the control test while `FUNCTION_HEAD` matched its trailing
+// `) {`, so the `if` was taken for the handler, the request above it fell outside, and the scan
+// answered "no offender". Blindness, which is the direction that passes silently.
+export function headKeyword(code: string, brace: number): string {
+  let i = brace - 1;
+  while (i >= 0 && /\s/.test(code[i] as string)) i--;
+  if (code[i] !== ")") return "";
+  let depth = 0;
+  for (; i >= 0; i--) {
+    if (code[i] === ")") depth++;
+    else if (code[i] === "(") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  if (i < 0) return "";
+  let j = i - 1;
+  while (j >= 0 && /\s/.test(code[j] as string)) j--;
+  const end = j + 1;
+  while (j >= 0 && /[\w$]/.test(code[j] as string)) j--;
+  return code.slice(j + 1, end);
+}
+
+const CONTROL_WORDS = new Set([
+  "if",
+  "else",
+  "for",
+  "while",
+  "switch",
+  "catch",
+  "do",
+  "try",
+]);
 
 // The block that IS the handler: the innermost enclosing block whose head reads as a function, so a
 // `try`, an `if` or a loop in between does not truncate the search for the request.
 function enclosingHandler(
-  src: string,
+  code: string,
   chain: number[],
 ): { body: string; start: number } | null {
   for (let i = chain.length - 1; i >= 0; i--) {
     const start = chain[i] as number;
-    const head = src.slice(Math.max(0, start - 200), start + 1);
-    if (CONTROL_HEAD.test(head)) continue;
+    if (CONTROL_WORDS.has(headKeyword(code, start))) continue;
+    const head = code.slice(Math.max(0, start - 200), start + 1);
     if (FUNCTION_HEAD.test(head)) {
       return {
-        body: src.slice(start, chain[chain.length - 1] as number),
+        body: code.slice(start, chain[chain.length - 1] as number),
         start,
       };
     }
@@ -152,18 +188,31 @@ function enclosingHandler(
 //
 // Two ways: the catch binds it itself, or the try re-threw it. `throw err` is the idiom in this tree
 // (`if (err || !data) throw err`), and it is the one that reads like there is nothing to show.
-function catchSeesTheError(src: string, blockStart: number): boolean {
-  const head = src.slice(Math.max(0, blockStart - 40), blockStart + 1);
+function catchSeesTheError(code: string, blockStart: number): boolean {
+  const head = code.slice(Math.max(0, blockStart - 40), blockStart + 1);
   const bound = /catch\s*\(\s*\w+\s*\)\s*\{$/.test(head);
   if (bound) return true;
   if (!/catch\s*\{$/.test(head)) return false;
-  // The `try` this catch belongs to: the block that ends where the catch begins.
-  const before = src.slice(0, blockStart);
-  const tryEnd = before.lastIndexOf("}");
+  // The `try` this catch belongs to, brace-matched. A fixed window backwards instead accepted a
+  // `throw err` from ANOTHER function entirely: a local `JSON.parse` catch two functions below a
+  // request handler was read as receiving a server error, and the tree scan then demanded a fix for a
+  // refusal that does not exist.
+  const tryEnd = code.lastIndexOf("}", blockStart);
   if (tryEnd < 0) return false;
-  return /\bthrow\s+(err|error|e)\b/.test(
-    before.slice(Math.max(0, tryEnd - 3000), tryEnd),
-  );
+  let depth = 0;
+  let tryStart = -1;
+  for (let i = tryEnd; i >= 0; i--) {
+    if (code[i] === "}") depth++;
+    else if (code[i] === "{") {
+      depth--;
+      if (depth === 0) {
+        tryStart = i;
+        break;
+      }
+    }
+  }
+  if (tryStart < 0) return false;
+  return /\bthrow\s+(err|error|e)\b/.test(code.slice(tryStart, tryEnd));
 }
 
 // Has this handler awaited a request, up to here?
@@ -451,6 +500,44 @@ describe("an error toast shows what the server said", () => {
         return data.id;
       }`;
     expect(unreadRefusals(annotated)).toEqual([]);
+  });
+
+  test("a nested call in an `if` head does not make it the handler", () => {
+    // `if (error && isKnown(error)) {` reads as `<word>(…) {` just like a function head does, and a
+    // regex over the head cannot tell them apart: `[^()]*` stops at the inner call's paren. The `if`
+    // was then taken for the handler, the request above it fell OUTSIDE the body being searched, and
+    // the scan answered "never talked to the server" — blindness, which is the direction that passes
+    // in silence.
+    const nested = `
+      async function save() {
+        const { data, error } = await api.api.v1.things.post(body);
+        if (error && isKnown(error)) {
+          showToast(t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(unreadRefusals(nested).length).toBe(1);
+  });
+
+  test("a throw in another function does not feed this catch", () => {
+    // The `try` a bare catch belongs to is brace-matched, not a fixed window backwards. With a
+    // window, any earlier `throw err` in the file counted: a local `JSON.parse` catch was read as
+    // holding a server refusal, and the tree scan demanded a fix for a sentence that cannot exist.
+    const elsewhere = `
+      async function save() {
+        const { data, error: err } = await api.api.v1.things.post(body);
+        if (err || !data) throw err;
+        render(data);
+      }
+
+      function parseLocal(raw) {
+        try {
+          return JSON.parse(raw);
+        } catch {
+          showToast(t("x.parseError", "Could not read the file."), "error");
+          return null;
+        }
+      }`;
+    expect(unreadRefusals(elsewhere)).toEqual([]);
   });
 
   test("a handler that reads the sentence is not an offender", () => {

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -259,12 +259,67 @@ export function talkedToTheServer(body: string): boolean {
   return false;
 }
 
-// The handler's own name, when it has one: `const failed = useCallback(() => {`, `function load() {`,
-// `const save = async () => {`. Read off the head, so an anonymous callback answers null and the
-// delegation question is simply not asked of it.
+// The handler's own name, when it has one: `function load() {`, `const save = async () => {`,
+// `const failed = useCallback(\n  (reason) => {`. Anonymous callbacks answer null, and the delegation
+// question is simply not asked of them.
+//
+// Walked back as TOKENS, not matched on the line the block opens. A one-line regex read the
+// production shape as anonymous, because biome wraps `useCallback(` the moment its argument grows a
+// parameter — which is exactly what the fix for `DocumentsPanel` made it do. The conservative
+// direction of that miss is the dangerous one: the fence went quiet about the site it had just been
+// taught to see, and reverting the fix produced no offender at all. Found by review.
 function handlerName(code: string, start: number): string | null {
-  const before = code.slice(Math.max(0, start - 200), start);
-  return before.match(/(?:const|let|function)\s+(\w+)[^\n]*$/)?.[1] ?? null;
+  let i = start - 1;
+  let seen: string | null = null;
+  const skipSpace = () => {
+    while (i >= 0 && /\s/.test(code[i] as string)) i--;
+  };
+  for (let step = 0; step < 24; step++) {
+    skipSpace();
+    if (i < 0) return null;
+    const c = code[i] as string;
+    // A balanced group ending here: a parameter list, an index, an object.
+    if (c === ")" || c === "]" || c === "}") {
+      const open = c === ")" ? "(" : c === "]" ? "[" : "{";
+      let depth = 0;
+      for (; i >= 0; i--) {
+        if (code[i] === c) depth++;
+        else if (code[i] === open && --depth === 0) break;
+      }
+      i--;
+      continue;
+    }
+    if (c === ">" && code[i - 1] === "=") {
+      i -= 2; // the arrow
+      continue;
+    }
+    // A return annotation: `function f(): Promise<string | null> {`, `function g(): boolean {`. The
+    // generic form is skipped back to its colon in one go; the bare one falls through to the
+    // identifier branch and lands on the colon below.
+    if (c === ">") {
+      while (i >= 0 && /[\w\s$.<>|&,'"[\]?]/.test(code[i] as string)) i--;
+      if (code[i] !== ":") return null;
+      i--;
+      continue;
+    }
+    // `:` is the annotation's own colon. An object property (`{ onSave: () => {` ) reaches the `{`
+    // one step later and answers null there, which is the abstention we want.
+    if (c === "=" || c === "(" || c === ":") {
+      i--;
+      continue;
+    }
+    if (/[\w$]/.test(c)) {
+      let j = i;
+      while (j >= 0 && /[\w$.]/.test(code[j] as string)) j--;
+      const word = code.slice(j + 1, i + 1);
+      if (["const", "let", "var", "function"].includes(word)) return seen;
+      seen = word;
+      i = j;
+      continue;
+    }
+    return null;
+  }
+  return null;
 }
 
 // Is this handler CALLED from a place that had already asked the server?
@@ -299,8 +354,25 @@ export interface Offender {
   shown: string;
 }
 
-export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
-  const out: Offender[] = [];
+// Every error toast in one file, each with the verdict the rules above reach about it. One walker
+// rather than two: the filter chain was copied once, and a rule added to one copy and not the other
+// is how a fence starts claiming an invariant it does not hold — which is the defect this whole file
+// is a guard against.
+type Verdict =
+  // the sentence is already read, or computed by name from a read
+  | "reads"
+  // no server sentence exists at this line: nothing sent yet, or a catch no throw reaches
+  | "nothing-to-read"
+  // its handler awaits nothing AND has no name, so there is no call site to put the question to
+  | "unasked"
+  // a fixed sentence where the server had sent one
+  | "offender";
+
+function verdicts(
+  src: string,
+  file: string,
+): { verdict: Verdict; at: Offender }[] {
+  const out: { verdict: Verdict; at: Offender }[] = [];
   // Structure is read off the skeleton and TEXT off the source: the braces have to be real code, and
   // the sentence being shown is exactly the part the skeleton blanks.
   const code = codeSkeleton(src);
@@ -311,26 +383,41 @@ export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
     // requiring the quote to be last silently skipped every toast the formatter had wrapped — which
     // is most of the long ones, and they are the ones with a sentence worth replacing.
     if (!/["']error["'],?$/.test(args.trim())) continue;
+    const at: Offender = {
+      file,
+      line: src.slice(0, m.index).split("\n").length,
+      shown: args.replace(/\s+/g, " ").slice(0, 70),
+    };
+    const say = (verdict: Verdict) => out.push({ verdict, at });
+
     // `.value.error` is the same read by hand, and one screen does it on purpose: `mapSaveError`
     // (CredentialForm) answers a LOCALIZED sentence for 409 and the server's own for 400, which is a
     // policy, not an oversight. A fence that only knows the helper's name calls that an offender and
     // the sweep then overrides the 409 branch.
-    if (/apiErrorMessage|refusal\.|\.value\??\.error/.test(args)) continue;
+    if (/apiErrorMessage|refusal\.|\.value\??\.error/.test(args)) {
+      say("reads");
+      continue;
+    }
+
+    const chain = openBlocks(code, m.index);
+    if (!chain.length) {
+      say("nothing-to-read");
+      continue;
+    }
+
     // The sentence can be computed a few lines up and shown by name — `const toast =
     // refusal.capture(…)` then `showToast(toast, "error")`. Reading only the argument list calls that
     // handler an offender while it is the reference implementation of the rule.
     const named = args.trim().match(/^(\w+)\s*(?:\?\?[^,]*)?,/);
     if (named) {
-      const chainForName = openBlocks(code, m.index);
-      const from = chainForName[0] ?? 0;
       const assigned = new RegExp(
         `\\b${named[1]}\\b\\s*=[^;]*(?:apiErrorMessage|refusal\\.)`,
       );
-      if (assigned.test(src.slice(from, m.index))) continue;
+      if (assigned.test(src.slice(chain[0] ?? 0, m.index))) {
+        say("reads");
+        continue;
+      }
     }
-
-    const chain = openBlocks(code, m.index);
-    if (!chain.length) continue;
 
     // The innermost enclosing `catch`, if the toast is in one at all.
     const catchStart = chain.findLast((start) =>
@@ -342,30 +429,52 @@ export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
     if (catchStart !== undefined) {
       // A catch nothing of the request's can reach. See the header: Eden resolves transport failures,
       // so this one only ever holds a fault in our own handler.
-      if (!catchSeesTheError(code, catchStart)) continue;
-    } else {
-      // A client-side check: the handler has not asked the server BEFORE this line, so no sentence
-      // of its exists yet. Asked of the handler, not of the `if` the toast happens to sit in.
-      const handler = enclosingHandler(code, chain);
-      // NOTE: unreachable on this tree and on every fixture here — every toast sits inside some
-      // function — and kept anyway, deliberately: a source scanner that meets a shape it does not
-      // understand must answer "I cannot tell", not throw a null dereference in the middle of the
-      // suite. Mutation-surviving on purpose; the alternative is a crash instead of an abstention.
-      if (!handler) continue;
-      if (
-        !talkedToTheServer(code.slice(handler.start, m.index)) &&
-        !calledAfterARequest(code, handler.start)
-      )
-        continue;
+      say(catchSeesTheError(code, catchStart) ? "offender" : "nothing-to-read");
+      continue;
     }
 
-    out.push({
-      file,
-      line: src.slice(0, m.index).split("\n").length,
-      shown: args.replace(/\s+/g, " ").slice(0, 70),
-    });
+    // A client-side check: the handler has not asked the server BEFORE this line, so no sentence of
+    // its exists yet. Asked of the handler, not of the `if` the toast happens to sit in.
+    const handler = enclosingHandler(code, chain);
+    // NOTE: unreachable on this tree and on every fixture here — every toast sits inside some
+    // function — and kept anyway, deliberately: a source scanner that meets a shape it does not
+    // understand must answer "I cannot tell", not throw a null dereference in the middle of the
+    // suite. Mutation-surviving on purpose; the alternative is a crash instead of an abstention.
+    if (!handler) {
+      say("unasked");
+      continue;
+    }
+    if (talkedToTheServer(code.slice(handler.start, m.index))) {
+      say("offender");
+      continue;
+    }
+    // Awaits nothing itself. It is a preflight only if nobody who HAD asked the server handed it the
+    // toast, and that question needs a name to ask it of.
+    if (!handlerName(code, handler.start)) {
+      say("unasked");
+      continue;
+    }
+    say(
+      calledAfterARequest(code, handler.start) ? "offender" : "nothing-to-read",
+    );
   }
   return out;
+}
+
+export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
+  return verdicts(src, file)
+    .filter((v) => v.verdict === "offender")
+    .map((v) => v.at);
+}
+
+// Toasts the scanner cannot ASK about: their handler awaits nothing and has no name, so there is no
+// call site to put the question to. It abstains, which is the right answer and also a silent one —
+// and silence is the shape every bug in this predicate has taken. Pinned below, so a new one costs an
+// edit and a look rather than passing as a clean scan.
+export function unaskedToasts(src: string, file = "<memory>"): Offender[] {
+  return verdicts(src, file)
+    .filter((v) => v.verdict === "unasked")
+    .map((v) => v.at);
 }
 
 // `a || b ? c : d` is `(a || b) ? c : d`, and that is how the sweep for this issue broke the one
@@ -433,6 +542,18 @@ const WAIVED: Record<string, string> = {
     "Same as the Google section: the browser blocked the popup before any request.",
   "components/McpOAuthSection.tsx :: vault.mcpOAuth.authFailed":
     "Same as the Google section: the popup outcome, decided in the browser.",
+  "pages/agents/AgentEditorPage.tsx :: editor.conflictToast":
+    "Gated on `status === 409`, and all three 409s these routes answer are the same `errors.agentModifiedElsewhere`. The client's sentence says the same thing plus the affordance the server cannot know about — the banner's `save again to overwrite` — so passing the server's through would make the toast WORSE.",
+};
+
+// Toasts raised from an anonymous handler, where the delegation question has nowhere to go. Both are
+// `useEffect(() => {` reacting to state that is already on screen, so neither has a request behind it
+// — but that is a JUDGEMENT, and it is written down here rather than left to a scan that says nothing.
+const UNASKED: Record<string, string> = {
+  "components/TenantDeepLink.tsx :: tenant.deepLinkUnavailable":
+    'An effect over the tenant list already loaded: `action.kind === "unavailable"` is decided here, and no request was made to reach it.',
+  "pages/resources/VaultPanel.tsx :: vault.fillLinkNotHere":
+    "An effect over `entries` already loaded. The comment above it says why a failed load says nothing instead: an empty list is not the same claim as `the tenant does not have it`.",
 };
 
 // The subject of a waiver: the file, and the first translation key or bare identifier the toast
@@ -639,6 +760,29 @@ describe("an error toast shows what the server said", () => {
     expect(unreadRefusals(delegated).length).toBe(1);
   });
 
+  test("a wrapped `useCallback(` still names its handler", () => {
+    // The production shape, and the reason it is a fixture of its own: biome wraps `useCallback(` the
+    // moment its argument grows a parameter, which is exactly what the fix for `DocumentsPanel` made
+    // it do. Reading the name off the line the block opens then answered "anonymous", the delegation
+    // question was never asked, and the fence went quiet about the site it had just been taught to
+    // see. Measured by reverting the fix: zero offenders, with and without it.
+    const wrapped = `
+      const failed = useCallback(
+        (reason?: unknown) => {
+          showToast(t("x.refreshError", "Could not refresh."), "error");
+        },
+        [showToast, t],
+      );
+      const load = useCallback(async () => {
+        const [list] = await Promise.all([api.api.v1.things.get()]);
+        if (list.error) {
+          failed(list.error);
+          return;
+        }
+      }, [failed]);`;
+    expect(unreadRefusals(wrapped).length).toBe(1);
+  });
+
   test("a helper called from a preflight stays a preflight", () => {
     // The call site is asked the SAME question, so delegation does not turn every shared toast into
     // an accusation. Without this control the rule above is a blanket one, and the ledger grows to
@@ -724,6 +868,20 @@ describe("an error toast shows what the server said", () => {
   // The ledger may only shrink, and its size is the anchor the tree cannot supply: appending a name
   // silences a new offender AND satisfies every other rule here.
   test("the waiver ledger is pinned to its size", () => {
-    expectWaiverLedger("WAIVED", WAIVED, 6);
+    expectWaiverLedger("WAIVED", WAIVED, 7);
+  });
+
+  test("every toast the scanner cannot ask about is named", () => {
+    const unasked = sources(ROOT).flatMap((f) =>
+      unaskedToasts(readFileSync(f, "utf8"), f),
+    );
+    expect(
+      unasked.map(waiverKey).sort(),
+      "the scanner abstains on these because their handler is anonymous: name the handler, or add it here with its reason",
+    ).toEqual(Object.keys(UNASKED).sort());
+  });
+
+  test("the abstention ledger is pinned to its size", () => {
+    expectWaiverLedger("UNASKED", UNASKED, 2);
   });
 });

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -166,6 +166,23 @@ function catchSeesTheError(src: string, blockStart: number): boolean {
   );
 }
 
+// Has this handler awaited a request, up to here?
+//
+// Not `await api.` as literal text: a handler is free to name the endpoint first, and one does —
+// `KnowledgeApprovals.act` writes `const endpoint = api.api.v1.knowledge.approvals({ id })` and then
+// awaits `endpoint.approve.post()`. Reading only the literal call let the fence pass while that
+// handler discarded its `err` in a fixed "Action failed.", which is the invariant this file claims to
+// hold. Found by review, and it is the same shape as every other bug this predicate has had: a rule
+// stated over the TEXT rather than over what the text means.
+export function talkedToTheServer(body: string): boolean {
+  if (/await\s+api\./.test(body)) return true;
+  // Anything named from `api.` in this handler, then awaited under that name.
+  const aliases = [...body.matchAll(/(?:const|let)\s+(\w+)\s*=\s*api\./g)].map(
+    (m) => m[1],
+  );
+  return aliases.some((name) => new RegExp(`await\\s+${name}\\b`).test(body));
+}
+
 export interface Offender {
   file: string;
   line: number;
@@ -225,7 +242,7 @@ export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
       // understand must answer "I cannot tell", not throw a null dereference in the middle of the
       // suite. Mutation-surviving on purpose; the alternative is a crash instead of an abstention.
       if (!handler) continue;
-      if (!/await\s+api\./.test(code.slice(handler.start, m.index))) continue;
+      if (!talkedToTheServer(code.slice(handler.start, m.index))) continue;
     }
 
     out.push({
@@ -357,6 +374,22 @@ describe("an error toast shows what the server said", () => {
         }
       }`;
     expect(unreadRefusals(ownFault)).toEqual([]);
+  });
+
+  test("an endpoint named before it is awaited still counts as a request", () => {
+    // The alias shape, verbatim from `KnowledgeApprovals.act`. Reading `await api.` as literal text
+    // called this handler "never talked to the server" and let it discard its error.
+    const aliased = `
+      async function act(id) {
+        try {
+          const endpoint = api.api.v1.knowledge.approvals({ id });
+          const { error: err } = await endpoint.approve.post();
+          if (err) {
+            showToast(t("approvals.actionError", "Action failed."), "error");
+          }
+        } catch {}
+      }`;
+    expect(unreadRefusals(aliased).length).toBe(1);
   });
 
   test("a check that runs before the request is not an offender", () => {

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -406,6 +406,13 @@ function bindingIsDead(body: string, name: string): boolean {
       }
     }
     if (close < 0) continue;
+    // The guard has to DOMINATE the toast: nested under another condition
+    // (`if (skip) { if (err) return; }`) it proves nothing about the path that skipped it. Every block
+    // open at the guard must still be open at the toast — `body` ends there, so that is the whole
+    // test. Second rule in a row pointing outward, and the direction that refuses correct code.
+    const atGuard = openBlocks(body, m.index);
+    const atToast = openBlocks(body, body.length);
+    if (!atGuard.every((b, k) => atToast[k] === b)) continue;
     // Leaving proves the binding falsy only when the binding ALONE would have entered: `if (err)` and
     // `if (err || !data)` do, `if (err && err.status === 409)` does not — its exit is compatible with
     // a truthy `err`, and the read below it is real. One such guard on this tree
@@ -413,16 +420,40 @@ function bindingIsDead(body: string, name: string): boolean {
     if (!entersOnItsOwn(body.slice(paren + 1, close), name)) continue;
     let i = close + 1;
     while (i < body.length && /\s/.test(body[i] as string)) i++;
+    let exits = false;
+    let after = -1;
     if (body[i] === "{") {
       const end = blockEnd(body, i);
       // Still open here ⇒ the toast is INSIDE the guard, which is where the binding is live.
       if (end < 0) continue;
-      if (/\b(return|throw)\b[^;]*;\s*$/.test(body.slice(i, end))) return true;
+      // The exit has to be the guard's OWN last statement: at its brace level, and the WHOLE
+      // statement. `if (err) { if (x) return; }` ends in a `return` only one path takes, and the tail
+      // read as text is indistinguishable from an unconditional one — the difference is what sits
+      // between the previous statement boundary and the keyword.
+      const guarded = body.slice(i, end);
+      const tail = /\b(return|throw)\b[^;]*;\s*$/.exec(guarded);
+      const stmtStart = tail
+        ? Math.max(
+            guarded.lastIndexOf(";", tail.index - 1),
+            guarded.lastIndexOf("{", tail.index - 1),
+            guarded.lastIndexOf("}", tail.index - 1),
+          )
+        : -1;
+      exits =
+        !!tail &&
+        openBlocks(guarded, tail.index).length === 1 &&
+        guarded.slice(stmtStart + 1, tail.index).trim() === "";
+      after = end + 1;
     } else {
       const semi = body.indexOf(";", i);
-      if (semi >= 0 && /\b(return|throw)\b/.test(body.slice(i, semi)))
-        return true;
+      exits = semi >= 0 && /\b(return|throw)\b/.test(body.slice(i, semi));
+      after = semi + 1;
     }
+    if (!exits) continue;
+    // And nothing put a value back into it between the guard and the toast. `err = await retry()`
+    // makes the binding live again, and the guard above says nothing about what it holds now.
+    if (new RegExp(`\\b${name}\\s*=[^=]`).test(body.slice(after))) continue;
+    return true;
   }
   return false;
 }
@@ -927,6 +958,54 @@ describe("an error toast shows what the server said", () => {
         }
       }`;
     expect(deadReads(live)).toEqual([]);
+  });
+
+  test("a guard nested under another condition proves nothing", () => {
+    // `if (skip) { if (err) return; }` never ran on the path where `skip` was false, so `err` is as
+    // live below it as it was above. The guard has to dominate the toast, not merely precede it.
+    const nested = `
+      async function save() {
+        const { data, error: err } = await api.api.v1.things.post(body);
+        if (skip) {
+          if (err) return;
+        }
+        if (err || !data) {
+          showToast(apiErrorMessage(err) || t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(deadReads(nested)).toEqual([]);
+  });
+
+  test("a guard whose exit is itself conditional proves nothing", () => {
+    // `if (err) { if (fatal) return; }` ends in a `return` that only one path takes. Read as text the
+    // tail looks identical to an unconditional exit; the difference is the brace level it sits at.
+    const conditional = `
+      async function save() {
+        const { data, error: err } = await api.api.v1.things.post(body);
+        if (err) {
+          if (fatal) return;
+        }
+        if (err || !data) {
+          showToast(apiErrorMessage(err) || t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(deadReads(conditional)).toEqual([]);
+  });
+
+  test("a binding written again after the guard is live again", () => {
+    // The guard proved the OLD value null. `err = …` below it makes the read real, and no amount of
+    // looking at the guard can see that.
+    const rewritten = `
+      async function save() {
+        let { data, error: err } = await api.api.v1.things.post(body);
+        if (err) return;
+        ({ data, error: err } = await api.api.v1.things.confirm.post());
+        err = err ?? null;
+        if (err || !data) {
+          showToast(apiErrorMessage(err) || t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(deadReads(rewritten)).toEqual([]);
   });
 
   test("a guard with a second condition proves nothing", () => {

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -215,21 +215,82 @@ function catchSeesTheError(code: string, blockStart: number): boolean {
   return /\bthrow\s+(err|error|e)\b/.test(code.slice(tryStart, tryEnd));
 }
 
+// The expression one `await` waits on: from just after the keyword to the end of the term, brackets
+// balanced. Needed because "did this handler ask the server" is a question about what is being
+// awaited, and the call is not always the first thing after the keyword.
+function awaitedExpression(body: string, afterKeyword: number): string {
+  let depth = 0;
+  let i = afterKeyword;
+  for (; i < body.length; i++) {
+    const c = body[i] as string;
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") {
+      if (depth === 0) break;
+      depth--;
+    } else if (depth === 0 && (c === ";" || c === ",")) break;
+  }
+  return body.slice(afterKeyword, i);
+}
+
 // Has this handler awaited a request, up to here?
 //
-// Not `await api.` as literal text: a handler is free to name the endpoint first, and one does —
-// `KnowledgeApprovals.act` writes `const endpoint = api.api.v1.knowledge.approvals({ id })` and then
-// awaits `endpoint.approve.post()`. Reading only the literal call let the fence pass while that
-// handler discarded its `err` in a fixed "Action failed.", which is the invariant this file claims to
-// hold. Found by review, and it is the same shape as every other bug this predicate has had: a rule
-// stated over the TEXT rather than over what the text means.
+// Asked of each awaited EXPRESSION, not of the text `await api.`, because the call is routinely not
+// the first thing after the keyword. Two shapes in this tree, and reading the literal text missed
+// both:
+//
+//   - the endpoint named first — `KnowledgeApprovals.act` writes `const endpoint =
+//     api.api.v1.knowledge.approvals({ id })` and awaits `endpoint.approve.post()`. The fence passed
+//     while that handler discarded its `err` in a fixed "Action failed.";
+//   - four requests at once — `DocumentsPanel.load` awaits `Promise.all([api…, api…, api…, api…])`,
+//     and ten files in `src/client` load a screen that way.
+//
+// It is the same shape as every other bug this predicate has had: a rule stated over the TEXT rather
+// than over what the text means.
 export function talkedToTheServer(body: string): boolean {
-  if (/await\s+api\./.test(body)) return true;
-  // Anything named from `api.` in this handler, then awaited under that name.
   const aliases = [...body.matchAll(/(?:const|let)\s+(\w+)\s*=\s*api\./g)].map(
-    (m) => m[1],
+    (m) => m[1] as string,
   );
-  return aliases.some((name) => new RegExp(`await\\s+${name}\\b`).test(body));
+  for (const kw of body.matchAll(/\bawait\b/g)) {
+    const expr = awaitedExpression(body, (kw.index as number) + "await".length);
+    if (/\bapi\./.test(expr)) return true;
+    if (aliases.some((name) => new RegExp(`\\b${name}\\b`).test(expr)))
+      return true;
+  }
+  return false;
+}
+
+// The handler's own name, when it has one: `const failed = useCallback(() => {`, `function load() {`,
+// `const save = async () => {`. Read off the head, so an anonymous callback answers null and the
+// delegation question is simply not asked of it.
+function handlerName(code: string, start: number): string | null {
+  const before = code.slice(Math.max(0, start - 200), start);
+  return before.match(/(?:const|let|function)\s+(\w+)[^\n]*$/)?.[1] ?? null;
+}
+
+// Is this handler CALLED from a place that had already asked the server?
+//
+// A handler that never awaits anything is normally a client-side check, and that is what the rule
+// above assumes. It stops being true the moment the toast is delegated: `DocumentsPanel` writes
+// `const failed = useCallback(…)` holding the sentence, and `load` calls it from inside
+// `if (list.error || settings.error)` — the refusal is right there at the call site, and the helper,
+// asked on its own, looks like a preflight. Found by review; the fence claimed an invariant it was
+// not enforcing, which is the only kind of hole in a fence that matters.
+//
+// The call site is asked the SAME question, so a helper called from another preflight stays a
+// preflight. On this tree exactly one toast changes hands, and it is the one above.
+function calledAfterARequest(code: string, start: number): boolean {
+  const name = handlerName(code, start);
+  if (!name) return false;
+  for (const call of code.matchAll(new RegExp(`\\b${name}\\s*\\(`, "g"))) {
+    const at = call.index as number;
+    // `function failed(` is the declaration, not a call, and its enclosing block is the component —
+    // which awaits somewhere for sure. Without this every named helper reads as delegated.
+    if (/(?:function|const|let)\s+$/.test(code.slice(Math.max(0, at - 20), at)))
+      continue;
+    const caller = enclosingHandler(code, openBlocks(code, at));
+    if (caller && talkedToTheServer(code.slice(caller.start, at))) return true;
+  }
+  return false;
 }
 
 export interface Offender {
@@ -291,7 +352,11 @@ export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
       // understand must answer "I cannot tell", not throw a null dereference in the middle of the
       // suite. Mutation-surviving on purpose; the alternative is a crash instead of an abstention.
       if (!handler) continue;
-      if (!talkedToTheServer(code.slice(handler.start, m.index))) continue;
+      if (
+        !talkedToTheServer(code.slice(handler.start, m.index)) &&
+        !calledAfterARequest(code, handler.start)
+      )
+        continue;
     }
 
     out.push({
@@ -538,6 +603,58 @@ describe("an error toast shows what the server said", () => {
         }
       }`;
     expect(unreadRefusals(elsewhere)).toEqual([]);
+  });
+
+  test("four requests awaited at once still count as a request", () => {
+    // Ten files in `src/client` load a screen with `await Promise.all([api…, api…])`, and reading
+    // `await api.` as literal text answered "never talked to the server" about every one of them.
+    const batched = `
+      async function load() {
+        const [list, settings] = await Promise.all([
+          api.api.v1.things.get(),
+          api.api.v1["tenant-settings"].get(),
+        ]);
+        if (list.error || settings.error) {
+          showToast(t("x.refreshError", "Could not refresh."), "error");
+        }
+      }`;
+    expect(unreadRefusals(batched).length).toBe(1);
+  });
+
+  test("a toast delegated to a helper is asked about its caller", () => {
+    // Verbatim in shape from `DocumentsPanel`: the sentence lives in a `useCallback` that awaits
+    // nothing, and the refusal is at the call site. Asked on its own the helper looks like a
+    // preflight, which is how it passed a fence that claims exactly this invariant.
+    const delegated = `
+      const failed = useCallback(() => {
+        showToast(t("x.refreshError", "Could not refresh."), "error");
+      }, [showToast, t]);
+      const load = useCallback(async () => {
+        const [list] = await Promise.all([api.api.v1.things.get()]);
+        if (list.error) {
+          failed();
+          return;
+        }
+      }, [failed]);`;
+    expect(unreadRefusals(delegated).length).toBe(1);
+  });
+
+  test("a helper called from a preflight stays a preflight", () => {
+    // The call site is asked the SAME question, so delegation does not turn every shared toast into
+    // an accusation. Without this control the rule above is a blanket one, and the ledger grows to
+    // hold sentences that are correct as they are.
+    const shared = `
+      const complain = useCallback(() => {
+        showToast(t("x.nameRequired", "Name is required."), "error");
+      }, [showToast, t]);
+      const save = useCallback(async () => {
+        if (!name.trim()) {
+          complain();
+          return;
+        }
+        await api.api.v1.things.post(body);
+      }, [complain]);`;
+    expect(unreadRefusals(shared)).toEqual([]);
   });
 
   test("a handler that reads the sentence is not an offender", () => {

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -354,6 +354,59 @@ export interface Offender {
   shown: string;
 }
 
+// The `}` that closes the block opened at `start`, or -1 when it is still open at the end of `code`.
+function blockEnd(code: string, start: number): number {
+  let depth = 0;
+  for (let i = start; i < code.length; i++) {
+    if (code[i] === "{") depth++;
+    else if (code[i] === "}" && --depth === 0) return i;
+  }
+  return -1;
+}
+
+// Is `name` provably falsy where this toast is raised?
+//
+// `apiErrorMessage(err)` reads as compliance, and the fence took it as such — from the ARGUMENT TEXT,
+// which says nothing about whether the argument can still hold anything. This sweep put one of those
+// in by hand: `WebhooksPage.runTest` guards with `if (err || !result) { … return; }` and then reads
+// `err` again in the branch below, where the guard has proved it null. The toast looked swept and
+// showed the fixed sentence for every refusal, which is the defect this issue is about wearing the
+// costume of the fix for it. Found by review.
+//
+// The discriminator is whether the guard's block CLOSED before the toast: a toast inside
+// `if (err || !data) { … }` is exactly where the binding is live, and it is also the commonest shape
+// in this tree, so getting that backwards would accuse every correct site at once.
+function bindingIsDead(body: string, name: string): boolean {
+  for (const m of body.matchAll(
+    new RegExp(`\\bif\\s*\\(\\s*${name}\\b`, "g"),
+  )) {
+    const paren = body.indexOf("(", m.index);
+    let depth = 0;
+    let close = -1;
+    for (let i = paren; i < body.length; i++) {
+      if (body[i] === "(") depth++;
+      else if (body[i] === ")" && --depth === 0) {
+        close = i;
+        break;
+      }
+    }
+    if (close < 0) continue;
+    let i = close + 1;
+    while (i < body.length && /\s/.test(body[i] as string)) i++;
+    if (body[i] === "{") {
+      const end = blockEnd(body, i);
+      // Still open here ⇒ the toast is INSIDE the guard, which is where the binding is live.
+      if (end < 0) continue;
+      if (/\b(return|throw)\b[^;]*;\s*$/.test(body.slice(i, end))) return true;
+    } else {
+      const semi = body.indexOf(";", i);
+      if (semi >= 0 && /\b(return|throw)\b/.test(body.slice(i, semi)))
+        return true;
+    }
+  }
+  return false;
+}
+
 // Every error toast in one file, each with the verdict the rules above reach about it. One walker
 // rather than two: the filter chain was copied once, and a rule added to one copy and not the other
 // is how a fence starts claiming an invariant it does not hold — which is the defect this whole file
@@ -366,7 +419,9 @@ type Verdict =
   // its handler awaits nothing AND has no name, so there is no call site to put the question to
   | "unasked"
   // a fixed sentence where the server had sent one
-  | "offender";
+  | "offender"
+  // it calls apiErrorMessage, but on a binding a guard above has already proved falsy
+  | "dead-read";
 
 function verdicts(
   src: string,
@@ -390,18 +445,26 @@ function verdicts(
     };
     const say = (verdict: Verdict) => out.push({ verdict, at });
 
+    const chain = openBlocks(code, m.index);
+    if (!chain.length) {
+      say("nothing-to-read");
+      continue;
+    }
+
     // `.value.error` is the same read by hand, and one screen does it on purpose: `mapSaveError`
     // (CredentialForm) answers a LOCALIZED sentence for 409 and the server's own for 400, which is a
     // policy, not an oversight. A fence that only knows the helper's name calls that an offender and
     // the sweep then overrides the 409 branch.
     if (/apiErrorMessage|refusal\.|\.value\??\.error/.test(args)) {
-      say("reads");
-      continue;
-    }
-
-    const chain = openBlocks(code, m.index);
-    if (!chain.length) {
-      say("nothing-to-read");
+      const read = args.match(/apiErrorMessage\(\s*(\w+)\s*\)/);
+      const scope = enclosingHandler(code, chain);
+      say(
+        read &&
+          scope &&
+          bindingIsDead(code.slice(scope.start, m.index), read[1] as string)
+          ? "dead-read"
+          : "reads",
+      );
       continue;
     }
 
@@ -459,6 +522,14 @@ function verdicts(
     );
   }
   return out;
+}
+
+// Toasts that call `apiErrorMessage` on a binding a guard above has already proved falsy. Swept in
+// appearance, unswept in fact.
+export function deadReads(src: string, file = "<memory>"): Offender[] {
+  return verdicts(src, file)
+    .filter((v) => v.verdict === "dead-read")
+    .map((v) => v.at);
 }
 
 export function unreadRefusals(src: string, file = "<memory>"): Offender[] {
@@ -542,6 +613,8 @@ const WAIVED: Record<string, string> = {
     "Same as the Google section: the browser blocked the popup before any request.",
   "components/McpOAuthSection.tsx :: vault.mcpOAuth.authFailed":
     "Same as the Google section: the popup outcome, decided in the browser.",
+  "pages/WebhooksPage.tsx :: webhooks.testFailedReason":
+    "A 200 carrying the TARGET's rejection, not a refusal of ours — same class as `approvals.editGone`. `err` is null by the guard above, and the reason shown is `result.error`, which is the endpoint's own. The sweep put `apiErrorMessage(err)` here and it could only ever answer null.",
   "pages/agents/AgentEditorPage.tsx :: editor.conflictToast":
     "Gated on `status === 409`, and all three 409s these routes answer are the same `errors.agentModifiedElsewhere`. The client's sentence says the same thing plus the affordance the server cannot know about — the banner's `save again to overwrite` — so passing the server's through would make the toast WORSE.",
 };
@@ -801,6 +874,58 @@ describe("an error toast shows what the server said", () => {
     expect(unreadRefusals(shared)).toEqual([]);
   });
 
+  test("a read of a binding the guard already killed is not a read", () => {
+    // The sweep's own idiom applied one branch too far, verbatim from `WebhooksPage.runTest`: the
+    // guard proves `err` null and returns, and the branch below reads it again. It looks swept and
+    // shows the fixed sentence for every refusal — the defect this issue is about, wearing the
+    // costume of the fix for it.
+    const dead = `
+      async function runTest() {
+        const { data, error: err } = await api.api.v1.things.test.post();
+        const result = data?.result;
+        if (err || !result) {
+          showToast(apiErrorMessage(err) || t("x.failed", "Failed."), "error");
+          return;
+        }
+        if (!result.ok) {
+          showToast(apiErrorMessage(err) || t("x.failedReason", "Failed."), "error");
+        }
+      }`;
+    expect(deadReads(dead).map((o) => o.line)).toEqual([10]);
+  });
+
+  test("a read inside the guard that proved it is a live read", () => {
+    // The discriminator, and the direction that matters: a toast INSIDE `if (err || !data) { … }` is
+    // exactly where the binding is live, and it is the commonest shape in this tree. Getting this
+    // backwards accuses every correct site at once.
+    const live = `
+      async function save() {
+        const { data, error: err } = await api.api.v1.things.post(body);
+        if (err || !data) {
+          showToast(apiErrorMessage(err) || t("x.saveError", "Could not save."), "error");
+          return;
+        }
+      }`;
+    expect(deadReads(live)).toEqual([]);
+  });
+
+  test("a guard that does not leave keeps the binding live", () => {
+    // The other half of the discriminator. `if (err) { … }` without a `return` proves nothing about
+    // `err` below it, so the read there is a real one. Without this control the rule reads "any
+    // earlier `if (err)` kills the binding", which is how a fence starts refusing correct code.
+    const kept = `
+      async function save() {
+        const { data, error: err } = await api.api.v1.things.post(body);
+        if (err) {
+          setBanner(true);
+        }
+        if (!data) {
+          showToast(apiErrorMessage(err) || t("x.saveError", "Could not save."), "error");
+        }
+      }`;
+    expect(deadReads(kept)).toEqual([]);
+  });
+
   test("a handler that reads the sentence is not an offender", () => {
     const reads = `
       async function save() {
@@ -868,7 +993,7 @@ describe("an error toast shows what the server said", () => {
   // The ledger may only shrink, and its size is the anchor the tree cannot supply: appending a name
   // silences a new offender AND satisfies every other rule here.
   test("the waiver ledger is pinned to its size", () => {
-    expectWaiverLedger("WAIVED", WAIVED, 7);
+    expectWaiverLedger("WAIVED", WAIVED, 8);
   });
 
   test("every toast the scanner cannot ask about is named", () => {
@@ -883,5 +1008,15 @@ describe("an error toast shows what the server said", () => {
 
   test("the abstention ledger is pinned to its size", () => {
     expectWaiverLedger("UNASKED", UNASKED, 2);
+  });
+
+  test("no toast reads a binding a guard above already killed", () => {
+    const dead = sources(ROOT).flatMap((f) =>
+      deadReads(readFileSync(f, "utf8"), f),
+    );
+    expect(
+      dead.map((o) => `${o.file}:${o.line}  ${o.shown}`),
+      "`apiErrorMessage` here is called on a binding the guard above proved falsy: it always answers null and the fixed sentence always wins",
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #233

## What happens

The API answers a refusal with a sentence already localized for the request's `Accept-Language`. A handler that catches it and shows "could not save" throws away the only part the operator can act on — and a fixed sentence that *sounds* specific is worse than one that does not, because it sends them to fix something that was never the problem.

Measured live, before this change, on a real server with the console in pt-BR:

```
server   POST /v1/chatwoot/deployment → {"error":"Não foi possível acessar o Chatwoot com a URL e o token informados."}
console  "Não foi possível conectar. Verifique a URL e o token."
```

## The denominator, re-measured

The issue's original count ("28 files, 106 call sites, exactly one reads the server's message") is stale and, more importantly, was the wrong denominator: a third of those call sites are showing a fixed sentence **correctly**. Counted on `main`:

| | n | |
| --- | --- | --- |
| the error is destructured and in scope | 42 | swept |
| a bare `catch {}` the `try` reached by `throw err` | 24 | swept |
| a `catch (e)` that ignored `e` | 2 | swept |
| already read it | 10 | untouched |
| a bare `catch {}` no `throw` reaches — nothing to read | 16 | correct as is |
| client-side validation, or a race reported inside a 200 | 18 | out of scope |
| **total** | **112** | |

**67 call sites** in 30 files, of which 63 are in this PR: four live on the Pro-only admin pages (`AdminTenantsPage`, `AdminBrandingPage`), which are paired files with no counterpart in the Free tree.

The third row is the one worth naming. `catch {}` sitting under `if (err || !data) throw err` **receives** the Eden error object and drops it at the binding, so it reads like there was nothing to show. `BusinessHoursForm` is the example: it answered "Could not save (check the timezone)" for every refusal that route can make.

## The fence

`tests/client/error-toast-reason.test.ts`. What counts as an offender is a **rule**, not a list, because both legitimate reasons to show a fixed sentence are derivable from the source: the toast fires before the handler has talked to the server, or it is in a `catch` no `throw` can reach.

That second rule rests on a measurement: **Eden does not reject on a transport failure.** It resolves with `{ status: 503, value: { message, line, column, sourceURL } }` — a `value` with no `error` key — so `apiErrorMessage` correctly answers `null` there. Several comments in the tree say the opposite ("Eden REJECTS on a transport failure") and are wrong.

Eight judgement calls are waived by name, each with its reason, and the ledger is pinned to its size. It is keyed by the **sentence**, not the line: adding one import to `GoogleOAuthSection` moved four waivers by two lines each and un-waived all of them at once.

A second ledger holds what the scan **cannot ask about**: two toasts raised from an anonymous `useEffect`, where there is no name and so no call site to put the question to. Abstaining is the right answer and a silent one, and silence is the shape every bug in this predicate has taken.

A second rule guards the fix itself: `a || b ? c : d` binds as `(a || b) ? c : d`, and that is how this sweep broke the one call site whose fallback was a ternary — `apiErrorMessage(err) || status === 409 ? … : …` answered the 409 sentence for *every* refusal carrying a message. The defect this issue is about, reintroduced by the fix for it, invisible to both the compiler and the fence above.

## Validation scope

### Proven live

Real browser, real server, throwaway database, A/B run in one worktree by checking `ChannelsPage.tsx` back and forth so the only variable is the code. Toasts counted with a 30 ms observer armed **before** the click, because a single read after the fact cannot tell "no toast" from "the toast already expired".

| | base | with the change |
| --- | --- | --- |
| toast | `Não foi possível conectar. Verifique a URL e o token.` (the client's fixed sentence) | `Não foi possível acessar o Chatwoot com a URL e o token informados.` (the server's) |

Two things the same session established that the source could not:

- **The `discover` route answers a raw `MCPClientError: …` string, not `{ error }`.** `apiErrorMessage` returns null and the fixed sentence survives — which is correct, and is the rule working rather than failing.
- **`POST /v1/business-hours` with an empty name answered 500 with a raw `ZodError` dump** instead of a refusal body, measured against the base this branch started from. Already fixed independently by #309, which landed while this was in review — the note is kept because it is what the live run saw, not what `main` does now.

### Proven by test

32 tests. The rules are proven against synthetic fixtures that **offend**, because after the sweep the real scan finds nothing and a predicate matching nothing would pass that assertion just as well.

Mutation battery, one at a time: **27 of 28 killed**. The survivor is the `if (!handler) continue` guard, unreachable on this tree and on every fixture, kept deliberately and labelled: a source scanner that meets a shape it does not understand must abstain, not throw a null dereference in the middle of the suite. One guard the battery found *dead* — a self-call exclusion absorbed by the rule right after it — was deleted rather than given a fixture.

Eight of the predicate's own bugs were caught by these controls rather than by reading. Every one of them is the same shape: a rule stated over the **text** instead of over what the text means.

- it did not flag its own offending fixture — the enclosing block stopped at the `if`, which contains no `await`;
- `FUNCTION_HEAD` matched `if (…) {` as a function;
- counting braces on raw source **drifts**, because this tree's comments are prose full of `{ error }` and `{{placeholder}}`, and one unbalanced comment shifts every block boundary after it;
- requiring `"error"` to be the last token skipped every toast the formatter had wrapped with a trailing comma — **50 of the 67** on its own;
- reading the endpoint as the literal text `await api.` missed the handler that names it first (`KnowledgeApprovals.act`);
- excluding a control head by regex over its text cannot cross a nested call, so `if (error && isKnown(error)) {` was read as the handler and the request above it fell outside the search;
- a bare `catch` found its `throw` in a fixed window backwards, so a local `JSON.parse` catch two functions below a request handler counted as holding a server refusal;
- `await Promise.all([api…, api…])` is how **ten** files here load a screen, and none of them registered as having asked the server — which is also what hid `DocumentsPanel`, where the toast is **delegated** to a `useCallback` that awaits nothing while the refusal sits at the call site;
- and reading the handler's name off the line its block opens missed the wrapped form. This one is worth its own paragraph.

Four were found by disagreeing with a second, independent measurement (28 offenders versus 68) or by a positive control; five came from review, and each of those was reproduced with a probe before it was fixed. Two of them are the reason `DocumentsPanel.failed` and `AgentEditorPage.handleConflict` appear here at all.

**One of the sweep's own edits was a fake.** `apiErrorMessage(err)` reads as compliance, and the fence took it as such — off the argument *text*, which says nothing about whether the argument can still hold anything. `WebhooksPage.runTest` guards with `if (err || !result) { … return; }`, and the sweep put `apiErrorMessage(err)` in the branch below, where the guard has already proved it null. It looked swept and showed the fixed sentence for every refusal: the defect this issue is about, wearing the costume of the fix for it. The scan now asks whether the guard's block **closed** before the toast — a toast *inside* `if (err || !data) { … }` is exactly where the binding is live, and that is the commonest shape here, so the two directions are both positive controls. One dead read on this tree, and it was mine.

That rule's own drafts are the only bugs in this file that pointed **outward** — over-claiming refuses correct code, which is the loud direction. Two review rounds said so from different angles, so the fourth commit closes the family instead of waiting for the next two. A guard proves the binding falsy only when all four hold:

| the guard must | or else |
| --- | --- |
| be entered by the binding **alone** (`err`, `err \|\| …`) | `if (err && err.status === 409)` exits on one kind of error and leaves every other kind truthy — and `AgentEditorPage.handleConflict` is exactly that shape |
| **dominate** the toast | `if (skip) { if (err) return; }` never ran on the path where `skip` was false |
| exit as its own last statement, whole and at its brace level | `if (err) { if (fatal) return; }` ends in a `return` only one path takes, and read as text that is identical to an unconditional one |
| not have the binding written again before the toast | `err = await retry()` makes the read real, and no amount of looking at the guard can see it |

The tree is clean under every version of the rule. This is about what the rule *means*, not about a count.

**The fix silenced the guard written for it.** biome wraps `useCallback(` the moment its argument grows a parameter, which is exactly what adding `reason` to `failed` did. The helper then read as anonymous, the delegation question was never asked, and reverting the fix produced *no offender at all* — the fence went quiet about the one site it had just been taught to see, and nothing said so. The name is walked back as tokens now, its fixture is written in the shape biome produces, and the A/B is recorded above.

Walking the tokens also reached two handlers a one-line read never could. One is a preflight and stays one. The other, `AgentEditorPage.handleConflict`, is a real refusal the sweep had missed — and it is **waived** rather than swept: gated on `status === 409`, all three 409s those routes answer are the same `errors.agentModifiedElsewhere`, and the client's sentence adds the affordance the server cannot know about (the banner's "save again to overwrite"). Passing the server's through would make the toast worse.

The delegation rule has its own negative control: the call site is asked the **same** question, so a helper called from another preflight stays a preflight. Without it the rule is a blanket one and the ledger grows to hold sentences that are already correct. On this tree exactly one toast changes hands.

`bun check`: **5684 pass / 0 fail**.

### Not validated

- **Refusals rendered into local error state**, not a toast: 22 more sites the fence is blind to by construction. Found by driving this fix live — an MCP server saved with a duplicate name answers `mcp connection name already in use` and the modal says "check the URL/command". Filed as its own issue with that evidence.
- **12 call sites read the wire by hand** (`(apiError.value as ApiErrorPayload)?.error || …`), twelve copies of what `apiErrorMessage` does, each with its own idea of what a blank message means. They work, so replacing them is a simplification, not a fix, and is not in this PR.
- **The four Pro-only sites** are swept in the master tree and cannot be exercised from this repo.
