### PR TITLE
Publish the 422 a route already answers, and only where it answers it

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -302,6 +302,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postAuthSetup"
@@ -427,6 +449,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postAuthSignup"
@@ -537,6 +581,28 @@
               "application/json": {
                 "schema": {
                   "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -698,6 +764,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchAuthPassword",
@@ -766,6 +854,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -949,6 +1059,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postAuthAccept-invite"
@@ -1095,6 +1227,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -1698,6 +1852,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchAdminUsersByIdRole"
@@ -1855,6 +2031,28 @@
               "application/json": {
                 "schema": {
                   "description": "Conflict — a duplicate or a state conflict.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -2044,6 +2242,28 @@
               "application/json": {
                 "schema": {
                   "description": "Conflict — a duplicate or a state conflict.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -2656,6 +2876,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchV1Branding",
@@ -2737,6 +2979,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -2918,6 +3182,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1BrandingAssetByKindByVariant"
@@ -3016,6 +3302,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -3315,6 +3623,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Tenants",
@@ -3592,6 +3922,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchV1TenantsById"
@@ -3762,6 +4114,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -4222,6 +4596,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1ConversationsByIdMedia"
@@ -4372,6 +4768,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -4540,6 +4958,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -4914,6 +5354,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1ConversationsByIdStatus"
@@ -5011,6 +5473,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -5210,6 +5694,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -5488,6 +5994,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -5804,6 +6332,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -6317,6 +6867,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchV1AgentsById"
@@ -6487,6 +7059,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -6909,6 +7503,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1AgentsByIdClone"
@@ -7178,6 +7794,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -7757,6 +8395,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1AgentsByIdTool-selections"
@@ -8094,6 +8754,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -8559,6 +9241,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1AgentsByIdPlaygroundFollowup"
@@ -8884,6 +9588,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -9287,6 +10013,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1AgentsByIdPlaygroundAudio"
@@ -9612,6 +10360,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -10012,6 +10782,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -10738,6 +11530,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1AgentsModelsList",
@@ -10934,6 +11748,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -11565,6 +12401,28 @@
               "application/json": {
                 "schema": {
                   "description": "Conflict — a duplicate or a state conflict.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -12246,6 +13104,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchV1ToolsById"
@@ -12862,6 +13742,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Mcp-connections",
@@ -13253,6 +14155,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -14150,6 +15074,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Business-hours",
@@ -14725,6 +15671,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchV1Business-hoursById"
@@ -15213,6 +16181,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Experiments",
@@ -15620,6 +16610,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -16246,6 +17258,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Vault",
@@ -16538,6 +17572,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1VaultById"
@@ -16622,6 +17678,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -16723,6 +17801,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -16947,6 +18047,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1VaultTest",
@@ -17127,6 +18249,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -17324,6 +18468,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1VaultByIdOauthGoogleAuthorize"
@@ -17447,6 +18613,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1VaultByIdOauthGoogleStatus"
@@ -17555,6 +18743,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -17793,6 +19003,28 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "502": {
             "description": "Bad gateway — an upstream dependency failed.",
             "content": {
@@ -17937,6 +19169,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1VaultByIdOauthMcpStatus"
@@ -18045,6 +19299,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -18463,6 +19739,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1Tenant-settingsEmbedding",
@@ -18671,6 +19969,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1Tenant-settingsLangfuse",
@@ -18848,6 +20168,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -19092,6 +20434,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "putV1Tenant-settingsCompany",
@@ -19243,6 +20607,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -19838,6 +21224,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1WebhooksSubscriptions",
@@ -20077,6 +21485,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -20561,6 +21991,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -21715,6 +23167,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Alert-channels",
@@ -22011,6 +23485,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -22450,6 +23946,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "getV1IntegrationsGoogleCalendars"
@@ -22557,6 +24075,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -22937,6 +24477,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -23359,6 +24921,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -23879,6 +25463,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1KnowledgeBases",
@@ -24301,6 +25907,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -24822,6 +26450,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -25388,6 +27038,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchV1KnowledgeDocumentsById"
@@ -25783,6 +27455,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1KnowledgeBasesByIdReindex"
@@ -26008,6 +27702,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1KnowledgeSearch",
@@ -26195,6 +27911,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -26483,6 +28221,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -27317,6 +29077,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Document-templates",
@@ -27742,6 +29524,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Document-templatesPreview",
@@ -27863,6 +29667,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -28263,6 +30089,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "patchV1Document-templatesById"
@@ -28369,6 +30217,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -28492,6 +30362,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -28634,6 +30526,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -28894,6 +30808,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1Documents",
@@ -29030,6 +30966,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1DocumentsByIdRevoke"
@@ -29138,6 +31096,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -29355,6 +31335,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1McpOauthRegister"
@@ -29494,6 +31496,28 @@
               "application/json": {
                 "schema": {
                   "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -29761,6 +31785,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1McpOauthConsentByReq"
@@ -29916,6 +31962,28 @@
                       "type": "string"
                     },
                     "error_description": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
                       "type": "string"
                     }
                   }
@@ -30587,6 +32655,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "postV1McpAdminClients",
@@ -30796,6 +32886,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -31257,6 +33369,28 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "operationId": "deleteV1McpAdminApprovalsById"
@@ -31639,6 +33773,28 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "502": {
             "description": "Bad gateway — an upstream dependency failed.",
             "content": {
@@ -31806,6 +33962,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -32004,6 +34182,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -32333,6 +34533,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -32799,6 +35021,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -33925,6 +36169,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"

--- a/src/api/features/admin/admin.controller.ts
+++ b/src/api/features/admin/admin.controller.ts
@@ -191,7 +191,7 @@ export const adminController = new Elysia({
         "Update user role",
         "Change a user's role within the caller's tenant scope.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // Permanently delete a user (within the caller's tenant scope). Step-up: the acting admin re-enters
@@ -261,7 +261,7 @@ export const adminController = new Elysia({
         "Delete user",
         "Permanently delete a user within the caller's tenant scope. Requires the acting admin's password; cannot delete yourself or the last admin.",
       ),
-      response: errors(401, 403, 404, 409),
+      response: errors(401, 403, 404, 409, 422),
     },
   )
   // Invite a user into a tenant. A SUPER_ADMIN targets one explicitly via body.tenantId (400 if
@@ -337,7 +337,7 @@ export const adminController = new Elysia({
         "Create invitation",
         "Invite a user into a tenant and return an accept link.",
       ),
-      response: errors(400, 401, 403, 409),
+      response: errors(400, 401, 403, 409, 422),
     },
   )
   .get(

--- a/src/api/features/auth/auth.controller.ts
+++ b/src/api/features/auth/auth.controller.ts
@@ -170,7 +170,7 @@ const baseAuthController = new Elysia({
         ),
         security: [],
       },
-      response: errors(400, 401, 409),
+      response: errors(400, 401, 409, 422),
     },
   )
   .post(
@@ -252,7 +252,7 @@ const baseAuthController = new Elysia({
         ),
         security: [],
       },
-      response: errors(400, 403),
+      response: errors(400, 403, 422),
     },
   )
   .post(
@@ -318,7 +318,7 @@ const baseAuthController = new Elysia({
         ),
         security: [],
       },
-      response: errors(400, 401),
+      response: errors(400, 401, 422),
     },
   )
   .get(
@@ -444,7 +444,7 @@ const baseAuthController = new Elysia({
         "Change own password",
         "Verifies the current password and stores a new one for the authenticated user. Returns 400 for Google-only accounts (no local password) or an incorrect current password.",
       ),
-      response: errors(400, 401),
+      response: errors(400, 401, 422),
     },
   )
   // ── invitation acceptance (public: the invitee has no account yet) ──
@@ -480,7 +480,7 @@ const baseAuthController = new Elysia({
         ),
         security: [],
       },
-      response: errors(400, 404),
+      response: errors(400, 404, 422),
     },
   )
   // Consume the invite: create the user (tenant + role bound to the invite row, never the
@@ -555,7 +555,7 @@ const baseAuthController = new Elysia({
         ),
         security: [],
       },
-      response: errors(400, 409, 410),
+      response: errors(400, 409, 410, 422),
     },
   )
   .post(
@@ -666,7 +666,7 @@ const googleAuthController = baseAuthController.post(
       ),
       security: [],
     },
-    response: errors(400, 401, 403),
+    response: errors(400, 401, 403, 422),
   },
 );
 

--- a/src/api/features/branding/branding.controller.ts
+++ b/src/api/features/branding/branding.controller.ts
@@ -82,7 +82,7 @@ export const brandingController = new Elysia({
         ),
         security: [],
       },
-      response: errors(400, 404),
+      response: errors(400, 404, 422),
     },
   )
   // SUPER_ADMIN: update colors (mode + brand color and/or per-theme token maps).
@@ -139,7 +139,7 @@ export const brandingController = new Elysia({
       "Update branding colors",
       "Updates the global branding color mode, brand color, and per-theme token maps. SUPER_ADMIN only.",
     ),
-    response: errors(400, 401, 403),
+    response: errors(400, 401, 403, 422),
   })
   // SUPER_ADMIN: upload a logo/favicon variant (multipart). The service re-checks type + size.
   .put(
@@ -164,7 +164,7 @@ export const brandingController = new Elysia({
         "Upload branding asset",
         "Uploads a logo or favicon binary for the given kind and theme variant (multipart). SUPER_ADMIN only.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 422),
     },
   )
   // SUPER_ADMIN: remove a logo/favicon variant.
@@ -178,6 +178,6 @@ export const brandingController = new Elysia({
         "Delete branding asset",
         "Removes the stored logo or favicon binary for the given kind and theme variant. SUPER_ADMIN only.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 422),
     },
   );

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -268,7 +268,7 @@ export const agentsController = new Elysia({
         "List agents",
         "Returns a paginated list of agents for the tenant.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       query: t.Object({
         q: t.Optional(
@@ -391,7 +391,7 @@ export const agentsController = new Elysia({
     }),
     {
       detail: doc("Create agent", "Creates a new agent for the tenant."),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         name: t.String({
@@ -470,7 +470,7 @@ export const agentsController = new Elysia({
     },
     {
       detail: doc("Update agent", "Partially updates an existing agent."),
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -578,7 +578,7 @@ export const agentsController = new Elysia({
         "Delete agent",
         "Deletes an agent by id. Requires re-typing the agent name and the current password (step-up).",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -608,7 +608,7 @@ export const agentsController = new Elysia({
     }),
     {
       detail: doc("Clone agent", "Creates a copy of an existing agent."),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -689,7 +689,7 @@ export const agentsController = new Elysia({
         "Import agent config",
         "Recreates an agent (disabled) from an exported config, resolving references by name.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         export: t.Unknown({
@@ -752,7 +752,7 @@ export const agentsController = new Elysia({
         "Run playground turn",
         "Runs one chat turn against the agent in the playground, with no Chatwoot side effects.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -819,7 +819,7 @@ export const agentsController = new Elysia({
         "Run playground follow-up",
         "Simulates the proactive follow-up nudge on the current playground thread, with no Chatwoot post.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -852,7 +852,7 @@ export const agentsController = new Elysia({
         "Transcribe playground audio",
         "Transcribes an uploaded voice note only (step 1 of 2), returning the transcription.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -907,7 +907,7 @@ export const agentsController = new Elysia({
         "Run playground audio turn",
         "Runs a turn on an uploaded voice note (step 2 of 2), returning the transcription and the reply.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -973,7 +973,7 @@ export const agentsController = new Elysia({
         "Extract playground file",
         "Extracts content from an uploaded image or document only (step 1 of 2), returning the kind and content.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -1030,7 +1030,7 @@ export const agentsController = new Elysia({
         "Run playground file turn",
         "Runs a turn on an uploaded image or document (step 2 of 2), returning the extraction and the reply.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
@@ -1225,7 +1225,7 @@ export const agentsController = new Elysia({
         "List provider models",
         "Lists the available models for a model provider, using a vault credential reference.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         provider: t.String({
@@ -1286,7 +1286,7 @@ export const agentsController = new Elysia({
         "List TTS voices/models",
         "Lists the voices or models for a text-to-speech provider. OpenAI returns a curated set; ElevenLabs is fetched live with the vault credential.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       requireRole: "TENANT_ADMIN",
       body: t.Object({
         provider: t.String({
@@ -1331,7 +1331,7 @@ export const agentsController = new Elysia({
         "Replace tool selections",
         "Replaces the agent's entire set of tool grants (replace-the-set semantics).",
       ),
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({

--- a/src/api/v1/alert-channels.controller.ts
+++ b/src/api/v1/alert-channels.controller.ts
@@ -117,7 +117,7 @@ export const alertChannelsController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .patch(
@@ -191,7 +191,7 @@ export const alertChannelsController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .delete(

--- a/src/api/v1/api-keys.controller.ts
+++ b/src/api/v1/api-keys.controller.ts
@@ -74,7 +74,7 @@ export const apiKeysController = new Elysia({
             "Human-readable label for the key (1 to 120 characters).",
         }),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .delete(

--- a/src/api/v1/business-hours.controller.ts
+++ b/src/api/v1/business-hours.controller.ts
@@ -187,7 +187,7 @@ export const businessHoursController = new Elysia({
         "Create business hours",
         "Create a new business-hours schedule for the current tenant.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       body: createBody,
     },
   )
@@ -207,7 +207,7 @@ export const businessHoursController = new Elysia({
         "Update business hours",
         "Update a business-hours schedule name, timezone, or windows.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       params: t.Object({
         id: t.String({
           description: "Business-hours schedule id (BigInt as a string).",

--- a/src/api/v1/chatwoot-admin.controller.ts
+++ b/src/api/v1/chatwoot-admin.controller.ts
@@ -117,7 +117,7 @@ export const chatwootAdminController = new Elysia({
             "Chatwoot admin/user access token; encrypted at rest, never returned.",
         }),
       }),
-      response: errors(400, 401, 403, 404, 409, 502),
+      response: errors(400, 401, 403, 404, 409, 422, 502),
     },
   )
   // Rotate the deployment's admin token (validated against the live deployment before it persists).
@@ -145,7 +145,7 @@ export const chatwootAdminController = new Elysia({
           description: "New admin token; encrypted at rest, never returned.",
         }),
       }),
-      response: errors(400, 401, 403, 404, 502),
+      response: errors(400, 401, 403, 404, 422, 502),
     },
   )
   // Tear down the whole Chatwoot connection (the "switch servers" path): wipes the local mirror
@@ -205,7 +205,7 @@ export const chatwootAdminController = new Elysia({
           description: "The acting user's password (step-up confirmation).",
         }),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // Re-list the accounts the deployment's STORED token can reach (for the "manage accounts" editor —
@@ -250,7 +250,7 @@ export const chatwootAdminController = new Elysia({
           description: "The Chatwoot account ids that should be connected.",
         }),
       }),
-      response: errors(400, 401, 403, 404, 502),
+      response: errors(400, 401, 403, 404, 422, 502),
     },
   )
   .delete(
@@ -345,7 +345,7 @@ export const chatwootAdminController = new Elysia({
           description: "The acting user's password (step-up confirmation).",
         }),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .post(
@@ -549,7 +549,7 @@ export const chatwootAdminController = new Elysia({
             "Agent id (BigInt string) to bind, or null to unbind the inbox.",
         }),
       }),
-      response: errors(400, 401, 403, 404, 502),
+      response: errors(400, 401, 403, 404, 422, 502),
     },
   )
   // Re-provision + reconnect the bound inbox's persona bot (recovery when the bot was deleted on

--- a/src/api/v1/document-templates.controller.ts
+++ b/src/api/v1/document-templates.controller.ts
@@ -143,7 +143,7 @@ export const documentTemplatesController = new Elysia({
         "Create document template",
         "Creates a document template from blocks, fields and style.",
       ),
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   .post(
@@ -229,7 +229,7 @@ export const documentTemplatesController = new Elysia({
       // write takes for a template a newer build wrote (`documentTemplateUnreadable`). Create and
       // patch both declared it; nothing at runtime told anyone this one did not, because Elysia
       // answers the 409 either way and only the generated client is left holding the wrong union.
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   .get(
@@ -250,7 +250,7 @@ export const documentTemplatesController = new Elysia({
         }),
       }),
       detail: doc("Get document template", "Returns one document template."),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .get(
@@ -274,7 +274,7 @@ export const documentTemplatesController = new Elysia({
         "List template references",
         "Agents that were granted this template, so deletion can warn first.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .patch(
@@ -301,7 +301,7 @@ export const documentTemplatesController = new Elysia({
         "Patches a document template; omitted fields keep their value.",
       ),
       // 409 for a slug already taken, and for a stored template this version cannot read.
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   .delete(
@@ -325,6 +325,6 @@ export const documentTemplatesController = new Elysia({
         "Delete document template",
         "Deletes a document template. Documents already issued from it keep their own copy.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   );

--- a/src/api/v1/documents.controller.ts
+++ b/src/api/v1/documents.controller.ts
@@ -124,7 +124,7 @@ export const documentsController = new Elysia({
       // and one past 2^63-1 is refused by the range check rather than by the transport. A status the
       // route returns and the contract does not name is a status no generated client knows how to
       // handle — the same reason the issue route names 409.
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .post(
@@ -182,7 +182,7 @@ export const documentsController = new Elysia({
       // 409 is a real answer here: an idempotency key can land on a row that was revoked, that could
       // not be numbered, or that nobody managed to store. A status the route returns and the
       // contract does not name is a status no generated client knows how to handle.
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   .post(
@@ -206,7 +206,7 @@ export const documentsController = new Elysia({
         "Revoke document",
         "Revokes an issued document; its PDF stops being served.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .get(
@@ -243,6 +243,6 @@ export const documentsController = new Elysia({
         "Download document PDF",
         "Streams the rendered PDF for inline viewing.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   );

--- a/src/api/v1/experiments.controller.ts
+++ b/src/api/v1/experiments.controller.ts
@@ -147,7 +147,7 @@ export const experimentsController = new Elysia({
         "Create experiment",
         "Create a prompt A/B experiment with one or more variants.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       body: t.Object({
         name: t.String({
           minLength: 1,
@@ -203,7 +203,7 @@ export const experimentsController = new Elysia({
         "Update experiment",
         "Update an experiment name, target agent, variants, or enabled flag.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       params: t.Object({
         id: t.String({ description: "Experiment id (BigInt as a string)." }),
       }),

--- a/src/api/v1/integrations-admin.controller.ts
+++ b/src/api/v1/integrations-admin.controller.ts
@@ -102,7 +102,7 @@ export const integrationsAdminController = new Elysia({
             "Vault reference (vault:<id>) of a connected google_oauth credential.",
         }),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .get(
@@ -127,7 +127,7 @@ export const integrationsAdminController = new Elysia({
             "Vault reference (vault:<id>) of a connected google_oauth credential.",
         }),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .get(
@@ -235,7 +235,7 @@ export const integrationsAdminController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .patch(
@@ -299,7 +299,7 @@ export const integrationsAdminController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // NOTE: Rotation is a POST because it MUTATES: the old URL stops resolving the moment it commits.

--- a/src/api/v1/knowledge.controller.ts
+++ b/src/api/v1/knowledge.controller.ts
@@ -127,7 +127,7 @@ export const knowledgeController = new Elysia({
         "Create knowledge base",
         "Create a new knowledge base for the current tenant.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       body: t.Object({
         name: t.String({
           minLength: 1,
@@ -189,7 +189,7 @@ export const knowledgeController = new Elysia({
         "Update knowledge base",
         "Update a knowledge base name, description, or chunking parameters.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       params: t.Object({
         id: t.String({
           description: "Knowledge base id (BigInt as a string).",
@@ -323,7 +323,7 @@ export const knowledgeController = new Elysia({
         "Add text document",
         "Add a plain-text document to a knowledge base for embedding.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       params: t.Object({
         id: t.String({
           description: "Knowledge base id (BigInt as a string).",
@@ -440,7 +440,7 @@ export const knowledgeController = new Elysia({
         "Update document",
         "Edit a document's title and/or text. Changing the text re-ingests and re-embeds it.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       params: t.Object({
         id: t.String({ description: "Document id (BigInt as a string)." }),
       }),
@@ -513,7 +513,7 @@ export const knowledgeController = new Elysia({
         "Index pending knowledge-base documents",
         "Queue ingestion + embedding for every not-yet-indexed (UNINDEXED) document in the base, e.g. after importing an agent that bundled its documents. Pass includeFailed=true to also re-queue FAILED documents (bulk recovery). If the tenant's embedding credential is unconfigured or its secret is not filled yet, nothing is queued and `blocked` explains why (the documents keep their status).",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       params: t.Object({
         id: t.String({
           description: "Knowledge base id (BigInt as a string).",
@@ -546,7 +546,7 @@ export const knowledgeController = new Elysia({
         "Search knowledge",
         "Run a semantic search across one or more knowledge bases and return ranked chunks.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       body: t.Object({
         query: t.String({
           minLength: 1,
@@ -589,7 +589,7 @@ export const knowledgeController = new Elysia({
         "Suggest knowledge entry",
         "Create a pending suggestion to add an entry to a knowledge base, awaiting human approval.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       body: t.Object({
         knowledgeBaseId: t.String({
           description: "Target knowledge base id (BigInt as a string).",
@@ -640,7 +640,7 @@ export const knowledgeController = new Elysia({
         "Edit pending approval",
         "Edit the title, content, or rationale of a pending knowledge-base suggestion before approving it.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
       params: t.Object({
         id: t.String({ description: "Approval item id (BigInt as a string)." }),
       }),

--- a/src/api/v1/mcp-admin.controller.ts
+++ b/src/api/v1/mcp-admin.controller.ts
@@ -101,7 +101,7 @@ export const mcpAdminController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 422),
     },
   )
   .patch(
@@ -125,7 +125,7 @@ export const mcpAdminController = new Elysia({
         scopes: t.Optional(t.Array(t.String())),
         firstParty: t.Optional(t.Boolean()),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .delete(
@@ -225,6 +225,6 @@ export const mcpAdminController = new Elysia({
           description: "The approval id.",
         }),
       }),
-      response: errors(401, 403, 404),
+      response: errors(401, 403, 404, 422),
     },
   );

--- a/src/api/v1/mcp-connections.controller.ts
+++ b/src/api/v1/mcp-connections.controller.ts
@@ -169,7 +169,7 @@ export const mcpConnectionsController = new Elysia({
         "Registers a new consumed MCP server connection for the tenant.",
       ),
       body: createBody,
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .patch(
@@ -190,7 +190,7 @@ export const mcpConnectionsController = new Elysia({
       ),
       params: idParams,
       body: writeBody,
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .delete(

--- a/src/api/v1/mcp-oauth.controller.ts
+++ b/src/api/v1/mcp-oauth.controller.ts
@@ -172,7 +172,11 @@ export const mcpOAuthController = new Elysia({
         ),
         security: [],
       },
-      response: { 400: OAuthErrorResponse, 404: OAuthErrorResponse },
+      response: {
+        400: OAuthErrorResponse,
+        404: OAuthErrorResponse,
+        ...errors(422),
+      },
       body: t.Object({
         redirect_uris: t.Array(
           t.String({ minLength: 1, description: "An allowed redirect URI." }),
@@ -323,7 +327,7 @@ export const mcpOAuthController = new Elysia({
           description:
             "Redirect to the login screen, the consent screen, or the client's registered callback (with code + state + iss). Destination in the `Location` header.",
         }),
-        ...errors(400, 403),
+        ...errors(400, 403, 422),
       },
       query: t.Object({
         client_id: t.String({
@@ -491,7 +495,7 @@ export const mcpOAuthController = new Elysia({
         "Approves or denies a pending authorization. Verifies the CSRF token and single-use-consumes the request; on approve, mints the authorization code from the stored record and remembers the approval (revocable). Returns { redirect } for the SPA to navigate to.",
       ),
       requireAuth: true,
-      response: errors(400, 401, 404),
+      response: errors(400, 401, 404, 422),
       params: t.Object({
         req: t.String({
           minLength: 1,
@@ -553,7 +557,7 @@ export const mcpOAuthController = new Elysia({
         ),
         security: [],
       },
-      response: { 400: OAuthErrorResponse },
+      response: { 400: OAuthErrorResponse, ...errors(422) },
       body: t.Object({
         grant_type: t.String({
           description: 'Either "authorization_code" or "refresh_token".',

--- a/src/api/v1/oauth-google.controller.ts
+++ b/src/api/v1/oauth-google.controller.ts
@@ -134,7 +134,7 @@ export const oauthGoogleVaultController = new Elysia({
           { description: "Google OAuth scopes to request during consent." },
         ),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // Connection status (never returns tokens or the client secret).
@@ -152,7 +152,7 @@ export const oauthGoogleVaultController = new Elysia({
         "Returns the connection state of a google_oauth vault entry; never returns tokens or the client secret.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // Disconnect: best-effort revoke the refresh token, then drop the tokens (keep clientId/secret).
@@ -182,7 +182,7 @@ export const oauthGoogleVaultController = new Elysia({
         "Best-effort revokes the refresh token and drops the stored tokens for a google_oauth vault entry, keeping the client id and secret.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   );
 

--- a/src/api/v1/oauth-mcp.controller.ts
+++ b/src/api/v1/oauth-mcp.controller.ts
@@ -208,7 +208,7 @@ export const oauthMcpVaultController = new Elysia({
         "Discovers the MCP server OAuth configuration, registers a client via DCR if needed, and builds the authorization URL and signed state to start the consent flow for an mcp_oauth vault entry.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404, 502),
+      response: errors(400, 401, 403, 404, 422, 502),
     },
   )
   // Connection status (never returns tokens or the client secret).
@@ -226,7 +226,7 @@ export const oauthMcpVaultController = new Elysia({
         "Returns the connection state of an mcp_oauth vault entry; never returns tokens or the client secret.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // Disconnect: drop the tokens but keep the discovered config + registered client so a reconnect
@@ -262,7 +262,7 @@ export const oauthMcpVaultController = new Elysia({
         "Drops the stored tokens for an mcp_oauth vault entry, keeping the discovered OAuth config and registered client.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   );
 

--- a/src/api/v1/tenant-settings.controller.ts
+++ b/src/api/v1/tenant-settings.controller.ts
@@ -114,7 +114,7 @@ export const tenantSettingsController = new Elysia({
         "Update embedding settings",
         "Updates the tenant's RAG embedding configuration.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .put(
@@ -161,7 +161,7 @@ export const tenantSettingsController = new Elysia({
         "Update Langfuse settings",
         "Updates the tenant's Langfuse tracing configuration.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .post(
@@ -197,7 +197,7 @@ export const tenantSettingsController = new Elysia({
         "Test Langfuse connection",
         "Probes the Langfuse instance with the supplied keys without saving them.",
       ),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 422),
     },
   )
   .put(
@@ -238,7 +238,7 @@ export const tenantSettingsController = new Elysia({
         "Update company profile",
         "Updates the letterhead the tenant's issued documents carry.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .post(
@@ -260,7 +260,7 @@ export const tenantSettingsController = new Elysia({
         "Upload company logo",
         "Stores the letterhead logo used by document templates whose header shows one.",
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .delete(

--- a/src/api/v1/tools.controller.ts
+++ b/src/api/v1/tools.controller.ts
@@ -239,7 +239,7 @@ export const toolsController = new Elysia({
         "Create tool",
         "Create a custom HTTP tool definition for the current tenant.",
       ),
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
       body: createBody,
     },
   )
@@ -259,7 +259,7 @@ export const toolsController = new Elysia({
         "Update tool",
         "Update fields of a custom HTTP tool definition.",
       ),
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
       params: t.Object({
         id: t.String({
           description: "Tool definition id (BigInt as a string).",

--- a/src/api/v1/v1.controller.ts
+++ b/src/api/v1/v1.controller.ts
@@ -139,7 +139,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ...doc("Update tenant", "Updates a tenant's mutable fields by id."),
         tags: ["Tenants"],
       },
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // Permanently delete a tenant and ALL its data (cascade). HARD-gated: SUPER_ADMIN, re-typed tenant
@@ -195,7 +195,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Tenants"],
       },
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   // SUPER_ADMIN provisions a tenant; with adminEmail it also issues the first TENANT_ADMIN invite
@@ -257,7 +257,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Tenants"],
       },
-      response: errors(400, 401, 403, 409),
+      response: errors(400, 401, 403, 409, 422),
     },
   )
   .get(
@@ -428,7 +428,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Conversations"],
       },
-      response: errors(400, 401, 404),
+      response: errors(400, 401, 404, 422),
     },
   )
   .post(
@@ -470,7 +470,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Conversations"],
       },
-      response: errors(400, 401, 404),
+      response: errors(400, 401, 404, 422),
     },
   )
   .post(
@@ -506,7 +506,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Conversations"],
       },
-      response: errors(400, 401, 404),
+      response: errors(400, 401, 404, 422),
     },
   )
   .post(
@@ -600,7 +600,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Conversations"],
       },
-      response: errors(400, 401, 404),
+      response: errors(400, 401, 404, 422),
     },
   )
   .get(
@@ -637,7 +637,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(400, 401, 404),
+      response: errors(400, 401, 404, 422),
     },
   )
   .get(
@@ -709,7 +709,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(400, 401, 404),
+      response: errors(400, 401, 404, 422),
     },
   )
   .get(

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -123,7 +123,7 @@ export const vaultController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   .put(
@@ -177,7 +177,7 @@ export const vaultController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404, 409),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   .get(
@@ -196,7 +196,7 @@ export const vaultController = new Elysia({
         "Returns where a vault entry is referenced across the tenant's configuration.",
       ),
       params: idParams,
-      response: errors(401, 403, 404),
+      response: errors(401, 403, 404, 422),
     },
   )
   // Test-on-save: probe a typed value (pre-save) or a stored credential by id. Stateless for the
@@ -244,7 +244,7 @@ export const vaultController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403),
+      response: errors(400, 401, 403, 422),
     },
   )
   .post(
@@ -276,7 +276,7 @@ export const vaultController = new Elysia({
           ),
         }),
       ),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .delete(
@@ -292,6 +292,6 @@ export const vaultController = new Elysia({
         "Permanently removes a tenant secret by id.",
       ),
       params: idParams,
-      response: errors(401, 403, 404),
+      response: errors(401, 403, 404, 422),
     },
   );

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -107,7 +107,7 @@ export const webhooksController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .patch(
@@ -163,7 +163,7 @@ export const webhooksController = new Elysia({
           }),
         ),
       }),
-      response: errors(400, 401, 403, 404),
+      response: errors(400, 401, 403, 404, 422),
     },
   )
   .delete(

--- a/tests/api/lib/schema-refusal-declared.test.ts
+++ b/tests/api/lib/schema-refusal-declared.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, test } from "bun:test";
+import { setupPrismaMock } from "@/tests/utils/prisma-mock";
+
+// Issue #314. The schema boundary (#255, src/api/lib/schema-refusal.ts) answers a TypeBox refusal
+// with 422, a localized sentence and the `field` the value failed on. It runs BEFORE the role guard,
+// so the status is reachable on any route with a request schema, authenticated or not — and one
+// route of the whole API declared it. `openapi.json` is a committed artifact and the Eden types the
+// console is built against come from the same `response:` maps, so a status a route returns was a
+// status no generated client knew how to handle.
+//
+// This fence MEASURES rather than infers, which is the lesson #297 paid for: "declares a body
+// schema" is a candidate list, not a result. A path parameter is always a string and always present,
+// so a bare `t.String()` param refuses nothing a caller can send; declaring 422 there would publish
+// a status the route never returns, which is the same wrong contract in the other direction.
+//
+// Measured on `main` before the change, over real HTTP against the built app, unauthenticated:
+//
+//   routes declaring a request schema  177
+//   answered 422                       104   (1 declared it)
+//   answered something else             73   (0 declared it)
+//
+// No probe reaches a handler: every one lands on the boundary (422) or on the role guard (401), so
+// nothing here touches the database or any external system.
+const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
+setupPrismaMock();
+const app = (await import("@/app")).default;
+
+type Schema = Record<string, unknown> | null | undefined;
+type Route = {
+  method: string;
+  path: string;
+  hooks?: {
+    body?: Schema;
+    query?: Schema;
+    params?: Schema;
+    response?: Record<string, unknown>;
+  };
+};
+
+function props(s: Schema): Record<string, Schema> {
+  return (s?.properties ?? {}) as Record<string, Schema>;
+}
+
+// A value the schema ACCEPTS, so a probe can violate one dimension while the rest stays valid.
+export function validFor(s: Schema): unknown {
+  if (!s || typeof s !== "object") return "x";
+  const anyOf = s.anyOf as Schema[] | undefined;
+  if (anyOf) return validFor(anyOf[0]);
+  if (s.const !== undefined) return s.const;
+  if (Array.isArray(s.enum)) return (s.enum as unknown[])[0];
+  if (s.default !== undefined) return s.default;
+  switch (s.type) {
+    case "string": {
+      if (s.pattern) return "1";
+      if (s.format === "email") return "a@b.co";
+      const min = Math.max(1, (s.minLength as number) ?? 1);
+      return "a".repeat(Math.min(min, (s.maxLength as number) ?? min));
+    }
+    case "integer":
+    case "number":
+      return (s.minimum as number) ?? 1;
+    case "boolean":
+      return true;
+    case "array":
+      return [];
+    case "object": {
+      const out: Record<string, unknown> = {};
+      for (const key of (s.required ?? []) as string[]) {
+        out[key] = validFor(props(s)[key]);
+      }
+      return out;
+    }
+    default:
+      return "x";
+  }
+}
+
+// A value the schema REFUSES, and where it sits. `null` when the schema refuses nothing that this
+// side of the request can carry.
+//
+// `inPath` is what separates a path parameter from a body value, and it is not a detail: a path
+// segment always exists (the route would not match otherwise) and is always a string, so `required`
+// and `minLength: 1` are satisfied by the routing itself. Measured — `/mcp/oauth/consent/` answers
+// 404 (no route), `/mcp/oauth/consent/%20` answers 401 (past the boundary), and neither is a 422.
+export function violation(
+  s: Schema,
+  path: string[] = [],
+  inPath = false,
+): { path: string[]; bad: unknown } | null {
+  if (!s || typeof s !== "object") return null;
+  const anyOf = s.anyOf as Schema[] | undefined;
+  if (anyOf) {
+    // A union refuses junk unless SOME member takes any string at all.
+    const permissive = anyOf.some(
+      (m) =>
+        m &&
+        typeof m === "object" &&
+        m.const === undefined &&
+        !Array.isArray(m.enum) &&
+        (m.type === undefined ||
+          (m.type === "string" &&
+            !m.pattern &&
+            !m.format &&
+            !m.minLength &&
+            !m.maxLength)),
+    );
+    return permissive ? null : { path, bad: "zzz-not-a-member" };
+  }
+  if (s.const !== undefined) return { path, bad: "zzz-not-the-const" };
+  if (Array.isArray(s.enum)) return { path, bad: "zzz-not-in-enum" };
+  switch (s.type) {
+    case "string": {
+      if (s.pattern) return { path, bad: "zzz not matching" };
+      const min = (s.minLength as number) ?? 0;
+      if (min > (inPath ? 1 : 0)) return { path, bad: inPath ? "z" : "" };
+      if (s.maxLength) {
+        return { path, bad: "z".repeat((s.maxLength as number) + 1) };
+      }
+      if (s.format) return { path, bad: "zzz" };
+      return null;
+    }
+    case "integer":
+    case "number":
+    case "boolean":
+      // Outside a JSON body every value arrives as a string, so a non-string type is refusable by
+      // construction: anything that does not coerce is refused.
+      return { path, bad: "zzz-not-coercible" };
+    case "object": {
+      for (const [key, sub] of Object.entries(props(s))) {
+        const hit = violation(sub, [...path, key], inPath);
+        if (hit) return hit;
+      }
+      return null;
+    }
+    case "array":
+      return violation(s.items as Schema, [...path, "0"], inPath);
+    default:
+      return null;
+  }
+}
+
+// A JSON body carries any type, so a declared property's TYPE is violable even when its value has no
+// constraint; and an object schema refuses the absence of a body outright.
+export function bodyViolation(s: Schema): { path: string[]; bad: unknown } {
+  const byConstraint = violation(s, [], false);
+  if (byConstraint) return byConstraint;
+  for (const [key, sub] of Object.entries(props(s))) {
+    const type = sub?.type;
+    if (type === "string") return { path: [key], bad: 42 };
+    if (type !== undefined) return { path: [key], bad: "zzz" };
+  }
+  return { path: [], bad: undefined };
+}
+
+function setAt(root: unknown, path: string[], value: unknown): unknown {
+  if (path.length === 0) return value;
+  let node = root as Record<string, unknown>;
+  for (const segment of path.slice(0, -1)) {
+    if (node[segment] === undefined) {
+      node[segment] = /^\d+$/.test(segment) ? [] : {};
+    }
+    node = node[segment] as Record<string, unknown>;
+  }
+  const last = path[path.length - 1];
+  if (last === undefined) return root;
+  if (value === undefined) delete node[last];
+  else node[last] = value;
+  return root;
+}
+
+function fillPath(
+  routePath: string,
+  params: Schema,
+  violate?: { name: string; bad: string },
+): string {
+  return routePath.replace(/:(\w+)/g, (_, name: string) =>
+    encodeURIComponent(
+      violate?.name === name
+        ? violate.bad
+        : String(validFor(props(params)[name])),
+    ),
+  );
+}
+
+function requiredQuery(query: Schema): Record<string, string> {
+  return Object.fromEntries(
+    ((query?.required ?? []) as string[]).map((key) => [
+      key,
+      String(validFor(props(query)[key])),
+    ]),
+  );
+}
+
+type Probe = { kind: string; request: () => Request };
+
+// Every probe the shape of the declared schemas justifies, one per dimension. A route is refusable
+// when this list is non-empty, and that is the predicate the measurement is checked against.
+function probesFor(route: Route): Probe[] {
+  const { body, query, params } = route.hooks ?? {};
+  const out: Probe[] = [];
+  const url = (path: string, search: Record<string, string>) =>
+    `http://localhost${path}${
+      Object.keys(search).length ? `?${new URLSearchParams(search)}` : ""
+    }`;
+  const withBody = body
+    ? {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(validFor(body)),
+      }
+    : {};
+
+  if (params) {
+    for (const [name, sub] of Object.entries(props(params))) {
+      const bad = violation(sub, [], true);
+      if (!bad) continue;
+      out.push({
+        kind: `params.${name}`,
+        request: () =>
+          new BunRequest(
+            url(
+              fillPath(route.path, params, { name, bad: String(bad.bad) }),
+              requiredQuery(query),
+            ),
+            { method: route.method, ...withBody },
+          ),
+      });
+      break;
+    }
+  }
+
+  if (query) {
+    const required = (query.required ?? []) as string[];
+    const search = requiredQuery(query);
+    let kind: string | null = null;
+    const first = required[0];
+    if (first !== undefined) {
+      delete search[first];
+      kind = `query.${first} absent`;
+    } else {
+      const bad = violation(query, [], true);
+      if (bad) {
+        search[bad.path.join(".")] = String(bad.bad);
+        kind = `query.${bad.path.join(".")}`;
+      }
+    }
+    if (kind) {
+      out.push({
+        kind,
+        request: () =>
+          new BunRequest(url(fillPath(route.path, params), search), {
+            method: route.method,
+            ...withBody,
+          }),
+      });
+    }
+  }
+
+  if (body) {
+    out.push({
+      kind: "body absent",
+      request: () =>
+        new BunRequest(
+          url(fillPath(route.path, params), requiredQuery(query)),
+          {
+            method: route.method,
+          },
+        ),
+    });
+    const bad = bodyViolation(body);
+    out.push({
+      kind: `body.${bad.path.join(".") || "(root)"}`,
+      request: () =>
+        new BunRequest(
+          url(fillPath(route.path, params), requiredQuery(query)),
+          {
+            method: route.method,
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(setAt(validFor(body), bad.path, bad.bad)),
+          },
+        ),
+    });
+  }
+
+  return out;
+}
+
+// The app is a singleton several test files import, and two of them REGISTER fixture routes on it
+// (`/__schema/...`, `/__refusal/...`) to exercise the boundary directly. Those are not API surface
+// and are not in the published spec, so sweeping them would make this fence's result depend on which
+// file loaded first in the worker. The API is everything the controllers mount, and they all mount
+// under `/api`; that the filter drops nothing real is asserted below against the spec itself.
+const apiRoutes = (app as unknown as { routes: Route[] }).routes.filter((r) =>
+  r.path.startsWith("/api/"),
+);
+const routes = apiRoutes.filter(
+  (r) => r.hooks?.body || r.hooks?.query || r.hooks?.params,
+);
+
+// The spec spells a parameter `{id}`, carries the `/api` prefix in its server base URL rather than
+// in the path, and drops the trailing slash of a prefix root.
+function specPathOf(path: string): string {
+  return path
+    .replace(/^\/api/, "")
+    .replace(/:(\w+)/g, "{$1}")
+    .replace(/(.)\/$/, "$1");
+}
+
+const spec = (await Bun.file("openapi.json").json()) as {
+  paths: Record<
+    string,
+    Record<string, { responses?: Record<string, unknown> }>
+  >;
+};
+
+// The app is a singleton, and so is the 600/min bucket its global rate limiter keys on. With
+// `trustProxy` off (the shipped default the suite runs under) the key is the SOCKET PEER, and
+// `app.handle(request)` has no server, so every request in the worker resolves to the same
+// `"unknown"` client: this file's ~180 probes would share one budget with every other file's
+// requests. A 429 answers BEFORE the schema boundary, so a rate-limited probe measures nothing and
+// is not evidence that a route cannot refuse. Measured inside the full suite, without this: 71
+// probes came back 429 and the sweep called those routes silent.
+//
+// So the probes bring their own peer. The limiter's generator reads `server.requestIP(request)`,
+// which is null under `handle`; a stand-in that answers a distinct address per probe puts each one
+// in its own bucket, which is what a real deployment would do anyway with 180 different clients.
+// It is installed for the sweep and taken back off, because the singleton outlives this file.
+type ServerStandIn = { requestIP: (request: Request) => { address: string } };
+const withServer = app as unknown as { server: ServerStandIn | null };
+const realServer = withServer.server;
+let probeNumber = 0;
+withServer.server = {
+  requestIP: () => ({ address: `probe-${probeNumber++}` }),
+};
+
+const measured: Array<{
+  id: string;
+  refusableByShape: boolean;
+  answers422: boolean;
+  declares422: boolean;
+  statuses: Array<{ kind: string; status: number }>;
+}> = [];
+
+try {
+  for (const route of routes) {
+    const probes = probesFor(route);
+    const statuses: Array<{ kind: string; status: number }> = [];
+    for (const probe of probes) {
+      const response = await app.handle(probe.request());
+      statuses.push({ kind: probe.kind, status: response.status });
+    }
+    measured.push({
+      id: `${route.method} ${route.path}`,
+      refusableByShape: probes.length > 0,
+      answers422: statuses.some((s) => s.status === 422),
+      declares422: Object.hasOwn(route.hooks?.response ?? {}, "422"),
+      statuses,
+    });
+  }
+} finally {
+  withServer.server = realServer;
+}
+
+describe("a route that can answer 422 declares it", () => {
+  test("the probe generator is exercised in both directions", () => {
+    const constrained = {
+      type: "object",
+      required: ["name"],
+      properties: { name: { type: "string", minLength: 1 } },
+    };
+    const bare = {
+      type: "object",
+      properties: { q: { type: "string" } },
+    };
+    expect(violation(constrained, [], false)).toEqual({
+      path: ["name"],
+      bad: "",
+    });
+    // The same schema as a PATH parameter refuses nothing: an empty segment does not route.
+    expect(violation(constrained, [], true)).toBeNull();
+    expect(violation(bare, [], true)).toBeNull();
+    // A body violates on TYPE where the value carries no constraint of its own.
+    expect(bodyViolation(bare)).toEqual({ path: ["q"], bad: 42 });
+    // A union of literals refuses anything outside it; one carrying a free string does not.
+    expect(
+      violation({ anyOf: [{ const: "a" }, { const: "b" }] }, [], true),
+    ).not.toBeNull();
+    expect(
+      violation({ anyOf: [{ type: "string" }, { type: "integer" }] }, [], true),
+    ).toBeNull();
+  });
+
+  test("the sweep sees the whole API and reaches the boundary", () => {
+    expect(routes.length).toBeGreaterThanOrEqual(150);
+    expect(measured.filter((r) => r.answers422).length).toBeGreaterThanOrEqual(
+      90,
+    );
+    // No probe reaches a handler: the boundary refuses (422) or the role guard does (401), and a
+    // path made unroutable by the violation answers 404. Anything else means a probe RAN something.
+    const unexpected = measured.flatMap((r) =>
+      r.statuses
+        .filter((s) => ![422, 401, 404].includes(s.status))
+        .map((s) => `${r.id} ${s.kind} -> ${s.status}`),
+    );
+    expect(unexpected).toEqual([]);
+  });
+
+  test("the shape predicate agrees with what the routes answered", () => {
+    // A route whose declared schemas refuse nothing a caller can send must not answer 422, and one
+    // that can be violated must. Divergence either way means the generator stopped finding a
+    // violation it used to find, which is how a sweep goes quietly blind.
+    const shapeSaysYes = measured.filter((r) => r.refusableByShape);
+    const silent = shapeSaysYes.filter((r) => !r.answers422).map((r) => r.id);
+    const surprising = measured
+      .filter((r) => !r.refusableByShape && r.answers422)
+      .map((r) => r.id);
+    expect(surprising).toEqual([]);
+    expect(silent).toEqual([]);
+  });
+
+  // The rule the agreement above rests on, named at the two routes that pay for it: a `minLength: 1`
+  // on a PATH parameter is the one constraint the shape reads as a refusal and the router never
+  // lets happen. Only an empty segment breaks it, and an empty segment is a different URL —
+  // measured, `/api/v1/mcp/oauth/consent/` answers 404 (no route at all) while
+  // `/api/v1/mcp/oauth/consent/%20` answers 401, past the boundary. Asserted as ROUTES rather than
+  // only as a predicate case so that renaming or dropping one of them shows up here.
+  test("a minLength on a path segment is not a refusal the caller can trigger", () => {
+    const byPath = new Map(measured.map((r) => [r.id, r]));
+    for (const id of [
+      "GET /api/v1/mcp/oauth/consent/:req",
+      "DELETE /api/v1/mcp/me/connections/:clientId",
+    ]) {
+      const route = byPath.get(id);
+      expect(route).toBeDefined();
+      expect(route?.refusableByShape).toBe(false);
+      expect(route?.answers422).toBe(false);
+      expect(route?.declares422).toBe(false);
+    }
+    const asBody = {
+      type: "object",
+      properties: { x: { type: "string", minLength: 1 } },
+    };
+    expect(violation(asBody, [], false)).not.toBeNull();
+    expect(violation(asBody, [], true)).toBeNull();
+    // A longer minimum IS reachable in a path: a one-character segment routes and then fails.
+    expect(
+      violation(
+        { type: "object", properties: { x: { type: "string", minLength: 4 } } },
+        [],
+        true,
+      ),
+    ).toEqual({ path: ["x"], bad: "z" });
+  });
+
+  test("every route that answered 422 declares it", () => {
+    const undeclared = measured
+      .filter((r) => r.answers422 && !r.declares422)
+      .map((r) => r.id);
+    expect(undeclared).toEqual([]);
+  });
+
+  test("no route declares a 422 it cannot answer", () => {
+    const overdeclared = measured
+      .filter((r) => !r.answers422 && r.declares422)
+      .map((r) => r.id);
+    expect(overdeclared).toEqual([]);
+  });
+
+  // The positive control for the `/api/` filter above: every operation the spec publishes must be a
+  // route this sweep can see. A filter that started dropping real routes would make the fence pass
+  // by looking at less, which is the failure mode a sweep cannot report on itself.
+  test("the filtered surface still covers every published operation", () => {
+    const swept = new Set(
+      apiRoutes.map((r) => `${r.method.toLowerCase()} ${specPathOf(r.path)}`),
+    );
+    const unseen: string[] = [];
+    for (const [path, operations] of Object.entries(spec.paths)) {
+      for (const method of Object.keys(operations)) {
+        if (!swept.has(`${method} ${path}`)) unseen.push(`${method} ${path}`);
+      }
+    }
+    expect(unseen).toEqual([]);
+  });
+
+  test("the published spec carries the same 422s", () => {
+    const missing: string[] = [];
+    for (const route of measured.filter((r) => r.answers422)) {
+      const [method, path] = route.id.split(" ");
+      if (method === undefined || path === undefined) {
+        throw new Error(`unreadable route id: ${route.id}`);
+      }
+      const operation = spec.paths[specPathOf(path)]?.[method.toLowerCase()];
+      if (!operation) {
+        missing.push(`${route.id} (absent from the spec)`);
+        continue;
+      }
+      if (!Object.hasOwn(operation.responses ?? {}, "422"))
+        missing.push(route.id);
+    }
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #314.

Every route that declares a request schema can answer **422**, and exactly **one** route of the whole
API said so. The schema boundary (#255, `src/api/lib/schema-refusal.ts`) answers a TypeBox refusal
with 422, a localized sentence and the `field` the value failed on, and it runs BEFORE the role
guard, so the status is reachable on any such route, authenticated or not. None of that reached the
contract: `openapi.json` is a committed artifact and the Eden types the console is built against come
from the same `response:` maps, so a status a route returns was a status no generated client knew how
to handle, and the body worth reading (`field` is exactly what points a console at the input) arrived
as a shape the caller never typed.

## Measured, not inferred

The issue's own sweep was a candidate list, and saying so was the point: "declares a body schema" is
not "can be refused". This PR probes instead. Every route in the BUILT app's route table that carries
a `body`, `query` or `params` schema gets a request whose violating value is derived from that
schema's published JSON Schema, sent unauthenticated:

```
routes declaring a request schema  177
answered 422                       104   (1 declared it)
answered something else             73   (0 declared it)
```

**The 73 are not an oversight, they are the other half of the contract.** A path parameter always
exists and is always a string, so a bare `t.String()` param refuses nothing a caller can send;
declaring 422 there would publish a status the route never returns, which is the same wrong contract
pointing the other way (the lesson #297 paid for). Same for the seventeen routes whose only schema is
a query of optional unconstrained strings.

**Two of them cost a rule rather than an exemption.** `GET /v1/mcp/oauth/consent/:req` and
`DELETE /v1/mcp/me/connections/:clientId` put `minLength: 1` on a PATH parameter, which the shape
reads as a refusal and the router never lets happen: only an empty segment breaks it, and an empty
segment is a different URL. Measured: `/v1/mcp/oauth/consent/` answers 404 (no route at all), and
`/v1/mcp/oauth/consent/%20` answers 401, past the boundary. So the predicate ignores `minLength <= 1`
in a path and keeps it everywhere else, and a longer minimum stays reachable (a one-character segment
routes and then fails).

## The change

- **103 routes gained `422`** in their `response` map, across 23 controllers. Three of them are the
  MCP OAuth routes, which declare an RFC 6749 error body rather than the app's: they get
  `...errors(422)` alongside it, because the boundary answers with the app's `{error, field}` shape
  and that is what the route actually returns.
- **`openapi.json` regenerated**: exactly 103 `"422"` additions, no deletions, no other status
  touched.
- **`tests/api/lib/schema-refusal-declared.test.ts`**, the fence, which has **no exemption list**.
  It measures and then requires agreement in both directions: a route that answers 422 declares it,
  and a route that cannot answer it does not declare it. A route added tomorrow with a body schema is
  covered the day it is added.

## Validation scope

**Proved by test**, driven through the real app over HTTP with the Prisma client mocked (no database,
no external system, and none is needed, because no probe reaches a handler: every one lands on the
boundary at 422 or the role guard at 401, which is asserted rather than assumed):

- red first on the pre-change tree: `every route that answered 422 declares it` fails naming all 103,
  and the published-spec check fails alongside it;
- the probe generator is exercised in **both** directions, so a generator that silently stops finding
  violations fails instead of passing: a constrained body schema must yield a violation, the same
  schema as a path parameter must not, a bare property must still be violable on TYPE inside a JSON
  body, and a union of literals must be violable while one carrying a free string must not;
- the shape predicate is checked AGAINST the measurement, both ways: nothing the shape calls
  unrefusable may answer 422, and nothing it calls refusable may stay silent;
- floors on the sweep itself (routes seen, routes answering 422) so a sweep that stops seeing the API
  fails rather than passing vacuously;
- the published `openapi.json` is checked separately from the route table, since it is the artifact a
  client actually reads, with a control that the `/api/` filter still covers every published
  operation (a filter that started dropping real routes would make the fence pass by looking at
  less);
- **the probes bring their own client**, and that is a measurement, not a convenience. The global
  rate limiter keys on the socket peer, which `app.handle` does not have, so every request in the
  worker resolves to the same `"unknown"` bucket of 600/min. Measured inside the full suite without
  this: **71 probes came back 429**, which answers BEFORE the boundary, and the sweep reported those
  routes as silent. A stand-in `server.requestIP` answering a distinct address per probe puts each in
  its own bucket, installed for the sweep and taken back off since the singleton outlives the file.
  Controlled both ways at a 5/min global budget: with the stand-in the sweep is unchanged, with a
  single fixed address three tests fail. And a status other than 422/401/404 anywhere in the sweep is
  a hard failure, so a rate-limited probe can never be read as a route that cannot refuse.

**Mutation**, one at a time: `422` removed from one controller's `errors(...)` (1 fail), `422` added
to a route that cannot answer it (1), the generator blinded to `minLength` (3), the path/body
distinction dropped so a path parameter is treated like a body value (2), `422` deleted from one
operation of the committed spec (1), and the per-probe peer collapsed to one address under a tight
budget (3).

**Not validated**: nothing about how the console renders the boundary's `field`. No client code is
touched here, and the recovery that reads it is unchanged. The probes assert the STATUS a route can
answer, not that a 422 body is well-formed for every schema shape; `tests/api/lib/schema-refusal.test.ts`
already owns that. Route surface is identical across editions per the derivation manifest, so the
counts here are not edition-specific, and the fence's floors are ranges rather than exact totals for
that reason.
