### PR TITLE
Spend the failure budget on the failures in a row, not on the ones in a lifetime

### DIFF
--- a/src/graph/ingest-drain.ts
+++ b/src/graph/ingest-drain.ts
@@ -82,7 +82,8 @@ export async function drainPendingIngest(
     // Every row this drain has touched, kept out of the next pass. It used to carry the failure case
     // too, and no longer does: the claim itself now honours backoff for a row that has failed
     // (../modules/scheduler/service.ts). What is left is the DEFERRAL loop, which the claim cannot
-    // see — a job that stands down for a turn keeps `attempts` at zero, so it stays claimable, and
+    // see — a job that stands down for a turn carries no error and no spent budget, so it stays
+    // claimable exactly like a fresh row, and
     // without this the same row would be claimed and deferred once per pass, five times over, inside
     // a customer's turn.
     const seen: bigint[] = [];

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -31,8 +31,9 @@ import {
 // it must see every tenant's due jobs — so it runs via asSuperAdmin with FOR UPDATE SKIP LOCKED;
 // the GUC is transaction-local (set_config(...,true)) so it never leaks to the next request on a
 // pooled connection. Each job's EFFECT and status update run under the job's OWN tenant scope
-// (runScoped), so RLS still fences the work. `attempts` grows only on failure/crash (a reschedule
-// for out-of-hours is free), and the reaper bounds crash loops by pushing exhausted jobs to DEAD.
+// (runScoped), so RLS still fences the work. `attempts` grows only on failure/crash and is CLEARED
+// by a completed pass (rescheduleJob), so the cap bounds CONSECUTIVE failures rather than the row's
+// lifetime — issue #287; the reaper bounds crash loops by pushing exhausted jobs to DEAD.
 
 const MAX_ATTEMPTS = 5;
 
@@ -434,10 +435,12 @@ async function claimWhere(
   // answers that WITHIN one drain; this is the same question ACROSS them.
   //
   // TOLD APART BY `last_error`, NOT BY `attempts`. The first version of this asked whether the job
-  // had ever failed, which is a different question wearing the same clothes: `rescheduleJob`
-  // preserves the attempt count, so a job that failed once and LATER stood down for a turn read as
-  // backing off, and the barrier skipped the very message it exists to fold in. The error is the
-  // state, and it is cleared the moment the row leaves it.
+  // had ever failed, which is a different question wearing the same clothes: a job that failed once
+  // and LATER stood down for a turn read as backing off, and the barrier skipped the very message it
+  // exists to fold in. The error is the state, and it is cleared the moment the row leaves it. Both
+  // columns now clear on a completed pass (issue #287), so the two agree here; `last_error` remains
+  // the one to read, because it is the column that says which STATE the row is in rather than how
+  // much budget it has left.
   //
   // Nothing is lost by waiting: a row left here is still PENDING, so `countOwedByKeyPrefix` reports
   // the thread as owing something and the one reader that cannot be corrected afterwards still
@@ -637,13 +640,26 @@ export async function completeJob(
   return { applied: count > 0 };
 }
 
-// Not a failure (e.g. out-of-hours): back to PENDING at a new time, attempts UNCHANGED — and
-// `lastError` CLEARED, because the row is no longer in the state that error describes. That is also
-// what makes the two future-dated states tellable apart: a row waiting on a backoff still carries
-// the error that caused it, a row that merely stood down carries none, and `attempts` cannot say
-// which (it survives a reschedule by design, so a job that failed once and later defers looks
-// exactly like one that is backing off). The ingestion barrier reads that difference — see
-// claimWhere's prefix branch. `enqueueJob` already clears it on a re-arm, for the same reason.
+// Not a failure (e.g. out-of-hours): back to PENDING at a new time, with the failure budget and
+// `lastError` both CLEARED, because the row is no longer in the state that error describes. That is
+// also what makes the two future-dated states tellable apart: a row waiting on a backoff still
+// carries the error that caused it, a row that merely stood down carries none. The ingestion
+// barrier reads that difference — see claimWhere's prefix branch. `enqueueJob` already clears
+// `lastError` on a re-arm, for the same reason.
+//
+// `attempts` is reset here, which is what makes MAX_ATTEMPTS bound CONSECUTIVE failures rather than
+// the row's lifetime (issue #287). Reaching this call means the handler neither threw nor reported
+// failure — runClaimed routes those to failJob — so the pass proved the job works, and the budget it
+// spent was for a state it is no longer in. Without this, a job that reschedules itself forever
+// (FLOWLOG_SWEEP, FOLLOWUP_SWEEP, HEARTBEAT) accumulates every failure it has ever had across weeks
+// of healthy passes and dead-letters on the fifth, permanently and silently.
+//
+// It does NOT hand a broken unit of work an unbounded retry, and the reason is the shape of a
+// failure rather than a rule stated here: failJob re-pends with a backoff, so the next claim runs
+// the same work again and fails again. Consecutive failures are never interleaved with a completed
+// pass, so a genuinely failing FOLLOWUP step or MEMORY_COMPACT still burns its five and dies. What
+// this does exempt is a job that fails INTERMITTENTLY, which is a job that works, and one that
+// dies for good in silence is the worse of the two outcomes.
 //
 // An optional
 // `payload` REPLACES the row's payload (used to advance a multi-step follow-up's stepIndex on the
@@ -676,6 +692,7 @@ export async function rescheduleJob(
            SET status = 'PENDING'::"SchedulerJobStatus",
                run_at = ${runAt},
                last_error = NULL,
+               attempts = 0,
                payload = payload || ${patch}::jsonb,
                updated_at = now()
          WHERE id = ${id}
@@ -692,6 +709,7 @@ export async function rescheduleJob(
         status: "PENDING",
         runAt,
         lastError: null,
+        attempts: 0,
         ...(payload !== undefined
           ? { payload: payload as Prisma.InputJsonValue }
           : {}),

--- a/src/modules/scheduler/worker.ts
+++ b/src/modules/scheduler/worker.ts
@@ -21,7 +21,8 @@ import {
 // Single-replica worker that drains the scheduler. The handler registry decouples the scheduler
 // from feature logic (follow-ups register their handlers); a job kind with no handler fails (and
 // eventually goes DEAD) rather than silently vanishing. `reschedule` is for "not yet" (out of
-// hours) and does not consume an attempt; `fail` retries with backoff up to the cap.
+// hours) and CLEARS the failure budget, because it means the pass completed (issue #287); `fail`
+// retries with backoff up to the cap.
 
 export type JobResult =
   | { outcome: "done" }

--- a/tests/graph/ingest-job.test.ts
+++ b/tests/graph/ingest-job.test.ts
@@ -12,7 +12,7 @@ import { runScopedOn } from "@/lib/tenancy";
 import {
   type ClaimedJob,
   claimDueTrafficJobs,
-  failJob,
+  reapStaleJobs,
   rescheduleJob,
   revokeJobsByKeyPrefixOn,
 } from "@/modules/scheduler/service";
@@ -704,12 +704,19 @@ describe.skipIf(!dbUp)("the ingestion job defers to a turn in flight", () => {
 
   // Round-16 review finding (P2), and the other half of the one above. The barrier has to tell a row
   // that is BACKING OFF from one that merely STOOD DOWN, and the first version asked `attempts`,
-  // which answers a different question: `rescheduleJob` preserves the attempt count, so a job that
-  // failed once and later deferred for a turn read as backing off and the barrier skipped it — a
-  // turn then answering without the message the barrier exists to fold in.
+  // which answers a different question — a row can carry a spent budget while carrying no error, and
+  // reading the budget made the barrier skip the very message it exists to fold in.
   //
   // `last_error` is the state itself, and a reschedule clears it because the row has left it.
-  test("a job that failed once and then deferred is still drained", async () => {
+  //
+  // The state is built with the REAPER, and that is a consequence of issue #287 rather than a
+  // preference: a reschedule now clears the budget too, so fail-then-defer (what this test used to
+  // do) leaves `attempts` at zero and no longer constructs the divergence at all. A crashed claim
+  // still does, and more honestly — `reapStaleJobs` increments `attempts` and never writes
+  // `last_error`, because a claim that died has no message to record. Rebuilt rather than deleted:
+  // the guarantee is the barrier's, not the reschedule's, and a test that stopped being able to
+  // build its own offending state would have gone on passing while guarding nothing.
+  test("a job whose claim died and then deferred is still drained", async () => {
     const saver = new MemorySaver();
     const contactInboxId = 12514;
     const graphThreadId = contactInboxThreadId(
@@ -723,35 +730,16 @@ describe.skipIf(!dbUp)("the ingestion job defers to a turn in flight", () => {
       860,
       "falhou uma vez, depois esperou um turno",
     );
-    // One real failure: attempts goes to 1, a backoff is set, and the error is recorded.
-    await failJob(tenantId, job.id, job.claimSeq, job.attempts, "blip", appDb);
-    const failed = await suDb.schedulerJob.findFirstOrThrow({
-      where: { id: job.id },
-      select: { attempts: true, lastError: true },
-    });
-    expect(failed.attempts).toBe(1);
-    expect(failed.lastError).not.toBeNull();
-
-    // The tick picks it up after the backoff, finds a turn in flight, and stands down. The attempt
-    // count survives that — which is exactly why it cannot be the thing the barrier reads.
-    const retried = (
-      await claimDueTrafficJobs(
-        50,
-        appDb,
-        new Date(Date.now() + 600_000),
-        tenantId,
-      )
-    ).find((j) => j.id === job.id);
-    if (!retried) throw new Error("the backed-off row was not re-claimed");
+    // It stands down for a turn first: the row goes to a future run_at carrying no error.
     markTurnInFlight(graphThreadId);
     try {
-      expect((await ingestHandler(retried, appDb, saver)).outcome).toBe(
+      expect((await ingestHandler(job, appDb, saver)).outcome).toBe(
         "reschedule",
       );
       await rescheduleJob(
         tenantId,
-        retried.id,
-        retried.claimSeq,
+        job.id,
+        job.claimSeq,
         new Date(Date.now() + 60_000),
         undefined,
         appDb,
@@ -759,10 +747,32 @@ describe.skipIf(!dbUp)("the ingestion job defers to a turn in flight", () => {
     } finally {
       clearTurnInFlight(graphThreadId);
     }
+
+    // Then a claim on it dies. The reaper re-pends the row and charges the crash, leaving the
+    // future run_at alone and writing no error: a spent budget on a row that merely stood down.
+    const claimed = (
+      await claimDueTrafficJobs(
+        50,
+        appDb,
+        new Date(Date.now() + 600_000),
+        tenantId,
+      )
+    ).find((j) => j.id === job.id);
+    if (!claimed) throw new Error("the deferred row was not re-claimed");
+    await suDb.schedulerJob.update({
+      where: { id: job.id },
+      data: {
+        claimedAt: new Date(Date.now() - 3_600_000),
+        runAt: new Date(Date.now() + 60_000),
+      },
+    });
+    await reapStaleJobs(60_000, appDb, new Date(), tenantId, "INGEST_MESSAGE");
+
     const deferred = await suDb.schedulerJob.findFirstOrThrow({
       where: { id: job.id },
-      select: { attempts: true, lastError: true, runAt: true },
+      select: { attempts: true, lastError: true, runAt: true, status: true },
     });
+    expect(deferred.status).toBe("PENDING");
     expect(deferred.attempts).toBe(1);
     expect(deferred.lastError).toBeNull();
     expect(deferred.runAt.getTime()).toBeGreaterThan(Date.now());

--- a/tests/modules/scheduler.test.ts
+++ b/tests/modules/scheduler.test.ts
@@ -286,7 +286,11 @@ describe.skipIf(!dbUp)("scheduler", () => {
     expect((await statusOf(id)).status).toBe("DONE");
   });
 
-  test("reschedule keeps attempts unchanged and re-pends", async () => {
+  // Issue #287. The failure budget bounds CONSECUTIVE failures, not the row's lifetime, so a pass
+  // that completed spends the budget it earned. Started from a NON-ZERO count on purpose: the first
+  // spelling of this test enqueued a fresh row and asserted `attempts === 0`, which is what the row
+  // already carried, so it passed either way and pinned nothing.
+  test("reschedule re-pends and clears the failure budget a completed pass earned", async () => {
     const id = await enqueueJob({
       tenantId,
       kind: "WEBHOOK_RETRY",
@@ -294,6 +298,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
       runAt: past(),
       base: appDb,
     });
+    await suDb.schedulerJob.update({ where: { id }, data: { attempts: 3 } });
     await claimDueJobs(10, appDb, new Date(), tenantId);
     await rescheduleJob(
       tenantId,
@@ -306,6 +311,116 @@ describe.skipIf(!dbUp)("scheduler", () => {
     const s = await statusOf(id);
     expect(s.status).toBe("PENDING");
     expect(s.attempts).toBe(0);
+  });
+
+  // `rescheduleJob` has TWO write paths — a Prisma update and a raw statement for the merging
+  // `payloadPatch` — and the budget has to mean the same thing on both, or the reset depends on
+  // whether the caller happened to carry a counter forward. Measured: removing it from the raw
+  // branch alone left the rest of this file green, which is how the two would have drifted.
+  // APPOINTMENT_REMINDER is the caller that takes it, and its own retry ladder (`nudgeRetries`) is
+  // what bounds that work, not the scheduler's budget.
+  test("the merging reschedule clears the budget too", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "APPOINTMENT_REMINDER",
+      dedupeKey: "dk-resched-patch",
+      runAt: past(),
+      payload: { threadId: "1:2:3" },
+      base: appDb,
+    });
+    await suDb.schedulerJob.update({ where: { id }, data: { attempts: 4 } });
+    await claimDueJobs(10, appDb, new Date(), tenantId);
+    await rescheduleJob(
+      tenantId,
+      id,
+      await seqOf(id),
+      past(),
+      undefined,
+      appDb,
+      { nudgeRetries: 1 },
+    );
+    const row = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id },
+      select: { status: true, attempts: true, payload: true },
+    });
+    expect(row.status).toBe("PENDING");
+    expect(row.attempts).toBe(0);
+    // The patch still MERGES rather than replacing, which is the reason this branch exists.
+    expect(row.payload).toEqual({ threadId: "1:2:3", nudgeRetries: 1 });
+  });
+
+  // The defect this issue reports, in the shape that produces it: a job that reschedules itself
+  // forever (FLOWLOG_SWEEP, FOLLOWUP_SWEEP, HEARTBEAT) accumulates every failure it has ever had,
+  // across weeks of otherwise successful passes, and the fifth one dead-letters the row for good.
+  // Measured before the fix: DEAD after the fifth, with four healthy passes in between.
+  test("a perpetual job outlives more lifetime failures than the cap", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "FLOWLOG_SWEEP",
+      dedupeKey: "dk-perpetual",
+      runAt: past(),
+      base: appDb,
+    });
+    for (let round = 0; round < 8; round++) {
+      await claimDueJobs(10, appDb, new Date(), tenantId);
+      const before = await statusOf(id);
+      await failJob(
+        tenantId,
+        id,
+        await seqOf(id),
+        before.attempts,
+        "blip",
+        appDb,
+      );
+      expect((await statusOf(id)).status).toBe("PENDING");
+      // The next pass succeeds, which is what a transient blip looks like.
+      await suDb.schedulerJob.update({
+        where: { id },
+        data: { runAt: past() },
+      });
+      await claimDueJobs(10, appDb, new Date(), tenantId);
+      await rescheduleJob(
+        tenantId,
+        id,
+        await seqOf(id),
+        past(),
+        undefined,
+        appDb,
+      );
+    }
+    expect((await statusOf(id)).status).toBe("PENDING");
+  });
+
+  // The control for the test above: the budget still bounds a unit of work that is genuinely broken,
+  // because consecutive failures are never interleaved with a completed pass — a failure re-pends
+  // with a backoff and the next claim fails again.
+  test("consecutive failures still dead-letter at the cap", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "FLOWLOG_SWEEP",
+      dedupeKey: "dk-consecutive",
+      runAt: past(),
+      base: appDb,
+    });
+    let status = "";
+    for (let round = 0; round < 5; round++) {
+      await suDb.schedulerJob.update({
+        where: { id },
+        data: { runAt: past() },
+      });
+      await claimDueJobs(10, appDb, new Date(), tenantId);
+      const before = await statusOf(id);
+      await failJob(
+        tenantId,
+        id,
+        await seqOf(id),
+        before.attempts,
+        "broken",
+        appDb,
+      );
+      status = (await statusOf(id)).status;
+    }
+    expect(status).toBe("DEAD");
   });
 
   test("reschedule with a payload REPLACES the row payload (step advance)", async () => {


### PR DESCRIPTION
Fixes #287.

`MAX_ATTEMPTS = 5` was a job's LIFETIME failure budget. For a job with a finite life that is right:
a follow-up's five attempts are five attempts at that follow-up. For a job that reschedules itself
forever it is not. A per-tenant sweep accumulated every failure it had ever had, across weeks of
otherwise successful passes, and the fifth one dead-lettered the row. The sweep then stopped,
permanently, and nothing in the product said so.

## The change

**`rescheduleJob` clears `attempts`**, which makes the cap bound **consecutive** failures rather than
the row's lifetime.

Reaching that call means the handler neither threw nor reported failure: `runClaimed` routes both to
`failJob`, and `reschedule` is the third outcome. So the pass completed, and the budget it was
carrying was spent on a state the row has left. `lastError` was already cleared there for exactly
that reason; the two now agree.

**It does not hand a broken unit of work an unbounded retry**, and the reason is the shape of a
failure rather than a rule added here. `failJob` re-pends with a backoff, so the next claim runs the
same work and fails again: consecutive failures are never interleaved with a completed pass, and a
genuinely failing `FOLLOWUP` step or `MEMORY_COMPACT` still burns its five and dies (asserted, as the
control for the fix). What this exempts is a job that fails INTERMITTENTLY, which is a job that
works, and one that dies for good in silence is the worse of the two outcomes.

This also removes the need for option 2 in the issue, including on the restart path: a revived row
still comes back with its old count, and the first successful pass now clears it instead of leaving
the sweep one failure from dead forever.

## A third perpetual job the issue does not list

The issue names `FLOWLOG_SWEEP` and `FOLLOWUP_SWEEP`. There is a third: **`HEARTBEAT`**
(`webhooks/outbound/heartbeat.ts`), armed by `ensureTenantHeartbeat` without `resetAttempts`, which
reschedules itself for as long as an enabled `heartbeat` subscription remains.

It is the worst of the three to lose. A heartbeat exists so a subscriber's liveness monitor can tell
"the system is up" from "the system is gone", so the row dead-lettering produces the exact signal the
feature exists to make impossible. And its only re-arm is a subscription mutation, which on a stable
tenant may never come.

## Two things the code said that stopped being true

Prose that described the old semantics, updated rather than left to be rediscovered: the module
header on `scheduler/service.ts`, the `JobResult` doc on `worker.ts` ("does not consume an attempt"),
and the deferral note in `graph/ingest-drain.ts`.

The fourth one is the one worth reading. `claimPendingByKeyPrefix`'s barrier tells a row that is
BACKING OFF from one that merely STOOD DOWN, and it reads `last_error` **and not `attempts`**, a
round-16 review finding on the PR that added it. Its justification was that "`rescheduleJob`
preserves the attempt count", which is no longer how the divergence arises. The decision is unchanged
and still correct, so the sentence is restated rather than the code changed: `last_error` says which
STATE the row is in, `attempts` says how much budget is left, and the barrier is asking the first
question.

## What that cost, and why the test moved rather than being deleted

`tests/graph/ingest-job.test.ts` had a test building exactly that divergence (fail once, then defer)
and asserting the barrier still drains the row. After this change that construction leaves
`attempts` at zero, so the test would have gone on passing while guarding nothing.

The divergence is still reachable, by a more honest route: `reapStaleJobs` increments `attempts` and
never writes `last_error`, because a claim that died has no message to record. The test is rebuilt on
that, and it is a rebuild rather than a rewrite of the assertion: the guarantee belongs to the
barrier, not to the reschedule.

## Validation scope

**Proved by test**, against a real Postgres:

- red first: the two new scheduler tests fail on the pre-change tree, one of them dead-lettering a
  perpetual job after five lifetime failures with four healthy passes in between;
- the control passes on BOTH sides: five consecutive failures still reach DEAD;
- `rescheduleJob` has two write paths (a Prisma update, and a raw statement for the merging
  `payloadPatch`) and both are asserted. The `payloadPatch` one is covered because the mutation
  removing the reset from it alone left the whole file green;
- the existing `"reschedule keeps attempts unchanged"` test was rewritten: it enqueued a fresh row and
  asserted `attempts === 0`, which is what the row already carried, so it passed either way and
  pinned nothing;
- the rebuilt barrier test is checked to still guard: with the barrier reading `attempts` instead of
  `last_error`, it fails.


**Mutation**, one at a time: the reset dropped from the raw branch (1 fail), from the Prisma branch
(2), from both (3), and `failJob` no longer counting (2).

**Not validated**: no live exercise of a perpetual sweep actually failing in a deployment. The
failure needs a transient database fault to reach at all, which is why the issue notes it has gone
unnoticed. The behaviour is driven through the real scheduler functions against a real Postgres, not
through a real outage.

## What review found and this PR does NOT carry

Round 1 found the same defect one door over: `enqueueJob` re-arms one physical row for a new unit of
work (`DEBOUNCE`, `FOLLOWUP`, `RAG_INGEST` and `MEMORY_COMPACT` key their dedupe key to a thread, a
conversation or a document), and the budget was inherited.

Three fixes for it were built and measured on this branch, and each one was refuted:

- resetting on every re-arm hands a broken unit of work a fresh five per sweep, because
  `sweepHandler` re-enqueues the SAME follow-up key every minute while the conversation stays
  eligible (round 2);
- deriving it from the row's status cannot separate them: a `DEAD` row re-armed by `armCompaction` is
  a new attendance that must start clean, and `memory-compaction-arm.test.ts` pins that today, while
  a `DEAD` row re-armed by `sweepHandler` is the same broken follow-up (found by the full suite, not
  by review);
- per kind fails too, since `FOLLOWUP`'s key is the thread and the sweep re-arms it for a new episode
  and for the same one.

The knowledge is the caller's, which is what the existing `resetAttempts` parameter already says; the
defect is that it holds at one call site and nothing makes a new one decide. That is a classification
job over every call site plus a fence, with contested semantics, so it is #339 rather than a second
half of this one. Nothing here changes `enqueueJob`.

**Base**: `src/modules/scheduler/service.ts`, `worker.ts`, `tests/modules/scheduler.test.ts` and
`tests/modules/scheduler-lanes.test.ts` are also touched by #282, which is open. That PR takes the
issue's option 2 at its own arming call with a comment pointing here; whichever lands second should
re-measure rather than only rebase, and the `resetAttempts: true` there becomes redundant once this
is in.
