### PR TITLE
Store a credential without the whitespace the paste carried, on every surface that writes one

### DIFF
--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -183,6 +183,7 @@
     "vaultNameInUse": "A secret with this name and type already exists",
     "vaultParamNameRequired": "Param name is required for this credential type",
     "vaultRefNotFound": "That vault reference does not point to any credential: {{ref}}",
+    "vaultSecretWhitespace": "A vault secret must not begin or end with a space or line break. Remove it and save again.",
     "visionCredentialMissing": "Vision credential not found",
     "visionFailed": "Image/document extraction failed",
     "visionNotConfigured": "Image/document reading is not configured",

--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -180,6 +180,7 @@
     "vaultBaseUrlRequired": "This credential type requires a base URL.",
     "vaultFieldRequired": "The \"{{field}}\" field must not be empty",
     "vaultFieldUnknown": "This credential type has no field called \"{{field}}\"",
+    "vaultFieldWhitespace": "The \"{{field}}\" field must not begin or end with a space or line break. Remove it and save again.",
     "vaultNameInUse": "A secret with this name and type already exists",
     "vaultParamNameRequired": "Param name is required for this credential type",
     "vaultRefNotFound": "That vault reference does not point to any credential: {{ref}}",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -180,6 +180,7 @@
     "vaultBaseUrlRequired": "Este tipo de credencial exige uma URL base.",
     "vaultFieldRequired": "O campo \"{{field}}\" não pode ficar vazio",
     "vaultFieldUnknown": "Este tipo de credencial não tem um campo chamado \"{{field}}\"",
+    "vaultFieldWhitespace": "O campo \"{{field}}\" não pode começar nem terminar com espaço ou quebra de linha. Remova e salve de novo.",
     "vaultNameInUse": "Já existe um segredo com esse nome e tipo",
     "vaultParamNameRequired": "O nome do parâmetro é obrigatório para este tipo de credencial",
     "vaultRefNotFound": "Essa referência do cofre não aponta para nenhuma credencial: {{ref}}",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -183,6 +183,7 @@
     "vaultNameInUse": "Já existe um segredo com esse nome e tipo",
     "vaultParamNameRequired": "O nome do parâmetro é obrigatório para este tipo de credencial",
     "vaultRefNotFound": "Essa referência do cofre não aponta para nenhuma credencial: {{ref}}",
+    "vaultSecretWhitespace": "Um segredo do cofre não pode começar nem terminar com espaço ou quebra de linha. Remova e salve de novo.",
     "visionCredentialMissing": "Credencial de visão não encontrada",
     "visionFailed": "Falha ao extrair imagem/documento",
     "visionNotConfigured": "A leitura de imagens/documentos não está configurada",

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -38,6 +38,7 @@ import {
 // translate('errors.vaultNameInUse', 'A secret with this name and type already exists')
 // translate('errors.vaultParamNameRequired', 'Param name is required for this credential type')
 // translate('errors.vaultRefNotFound', 'That vault reference does not point to any credential: {{ref}}')
+// translate('errors.vaultFieldWhitespace', 'The "{{field}}" field must not begin or end with a space or line break. Remove it and save again.')
 // translate('errors.vaultSecretWhitespace', 'A vault secret must not begin or end with a space or line break. Remove it and save again.')
 
 function ctxOrThrow(ctx: TenantContext | null): TenantContext {

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -38,6 +38,7 @@ import {
 // translate('errors.vaultNameInUse', 'A secret with this name and type already exists')
 // translate('errors.vaultParamNameRequired', 'Param name is required for this credential type')
 // translate('errors.vaultRefNotFound', 'That vault reference does not point to any credential: {{ref}}')
+// translate('errors.vaultSecretWhitespace', 'A vault secret must not begin or end with a space or line break. Remove it and save again.')
 
 function ctxOrThrow(ctx: TenantContext | null): TenantContext {
   if (!ctx) throw new ForbiddenError();

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -638,13 +638,16 @@ export function CredentialForm({
   const genericTypes = GENERIC_TYPE_ORDER.filter(matchesTypeSearch);
   const noTypeResults = serviceTypes.length === 0 && genericTypes.length === 0;
 
-  // The Save button label changes to "Save anyway" after a failed test.
-  const saveLabel =
-    testResult?.kind === "fail"
-      ? t("vault.saveAnyway", "Save anyway")
-      : t("common.save", "Save");
-  const onSaveClick =
-    testResult?.kind === "fail" ? () => save(true) : () => save();
+  // The Save button label changes to "Save anyway" after a failed test — but only for a failure the
+  // operator can decide to ignore. `surrounding_whitespace` is the write's own verdict, not a
+  // connectivity one, so saving anyway is refused by createVaultEntry/updateVaultEntry every time:
+  // offering it advertises an action that cannot succeed (#338).
+  const testFailedRecoverably =
+    testResult?.kind === "fail" && testResult.code !== "surrounding_whitespace";
+  const saveLabel = testFailedRecoverably
+    ? t("vault.saveAnyway", "Save anyway")
+    : t("common.save", "Save");
+  const onSaveClick = testFailedRecoverably ? () => save(true) : () => save();
 
   // Param-name placeholder depends on the kind.
   const paramNamePlaceholder =

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -279,11 +279,13 @@ export function CredentialForm({
     }
   }, [typeOpen]);
 
-  // Build the value to send for multi-field types.
+  // Build the value to send for multi-field types. Sent VERBATIM, like the single-value path: the
+  // server refuses a secret that begins or ends in whitespace rather than repairing it (#338), and
+  // trimming here would hide that refusal from the console while the MCP surface still got it.
   function buildMultiFieldValue(): Record<string, string> {
     const result: Record<string, string> = {};
     for (const f of fields ?? []) {
-      result[f.key] = (fieldValues[f.key] ?? "").trim();
+      result[f.key] = fieldValues[f.key] ?? "";
     }
     return result;
   }

--- a/src/client/components/CredentialTestResult.tsx
+++ b/src/client/components/CredentialTestResult.tsx
@@ -48,6 +48,12 @@ export function CredentialTestResult({
         "Blocked URL (internal addresses are not allowed).",
       );
       break;
+    case "surrounding_whitespace":
+      message = t(
+        "vault.testFail.surroundingWhitespace",
+        "The value begins or ends with a space or line break. Remove it before testing.",
+      );
+      break;
     case "missing_base_url":
       message = t(
         "vault.testFail.missingBaseUrl",

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -2330,6 +2330,7 @@
       "blockedUrl": "Blocked URL (internal addresses are not allowed).",
       "httpError": "The service responded with an error (HTTP {{status}}).",
       "missingBaseUrl": "Enter the base URL to test.",
+      "surroundingWhitespace": "The value begins or ends with a space or line break. Remove it before testing.",
       "timeout": "The test timed out.",
       "unauthorized": "The service rejected the credential.",
       "unreachable": "Could not reach the service."

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -2338,6 +2338,7 @@
       "blockedUrl": "URL bloqueada (endereços internos não são permitidos).",
       "httpError": "O serviço respondeu com erro (HTTP {{status}}).",
       "missingBaseUrl": "Informe a URL base para testar.",
+      "surroundingWhitespace": "O valor começa ou termina com espaço ou quebra de linha. Remova antes de testar.",
       "timeout": "O teste expirou.",
       "unauthorized": "O serviço rejeitou a credencial.",
       "unreachable": "Não foi possível alcançar o serviço."

--- a/src/modules/vault/secret-test.ts
+++ b/src/modules/vault/secret-test.ts
@@ -23,7 +23,12 @@ export type SecretTestFailCode =
   | "unreachable"
   | "timeout"
   | "blocked_url"
-  | "missing_base_url";
+  | "missing_base_url"
+  // Not a connectivity outcome: the value the operator typed would be refused by the write, so the
+  // probe answers with that instead of reporting on a credential nobody can store (#338). Sending it
+  // would report "Connection OK" for a header kind (fetch strips the padding on the way out) and
+  // then the save would refuse the same value.
+  | "surrounding_whitespace";
 
 export type SecretTestResult =
   | { testable: false }

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -353,6 +353,42 @@ function validateParamName(raw: string, kind: string): string {
   return trimmed;
 }
 
+// A credential is pasted, and a paste out of a provider's panel routinely carries a newline or a
+// space. Nothing downstream can recover from it, because the comparison is asymmetric by protocol:
+// an HTTP field value has its surrounding whitespace stripped before any handler sees it, so the
+// whitespace can live on our side and can never arrive from the other one. The refusal that follows
+// is byte-identical to a wrong token, so the operator retypes the value on the provider's side and
+// nothing changes (issue #338).
+//
+// Normalizing HERE rather than in the form is what makes the stored shape an invariant: the REST
+// controller and the MCP write surface both land on createVaultEntry/updateVaultEntry, and the MCP
+// one never had a form to trim in.
+//
+// It runs BEFORE validateVaultValue, so a value that is only whitespace becomes "" and is refused as
+// empty instead of being stored as a secret nothing can match. Anything this cannot narrow is
+// returned untouched, for validation to refuse by shape.
+export function normalizeVaultValue(kind: string, value: unknown): unknown {
+  if (typeof value === "string") return value.trim();
+  // Managed-blob kinds hold a server-managed object with no operator-typed fields.
+  if (secretTypeIsManagedBlob(kind)) return value;
+  const fields = getSecretTypeFields(kind);
+  if (
+    !fields ||
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value)
+  ) {
+    return value;
+  }
+  const rec = value as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...rec };
+  for (const { key } of fields) {
+    const v = rec[key];
+    if (typeof v === "string") out[key] = v.trim();
+  }
+  return out;
+}
+
 // Validates the secret value against the kind's declared shape.
 // - kinds with `fields` declared: must be a Record<string, string> with exactly those keys, all non-empty.
 // - all other kinds: must be a non-empty string.
@@ -538,8 +574,9 @@ export async function createVaultEntry(
 
   const normalizedKind = rawKind ?? "generic";
 
-  // Validate value shape for the kind.
-  validateVaultValue(normalizedKind, rawValue);
+  // Normalize before validating: whitespace-only becomes "" and is refused as empty.
+  const normalizedValue = normalizeVaultValue(normalizedKind, rawValue);
+  validateVaultValue(normalizedKind, normalizedValue);
 
   // Validate and normalize baseUrl.
   let normalizedBaseUrl: string | null = null;
@@ -581,7 +618,7 @@ export async function createVaultEntry(
         "errors.vaultNameInUse",
       );
     }
-    const blob = encryptJson(rawValue);
+    const blob = encryptJson(normalizedValue);
     try {
       const created = await db.vaultEntry.create({
         data: {
@@ -763,8 +800,9 @@ export async function updateVaultEntry(
     }
 
     if (patch.value !== undefined) {
-      validateVaultValue(entry.kind, patch.value);
-      data.secret = encryptJson(patch.value);
+      const normalizedValue = normalizeVaultValue(entry.kind, patch.value);
+      validateVaultValue(entry.kind, normalizedValue);
+      data.secret = encryptJson(normalizedValue);
       // Writing a real value promotes a pending entry (reference-only) to active. No-op for entries
       // already active. This is how "filling" a pending credential in the UI completes it.
       data.status = "active";

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -855,6 +855,12 @@ export async function testVaultValue(
   if (kind && !isSecretTypeId(kind)) {
     throw new AppError("invalid secret type", 400, "errors.invalidSecretType");
   }
+  // A value the write would refuse is not a connectivity question, and probing it answers the wrong
+  // one: fetch strips the padding out of a header, so a fixed-header kind reports "Connection OK"
+  // and the save then refuses the same bytes.
+  if (value !== value.trim()) {
+    return { testable: true, ok: false, code: "surrounding_whitespace" };
+  }
   return runSecretTest({ kind, value, baseURL, paramName }, deps);
 }
 

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -353,44 +353,25 @@ function validateParamName(raw: string, kind: string): string {
   return trimmed;
 }
 
-// A credential is pasted, and a paste out of a provider's panel routinely carries a newline or a
-// space. Nothing downstream can recover from it, because the comparison is asymmetric by protocol:
-// an HTTP field value has its surrounding whitespace stripped before any handler sees it, so the
-// whitespace can live on our side and can never arrive from the other one. The refusal that follows
-// is byte-identical to a wrong token, so the operator retypes the value on the provider's side and
-// nothing changes (issue #338).
+// A credential is stored as its exact bytes, so a paste artifact is not a detail: an HTTP field
+// value has its surrounding whitespace stripped before any handler sees it, so a token stored with a
+// trailing newline can never be matched by the one that arrives, and the refusal that follows is
+// byte-identical to a wrong token (issue #338).
 //
-// Normalizing HERE rather than in the form is what makes the stored shape an invariant: the REST
-// controller and the MCP write surface both land on createVaultEntry/updateVaultEntry, and the MCP
-// one never had a form to trim in.
-//
-// It runs BEFORE validateVaultValue, so a value that is only whitespace becomes "" and is refused as
-// empty instead of being stored as a secret nothing can match. Anything this cannot narrow is
-// returned untouched, for validation to refuse by shape.
-export function normalizeVaultSecret(value: string): string {
-  return value.trim();
-}
-
-export function normalizeVaultValue(kind: string, value: unknown): unknown {
-  if (typeof value === "string") return normalizeVaultSecret(value);
-  // Managed-blob kinds hold a server-managed object with no operator-typed fields.
-  if (secretTypeIsManagedBlob(kind)) return value;
-  const fields = getSecretTypeFields(kind);
-  if (
-    !fields ||
-    typeof value !== "object" ||
-    value === null ||
-    Array.isArray(value)
-  ) {
-    return value;
-  }
-  const rec = value as Record<string, unknown>;
-  const out: Record<string, unknown> = { ...rec };
-  for (const { key } of fields) {
-    const v = rec[key];
-    if (typeof v === "string") out[key] = normalizeVaultSecret(v);
-  }
-  return out;
+// This REFUSES rather than trimming, and the difference is the whole point. Trimming would repair
+// the header case silently while breaking the one where the bytes are shared rather than sent: an
+// HMAC key never travels, both sides hold it, and `createHmac` uses it verbatim — so rewriting ours
+// would fail every signature at the provider instead of here. Refusing changes no secret, needs no
+// per-kind exception, and hands the operator the one fact they could not see.
+function assertNoSurroundingWhitespace(value: string, field?: string): void {
+  if (value === value.trim()) return;
+  throw new AppError(
+    "vault secret must not begin or end with whitespace",
+    400,
+    "errors.vaultSecretWhitespace",
+    undefined,
+    field,
+  );
 }
 
 // Validates the secret value against the kind's declared shape.
@@ -434,6 +415,7 @@ function validateVaultValue(kind: string, value: unknown): void {
           key,
         );
       }
+      assertNoSurroundingWhitespace(v, key);
     }
     // Reject extra keys not in the declared field list.
     const declaredKeys = new Set(fields.map((f) => f.key));
@@ -455,6 +437,7 @@ function validateVaultValue(kind: string, value: unknown): void {
         "errors.emptyVaultSecret",
       );
     }
+    assertNoSurroundingWhitespace(value);
   }
 }
 
@@ -578,9 +561,8 @@ export async function createVaultEntry(
 
   const normalizedKind = rawKind ?? "generic";
 
-  // Normalize before validating: whitespace-only becomes "" and is refused as empty.
-  const normalizedValue = normalizeVaultValue(normalizedKind, rawValue);
-  validateVaultValue(normalizedKind, normalizedValue);
+  // Validate value shape for the kind.
+  validateVaultValue(normalizedKind, rawValue);
 
   // Validate and normalize baseUrl.
   let normalizedBaseUrl: string | null = null;
@@ -622,7 +604,7 @@ export async function createVaultEntry(
         "errors.vaultNameInUse",
       );
     }
-    const blob = encryptJson(normalizedValue);
+    const blob = encryptJson(rawValue);
     try {
       const created = await db.vaultEntry.create({
         data: {
@@ -804,9 +786,8 @@ export async function updateVaultEntry(
     }
 
     if (patch.value !== undefined) {
-      const normalizedValue = normalizeVaultValue(entry.kind, patch.value);
-      validateVaultValue(entry.kind, normalizedValue);
-      data.secret = encryptJson(normalizedValue);
+      validateVaultValue(entry.kind, patch.value);
+      data.secret = encryptJson(patch.value);
       // Writing a real value promotes a pending entry (reference-only) to active. No-op for entries
       // already active. This is how "filling" a pending credential in the UI completes it.
       data.status = "active";
@@ -874,13 +855,7 @@ export async function testVaultValue(
   if (kind && !isSecretTypeId(kind)) {
     throw new AppError("invalid secret type", 400, "errors.invalidSecretType");
   }
-  // The probe has to see exactly what a save would persist. They used to agree by both taking the
-  // typed value raw; now that the write normalizes, testing the raw value would fail the probe on a
-  // credential this would store working (" tok" probes as `Bearer  tok`) and abort the save with it.
-  return runSecretTest(
-    { kind, value: normalizeVaultSecret(value), baseURL, paramName },
-    deps,
-  );
+  return runSecretTest({ kind, value, baseURL, paramName }, deps);
 }
 
 // Tests an ALREADY-stored credential by its `vault:<id>` ref (decrypts server-side; the value is

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -367,8 +367,12 @@ function validateParamName(raw: string, kind: string): string {
 // It runs BEFORE validateVaultValue, so a value that is only whitespace becomes "" and is refused as
 // empty instead of being stored as a secret nothing can match. Anything this cannot narrow is
 // returned untouched, for validation to refuse by shape.
+export function normalizeVaultSecret(value: string): string {
+  return value.trim();
+}
+
 export function normalizeVaultValue(kind: string, value: unknown): unknown {
-  if (typeof value === "string") return value.trim();
+  if (typeof value === "string") return normalizeVaultSecret(value);
   // Managed-blob kinds hold a server-managed object with no operator-typed fields.
   if (secretTypeIsManagedBlob(kind)) return value;
   const fields = getSecretTypeFields(kind);
@@ -384,7 +388,7 @@ export function normalizeVaultValue(kind: string, value: unknown): unknown {
   const out: Record<string, unknown> = { ...rec };
   for (const { key } of fields) {
     const v = rec[key];
-    if (typeof v === "string") out[key] = v.trim();
+    if (typeof v === "string") out[key] = normalizeVaultSecret(v);
   }
   return out;
 }
@@ -870,7 +874,13 @@ export async function testVaultValue(
   if (kind && !isSecretTypeId(kind)) {
     throw new AppError("invalid secret type", 400, "errors.invalidSecretType");
   }
-  return runSecretTest({ kind, value, baseURL, paramName }, deps);
+  // The probe has to see exactly what a save would persist. They used to agree by both taking the
+  // typed value raw; now that the write normalizes, testing the raw value would fail the probe on a
+  // credential this would store working (" tok" probes as `Bearer  tok`) and abort the save with it.
+  return runSecretTest(
+    { kind, value: normalizeVaultSecret(value), baseURL, paramName },
+    deps,
+  );
 }
 
 // Tests an ALREADY-stored credential by its `vault:<id>` ref (decrypts server-side; the value is

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -363,14 +363,25 @@ function validateParamName(raw: string, kind: string): string {
 // HMAC key never travels, both sides hold it, and `createHmac` uses it verbatim — so rewriting ours
 // would fail every signature at the provider instead of here. Refusing changes no secret, needs no
 // per-kind exception, and hands the operator the one fact they could not see.
+// The sentence names the field when there is one, because that is the only place the name survives:
+// `AppError.field` is dropped by the MCP writer (`failOf` sends `e.message`) and by the console's
+// save-error path, so a padded Langfuse key would otherwise refuse with a sentence that cannot say
+// WHICH of the two is padded — for whitespace, of all things, which the operator cannot see.
 function assertNoSurroundingWhitespace(value: string, field?: string): void {
   if (value === value.trim()) return;
+  if (field !== undefined) {
+    throw new AppError(
+      `value.${field} must not begin or end with whitespace`,
+      400,
+      "errors.vaultFieldWhitespace",
+      { field },
+      field,
+    );
+  }
   throw new AppError(
     "vault secret must not begin or end with whitespace",
     400,
     "errors.vaultSecretWhitespace",
-    undefined,
-    field,
   );
 }
 

--- a/tests/client/credential-whitespace-not-overridable.test.tsx
+++ b/tests/client/credential-whitespace-not-overridable.test.tsx
@@ -1,0 +1,108 @@
+/// <reference lib="dom" />
+
+import { afterAll, afterEach, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+// A failed connection test relabels Save to "Save anyway", because a probe can fail for reasons the
+// operator is entitled to overrule: a provider that is down, an endpoint we cannot reach from here.
+//
+// `surrounding_whitespace` is not one of them. It is the WRITE's verdict, reported early by the
+// probe, and `createVaultEntry`/`updateVaultEntry` refuse it every time — so "Save anyway" advertises
+// an action that cannot succeed, on the one failure the operator cannot see for themselves (#338).
+//
+// NOTE: `globalThis.fetch` is swapped rather than `mock.module`, whose restore is global to the
+// process and tears down other files' mocks. Assertions reduce to a string or a boolean BEFORE
+// expect: a failing expectation holding a DOM node serializes a cyclic happy-dom tree and stalls.
+
+const { CredentialForm } = await import("@/client/components/CredentialForm");
+const { ToastProvider } = await import("@/client/components/Toast");
+
+const realFetch = globalThis.fetch;
+
+function serveProbe(body: unknown): string[] {
+  const seen: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    seen.push(url);
+    if (url.includes("/v1/vault/test")) {
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ id: "1", ref: "vault:1" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return seen;
+}
+
+afterEach(cleanup);
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+// Returns the Save button's label AND whether clicking it wrote, because the label and the handler
+// are two different reads of the same condition: a fix that only relabels still fires save(true).
+async function probeWith(
+  body: unknown,
+): Promise<{ label: string; wrote: boolean }> {
+  const seen = serveProbe(body);
+  const { container } = render(
+    <ToastProvider>
+      <CredentialForm
+        mode="create"
+        initialKind="openai"
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />
+    </ToastProvider>,
+  );
+  const value = container.querySelector('input[type="password"]');
+  if (!value) throw new Error("no secret input rendered");
+  fireEvent.change(value, { target: { value: " sk-secret\n" } });
+  fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+  await waitFor(() => {
+    const labels = screen
+      .getAllByRole("button")
+      .map((b) => b.textContent ?? "");
+    if (!labels.some((l) => /save/i.test(l))) throw new Error("no save button");
+  });
+  const save = screen
+    .getAllByRole("button")
+    .find((b) => /save/i.test(b.textContent ?? ""));
+  const label = save?.textContent ?? "";
+  seen.length = 0;
+  if (save) fireEvent.click(save);
+  await waitFor(() => {
+    if (seen.length === 0) throw new Error("the click issued no request");
+  });
+  return { label, wrote: seen.some((u) => /\/v1\/vault(\?|$)/.test(u)) };
+}
+
+test("a whitespace verdict neither offers Save anyway nor writes", async () => {
+  const { label, wrote } = await probeWith({
+    testable: true,
+    ok: false,
+    code: "surrounding_whitespace",
+  });
+  expect(/anyway/i.test(label)).toBe(false);
+  expect(wrote).toBe(false);
+});
+
+test("an ordinary connection failure still offers it, and it writes", async () => {
+  const { label, wrote } = await probeWith({
+    testable: true,
+    ok: false,
+    code: "unreachable",
+  });
+  expect(/anyway/i.test(label)).toBe(true);
+  expect(wrote).toBe(true);
+});

--- a/tests/modules/vault/value-whitespace.test.ts
+++ b/tests/modules/vault/value-whitespace.test.ts
@@ -1,20 +1,15 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
-import { decryptJson } from "@/api/lib/crypto";
+import { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
-import {
-  createVaultEntry,
-  normalizeVaultValue,
-  testVaultValue,
-  updateVaultEntry,
-} from "@/modules/vault/service";
+import { createVaultEntry, updateVaultEntry } from "@/modules/vault/service";
 
-// A credential is PASTED, and a paste out of a provider's panel routinely carries a newline or a
-// space. Nothing downstream can recover from it: an HTTP field value has its surrounding whitespace
-// stripped before any handler sees it, so the whitespace can be stored on our side and can never
-// arrive from the other one. The refusal that follows is byte-identical to a wrong token, so the
-// operator retypes the value on the provider's side forever (issue #338).
+// A credential is stored as its exact bytes, and a paste out of a provider's panel routinely carries
+// a newline or a space. An HTTP field value has its surrounding whitespace stripped before any
+// handler sees it, so a token stored padded can never be matched by the one that arrives, and the
+// refusal is byte-identical to a wrong token: the operator retypes the value on the provider's side
+// forever (issue #338). The write refuses instead of repairing, so no secret is ever rewritten.
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
 const suUrl = process.env.MIGRATION_DATABASE_URL;
@@ -39,80 +34,29 @@ if (appUrl && suUrl) {
   }
 }
 
+// OUTSIDE the skipIf: when the superuser probe connects and the app one does not, `dbUp` is false
+// and the suite below never runs its own afterAll, leaving an open pool for the rest of the process.
+afterAll(async () => {
+  await su?.$disconnect();
+  await app?.$disconnect();
+});
+
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
 let tenantId = 0n;
 
-const storedValue = async <T>(id: bigint): Promise<T> => {
-  const row = await suDb.vaultEntry.findUnique({
-    where: { id },
-    select: { secret: true },
-  });
-  if (!row) throw new Error(`vault entry ${id} not found`);
-  return decryptJson<T>(row.secret);
+const refusal = async (run: () => Promise<unknown>): Promise<AppError> => {
+  try {
+    await run();
+  } catch (e) {
+    if (e instanceof AppError) return e;
+    throw e;
+  }
+  throw new Error("expected the write to be refused, and it was not");
 };
 
-// The rule itself, away from the database: what is stored for a value the operator typed. Proving
-// the function is not proving the call sites use it — the DB-backed tests below are that half.
-describe("normalizeVaultValue", () => {
-  const table: Array<[string, string, unknown, unknown]> = [
-    ["single value, trailing newline", "generic", "tok\n", "tok"],
-    ["single value, trailing space", "asaas", "tok ", "tok"],
-    ["single value, leading space", "openai", " tok", "tok"],
-    ["single value, both ends", "generic", "\t tok \r\n", "tok"],
-    ["single value, already clean", "generic", "tok", "tok"],
-    ["single value, inner space kept", "generic", " a b ", "a b"],
-    [
-      "whitespace only, left empty for validation to refuse",
-      "generic",
-      " \n",
-      "",
-    ],
-    [
-      "named fields, each end trimmed",
-      "langfuse",
-      { publicKey: "pk \n", secretKey: " sk" },
-      { publicKey: "pk", secretKey: "sk" },
-    ],
-    ["managed blob, untouched", "mcp_oauth", {}, {}],
-    ["non-string, untouched for validation to refuse", "generic", 7, 7],
-  ];
-
-  for (const [label, kind, input, expected] of table) {
-    test(label, () => {
-      expect(normalizeVaultValue(kind, input)).toEqual(expected);
-    });
-  }
-});
-
-// Test-on-save probes the value the operator just typed, and the form ABORTS the save when the probe
-// fails. Before the write normalized, the two agreed by both taking the value raw; they have to keep
-// agreeing, or a credential this stores working is refused before it is ever stored.
-describe("test-on-save probes what a save would store", () => {
-  test("a typed value with whitespace is probed trimmed, not raw", async () => {
-    const seen: string[] = [];
-    const fetchImpl = (async (
-      _input: string | URL | Request,
-      init?: RequestInit,
-    ) => {
-      const h = (init?.headers ?? {}) as Record<string, string>;
-      for (const [k, v] of Object.entries(h)) {
-        if (k.toLowerCase() === "authorization") seen.push(v);
-      }
-      return new Response("{}", { status: 200 });
-    }) as unknown as typeof fetch;
-
-    const r = await testVaultValue("openai", " sk-secret\n", null, {
-      fetchImpl,
-      assertSafe: async (u: string) => new URL(u),
-    });
-    expect(r).toEqual({ testable: true, ok: true });
-    expect(seen).toEqual(["Bearer sk-secret"]);
-  });
-});
-
 describe.skipIf(!dbUp)(
-  "vault: a stored value carries no surrounding whitespace",
+  "vault: a value that begins or ends in whitespace",
   () => {
     const ctx = (): TenantContext => ({
       tenantId,
@@ -137,22 +81,62 @@ describe.skipIf(!dbUp)(
           `DELETE FROM tenants WHERE id = ${tenantId}`,
         );
       }
-      await su?.$disconnect();
-      await app?.$disconnect();
     });
 
-    test("createVaultEntry stores a single value without the whitespace around it", async () => {
+    for (const [label, value] of [
+      ["a trailing newline", "abc123TOKEN\n"],
+      ["a trailing space", "abc123TOKEN "],
+      ["a leading space", " abc123TOKEN"],
+      ["a tab on both ends", "\tabc123TOKEN\t"],
+    ] as const) {
+      test(`createVaultEntry refuses ${label}, by name`, async () => {
+        const e = await refusal(() =>
+          createVaultEntry(
+            ctx(),
+            { name: `ws-${label.replace(/\s/g, "-")}`, value, kind: "asaas" },
+            undefined,
+            undefined,
+            appDb,
+          ),
+        );
+        expect(e.statusCode).toBe(400);
+        expect(e.translationKey).toBe("errors.vaultSecretWhitespace");
+      });
+    }
+
+    test("a clean value is stored, so the rule refuses the padding and nothing else", async () => {
       const { id } = await createVaultEntry(
         ctx(),
-        { name: "ws-create", value: "abc123TOKEN\n", kind: "asaas" },
+        { name: "ws-clean", value: "abc123TOKEN", kind: "asaas" },
         undefined,
         undefined,
         appDb,
       );
-      expect(await storedValue<string>(id)).toBe("abc123TOKEN");
+      const row = await suDb.vaultEntry.findUnique({
+        where: { id },
+        select: { status: true },
+      });
+      expect(row?.status).toBe("active");
     });
 
-    test("updateVaultEntry stores it trimmed too — the path an operator re-saves through", async () => {
+    test("an inner space is kept: the rule is about the ends, not about spaces", async () => {
+      const { id } = await createVaultEntry(
+        ctx(),
+        { name: "ws-inner", value: "two words", kind: "generic" },
+        undefined,
+        undefined,
+        appDb,
+      );
+      const { decryptJson } = await import("@/api/lib/crypto");
+      const row = await suDb.vaultEntry.findUnique({
+        where: { id },
+        select: { secret: true },
+      });
+      if (!row) throw new Error("created row not found");
+      expect(decryptJson<string>(row.secret)).toBe("two words");
+    });
+
+    test("updateVaultEntry refuses it too — the path an operator re-saves through", async () => {
       const { id } = await createVaultEntry(
         ctx(),
         { name: "ws-update", value: "first", kind: "generic" },
@@ -160,48 +144,26 @@ describe.skipIf(!dbUp)(
         undefined,
         appDb,
       );
-      await updateVaultEntry(ctx(), id, { value: "  abc123TOKEN  " }, appDb);
-      expect(await storedValue<string>(id)).toBe("abc123TOKEN");
-    });
-
-    test("a named-field credential is trimmed per field, on the surface that has no form", async () => {
-      const { id } = await createVaultEntry(
-        ctx(),
-        {
-          name: "ws-fields",
-          value: { publicKey: "pk-123\n", secretKey: " sk-456 " },
-          kind: "langfuse",
-          baseUrl: "https://cloud.langfuse.com",
-        },
-        undefined,
-        undefined,
-        appDb,
+      const e = await refusal(() =>
+        updateVaultEntry(ctx(), id, { value: "  abc123TOKEN  " }, appDb),
       );
-      expect(await storedValue<Record<string, string>>(id)).toEqual({
-        publicKey: "pk-123",
-        secretKey: "sk-456",
+      expect(e.translationKey).toBe("errors.vaultSecretWhitespace");
+      const { decryptJson } = await import("@/api/lib/crypto");
+      const row = await suDb.vaultEntry.findUnique({
+        where: { id },
+        select: { secret: true },
       });
+      if (!row) throw new Error("row not found");
+      expect(decryptJson<string>(row.secret)).toBe("first");
     });
 
-    test("a value that is only whitespace is refused as empty, never stored as one", async () => {
-      await expect(
-        createVaultEntry(
-          ctx(),
-          { name: "ws-blank", value: "   \n", kind: "generic" },
-          undefined,
-          undefined,
-          appDb,
-        ),
-      ).rejects.toThrow(/empty/i);
-    });
-
-    test("a named field that is only whitespace is refused, not stored blank", async () => {
-      await expect(
+    test("a named field is refused by ITS name, on the surface that has no form", async () => {
+      const e = await refusal(() =>
         createVaultEntry(
           ctx(),
           {
-            name: "ws-blank-field",
-            value: { publicKey: "  ", secretKey: "sk" },
+            name: "ws-fields",
+            value: { publicKey: "pk-123\n", secretKey: "sk-456" },
             kind: "langfuse",
             baseUrl: "https://cloud.langfuse.com",
           },
@@ -209,7 +171,9 @@ describe.skipIf(!dbUp)(
           undefined,
           appDb,
         ),
-      ).rejects.toThrow(/non-empty/i);
+      );
+      expect(e.translationKey).toBe("errors.vaultSecretWhitespace");
+      expect(e.field).toBe("publicKey");
     });
   },
 );

--- a/tests/modules/vault/value-whitespace.test.ts
+++ b/tests/modules/vault/value-whitespace.test.ts
@@ -210,7 +210,12 @@ describe.skipIf(!dbUp)(
           appDb,
         ),
       );
-      expect(e.translationKey).toBe("errors.vaultSecretWhitespace");
+      // The SENTENCE has to name it, not only `AppError.field`: the MCP writer sends `e.message` and
+      // the console's save path drops the field, so a generic sentence leaves the operator hunting
+      // invisible whitespace across two inputs.
+      expect(e.translationKey).toBe("errors.vaultFieldWhitespace");
+      expect(e.translationParams).toEqual({ field: "publicKey" });
+      expect(e.message).toContain("publicKey");
       expect(e.field).toBe("publicKey");
     });
   },

--- a/tests/modules/vault/value-whitespace.test.ts
+++ b/tests/modules/vault/value-whitespace.test.ts
@@ -6,6 +6,7 @@ import type { TenantContext } from "@/lib/tenancy";
 import {
   createVaultEntry,
   normalizeVaultValue,
+  testVaultValue,
   updateVaultEntry,
 } from "@/modules/vault/service";
 
@@ -82,6 +83,32 @@ describe("normalizeVaultValue", () => {
       expect(normalizeVaultValue(kind, input)).toEqual(expected);
     });
   }
+});
+
+// Test-on-save probes the value the operator just typed, and the form ABORTS the save when the probe
+// fails. Before the write normalized, the two agreed by both taking the value raw; they have to keep
+// agreeing, or a credential this stores working is refused before it is ever stored.
+describe("test-on-save probes what a save would store", () => {
+  test("a typed value with whitespace is probed trimmed, not raw", async () => {
+    const seen: string[] = [];
+    const fetchImpl = (async (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const h = (init?.headers ?? {}) as Record<string, string>;
+      for (const [k, v] of Object.entries(h)) {
+        if (k.toLowerCase() === "authorization") seen.push(v);
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const r = await testVaultValue("openai", " sk-secret\n", null, {
+      fetchImpl,
+      assertSafe: async (u: string) => new URL(u),
+    });
+    expect(r).toEqual({ testable: true, ok: true });
+    expect(seen).toEqual(["Bearer sk-secret"]);
+  });
 });
 
 describe.skipIf(!dbUp)(

--- a/tests/modules/vault/value-whitespace.test.ts
+++ b/tests/modules/vault/value-whitespace.test.ts
@@ -1,0 +1,188 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { decryptJson } from "@/api/lib/crypto";
+import type { TenantContext } from "@/lib/tenancy";
+import {
+  createVaultEntry,
+  normalizeVaultValue,
+  updateVaultEntry,
+} from "@/modules/vault/service";
+
+// A credential is PASTED, and a paste out of a provider's panel routinely carries a newline or a
+// space. Nothing downstream can recover from it: an HTTP field value has its surrounding whitespace
+// stripped before any handler sees it, so the whitespace can be stored on our side and can never
+// arrive from the other one. The refusal that follows is byte-identical to a wrong token, so the
+// operator retypes the value on the provider's side forever (issue #338).
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+let tenantId = 0n;
+
+const storedValue = async <T>(id: bigint): Promise<T> => {
+  const row = await suDb.vaultEntry.findUnique({
+    where: { id },
+    select: { secret: true },
+  });
+  if (!row) throw new Error(`vault entry ${id} not found`);
+  return decryptJson<T>(row.secret);
+};
+
+// The rule itself, away from the database: what is stored for a value the operator typed. Proving
+// the function is not proving the call sites use it — the DB-backed tests below are that half.
+describe("normalizeVaultValue", () => {
+  const table: Array<[string, string, unknown, unknown]> = [
+    ["single value, trailing newline", "generic", "tok\n", "tok"],
+    ["single value, trailing space", "asaas", "tok ", "tok"],
+    ["single value, leading space", "openai", " tok", "tok"],
+    ["single value, both ends", "generic", "\t tok \r\n", "tok"],
+    ["single value, already clean", "generic", "tok", "tok"],
+    ["single value, inner space kept", "generic", " a b ", "a b"],
+    [
+      "whitespace only, left empty for validation to refuse",
+      "generic",
+      " \n",
+      "",
+    ],
+    [
+      "named fields, each end trimmed",
+      "langfuse",
+      { publicKey: "pk \n", secretKey: " sk" },
+      { publicKey: "pk", secretKey: "sk" },
+    ],
+    ["managed blob, untouched", "mcp_oauth", {}, {}],
+    ["non-string, untouched for validation to refuse", "generic", 7, 7],
+  ];
+
+  for (const [label, kind, input, expected] of table) {
+    test(label, () => {
+      expect(normalizeVaultValue(kind, input)).toEqual(expected);
+    });
+  }
+});
+
+describe.skipIf(!dbUp)(
+  "vault: a stored value carries no surrounding whitespace",
+  () => {
+    const ctx = (): TenantContext => ({
+      tenantId,
+      userId: null,
+      role: "TENANT_ADMIN",
+    });
+
+    beforeAll(async () => {
+      if (!su) return;
+      const t = await su.tenant.create({
+        data: { name: "VaultWhitespace", slug: `vaultws-${process.pid}` },
+      });
+      tenantId = t.id;
+    });
+
+    afterAll(async () => {
+      if (su && tenantId) {
+        await su.$executeRawUnsafe(
+          `DELETE FROM vault_entries WHERE tenant_id = ${tenantId}`,
+        );
+        await su.$executeRawUnsafe(
+          `DELETE FROM tenants WHERE id = ${tenantId}`,
+        );
+      }
+      await su?.$disconnect();
+      await app?.$disconnect();
+    });
+
+    test("createVaultEntry stores a single value without the whitespace around it", async () => {
+      const { id } = await createVaultEntry(
+        ctx(),
+        { name: "ws-create", value: "abc123TOKEN\n", kind: "asaas" },
+        undefined,
+        undefined,
+        appDb,
+      );
+      expect(await storedValue<string>(id)).toBe("abc123TOKEN");
+    });
+
+    test("updateVaultEntry stores it trimmed too — the path an operator re-saves through", async () => {
+      const { id } = await createVaultEntry(
+        ctx(),
+        { name: "ws-update", value: "first", kind: "generic" },
+        undefined,
+        undefined,
+        appDb,
+      );
+      await updateVaultEntry(ctx(), id, { value: "  abc123TOKEN  " }, appDb);
+      expect(await storedValue<string>(id)).toBe("abc123TOKEN");
+    });
+
+    test("a named-field credential is trimmed per field, on the surface that has no form", async () => {
+      const { id } = await createVaultEntry(
+        ctx(),
+        {
+          name: "ws-fields",
+          value: { publicKey: "pk-123\n", secretKey: " sk-456 " },
+          kind: "langfuse",
+          baseUrl: "https://cloud.langfuse.com",
+        },
+        undefined,
+        undefined,
+        appDb,
+      );
+      expect(await storedValue<Record<string, string>>(id)).toEqual({
+        publicKey: "pk-123",
+        secretKey: "sk-456",
+      });
+    });
+
+    test("a value that is only whitespace is refused as empty, never stored as one", async () => {
+      await expect(
+        createVaultEntry(
+          ctx(),
+          { name: "ws-blank", value: "   \n", kind: "generic" },
+          undefined,
+          undefined,
+          appDb,
+        ),
+      ).rejects.toThrow(/empty/i);
+    });
+
+    test("a named field that is only whitespace is refused, not stored blank", async () => {
+      await expect(
+        createVaultEntry(
+          ctx(),
+          {
+            name: "ws-blank-field",
+            value: { publicKey: "  ", secretKey: "sk" },
+            kind: "langfuse",
+            baseUrl: "https://cloud.langfuse.com",
+          },
+          undefined,
+          undefined,
+          appDb,
+        ),
+      ).rejects.toThrow(/non-empty/i);
+    });
+  },
+);

--- a/tests/modules/vault/value-whitespace.test.ts
+++ b/tests/modules/vault/value-whitespace.test.ts
@@ -3,7 +3,11 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
-import { createVaultEntry, updateVaultEntry } from "@/modules/vault/service";
+import {
+  createVaultEntry,
+  testVaultValue,
+  updateVaultEntry,
+} from "@/modules/vault/service";
 
 // A credential is stored as its exact bytes, and a paste out of a provider's panel routinely carries
 // a newline or a space. An HTTP field value has its surrounding whitespace stripped before any
@@ -54,6 +58,40 @@ const refusal = async (run: () => Promise<unknown>): Promise<AppError> => {
   }
   throw new Error("expected the write to be refused, and it was not");
 };
+
+// Test-on-save answers about the same value the save would store, so the two have to agree. A header
+// kind is the trap: fetch strips the padding on the way out, so probing the raw value would report a
+// working connection for bytes the write refuses.
+describe("test-on-save agrees with the write", () => {
+  const neverCalled = (async () => {
+    throw new Error(
+      "the probe reached the network for a value the write refuses",
+    );
+  }) as unknown as typeof fetch;
+
+  test("a padded value answers with its own code, without probing", async () => {
+    expect(
+      await testVaultValue("asaas", "abc123TOKEN\n", null, {
+        fetchImpl: neverCalled,
+        assertSafe: async (u: string) => new URL(u),
+      }),
+    ).toEqual({ testable: true, ok: false, code: "surrounding_whitespace" });
+  });
+
+  test("a clean value still reaches the probe", async () => {
+    let reached = false;
+    const fetchImpl = (async () => {
+      reached = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const r = await testVaultValue("openai", "sk-secret", null, {
+      fetchImpl,
+      assertSafe: async (u: string) => new URL(u),
+    });
+    expect(reached).toBe(true);
+    expect(r).toEqual({ testable: true, ok: true });
+  });
+});
 
 describe.skipIf(!dbUp)(
   "vault: a value that begins or ends in whitespace",


### PR DESCRIPTION
## What was breaking

A credential whose value is a single string was stored **exactly as typed, whitespace around it
included**. One with named fields was trimmed by the form. Same dialog, same save button, two
different rules, and the server closed neither gap: `validateVaultValue` only asked for a non-empty
string.

Two of the eighteen secret types have named fields (`google_oauth`, `langfuse`). Every other one is a
bare string: `generic`, `bearer_token`, `header`, `query`, `basic_auth`, `asaas`,
`chatwoot_api_token`, `mcp_env`, and each of the model keys.

**Why a pasted newline is unrecoverable rather than untidy.** An HTTP field value has its surrounding
whitespace stripped before any handler sees it, so the whitespace can live on our side and can never
arrive from the other one. The refusal that follows is byte-identical to a wrong token, so the
operator retypes the value on the provider's side and nothing changes. Measured against a real socket
on `main`:

```
store("asaas-webhook-token-2f9c\n")  -> ACCEPTED, stored verbatim
inbound POST with the same token     -> 401 {"error":"Unauthorized"}
```

## The fix: refuse, do not repair

`validateVaultValue` now refuses a value that begins or ends in whitespace, on the single-value path
and per named field, with `errors.vaultSecretWhitespace` and (for a named field) the field's own name.

**Trimming was the first shape of this PR, and review was right to kill it.** For `STATIC_HEADER` the
transport argument holds and trimming is provably safe. For `HMAC_SHA256` it does not: the key never
travels, both sides hold it, and `createHmac` uses the bytes verbatim, so rewriting ours would fail
every signature at the provider instead of here. Any rule that trims some kinds and not others also
reopens this issue for whichever kind the operator picked, since `inboundSecretRef` accepts an entry
of any kind and nothing tells them which kinds trim.

Refusing needs no per-kind exception, changes no stored secret, and hands the operator the one fact
they could not see. It is also the shape this repo already uses at a write boundary (#248, #260,
#244). The console shows it verbatim: `mapSaveError` returns the API message for a 400.

The form's `buildMultiFieldValue()` stops trimming for the same reason. Left in, it would swallow the
refusal in the console while the MCP write surface still got it, which is this issue again in a new
place.

Three consequences that review drew out, each one a place the verdict had to travel to:

- **The sentence names the field, not just `AppError.field`.** `errors.vaultFieldWhitespace` carries
  `{{field}}`, mirroring the pair the catalog already has for the empty case
  (`emptyVaultSecret` / `vaultFieldRequired`). The MCP writer sends `e.message` and the console's save
  path drops the field, so without it a padded Langfuse key refuses with a sentence that cannot say
  which of two inputs to fix — for whitespace, which the operator cannot see.
- **Test-on-save answers with the write's verdict.** `SecretTestFailCode` gains
  `surrounding_whitespace`, returned without touching the network. Probing the raw value would report
  "Connection OK" for a fixed-header kind (fetch strips the padding on the way out) and the save would
  then refuse the same bytes.
- **That verdict is not overridable.** A failed probe relabels Save to "Save anyway", which is right
  for a provider that is down and wrong here: the write refuses every time, so the button advertised
  an action that cannot succeed.

## Validation scope

**Proven by test.** Four spellings of the padding (trailing newline, trailing space, leading space,
tabs on both ends) are refused by name on create; the update path is refused too and the previous
secret is still readable afterwards, so a refused re-save does not damage what was there; a named
field is refused by **its** name on the surface that has no form; and two controls keep the rule
honest, a clean value that stores and an inner space that is kept, because the rule is about the ends
and not about spaces. Five mutations, each on its own, each turning the suite red, with counts that
differ so the tests are not all keying on one thing: a guard that always passes (6 fail), the
single-value check removed (5), the named-field check removed (1), the refusal not naming the field
(1), and **trimming instead of refusing (6)**, which is the one that proves these tests demand a
refusal rather than a normalization.

The probe and the button get the same treatment. Two tests pin the probe: a padded value answers with
its code against a `fetch` that **throws if called**, so "it did not probe" is asserted rather than
assumed, and a clean value still reaches the network. A component test drives the real form and
returns both the Save label **and whether the click wrote**, because label and handler are two reads
of one condition: an earlier version asserted only the label, and the mutation that stops firing
`save(true)` altogether survived it. All three mutations there now fail.

Full suite green on the rebased base (5769 tests), both derived trees compile, no derivation markers
in any touched file.

**Proven live.** The same script on both arms, against a real Postgres and a real socket:

```
base:  store("asaas-webhook-token-2f9c\n") -> ACCEPTED, stored with the newline
       inbound POST -> 401 {"error":"Unauthorized"}

fix:   store("asaas-webhook-token-2f9c\n") -> REFUSED 400 errors.vaultSecretWhitespace
         en: A vault secret must not begin or end with a space or line break. Remove it and save again.
         pt: Um segredo do cofre não pode começar nem terminar com espaço ou quebra de linha. Remova e salve de novo.
       store("asaas-webhook-token-2f9c")   -> ACCEPTED
       inbound POST -> 400 {"error":"invalid JSON body"}   (authentication passed)
```

Auth runs before the body is parsed, so the malformed body separates "refused" from "authenticated"
without persisting anything.

**Not validated, and one deliberate limit.** This governs the write path and reaches **no entry
already stored**: an operator whose credential carries a newline today still has to re-save it, and
nothing tells them which one it is. Repairing them in place would mean decrypting and re-encrypting
every tenant's secrets in a migration, and it is the same silent rewrite this PR just argued against.
The refusal itself was exercised through the service and read back in both locales, not through the
console UI.

Fixes #338
