### PR TITLE
Record the thinking a provider billed, not just the words it returned

### DIFF
--- a/src/graph/usage.ts
+++ b/src/graph/usage.ts
@@ -134,6 +134,9 @@ function num(v: unknown): number {
 // consistent across providers; carries `input_token_details.{cache_read,cache_creation}` in
 // LangChain v1.x), then the OpenAI-style `llmOutput.tokenUsage`, then the Anthropic-style
 // `llmOutput.usage`. Cached counts are best-effort across the legacy bags too.
+//
+// The question every branch here answers is not "did it carry a number" but "did it carry every
+// counter the provider BILLED" (issue #334). Two of them used to answer no.
 export function extractTokenUsage(output: LLMResult): TokenUsage {
   let promptTokens = 0;
   let completionTokens = 0;
@@ -144,8 +147,26 @@ export function extractTokenUsage(output: LLMResult): TokenUsage {
       // biome-ignore lint/suspicious/noExplicitAny: generation message shape is provider-dependent.
       const meta = (gen as any).message?.usage_metadata;
       if (meta) {
-        promptTokens += num(meta.input_tokens);
-        completionTokens += num(meta.output_tokens);
+        const input = num(meta.input_tokens);
+        const generated = num(meta.output_tokens);
+        promptTokens += input;
+        // The remainder of the provider's OWN total is generation the integration could not name,
+        // and it is billed all the same. Gemini is the live case: `convertUsageMetadata` maps
+        // `output_tokens` from `candidatesTokenCount` alone and reads `thoughtsTokenCount` nowhere,
+        // so with thinking on (the default of the current generation) every turn recorded less
+        // output than it cost. The API reference defines the total as prompt + thoughts +
+        // candidates, so the gap IS the thinking, and `total_tokens` is the only trace of it that
+        // survives into `usage_metadata`.
+        //   Inert everywhere else by construction: OpenAI's total is prompt + completion exactly
+        // (reasoning already inside completion), Anthropic's is summed upstream before it gets
+        // here, and a response with no total at all leaves the term at zero.
+        //   The premise that the gap is only thinking is fenced, not assumed: Gemini also folds
+        // `toolUsePromptTokenCount` into the total, which is populated only by its BUILT-IN tools
+        // (Search grounding, code execution, URL context). We enable none — client-side function
+        // declarations are ordinary prompt tokens — and tests/graph/usage-provider-counts.test.ts
+        // goes red the day one is turned on.
+        completionTokens +=
+          generated + Math.max(0, num(meta.total_tokens) - input - generated);
         const det = meta.input_token_details;
         if (det) {
           cachedReadTokens += num(det.cache_read);
@@ -176,12 +197,19 @@ export function extractTokenUsage(output: LLMResult): TokenUsage {
   }
   const u = out.usage;
   if (u && (u.input_tokens != null || u.output_tokens != null)) {
+    // Anthropic raw exposes cache read/write as their own counters, and they are ADDITIVE here:
+    // `input_tokens` is documented as the tokens that were NOT read from or used to create a cache,
+    // so the billed input is the sum of the three. That is the opposite of what this row means by
+    // `cachedReadTokens` (a discounted SUBSET of `promptTokens`), which is why the sum happens here
+    // rather than at the reader — and it is what `ChatAnthropic` itself does in `buildUsageMetadata`
+    // before handing over the normalized path above.
+    const cacheRead = num(u.cache_read_input_tokens);
+    const cacheCreation = num(u.cache_creation_input_tokens);
     return {
-      promptTokens: num(u.input_tokens),
+      promptTokens: num(u.input_tokens) + cacheRead + cacheCreation,
       completionTokens: num(u.output_tokens),
-      // Anthropic raw exposes cache read/write as their own counters.
-      cachedReadTokens: num(u.cache_read_input_tokens),
-      cacheCreationTokens: num(u.cache_creation_input_tokens),
+      cachedReadTokens: cacheRead,
+      cacheCreationTokens: cacheCreation,
     };
   }
   return {

--- a/src/graph/usage.ts
+++ b/src/graph/usage.ts
@@ -150,7 +150,7 @@ export function extractTokenUsage(output: LLMResult): TokenUsage {
         const input = num(meta.input_tokens);
         const generated = num(meta.output_tokens);
         promptTokens += input;
-        // The remainder of the provider's OWN total is generation the integration could not name,
+        // NOTE: the remainder of the provider's OWN total is generation the integration could not name,
         // and it is billed all the same. Gemini is the live case: `convertUsageMetadata` maps
         // `output_tokens` from `candidatesTokenCount` alone and reads `thoughtsTokenCount` nowhere,
         // so with thinking on (the default of the current generation) every turn recorded less
@@ -197,9 +197,9 @@ export function extractTokenUsage(output: LLMResult): TokenUsage {
   }
   const u = out.usage;
   if (u && (u.input_tokens != null || u.output_tokens != null)) {
-    // Anthropic raw exposes cache read/write as their own counters, and they are ADDITIVE here:
-    // `input_tokens` is documented as the tokens that were NOT read from or used to create a cache,
-    // so the billed input is the sum of the three. That is the opposite of what this row means by
+    // NOTE: Anthropic raw exposes cache read/write as their own counters, and they are ADDITIVE
+    // here. `input_tokens` is documented as the tokens that were NOT read from or used to create a
+    // cache, so the billed input is the sum of the three. That is the opposite of what this row means by
     // `cachedReadTokens` (a discounted SUBSET of `promptTokens`), which is why the sum happens here
     // rather than at the reader — and it is what `ChatAnthropic` itself does in `buildUsageMetadata`
     // before handing over the normalized path above.

--- a/tests/graph/usage-provider-counts.test.ts
+++ b/tests/graph/usage-provider-counts.test.ts
@@ -1,0 +1,245 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { ChatOpenAI } from "@langchain/openai";
+import { UsageCapture, type UsageRow } from "@/graph/usage";
+
+// Issue #334, and the reason these drive the vendor adapters instead of asserting on a fake result:
+// the defect was never in our arithmetic over a shape we control, it was in what an ADAPTER hands
+// over. `@langchain/google-genai` maps `output_tokens` from `candidatesTokenCount` alone and reads
+// `thoughtsTokenCount` nowhere — a hand-written `usage_metadata` fixture would have encoded that
+// belief instead of testing it, which is exactly how the wrong number got into the ledger.
+//
+// So each server below answers in its own vendor's raw response shape, the real client parses it,
+// and the assertion is on the ROW the ledger would have written.
+
+// NOTE: happy-dom's `fetch` enforces same-origin (so every call is preflighted) and its `Response`
+// is not the one Bun's socket layer recognises. Same two workarounds as
+// tests/modules/guardrail-constrained.test.ts.
+const CORS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-headers": "*",
+  "access-control-allow-methods": "*",
+};
+const BunResponse = (globalThis as unknown as { BunResponse: typeof Response })
+  .BunResponse;
+const preflight = (req: Request) =>
+  req.method === "OPTIONS"
+    ? new BunResponse(null, { status: 204, headers: CORS })
+    : null;
+
+function serving(body: () => unknown) {
+  return Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const pre = preflight(req);
+      if (pre) return pre;
+      return BunResponse.json(body(), { headers: CORS });
+    },
+  });
+}
+
+// The one row the turn would have written, captured at the sink instead of the database.
+async function rowFor(model: BaseChatModel, label: string): Promise<UsageRow> {
+  const rows: UsageRow[] = [];
+  await model.invoke("oi", {
+    callbacks: [
+      new UsageCapture({
+        tenantId: 1n,
+        model: label,
+        node: "agent",
+        persist: async (row) => {
+          rows.push(row);
+        },
+      }),
+    ],
+  });
+  expect(rows.length).toBe(1);
+  return rows[0] as UsageRow;
+}
+
+// ── Gemini ──────────────────────────────────────────────────────────────────
+
+const geminiUsage = {
+  thinking: {
+    promptTokenCount: 1200,
+    candidatesTokenCount: 180,
+    thoughtsTokenCount: 640,
+    // The API reference defines this as prompt + thoughts + candidates.
+    totalTokenCount: 2020,
+  },
+  plain: {
+    promptTokenCount: 1200,
+    candidatesTokenCount: 180,
+    totalTokenCount: 1380,
+  },
+};
+let geminiMode: keyof typeof geminiUsage = "thinking";
+const geminiServer = serving(() => ({
+  candidates: [
+    {
+      content: { role: "model", parts: [{ text: "olá" }] },
+      finishReason: "STOP",
+    },
+  ],
+  usageMetadata: geminiUsage[geminiMode],
+}));
+
+const gemini = () =>
+  new ChatGoogleGenerativeAI({
+    model: "gemini-3.5-flash",
+    apiKey: "x",
+    baseUrl: `http://localhost:${geminiServer.port}`,
+  });
+
+// ── Anthropic ───────────────────────────────────────────────────────────────
+
+const anthropicServer = serving(() => ({
+  id: "msg_1",
+  type: "message",
+  role: "assistant",
+  model: "claude-haiku-4-5",
+  content: [{ type: "text", text: "olá" }],
+  stop_reason: "end_turn",
+  // The three are ADDITIVE: `input_tokens` counts what was neither read from nor written to cache.
+  usage: {
+    input_tokens: 30,
+    output_tokens: 12,
+    cache_read_input_tokens: 800,
+    cache_creation_input_tokens: 120,
+  },
+}));
+
+// ── OpenAI ──────────────────────────────────────────────────────────────────
+
+const openaiServer = serving(() => ({
+  id: "chatcmpl-1",
+  object: "chat.completion",
+  model: "gpt-5.4-nano",
+  choices: [
+    {
+      index: 0,
+      message: { role: "assistant", content: "olá" },
+      finish_reason: "stop",
+    },
+  ],
+  // `prompt_tokens` already contains the cached part, and `completion_tokens` already contains the
+  // reasoning. Both details are SUBSETS, and adding either is the mirror-image mistake.
+  usage: {
+    prompt_tokens: 1000,
+    completion_tokens: 200,
+    total_tokens: 1200,
+    prompt_tokens_details: { cached_tokens: 800 },
+    completion_tokens_details: { reasoning_tokens: 150 },
+  },
+}));
+
+afterAll(() => {
+  geminiServer.stop(true);
+  anthropicServer.stop(true);
+  openaiServer.stop(true);
+});
+
+describe("the ledger records what the provider billed", () => {
+  test("Gemini bills its thinking as output, and the row carries it", async () => {
+    geminiMode = "thinking";
+    const row = await rowFor(gemini(), "gemini-3.5-flash");
+    expect(row.promptTokens).toBe(1200);
+    // 180 candidates + 640 thoughts. Red before the fix: 180, and the 640 were billed to nobody.
+    expect(row.completionTokens).toBe(820);
+  });
+
+  test("a Gemini reply that did not think is unchanged", async () => {
+    geminiMode = "plain";
+    const row = await rowFor(gemini(), "gemini-3.5-flash");
+    expect(row.promptTokens).toBe(1200);
+    // The control that keeps the repair from being a blanket addition: with no gap, nothing is added.
+    expect(row.completionTokens).toBe(180);
+  });
+
+  test("Anthropic's cache counters are inside the prompt total, not beside it", async () => {
+    const row = await rowFor(
+      new ChatAnthropic({
+        model: "claude-haiku-4-5",
+        apiKey: "x",
+        clientOptions: { baseURL: `http://localhost:${anthropicServer.port}` },
+      }),
+      "claude-haiku-4-5",
+    );
+    // 30 + 800 + 120: what the adapter itself sums in `buildUsageMetadata`, and what the row means
+    // by `promptTokens` (a total, of which the cached counts are a discounted subset).
+    expect(row.promptTokens).toBe(950);
+    expect(row.completionTokens).toBe(12);
+    expect(row.cachedReadTokens).toBe(800);
+    expect(row.cacheCreationTokens).toBe(120);
+  });
+
+  test("OpenAI's cached prompt and reasoning output are subsets, never added on top", async () => {
+    const row = await rowFor(
+      new ChatOpenAI({
+        model: "gpt-5.4-nano",
+        apiKey: "x",
+        configuration: { baseURL: `http://localhost:${openaiServer.port}` },
+      }),
+      "gpt-5.4-nano",
+    );
+    expect(row.promptTokens).toBe(1000);
+    // 200, NOT 350: reasoning is already inside completion_tokens, and total is prompt + completion
+    // exactly, so the Gemini repair must find no gap here.
+    expect(row.completionTokens).toBe(200);
+    expect(row.cachedReadTokens).toBe(800);
+  });
+});
+
+// ── the premise the Gemini repair rests on ──────────────────────────────────
+
+// `toolUsePromptTokenCount` is summed into Gemini's `totalTokenCount` too, and it is populated by
+// Gemini's BUILT-IN tools (Search grounding, code execution, URL context). While none is enabled the
+// gap is only thinking; enable one and part of it becomes prompt-side spend booked as output.
+//
+// The premise is therefore checked rather than trusted, and this is where the check lives.
+const GEMINI_BUILTIN_TOOLS =
+  /\b(googleSearch|google_search|googleSearchRetrieval|codeExecution|code_execution|urlContext|url_context)\b/;
+
+function declaresBuiltinTool(source: string): boolean {
+  return GEMINI_BUILTIN_TOOLS.test(source);
+}
+
+async function tsFilesUnder(dir: string): Promise<string[]> {
+  const glob = new Bun.Glob("**/*.ts");
+  const out: string[] = [];
+  for await (const f of glob.scan({ cwd: dir, absolute: true })) out.push(f);
+  return out;
+}
+
+describe("no Gemini built-in tool is enabled", () => {
+  // A sweep that finds nothing passes whether the premise holds or the pattern is broken.
+  test("the predicate recognises a built-in tool declaration", () => {
+    expect(
+      declaresBuiltinTool(`const g = model.bindTools([{ googleSearch: {} }]);`),
+    ).toBe(true);
+    expect(
+      declaresBuiltinTool(
+        `const g = model.bindTools([{ codeExecution: {} }]);`,
+      ),
+    ).toBe(true);
+    expect(
+      declaresBuiltinTool(`const g = model.bindTools(toGeminiTools(tools));`),
+    ).toBe(false);
+  });
+
+  test("src/ enables none, so the total's gap is thinking alone", async () => {
+    const offenders: string[] = [];
+    for (const file of await tsFilesUnder(
+      new URL("../../src", import.meta.url).pathname,
+    )) {
+      if (declaresBuiltinTool(await Bun.file(file).text())) {
+        offenders.push(file.split("/src/")[1] as string);
+      }
+    }
+    // Turning one on is allowed — but then `extractTokenUsage` has to stop attributing the whole
+    // gap to generation, so this must be answered, not deleted.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/graph/usage-provider-counts.test.ts
+++ b/tests/graph/usage-provider-counts.test.ts
@@ -66,7 +66,7 @@ const geminiUsage = {
     promptTokenCount: 1200,
     candidatesTokenCount: 180,
     thoughtsTokenCount: 640,
-    // The API reference defines this as prompt + thoughts + candidates.
+    // NOTE: the API reference defines this as prompt + thoughts + candidates.
     totalTokenCount: 2020,
   },
   plain: {
@@ -102,7 +102,8 @@ const anthropicServer = serving(() => ({
   model: "claude-haiku-4-5",
   content: [{ type: "text", text: "olá" }],
   stop_reason: "end_turn",
-  // The three are ADDITIVE: `input_tokens` counts what was neither read from nor written to cache.
+  // NOTE: the three are ADDITIVE — `input_tokens` counts what was neither read from nor written
+  // to cache.
   usage: {
     input_tokens: 30,
     output_tokens: 12,
@@ -124,8 +125,8 @@ const openaiServer = serving(() => ({
       finish_reason: "stop",
     },
   ],
-  // `prompt_tokens` already contains the cached part, and `completion_tokens` already contains the
-  // reasoning. Both details are SUBSETS, and adding either is the mirror-image mistake.
+  // NOTE: `prompt_tokens` already contains the cached part, and `completion_tokens` already
+  // contains the reasoning. Both details are SUBSETS, and adding either is the mirror-image mistake.
   usage: {
     prompt_tokens: 1000,
     completion_tokens: 200,
@@ -146,7 +147,8 @@ describe("the ledger records what the provider billed", () => {
     geminiMode = "thinking";
     const row = await rowFor(gemini(), "gemini-3.5-flash");
     expect(row.promptTokens).toBe(1200);
-    // 180 candidates + 640 thoughts. Red before the fix: 180, and the 640 were billed to nobody.
+    // NOTE: 180 candidates + 640 thoughts. Red before the fix: 180, and the 640 were billed to
+    // nobody.
     expect(row.completionTokens).toBe(820);
   });
 
@@ -154,7 +156,8 @@ describe("the ledger records what the provider billed", () => {
     geminiMode = "plain";
     const row = await rowFor(gemini(), "gemini-3.5-flash");
     expect(row.promptTokens).toBe(1200);
-    // The control that keeps the repair from being a blanket addition: with no gap, nothing is added.
+    // NOTE: the control that keeps the repair from being a blanket addition — with no gap, nothing
+    // is added.
     expect(row.completionTokens).toBe(180);
   });
 
@@ -167,8 +170,8 @@ describe("the ledger records what the provider billed", () => {
       }),
       "claude-haiku-4-5",
     );
-    // 30 + 800 + 120: what the adapter itself sums in `buildUsageMetadata`, and what the row means
-    // by `promptTokens` (a total, of which the cached counts are a discounted subset).
+    // NOTE: 30 + 800 + 120, what the adapter itself sums in `buildUsageMetadata`, and what the row
+    // means by `promptTokens` (a total, of which the cached counts are a discounted subset).
     expect(row.promptTokens).toBe(950);
     expect(row.completionTokens).toBe(12);
     expect(row.cachedReadTokens).toBe(800);
@@ -185,8 +188,8 @@ describe("the ledger records what the provider billed", () => {
       "gpt-5.4-nano",
     );
     expect(row.promptTokens).toBe(1000);
-    // 200, NOT 350: reasoning is already inside completion_tokens, and total is prompt + completion
-    // exactly, so the Gemini repair must find no gap here.
+    // NOTE: 200, NOT 350 — reasoning is already inside completion_tokens, and total is prompt +
+    // completion exactly, so the Gemini repair must find no gap here.
     expect(row.completionTokens).toBe(200);
     expect(row.cachedReadTokens).toBe(800);
   });
@@ -214,7 +217,7 @@ async function tsFilesUnder(dir: string): Promise<string[]> {
 }
 
 describe("no Gemini built-in tool is enabled", () => {
-  // A sweep that finds nothing passes whether the premise holds or the pattern is broken.
+  // NOTE: a sweep that finds nothing passes whether the premise holds or the pattern is broken.
   test("the predicate recognises a built-in tool declaration", () => {
     expect(
       declaresBuiltinTool(`const g = model.bindTools([{ googleSearch: {} }]);`),
@@ -238,8 +241,8 @@ describe("no Gemini built-in tool is enabled", () => {
         offenders.push(file.split("/src/")[1] as string);
       }
     }
-    // Turning one on is allowed — but then `extractTokenUsage` has to stop attributing the whole
-    // gap to generation, so this must be answered, not deleted.
+    // NOTE: turning one on is allowed, but then `extractTokenUsage` has to stop attributing the
+    // whole gap to generation, so this must be answered, not deleted.
     expect(offenders).toEqual([]);
   });
 });

--- a/tests/graph/usage.test.ts
+++ b/tests/graph/usage.test.ts
@@ -72,7 +72,7 @@ describe("extractTokenUsage", () => {
     });
   });
 
-  test("falls back to Anthropic-style llmOutput.usage (+ cache read/write)", () => {
+  test("falls back to Anthropic-style llmOutput.usage (cache counters ADDITIVE)", () => {
     const r = {
       generations: [[{ text: "x" }]],
       llmOutput: {
@@ -84,8 +84,14 @@ describe("extractTokenUsage", () => {
         },
       },
     } as unknown as LLMResult;
+    // 11 + 8 + 2 (issue #334). Anthropic documents `input_tokens` as the tokens that were NEITHER
+    // read from NOR used to create a cache, so the billed input is the sum of the three — the
+    // opposite of the OpenAI shape above, where the cached count is already inside the prompt.
+    // This assertion used to read 11, which is the row disagreeing with itself: `cachedReadTokens`
+    // is documented as a discounted SUBSET of `promptTokens`, and 8 is not a subset of 11 when 11
+    // already excludes it.
     expect(extractTokenUsage(r)).toEqual({
-      promptTokens: 11,
+      promptTokens: 21,
       completionTokens: 5,
       cachedReadTokens: 8,
       cacheCreationTokens: 2,

--- a/tests/graph/usage.test.ts
+++ b/tests/graph/usage.test.ts
@@ -84,9 +84,9 @@ describe("extractTokenUsage", () => {
         },
       },
     } as unknown as LLMResult;
-    // 11 + 8 + 2 (issue #334). Anthropic documents `input_tokens` as the tokens that were NEITHER
-    // read from NOR used to create a cache, so the billed input is the sum of the three — the
-    // opposite of the OpenAI shape above, where the cached count is already inside the prompt.
+    // NOTE: 11 + 8 + 2 (issue #334). Anthropic documents `input_tokens` as the tokens that were
+    // NEITHER read from NOR used to create a cache, so the billed input is the sum of the three —
+    // the opposite of the OpenAI shape above, where the cached count is already inside the prompt.
     // This assertion used to read 11, which is the row disagreeing with itself: `cachedReadTokens`
     // is documented as a discounted SUBSET of `promptTokens`, and 8 is not a subset of 11 when 11
     // already excludes it.


### PR DESCRIPTION
`extractTokenUsage` is the single place a provider's response becomes the token counts written to `LlmUsage`. #316 established that a billed call has to reach a row; this asks the same question of a row that already exists: **does it carry every counter the provider billed?** Swept across the five branches, against the installed integrations and the vendor references. Two said no.

## Gemini recorded the words and not the thinking

`@langchain/google-genai@2.3.0` (the current release), `convertUsageMetadata`:

```js
output_tokens: usageMetadata?.candidatesTokenCount ?? 0,   // thoughts NOT included
```

`thoughtsTokenCount` is read nowhere and survives nowhere — not in `usage_metadata`, not in `additional_kwargs` (the candidate's `generationInfo`, which carries no usage), not in `llmOutput.tokenUsage`, which mirrors the already-converted values. The streaming path drops it the same way. `makeModel` builds the client with no `thinkingConfig`, so thinking sits at the model default, which is on.

**Measured live against `generativelanguage.googleapis.com`**, one reasoning prompt, the same call producing both lines:

```
base   usage_metadata  input=65  output=5  total=1031
       row             prompt=65 completion=5
       billed=1031  recorded=70  lost=961

fixed  usage_metadata  input=65  output=5  total=1006
       row             prompt=65 completion=941
       billed=1006  recorded=1006  lost=0
```

93% of that call was billed to nobody. The raw response confirms the reference's arithmetic exactly — `promptTokenCount 65 + thoughtsTokenCount 912 + candidatesTokenCount 5 = totalTokenCount 982` on the probe run — so the gap between the total and the parts the adapter names **is** the thinking, and `total_tokens` is the only trace of it that reaches us.

## The fix reads the remainder, and is inert everywhere else

```ts
completionTokens += generated + Math.max(0, num(meta.total_tokens) - input - generated);
```

The remainder of the provider's own total is generation the integration could not name, and it was billed the same. Nothing is provider-specific, and nothing else moves:

- **OpenAI / OpenRouter / DeepSeek**: `total_tokens` is `prompt + completion` exactly, with reasoning already inside completion and the cached count already inside prompt. Gap zero.
- **Anthropic**: `buildUsageMetadata` sums `input + cache_creation + cache_read` before handing over, and sets the total from that. Gap zero.
- **No total at all**: the term is zero, so every existing shape is untouched.

**The one premise, fenced rather than assumed.** Gemini also folds `toolUsePromptTokenCount` into the total, and it is populated by its **built-in** tools (Search grounding, code execution, URL context). None is enabled — client-side function declarations are ordinary prompt tokens — so the gap is thinking alone. A test sweeps `src/` and goes red the day one is turned on, because then part of the gap becomes prompt-side spend that must stop being booked as output.

## Anthropic's raw fallback undercounted by the whole cache

`input_tokens` is documented as the tokens that were **neither** read from **nor** used to create a cache, so the billed input is the sum of the three. The row was disagreeing with its own definition: `UsageRow` documents `cachedReadTokens` as "a discounted SUBSET of `promptTokens`", and 8 is not a subset of 11 when 11 already excludes it.

Narrow on purpose: `extractTokenUsage` prefers `usage_metadata` and returns as soon as it carries a count, so this branch is reached only when an Anthropic-shaped `usage` arrives without normalized metadata (an older integration, a compatible gateway). The assertion in `tests/graph/usage.test.ts` that read `promptTokens: 11` was the test agreeing with the defect, and now reads 21.

## Validation scope

**Proved by test** (`tests/graph/usage-provider-counts.test.ts`). These drive the vendor adapters against local servers answering in each vendor's raw response shape, rather than asserting on a hand-written `usage_metadata`: the defect was never in our arithmetic over a shape we control, it was in what an adapter hands over, and a fixture would have encoded the same belief that put the wrong number in the ledger.

- Gemini with thinking → row carries candidates + thoughts. Red before: candidates alone.
- Gemini without thinking → unchanged, which is what keeps the repair from being a blanket addition.
- Anthropic with cache → prompt is the sum, cached counts are its subsets.
- OpenAI with `cached_tokens` and `reasoning_tokens` → neither is added on top, and the gap term finds nothing.
- The built-in-tool fence, plus its positive control.

Mutation, one rule killed at a time: gap term removed → 2 fail; Anthropic sum removed → 1 fail; gap without the zero floor → 4 fail; gap added to prompt instead of generation → 2 fail; fence predicate always false → 1 fail. No survivors.

**Proved live**, as above, both halves on the same script: the defect reproduced on `main` and the repair observed against Google's own endpoint.

**Not validated live.** Anthropic and the OpenAI family were exercised against local servers in their documented response shapes, not against a live endpoint — the machine has a Google and an OpenAI credential and no Anthropic one, and the OpenAI arm here is a control (the assertion is that nothing changes), so what a live run would add is smaller than for the arm that moved. The raw Anthropic fallback has no live path at all by construction: reaching it requires a client that does **not** populate `usage_metadata`, which the current `ChatAnthropic` always does.

Fixes #334.
