### PR TITLE
Say a control command was dropped where the operator reads it, not only in the process log

### DIFF
--- a/src/client/lib/flowLabels.ts
+++ b/src/client/lib/flowLabels.ts
@@ -8,8 +8,12 @@ export function flowStageLabel(stage: string, t: TFunction): string {
   switch (stage) {
     case "route":
       return t("logs.stage.route", "Routing");
+    case "command":
+      return t("logs.stage.command", "Control command");
     case "stt":
       return t("logs.stage.stt", "Transcription");
+    case "vision":
+      return t("logs.stage.vision", "Image reading");
     case "embed":
       return t("logs.stage.embed", "Embedding");
     case "debounce":
@@ -18,6 +22,8 @@ export function flowStageLabel(stage: string, t: TFunction): string {
       return t("logs.stage.contact_auth", "Contact authorization");
     case "generate":
       return t("logs.stage.generate", "Generation");
+    case "guardrail":
+      return t("logs.stage.guardrail", "Guardrail check");
     case "tool":
       return t("logs.stage.tool", "Tool call");
     case "normalize":
@@ -28,6 +34,8 @@ export function flowStageLabel(stage: string, t: TFunction): string {
       return t("logs.stage.split", "Delivery");
     case "handoff":
       return t("logs.stage.handoff", "Handoff");
+    case "memory":
+      return t("logs.stage.memory", "Memory");
     default:
       return stage;
   }

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1557,17 +1557,21 @@
       "playground": "Playground"
     },
     "stage": {
+      "command": "Control command",
       "contact_auth": "Contact authorization",
       "debounce": "Message grouping",
       "embed": "Embedding",
       "generate": "Generation",
+      "guardrail": "Guardrail check",
       "handoff": "Handoff",
+      "memory": "Memory",
       "normalize": "Speech rewrite",
       "route": "Routing",
       "split": "Delivery",
       "stt": "Transcription",
       "tool": "Tool call",
-      "tts": "Audio synthesis"
+      "tts": "Audio synthesis",
+      "vision": "Image reading"
     },
     "steps": "{{n}} steps",
     "subtitle": "Per-step execution flow for each agent turn: transcription, generation, audio, delivery and handoffs.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1563,17 +1563,21 @@
       "playground": "Playground"
     },
     "stage": {
+      "command": "Comando de controle",
       "contact_auth": "Autorização do contato",
       "debounce": "Agrupamento de mensagens",
       "embed": "Embedding",
       "generate": "Geração",
+      "guardrail": "Verificação de guardrails",
       "handoff": "Transferência",
+      "memory": "Memória",
       "normalize": "Reescrita para fala",
       "route": "Roteamento",
       "split": "Entrega",
       "stt": "Transcrição",
       "tool": "Chamada de ferramenta",
-      "tts": "Síntese de áudio"
+      "tts": "Síntese de áudio",
+      "vision": "Leitura de imagem"
     },
     "steps": "{{n}} etapas",
     "subtitle": "Fluxo de execução passo a passo de cada turno do agente: transcrição, geração, áudio, entrega e transferências.",

--- a/src/modules/chatwoot/command-route.ts
+++ b/src/modules/chatwoot/command-route.ts
@@ -1,0 +1,36 @@
+// WHICH DELIVERY RUNS A CONTROL COMMAND, WHEN CHATWOOT SENDS THE SAME ONE TWICE.
+//
+// Chatwoot dispatches an incoming message to the conversation's ASSIGNED agent bot and to the
+// inbox's (`agent_bot_listener.rb`), so a command typed once arrives as two deliveries with two
+// route ids. The inbox's persona is the one that runs it — the command is about the agent bound to
+// THIS inbox: it is that agent's memory being cleared and that agent the conversation goes back to.
+//
+// It fails CLOSED on an unresolvable identity, on either side, and the two closed answers are NOT
+// the same fact. `no_persona` means the inbox's agent has no `ChatwootAgentBot` row, so it cannot
+// speak anywhere (every bot-token call goes out with an empty token and comes back 401, issue #79)
+// and EVERY route drops the command: nobody runs it, and waiting does not help. `other_route` means
+// this delivery is not the one — the inbox's persona has an identity and will run it on its own
+// delivery. Measured on the webhook path (issue #317): both were silent, and the process log line
+// said "leaving it to the inbox's persona" for both, which is true of one and misleading for the
+// other.
+// The two answers that DROP the command, carrying what the line reporting them has to name. Returned
+// as data rather than re-derived at the report: a boolean here and a second reading there is exactly
+// the shape issue #270 was, one fact answered twice by two readings that can disagree.
+export type CommandRouteDrop =
+  | { reason: "other_route"; personaBot: number }
+  | { reason: "no_persona" };
+
+export type CommandRoute = { reason: "ours" } | CommandRouteDrop;
+
+export function commandRoute(
+  // The Chatwoot agent-bot id of the persona bound to this conversation's inbox.
+  personaBotId: number | null,
+  // The bot whose webhook route THIS delivery arrived on. Null = unattributed, which is not
+  // evidence that this is the right one.
+  deliveryBotId: number | null,
+): CommandRoute {
+  if (personaBotId === null) return { reason: "no_persona" };
+  if (deliveryBotId === null || deliveryBotId !== personaBotId)
+    return { reason: "other_route", personaBot: personaBotId };
+  return { reason: "ours" };
+}

--- a/src/modules/chatwoot/instance.ts
+++ b/src/modules/chatwoot/instance.ts
@@ -61,6 +61,31 @@ export interface AgentBotIdentity {
   accessToken: string;
 }
 
+// The persona's Chatwoot id, and ONLY that. Deliberately not `loadAgentBot`: that one decrypts the
+// access token on the way out, which a caller that never speaks does not need and cannot survive —
+// a rejected decrypt (a rotated key, a corrupt blob) would escape into whatever path was merely
+// asking WHICH bot. Callers that report rather than act use this one.
+export async function agentBotChatwootId(
+  tenantId: bigint,
+  instanceId: bigint,
+  agentId: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<number | null> {
+  const row = await runScopedOn(base, sysCtx(tenantId), (db) =>
+    db.chatwootAgentBot.findUnique({
+      where: {
+        tenantId_chatwootInstanceId_agentId: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          agentId,
+        },
+      },
+      select: { chatwootAgentBotId: true },
+    }),
+  );
+  return row?.chatwootAgentBotId ?? null;
+}
+
 export async function loadAgentBot(
   tenantId: bigint,
   instanceId: bigint,

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -84,6 +84,7 @@ import {
   resolveDebounceConfig,
 } from "@/modules/debounce/service";
 import { advanceHandledWatermark } from "@/modules/debounce/watermark";
+import { emitCommandDropped } from "@/modules/flowlog/command";
 import { emitFlowEvent } from "@/modules/flowlog/service";
 import { emitUnroutedMessage } from "@/modules/flowlog/unrouted";
 import { armCompaction } from "@/modules/memory/compact";
@@ -104,6 +105,7 @@ import {
 } from "@/modules/vision/service";
 import { hashRouteToken } from "@/modules/webhooks/inbound/route-token";
 import type { ChatwootClient } from "./client";
+import { type CommandRoute, commandRoute } from "./command-route";
 import {
   type AgentBotIdentity,
   loadAgentBot,
@@ -1201,19 +1203,38 @@ async function maybeConsumeCommandOrGate(params: {
   // let a command arriving on ANOTHER persona's route unassign that working bot and hand the
   // conversation to one that cannot speak. The same for a delivery whose own route bot is unknown:
   // an unattributed route is not evidence that this is the right one.
-  const commandBelongsHere = async (): Promise<boolean> => {
-    const ourBotId = (await persona())?.chatwootAgentBotId ?? null;
-    return (
-      ourBotId !== null &&
-      params.agentBotId !== null &&
-      params.agentBotId === ourBotId
-    );
-  };
-  if (command !== null && commandActive && !(await commandBelongsHere())) {
+  //
+  // The two closed answers are not the same fact, and `commandRoute` is where that distinction is
+  // made once: `other_route` leaves the command to a persona that will run it, `no_persona` means
+  // there is no such persona and NO route will. Asking the question as a boolean here and again for
+  // the line that reports it is the #270 shape — one fact, two readings that can disagree.
+  const route: CommandRoute =
+    command !== null && commandActive
+      ? commandRoute(
+          (await persona())?.chatwootAgentBotId ?? null,
+          params.agentBotId,
+        )
+      : { reason: "ours" };
+  if (command !== null && route.reason !== "ours") {
     logger.info(
-      "chatwoot: command not for this route, leaving it to the inbox's persona (conv=%s)",
+      route.reason === "no_persona"
+        ? "chatwoot: /%s dropped (conv=%s) — the inbox's agent has no Chatwoot bot identity, so no route can run it"
+        : "chatwoot: /%s not for this route, leaving it to the inbox's persona (conv=%s)",
+      command,
       String(conversationId),
     );
+    emitCommandDropped({
+      tenantId,
+      conversationRowId: ctx.conv.id,
+      agentId: ctx.agentId,
+      inboxRowId: ctx.conv.inboxId,
+      command,
+      routeBot: params.agentBotId,
+      // The classifier's own answer, carried through: what the row says about the route is the
+      // value that decided it, never a second look at the same two ids.
+      drop: route,
+      base,
+    });
     return true;
   }
 
@@ -2663,21 +2684,6 @@ export async function processChatwootDelivery(
     }
   }
   const commandActive = command !== null && commandMode === "test";
-  // NOTE: A command that will not run is otherwise indistinguishable from ordinary customer text, in the
-  // logs and in the conversation alike — which is what left issue #270 undiagnosable from the
-  // outside. This is the only place that knows all three values the diagnosis needs, and past it
-  // the command is simply gone: `isTeste`/`isReset` are both false, so every later line describes a
-  // plain message. `mode=unresolved` means no inbox on either reading named an agent at all.
-  if (command !== null && !commandActive) {
-    logger.info(
-      "chatwoot: /%s not run (conv=%s) — control commands apply only to a test-mode agent (agent mode=%s, route bot=%s)",
-      command,
-      n.conversationId === null ? "?" : String(n.conversationId),
-      commandMode ?? "unresolved",
-      params.agentBotId === null ? "unknown" : String(params.agentBotId),
-    );
-  }
-
   // Mirror metadata (idempotent, monotonic, per-conversation locked) BEFORE the gate so the
   // runtime reads fresh state. Unconditional: applies to every event, not just actionable ones.
   const mirror = await mirrorChatwootEvent(
@@ -2687,6 +2693,37 @@ export async function processChatwootDelivery(
     base,
     { suppressInboundWatermark: commandActive },
   );
+
+  // NOTE: A command that will not run is otherwise indistinguishable from ordinary customer text, in the
+  // logs and in the conversation alike — which is what left issue #270 undiagnosable from the
+  // outside. This is the only place that knows all three values the diagnosis needs, and past it
+  // the command is simply gone: `isTeste`/`isReset` are both false, so every later line describes a
+  // plain message. `mode=unresolved` means no inbox on either reading named an agent at all.
+  //
+  // BELOW the mirror, and that is the whole reason it sits here rather than where the values are
+  // computed: the row hangs off the conversation, and the conversation row is what the mirror just
+  // created (issue #317). The process line moved with it so one place still knows the fact.
+  if (command !== null && !commandActive) {
+    logger.info(
+      "chatwoot: /%s not run (conv=%s) — control commands apply only to a test-mode agent (agent mode=%s, route bot=%s)",
+      command,
+      n.conversationId === null ? "?" : String(n.conversationId),
+      commandMode ?? "unresolved",
+      params.agentBotId === null ? "unknown" : String(params.agentBotId),
+    );
+    if (mirror.conversationRowId !== null) {
+      emitCommandDropped({
+        tenantId: params.tenantId,
+        conversationRowId: mirror.conversationRowId,
+        agentId: rt?.agentId ?? null,
+        inboxRowId: rt?.inboxId ?? mirror.inboxRowId,
+        command,
+        routeBot: params.agentBotId,
+        drop: { reason: "inactive", mode: commandMode ?? "unresolved" },
+        base,
+      });
+    }
+  }
 
   // Canonical realtime fan-out: only on an applied (non-stale) change, with the
   // post-write snapshot the mirror computed. Metadata only — no PII on the wire.

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -216,27 +216,28 @@ async function inboxAgentRuntime(
   });
 }
 
-// The mode of the agent bound to a conversation's OWN (mirrored) inbox, or null when nothing
-// resolves. Deliberately keyed by the conversation rather than by a payload inbox id: it is the
+// The agent bound to a conversation's OWN (mirrored) inbox — its mode, and the two ids the same
+// query already reads — or null when nothing resolves. Deliberately keyed by the conversation rather
+// than by a payload inbox id: it is the
 // reading `maybeConsumeCommandOrGate` already uses for the test-mode gate, and it exists so the
 // question "is this command active?" and the gate that silences the conversation cannot be answered
 // by two different rows (issue #270).
 //
 // It answers about the AGENT and says nothing about the route, which is the split that keeps this
 // safe. Chatwoot fans one command out to the inbox's persona and to the conversation's assigned bot,
-// so more than one delivery can reach here with the same command; `commandBelongsHere` downstream is
+// so more than one delivery can reach here with the same command; `commandRoute` downstream is
 // the single fence that picks which one runs it and consumes the rest. Answering the route question
 // here too would give the losing delivery `commandActive === false`, which does not defer to that
 // fence — it walks past it and hands the agent "/teste" as ordinary customer text.
 //
 // Only ever called on the path where the payload named no inbox, so the common delivery pays for no
 // extra query.
-async function conversationAgentMode(
+async function conversationAgent(
   tenantId: bigint,
   instanceId: bigint,
   chatwootConversationId: number | null,
   base: PrismaClient,
-): Promise<string | null> {
+): Promise<{ agentId: bigint; inboxId: bigint; mode: string } | null> {
   if (chatwootConversationId == null) return null;
   return runScopedOn(base, sysCtx(tenantId), async (db) => {
     const conv = await db.conversation.findUnique({
@@ -259,7 +260,11 @@ async function conversationAgentMode(
       where: { id: inbox.agentId },
       select: { mode: true },
     });
-    return agent?.mode ?? null;
+    if (!agent) return null;
+    // NOTE: the ids come back with the mode because this query already read them, and the caller needs
+    // them for the same reason it needs the mode: a sparse payload answered by this reading has an
+    // agent, and a line that reports the command without naming it is attributable to nothing.
+    return { agentId: inbox.agentId, inboxId: conv.inboxId, mode: agent.mode };
   });
 }
 
@@ -2665,6 +2670,12 @@ export async function processChatwootDelivery(
   // The fallback can only ever turn a dropped command into an honoured one; it can never make an
   // active command inactive, so no delivery that works today changes.
   let commandMode: string | null = null;
+  // The agent the command was decided against, from whichever of the two readings answered. Named
+  // once and used by the line that reports a dropped one: `rt` is null on the sparse-payload path
+  // even though the stored conversation names an agent there, and reading only `rt` writes a row
+  // attributed to no agent and no inbox, on the one path where the ids cost nothing to keep.
+  let commandAgent: { agentId: bigint; inboxId: bigint } | null =
+    rt !== null ? { agentId: rt.agentId, inboxId: rt.inboxId } : null;
   if (command !== null) {
     if (rt !== null) {
       commandMode = rt.mode;
@@ -2675,12 +2686,15 @@ export async function processChatwootDelivery(
       // that just arrived. The command would then be active for an agent the delivery never reached,
       // the route check would find no persona to match, and it would be consumed without running and
       // without an acknowledgement — a worse silence than the one this fixes.
-      commandMode = await conversationAgentMode(
+      const stored = await conversationAgent(
         params.tenantId,
         params.instanceId,
         n.conversationId,
         base,
       );
+      commandMode = stored?.mode ?? null;
+      if (stored !== null)
+        commandAgent = { agentId: stored.agentId, inboxId: stored.inboxId };
     }
   }
   const commandActive = command !== null && commandMode === "test";
@@ -2716,12 +2730,12 @@ export async function processChatwootDelivery(
     // failure than a command nobody reports, and that state already has #318's `route` line per
     // delivery for the same reason.
     const personaBot =
-      rt !== null
+      commandAgent !== null
         ? ((
             await loadAgentBot(
               params.tenantId,
               params.instanceId,
-              rt.agentId,
+              commandAgent.agentId,
               base,
             )
           )?.chatwootAgentBotId ?? null)
@@ -2740,8 +2754,8 @@ export async function processChatwootDelivery(
       emitCommandDropped({
         tenantId: params.tenantId,
         conversationRowId: mirror.conversationRowId,
-        agentId: rt?.agentId ?? null,
-        inboxRowId: rt?.inboxId ?? mirror.inboxRowId,
+        agentId: commandAgent?.agentId ?? null,
+        inboxRowId: commandAgent?.inboxId ?? mirror.inboxRowId,
         command,
         routeBot: params.agentBotId,
         drop:

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -108,6 +108,7 @@ import type { ChatwootClient } from "./client";
 import { type CommandRoute, commandRoute } from "./command-route";
 import {
   type AgentBotIdentity,
+  agentBotChatwootId,
   loadAgentBot,
   loadChatwootClient,
 } from "./instance";
@@ -2729,16 +2730,28 @@ export async function processChatwootDelivery(
     // nothing here separates two deliveries, and both report the mode: a row twice is the lesser
     // failure than a command nobody reports, and that state already has #318's `route` line per
     // delivery for the same reason.
+    //
+    // BEST-EFFORT, and the id ONLY: this reading exists to report the delivery, and the mirror has
+    // already committed by the time it runs. A rejection escaping here would leave the ledger row on
+    // PROCESSING with nothing running, skip the gate and the turn, and never be retried — Chatwoot
+    // was handed its 200 long before. A line about a dropped command must not be able to drop the
+    // message it is describing, so an unreadable persona degrades to `no_persona`, which reports the
+    // mode and loses only the route distinction.
     const personaBot =
       commandAgent !== null
-        ? ((
-            await loadAgentBot(
-              params.tenantId,
-              params.instanceId,
-              commandAgent.agentId,
-              base,
-            )
-          )?.chatwootAgentBotId ?? null)
+        ? await agentBotChatwootId(
+            params.tenantId,
+            params.instanceId,
+            commandAgent.agentId,
+            base,
+          ).catch((err) => {
+            logger.warn(
+              "chatwoot: persona unreadable for the dropped-command line (conv=%s): %s",
+              n.conversationId === null ? "?" : String(n.conversationId),
+              err instanceof Error ? err.message : String(err),
+            );
+            return null;
+          })
         : null;
     const route = commandRoute(personaBot, params.agentBotId);
     logger.info(

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2704,8 +2704,33 @@ export async function processChatwootDelivery(
   // computed: the row hangs off the conversation, and the conversation row is what the mirror just
   // created (issue #317). The process line moved with it so one place still knows the fact.
   if (command !== null && !commandActive) {
+    // WHO SPEAKS FOR THE COMMAND, asked here too and by the same rule the fence downstream uses for
+    // an active one. Chatwoot fans a message out to the conversation's assigned bot AND the inbox's
+    // (`agent_bots_for`), and both deliveries reach this line: measured live, one `/teste` on a
+    // production agent produced two identical drops, one per route. They are not the same fact —
+    // the inbox's persona is the one the command was about, and the other route only deferred to
+    // it — so each delivery reports what IT did and the pair reads as one command.
+    //
+    // With no persona to compare against (no agent bound, or one with no `ChatwootAgentBot` row)
+    // nothing here separates two deliveries, and both report the mode: a row twice is the lesser
+    // failure than a command nobody reports, and that state already has #318's `route` line per
+    // delivery for the same reason.
+    const personaBot =
+      rt !== null
+        ? ((
+            await loadAgentBot(
+              params.tenantId,
+              params.instanceId,
+              rt.agentId,
+              base,
+            )
+          )?.chatwootAgentBotId ?? null)
+        : null;
+    const route = commandRoute(personaBot, params.agentBotId);
     logger.info(
-      "chatwoot: /%s not run (conv=%s) — control commands apply only to a test-mode agent (agent mode=%s, route bot=%s)",
+      route.reason === "other_route"
+        ? "chatwoot: /%s not for this route, leaving it to the inbox's persona (conv=%s, agent mode=%s, route bot=%s)"
+        : "chatwoot: /%s not run (conv=%s) — control commands apply only to a test-mode agent (agent mode=%s, route bot=%s)",
       command,
       n.conversationId === null ? "?" : String(n.conversationId),
       commandMode ?? "unresolved",
@@ -2719,7 +2744,10 @@ export async function processChatwootDelivery(
         inboxRowId: rt?.inboxId ?? mirror.inboxRowId,
         command,
         routeBot: params.agentBotId,
-        drop: { reason: "inactive", mode: commandMode ?? "unresolved" },
+        drop:
+          route.reason === "other_route"
+            ? route
+            : { reason: "inactive", mode: commandMode ?? "unresolved" },
         base,
       });
     }

--- a/src/modules/flowlog/command.ts
+++ b/src/modules/flowlog/command.ts
@@ -1,0 +1,69 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+import type { CommandRouteDrop } from "@/modules/chatwoot/command-route";
+import type { ControlCommand } from "@/modules/chatwoot/normalize";
+import { emitFlowEvent } from "./service";
+
+// A CONTROL COMMAND THE DELIVERY DID NOT RUN, AND THE ONE LINE THAT SAYS SO.
+//
+// `/teste` and `/reset` are the operator driving the tooling from inside the conversation. When one
+// does not run, the message is simply gone: past the two gates below every later line describes a
+// plain message, and the conversation looks exactly like an agent that is merely quiet. #311 gave
+// the first gate a process log line, which is not what an operator reads when they are asking why
+// nothing happened; #274 settled that the operator-facing signal for a silence is the `ExecutionLog`
+// row, because that is what the Logs page shows (issue #317).
+//
+// The three reasons are the three measured drops, and they are deliberately one vocabulary rather
+// than a line per gate — the operator's question is "did my command run?", asked once:
+//
+//   inactive     the agent this delivery resolved is not in `test` mode, so the command is ordinary
+//                customer text by design. `mode` carries which mode said so, and `unresolved` means
+//                no inbox on either reading named an agent at all.
+//   other_route  the delivery arrived on another persona's route and left the command to the
+//                inbox's own persona, which runs it on its own delivery. Correct behaviour.
+//   no_persona   the inbox's agent has no Chatwoot identity, so EVERY route fails closed and the
+//                command runs nowhere.
+//
+// `info`, except `no_persona`. Level is what an alert channel filters on, so it is the whole
+// difference between a signal and a page every time an operator types `/teste` at a production
+// agent: two of these are things the operator can see and fix from the row itself, and the third is
+// a misconfiguration that silently eats every command until someone repairs the binding.
+export type CommandDrop =
+  | { reason: "inactive"; mode: string }
+  | CommandRouteDrop;
+
+export function emitCommandDropped(args: {
+  tenantId: bigint;
+  // The mirrored conversation row, so the line hangs off the conversation the command was typed in.
+  conversationRowId: bigint;
+  // Null exactly when no agent resolved — the row then names the inbox instead, the same way the
+  // unrouted line does.
+  agentId: bigint | null;
+  inboxRowId: bigint | null;
+  command: ControlCommand;
+  // The bot whose webhook route this delivery arrived on, null when unattributed.
+  routeBot: number | null;
+  drop: CommandDrop;
+  base?: PrismaClient;
+}): void {
+  emitFlowEvent(
+    {
+      tenantId: args.tenantId,
+      turnId: crypto.randomUUID(),
+      source: "inbox",
+      conversationId: args.conversationRowId,
+      agentId: args.agentId,
+      inboxId: args.inboxRowId,
+      base: args.base,
+    },
+    {
+      stage: "command",
+      level: args.drop.reason === "no_persona" ? "warn" : "info",
+      status: "skipped",
+      detail: {
+        command: args.command,
+        ...args.drop,
+        ...(args.routeBot !== null ? { routeBot: args.routeBot } : {}),
+      },
+    },
+  );
+}

--- a/src/modules/flowlog/stages.ts
+++ b/src/modules/flowlog/stages.ts
@@ -8,6 +8,10 @@ export const FLOW_STAGES = [
   // inbox. It writes only when there is none — an inbox nobody bound consumes the message and
   // answers nothing, and until issue #318 the only trace was a process log line.
   "route",
+  // A control command (`/teste`, `/reset`) the delivery did NOT run. Also before the turn, and for
+  // the same reason as `route`: past the gate the command is gone and every later line describes a
+  // plain message, so the console had nothing to show for it (issue #317).
+  "command",
   "stt", // inbound voice-note transcription
   "vision", // inbound image/document extraction
   "embed", // RAG embedding (search / ingest)

--- a/tests/modules/chatwoot-command-active-e2e.test.ts
+++ b/tests/modules/chatwoot-command-active-e2e.test.ts
@@ -479,9 +479,9 @@ describe.skipIf(!dbUp)("control commands: one reading of the agent", () => {
     });
     expect(row?.testActivatedAt).toBeNull();
     expect(posted.filter((p) => p.conversationId === 6010)).toEqual([]);
-    expect(
-      lines.some((c) => String(c[0]).includes("command not for this route")),
-    ).toBe(true);
+    expect(lines.some((c) => String(c[0]).includes("not for this route"))).toBe(
+      true,
+    );
     expect(lines.some((c) => String(c[0]).includes("not run"))).toBe(false);
   });
 });

--- a/tests/modules/chatwoot-command-dropped.test.ts
+++ b/tests/modules/chatwoot-command-dropped.test.ts
@@ -166,11 +166,17 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
     inboxId: number,
     content: string,
     agentBotId: number | null,
-    // The SAME Chatwoot message, redelivered on another bot's route: that is the fan-out, not a
-    // second command (`agent_bots_for` sends one message to the conversation's assigned bot and to
-    // the inbox's).
-    sameMessage = false,
+    over: {
+      // The SAME Chatwoot message, redelivered on another bot's route: that is the fan-out, not a
+      // second command (`agent_bots_for` sends one message to the conversation's assigned bot and
+      // to the inbox's).
+      sameMessage?: boolean;
+      // A payload that names no inbox ANYWHERE, which is the shape issue #270's fallback exists
+      // for: the agent is resolved from the conversation the mirror already stored.
+      sparse?: boolean;
+    } = {},
   ): Promise<void> {
+    const { sameMessage = false, sparse = false } = over;
     deliverySeq += 1;
     if (!sameMessage) messageSeq += 1;
     stamp += 1;
@@ -183,7 +189,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
       sender: { id: 77, name: "Operadora", type: null },
       conversation: {
         id: convId,
-        inbox_id: inboxId,
+        ...(sparse ? {} : { inbox_id: inboxId }),
         status: "pending",
         contact_inbox: { id: 91_000 + convId },
         meta: { assignee: null, sender: { id: 77, name: "Operadora" } },
@@ -213,9 +219,12 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
     });
   }
 
-  // Scoped to the conversation by its INTERNAL id, and polled: the emit is fire-and-forget, so an
-  // unscoped read answers with a neighbour's row and an unpolled one races the write it asserts.
-  async function commandRows(convId: number, waitMs = 2000) {
+  // Scoped to the conversation by its INTERNAL id, and polled for the count the test EXPECTS: the
+  // emit is fire-and-forget, so an unscoped read answers with a neighbour's row and one that stops
+  // at the first row reads the fan-out's first delivery while the second is still in flight, then
+  // calls that the answer. Zero is the same rule from the other side: nothing to wait for, so the
+  // window is spent before reading rather than short-circuited.
+  async function commandRows(convId: number, expected: number, waitMs = 2000) {
     const conv = await suDb.conversation.findFirst({
       where: { tenantId, chatwootConversationId: convId },
       select: { id: true },
@@ -227,14 +236,15 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
         where: { tenantId, stage: "command", conversationId: conv.id },
         orderBy: { id: "asc" },
       });
-      if (rows.length > 0 || Date.now() > deadline) return rows;
+      if (expected > 0 && rows.length >= expected) return rows;
+      if (Date.now() > deadline) return rows;
       await new Promise((r) => setTimeout(r, 50));
     }
   }
 
   test("a command at a production agent is ordinary text, and the line says which mode dropped it", async () => {
     await deliver(9201, PROD_INBOX, "/teste", OUR_BOT);
-    const rows = await commandRows(9201);
+    const rows = await commandRows(9201, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("info");
     expect(rows[0]?.status).toBe("skipped");
@@ -249,7 +259,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
 
   test("a command at an inbox nobody bound names the mode as unresolved", async () => {
     await deliver(9301, UNBOUND_INBOX, "/reset", OUR_BOT);
-    const rows = await commandRows(9301);
+    const rows = await commandRows(9301, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.detail).toMatchObject({
       command: "reset",
@@ -270,7 +280,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
 
   test("a delivery on another persona's route says it left the command to the inbox's", async () => {
     await deliver(9101, TEST_INBOX, "/teste", OTHER_BOT);
-    const rows = await commandRows(9101);
+    const rows = await commandRows(9101, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("info");
     expect(rows[0]?.detail).toMatchObject({
@@ -286,7 +296,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
   // misconfiguration to repair rather than a route deferring to its sibling.
   test("an inbox whose agent has no bot identity drops the command on every route, at warn", async () => {
     await deliver(9401, NO_PERSONA_INBOX, "/teste", OUR_BOT);
-    const rows = await commandRows(9401);
+    const rows = await commandRows(9401, 1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("warn");
     expect(rows[0]?.status).toBe("skipped");
@@ -303,8 +313,8 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
   // stopped it, the other route reports that it deferred.
   test("the fan-out reports one command, not the same drop twice", async () => {
     await deliver(9202, PROD_INBOX, "/teste", OUR_BOT);
-    await deliver(9202, PROD_INBOX, "/teste", OTHER_BOT, true);
-    const rows = await commandRows(9202);
+    await deliver(9202, PROD_INBOX, "/teste", OTHER_BOT, { sameMessage: true });
+    const rows = await commandRows(9202, 2);
     expect(rows).toHaveLength(2);
     expect(
       rows.map((r) => (r.detail as { reason: string }).reason).sort(),
@@ -319,15 +329,42 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
     });
   });
 
+  // The sparse-payload path (#270): no inbox anywhere on the event, so `inboxAgentRuntime` answers
+  // nothing and the agent comes from the conversation the mirror already stored. The row has to name
+  // that agent, and the route question has to be asked against ITS persona — reading only the
+  // payload's runtime writes a row attributed to nobody, and calls both fan-out deliveries the same
+  // drop, on the one path where the ids cost nothing to keep.
+  test("a sparse payload names the agent the conversation stored", async () => {
+    await deliver(9203, PROD_INBOX, "bom dia", OUR_BOT);
+    await deliver(9203, PROD_INBOX, "/teste", OUR_BOT, { sparse: true });
+    await deliver(9203, PROD_INBOX, "/teste", OTHER_BOT, {
+      sparse: true,
+      sameMessage: true,
+    });
+    const rows = await commandRows(9203, 2);
+    expect(rows).toHaveLength(2);
+    for (const r of rows) expect(r.agentId).toBe(prodAgentId);
+    expect(
+      rows.map((r) => (r.detail as { reason: string }).reason).sort(),
+    ).toEqual(["inactive", "other_route"]);
+    const inactive = rows.find(
+      (r) => (r.detail as { reason: string }).reason === "inactive",
+    );
+    expect(inactive?.detail).toMatchObject({
+      mode: "production",
+      routeBot: OUR_BOT,
+    });
+  });
+
   test("a command that RUNS writes no dropped line", async () => {
     await deliver(9102, TEST_INBOX, "/teste", OUR_BOT);
-    const rows = await commandRows(9102, 400);
+    const rows = await commandRows(9102, 0, 400);
     expect(rows).toHaveLength(0);
   });
 
   test("an ordinary message writes no dropped line", async () => {
     await deliver(9103, PROD_INBOX, "bom dia", OUR_BOT);
-    const rows = await commandRows(9103, 400);
+    const rows = await commandRows(9103, 0, 400);
     expect(rows).toHaveLength(0);
   });
 });

--- a/tests/modules/chatwoot-command-dropped.test.ts
+++ b/tests/modules/chatwoot-command-dropped.test.ts
@@ -166,9 +166,13 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
     inboxId: number,
     content: string,
     agentBotId: number | null,
+    // The SAME Chatwoot message, redelivered on another bot's route: that is the fan-out, not a
+    // second command (`agent_bots_for` sends one message to the conversation's assigned bot and to
+    // the inbox's).
+    sameMessage = false,
   ): Promise<void> {
     deliverySeq += 1;
-    messageSeq += 1;
+    if (!sameMessage) messageSeq += 1;
     stamp += 1;
     const n = normalizeChatwootEvent({
       event: "message_created",
@@ -290,6 +294,28 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
       command: "teste",
       reason: "no_persona",
       routeBot: OUR_BOT,
+    });
+  });
+
+  // Measured live before this was written: one `/teste` on a production agent whose conversation is
+  // assigned to another persona's bot produced TWO identical `inactive` rows, one per route. They
+  // are not the same fact, and the pair now reads as one command: the inbox's persona reports what
+  // stopped it, the other route reports that it deferred.
+  test("the fan-out reports one command, not the same drop twice", async () => {
+    await deliver(9202, PROD_INBOX, "/teste", OUR_BOT);
+    await deliver(9202, PROD_INBOX, "/teste", OTHER_BOT, true);
+    const rows = await commandRows(9202);
+    expect(rows).toHaveLength(2);
+    expect(
+      rows.map((r) => (r.detail as { reason: string }).reason).sort(),
+    ).toEqual(["inactive", "other_route"]);
+    const deferred = rows.find(
+      (r) => (r.detail as { reason: string }).reason === "other_route",
+    );
+    expect(deferred?.detail).toMatchObject({
+      command: "teste",
+      routeBot: OTHER_BOT,
+      personaBot: OUR_BOT,
     });
   });
 

--- a/tests/modules/chatwoot-command-dropped.test.ts
+++ b/tests/modules/chatwoot-command-dropped.test.ts
@@ -1,0 +1,307 @@
+// A CONTROL COMMAND THAT DID NOT RUN, AND THE LINE THAT SAYS SO.
+//
+// `/teste` and `/reset` are the operator driving the tooling from inside the conversation, and a
+// delivery drops one in three measured ways: the agent it resolved is not in `test` mode (issue
+// #270's dead end, and the ordinary case of an operator typing `/teste` at a production agent), the
+// delivery arrived on another persona's route and leaves the command to the inbox's own persona
+// (correct behaviour), or the inbox's agent has no Chatwoot bot identity at all, in which case EVERY
+// route fails closed and the command runs nowhere.
+//
+// All three end the same way from the outside: the operator types the command and nothing happens.
+// #311 gave the first one a process log line, which is not what an operator reads; #274 settled that
+// the operator-facing signal for a silence is the `ExecutionLog` row, because that is what the Logs
+// page shows. This file asserts that row (issue #317).
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
+import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+// Never seeded: the mirror creates it, which is what makes an unbound inbox a real row.
+const UNBOUND_INBOX = 93;
+const PROD_INBOX = 92;
+const TEST_INBOX = 91;
+const NO_PERSONA_INBOX = 94;
+// The bot whose webhook route the delivery arrived on, and one that belongs to nobody here.
+const OUR_BOT = 9;
+const OTHER_BOT = 8;
+
+let tenantId = 0n;
+let instanceId = 0n;
+let testAgentId = 0n;
+let prodAgentId = 0n;
+let deliverySeq = 0;
+let messageSeq = 9000;
+let stamp = Math.floor(Date.now() / 1000);
+const realFetch = globalThis.fetch;
+
+describe.skipIf(!dbUp)("a control command that did not run says so", () => {
+  beforeAll(async () => {
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof globalThis.fetch;
+
+    const t = await suDb.tenant.create({
+      data: { name: "CD", slug: `cd-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 33,
+      baseUrl: "https://chat.dropped.example",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+
+    const mkAgent = async (name: string, mode: string) =>
+      (
+        await suDb.agent.create({
+          data: {
+            tenantId,
+            name,
+            mode,
+            systemPrompt: "Você é prestativa.",
+            modelConfig: { provider: "openai", model: "gpt-5.4-mini" },
+            settings: { debounce: { enabled: false } },
+          },
+          select: { id: true },
+        })
+      ).id;
+    const bind = async (
+      agentId: bigint,
+      chatwootInboxId: number,
+      name: string,
+    ) =>
+      suDb.inbox.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootInboxId,
+          name,
+          agentId,
+        },
+      });
+
+    testAgentId = await mkAgent("Teste", "test");
+    prodAgentId = await mkAgent("Producao", "production");
+    // The agent with no Chatwoot identity: bound to an inbox, in test mode, and unable to speak
+    // anywhere — every bot-token call it makes goes out with an empty token (issue #79).
+    const orphanAgentId = await mkAgent("SemPersona", "test");
+    for (const agentId of [testAgentId, prodAgentId]) {
+      await suDb.chatwootAgentBot.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          agentId,
+          chatwootAgentBotId: OUR_BOT,
+          accessToken: encryptJson("BOT"),
+          webhookSecret: encryptJson("S"),
+          webhookRouteTokenHash: `cd-${agentId}-${process.pid}`,
+          name: "bot",
+        },
+      });
+    }
+    await bind(testAgentId, TEST_INBOX, "Teste");
+    await bind(prodAgentId, PROD_INBOX, "Producao");
+    await bind(orphanAgentId, NO_PERSONA_INBOX, "SemPersona");
+  });
+
+  afterAll(async () => {
+    globalThis.fetch = realFetch;
+    if (!dbUp) return;
+    for (const table of [
+      "execution_logs",
+      "scheduler_jobs",
+      "chatwoot_webhook_deliveries",
+      "conversations",
+      "contacts",
+      "inboxes",
+      "chatwoot_agent_bots",
+      "agents",
+      "chatwoot_instances",
+      "chatwoot_deployments",
+    ]) {
+      await suDb
+        .$executeRawUnsafe(`DELETE FROM ${table} WHERE tenant_id = ${tenantId}`)
+        .catch(() => {});
+    }
+    await suDb.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  // Open gate throughout: `pending` with nobody assigned is the state a command arrives in.
+  async function deliver(
+    convId: number,
+    inboxId: number,
+    content: string,
+    agentBotId: number | null,
+  ): Promise<void> {
+    deliverySeq += 1;
+    messageSeq += 1;
+    stamp += 1;
+    const n = normalizeChatwootEvent({
+      event: "message_created",
+      id: messageSeq,
+      private: false,
+      content,
+      message_type: "incoming",
+      sender: { id: 77, name: "Operadora", type: null },
+      conversation: {
+        id: convId,
+        inbox_id: inboxId,
+        status: "pending",
+        contact_inbox: { id: 91_000 + convId },
+        meta: { assignee: null, sender: { id: 77, name: "Operadora" } },
+        channel: "Channel::Api",
+        last_activity_at: Math.floor(Date.now() / 1000),
+        updated_at: stamp,
+      },
+    });
+    if (!n) throw new Error("payload did not normalize");
+    const delivery = await suDb.chatwootWebhookDelivery.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        deliveryId: `cd-${process.pid}-${deliverySeq}`,
+        event: "message_created",
+        status: "PENDING",
+      },
+      select: { id: true },
+    });
+    await processChatwootDelivery({
+      tenantId,
+      instanceId,
+      deliveryRowId: delivery.id,
+      agentBotId,
+      normalized: n,
+      base: appDb,
+    });
+  }
+
+  // Scoped to the conversation by its INTERNAL id, and polled: the emit is fire-and-forget, so an
+  // unscoped read answers with a neighbour's row and an unpolled one races the write it asserts.
+  async function commandRows(convId: number, waitMs = 2000) {
+    const conv = await suDb.conversation.findFirst({
+      where: { tenantId, chatwootConversationId: convId },
+      select: { id: true },
+    });
+    if (!conv) return [];
+    const deadline = Date.now() + waitMs;
+    for (;;) {
+      const rows = await suDb.executionLog.findMany({
+        where: { tenantId, stage: "command", conversationId: conv.id },
+        orderBy: { id: "asc" },
+      });
+      if (rows.length > 0 || Date.now() > deadline) return rows;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+
+  test("a command at a production agent is ordinary text, and the line says which mode dropped it", async () => {
+    await deliver(9201, PROD_INBOX, "/teste", OUR_BOT);
+    const rows = await commandRows(9201);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("info");
+    expect(rows[0]?.status).toBe("skipped");
+    expect(rows[0]?.agentId).toBe(prodAgentId);
+    expect(rows[0]?.detail).toMatchObject({
+      command: "teste",
+      reason: "inactive",
+      mode: "production",
+      routeBot: OUR_BOT,
+    });
+  });
+
+  test("a command at an inbox nobody bound names the mode as unresolved", async () => {
+    await deliver(9301, UNBOUND_INBOX, "/reset", OUR_BOT);
+    const rows = await commandRows(9301);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.detail).toMatchObject({
+      command: "reset",
+      reason: "inactive",
+      mode: "unresolved",
+    });
+    // The two lines answer different questions and both belong: `route` says nothing will ever
+    // answer this inbox, `command` says the command the operator typed is gone.
+    const conv = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: 9301 },
+      select: { id: true },
+    });
+    const route = await suDb.executionLog.findMany({
+      where: { tenantId, stage: "route", conversationId: conv.id },
+    });
+    expect(route).toHaveLength(1);
+  });
+
+  test("a delivery on another persona's route says it left the command to the inbox's", async () => {
+    await deliver(9101, TEST_INBOX, "/teste", OTHER_BOT);
+    const rows = await commandRows(9101);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("info");
+    expect(rows[0]?.detail).toMatchObject({
+      command: "teste",
+      reason: "other_route",
+      routeBot: OTHER_BOT,
+      personaBot: OUR_BOT,
+    });
+  });
+
+  // The one state nobody recovers from by waiting: with no identity on the inbox's agent, the fence
+  // fails closed on EVERY route, so no delivery runs the command. `warn`, because it is a
+  // misconfiguration to repair rather than a route deferring to its sibling.
+  test("an inbox whose agent has no bot identity drops the command on every route, at warn", async () => {
+    await deliver(9401, NO_PERSONA_INBOX, "/teste", OUR_BOT);
+    const rows = await commandRows(9401);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.level).toBe("warn");
+    expect(rows[0]?.status).toBe("skipped");
+    expect(rows[0]?.detail).toMatchObject({
+      command: "teste",
+      reason: "no_persona",
+      routeBot: OUR_BOT,
+    });
+  });
+
+  test("a command that RUNS writes no dropped line", async () => {
+    await deliver(9102, TEST_INBOX, "/teste", OUR_BOT);
+    const rows = await commandRows(9102, 400);
+    expect(rows).toHaveLength(0);
+  });
+
+  test("an ordinary message writes no dropped line", async () => {
+    await deliver(9103, PROD_INBOX, "bom dia", OUR_BOT);
+    const rows = await commandRows(9103, 400);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/tests/modules/chatwoot-command-dropped.test.ts
+++ b/tests/modules/chatwoot-command-dropped.test.ts
@@ -47,6 +47,9 @@ const UNBOUND_INBOX = 93;
 const PROD_INBOX = 92;
 const TEST_INBOX = 91;
 const NO_PERSONA_INBOX = 94;
+// An inbox whose persona row exists but whose stored token cannot be decrypted (a rotated key, a
+// corrupt blob). The line about the dropped command must not read it, and must not die trying.
+const BAD_TOKEN_INBOX = 95;
 // The bot whose webhook route the delivery arrived on, and one that belongs to nobody here.
 const OUR_BOT = 9;
 const OTHER_BOT = 8;
@@ -134,6 +137,22 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
     await bind(testAgentId, TEST_INBOX, "Teste");
     await bind(prodAgentId, PROD_INBOX, "Producao");
     await bind(orphanAgentId, NO_PERSONA_INBOX, "SemPersona");
+
+    const badTokenAgentId = await mkAgent("TokenPodre", "production");
+    await suDb.chatwootAgentBot.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        agentId: badTokenAgentId,
+        chatwootAgentBotId: OUR_BOT,
+        // NOT an encryptJson blob: decrypting this throws.
+        accessToken: "nao-e-um-blob-cifrado",
+        webhookSecret: encryptJson("S"),
+        webhookRouteTokenHash: `cd-bad-${process.pid}`,
+        name: "bot",
+      },
+    });
+    await bind(badTokenAgentId, BAD_TOKEN_INBOX, "TokenPodre");
   });
 
   afterAll(async () => {
@@ -354,6 +373,25 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
       mode: "production",
       routeBot: OUR_BOT,
     });
+  });
+
+  // The line reports the delivery; it must not be able to drop it. The persona's token is
+  // undecryptable here, which is what `loadAgentBot` would have thrown on — after the mirror
+  // committed, leaving the ledger row on PROCESSING with nothing running and no upstream retry.
+  test("an unreadable persona still writes the line, and the delivery finishes", async () => {
+    await deliver(9501, BAD_TOKEN_INBOX, "/teste", OUR_BOT);
+    const rows = await commandRows(9501, 1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.detail).toMatchObject({
+      command: "teste",
+      reason: "inactive",
+      mode: "production",
+    });
+    const delivery = await suDb.chatwootWebhookDelivery.findFirstOrThrow({
+      where: { tenantId, deliveryId: `cd-${process.pid}-${deliverySeq}` },
+      select: { status: true },
+    });
+    expect(delivery.status).toBe("PROCESSED");
   });
 
   test("a command that RUNS writes no dropped line", async () => {

--- a/tests/modules/chatwoot-command-route.test.ts
+++ b/tests/modules/chatwoot-command-route.test.ts
@@ -1,0 +1,45 @@
+// WHICH DELIVERY RUNS THE COMMAND: the decision table.
+//
+// Chatwoot fans one command out to the conversation's assigned bot AND the inbox's, so the same
+// `/teste` arrives twice with two route ids and exactly one delivery may run it. The fence fails
+// CLOSED on an unresolvable identity on either side, and the two closed answers mean different
+// things to whoever reads the log line: one delivery deferring to a persona that will run it, versus
+// no persona existing at all and every route dropping the command (issue #317).
+import { describe, expect, test } from "bun:test";
+import {
+  type CommandRoute,
+  commandRoute,
+} from "@/modules/chatwoot/command-route";
+
+describe("commandRoute", () => {
+  const cases: [
+    label: string,
+    personaBotId: number | null,
+    deliveryBotId: number | null,
+    expected: CommandRoute["reason"],
+  ][] = [
+    ["the inbox's own persona, on its own route", 9, 9, "ours"],
+    ["another persona's route", 9, 8, "other_route"],
+    // Fails closed: an unattributed route is not evidence that this is the right one, and the
+    // persona's own delivery still carries its id.
+    ["an unattributed route, persona known", 9, null, "other_route"],
+    // No identity on the inbox's agent: EVERY route lands here, so nobody runs the command.
+    ["no persona identity, delivery attributed", null, 9, "no_persona"],
+    ["no persona identity, unattributed route", null, null, "no_persona"],
+    // The id belonging to nobody is still not ours: equality is the whole test, never truthiness.
+    ["persona 0, delivery 0", 0, 0, "ours"],
+    ["persona 0, delivery 9", 0, 9, "other_route"],
+  ];
+
+  for (const [label, persona, delivery, expected] of cases) {
+    test(`${label} → ${expected}`, () => {
+      const route = commandRoute(persona, delivery);
+      expect(route.reason).toBe(expected);
+      // The id the line reports comes back WITH the verdict, so the report cannot read the ids a
+      // second time and answer something else.
+      expect("personaBot" in route ? route.personaBot : null).toBe(
+        expected === "other_route" ? persona : null,
+      );
+    });
+  }
+});

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -161,6 +161,7 @@ const FLOWLOG_READERS: Record<string, number> = {
   "tests/graph/runtime.test.ts": 7,
   "tests/graph/side-effect-flowlog.test.ts": 1,
   "tests/graph/tool-flowlog.test.ts": 1,
+  "tests/modules/chatwoot-command-dropped.test.ts": 2,
   "tests/modules/chatwoot-gate-trail.test.ts": 1,
   "tests/modules/chatwoot-inbox-remove.test.ts": 1,
   "tests/modules/chatwoot-unbound-inbox.test.ts": 1,

--- a/tests/modules/flowlog-stage-labels.test.ts
+++ b/tests/modules/flowlog-stage-labels.test.ts
@@ -1,0 +1,77 @@
+// EVERY STAGE IN THE CLOSED VOCABULARY HAS A LABEL, AND THE FENCE THAT KEEPS IT THAT WAY.
+//
+// `FLOW_STAGES` is read by five places, and four of them derive their list from it directly (the
+// alert-channel validator, the /stages endpoint, the MCP enums, the channel picker) — adding a stage
+// reaches those for free. The fifth is `flowStageLabel`, which is a switch: a stage with no `case`
+// falls through to `default` and the Logs page renders the raw slug in the filter dropdown and on
+// every row. Nothing breaks, nothing is red, and the operator reads `contact_auth`.
+//
+// Measured on `main` while adding the `command` stage for issue #317: 11 labels for 14 stages —
+// `vision`, `guardrail` and `memory` were each added by a round that reached the four derived
+// readers and not this one. This is the per-call-site shape from the process skill: fixing only the
+// stage of the day guarantees the next one is born unlabelled, so the criterion is the sweep.
+import { describe, expect, test } from "bun:test";
+import { FLOW_STAGES } from "@/modules/flowlog/stages";
+
+const LABELS_FILE = "src/client/lib/flowLabels.ts";
+
+// The `case` values of ONE function in the file. Sliced by function, not read whole: `flowLevelLabel`
+// lives in the same source and its cases would otherwise count as stages.
+export function labelledCases(source: string, fn: string): string[] {
+  const start = source.indexOf(`export function ${fn}(`);
+  if (start === -1) return [];
+  const rest = source.slice(start + 1);
+  const end = rest.indexOf("\nexport function ");
+  const body = end === -1 ? rest : rest.slice(0, end);
+  return [...body.matchAll(/\bcase\s+"([a-z_]+)"\s*:/g)].map(
+    (m) => m[1] as string,
+  );
+}
+
+describe("the stage label sweep", () => {
+  // Control positive: the predicate has to SEE a missing case, and has to stay inside its function.
+  test("the predicate reads cases from the function it was asked for", () => {
+    const fixture = `
+export function flowStageLabel(stage: string, t: TFunction): string {
+  switch (stage) {
+    case "route":
+      return t("logs.stage.route", "Routing");
+    case "stt":
+      return t("logs.stage.stt", "Transcription");
+    default:
+      return stage;
+  }
+}
+
+export function flowLevelLabel(level: string, t: TFunction): string {
+  switch (level) {
+    case "warn":
+      return t("logs.level.warn", "Warning");
+    default:
+      return level;
+  }
+}
+`;
+    expect(labelledCases(fixture, "flowStageLabel")).toEqual(["route", "stt"]);
+    expect(labelledCases(fixture, "flowLevelLabel")).toEqual(["warn"]);
+    expect(labelledCases(fixture, "nothingHere")).toEqual([]);
+  });
+
+  test("every stage in the vocabulary has a label case", async () => {
+    // Read at assertion time, never a snapshot: a fence generated from the source it fences goes
+    // green against its own copy of yesterday's file.
+    const source = await Bun.file(LABELS_FILE).text();
+    const labelled = new Set(labelledCases(source, "flowStageLabel"));
+    const missing = FLOW_STAGES.filter((s) => !labelled.has(s));
+    expect(missing).toEqual([]);
+  });
+
+  test("no label case names a stage the vocabulary dropped", async () => {
+    const source = await Bun.file(LABELS_FILE).text();
+    const known = new Set<string>(FLOW_STAGES);
+    const stale = labelledCases(source, "flowStageLabel").filter(
+      (s) => !known.has(s),
+    );
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #317

## What happens

`/teste` and `/reset` are the operator driving the tooling from inside the conversation. When a delivery drops one, the message is simply gone: past the gate `isTeste` and `isReset` are both false, every later line describes a plain message, and the conversation looks exactly like an agent that is merely quiet. #311 gave one of those drops a process log line; #274 settled that the operator-facing signal for a silence is the `ExecutionLog` row, because that is what the Logs page reads.

Measured on `main`, driving the real webhook path against a seeded database, one delivery per state:

| state | command runs? | what the console shows today |
| --- | --- | --- |
| the inbox is bound to no agent | no | `route` / `no_agent` (warn), from #318. Says nothing about the command |
| the agent is in `production` | no, it is ordinary customer text | nothing |
| the delivery arrived on another persona's route | yes, on the inbox persona's own delivery | nothing |
| the delivery's route bot is unattributed | yes, same as above | nothing |
| **the inbox's agent has no `ChatwootAgentBot` row** | **no, on every route** | **nothing** |

## What of the report does not hold, and what it missed

**The first state is not invisible.** #318 already writes a `route` / `no_agent` warn row for that delivery, and that row names the inbox, which is the repair. It does not name the command, so a row is still owed, but "today the console cannot separate them" is not true of that one.

**The three states are not one gate.** The first two are `commandActive === false`, where #311 writes its line. The third is a different fence, further in (`commandBelongsHere`), which is why a row emitted only "where #311 writes its log line" would have covered two of the three.

**A fourth state was not in the report, and it is the only one nobody recovers from.** The route fence fails closed on an unresolvable identity on either side, and the two closed answers are not the same fact. When the inbox's agent has no `ChatwootAgentBot` row it cannot speak anywhere (every bot-token call goes out with an empty token and comes back 401, #79), so **every** route drops the command and no delivery runs it. The process log line said `leaving it to the inbox's persona` for that case too, which is true of the sibling-route case and misleading here.

## The fix

A `command` stage, emitted from one shared reading at both drop points, with the three reasons as a closed vocabulary: `inactive` (with the mode that said so, `unresolved` when no inbox on either reading named an agent), `other_route`, `no_persona`.

**One command, one reading of who speaks for it.** Chatwoot fans a message out to the conversation's assigned bot AND to the inbox's (`agent_bots_for`), so both deliveries reach the inactive-command line. The route question therefore runs at that drop too, not only at the fence downstream, and each delivery reports what IT did: the inbox's persona names what stopped the command, the other route says it deferred to that persona. One state still writes the same reason twice, and it is named in the code rather than left to be rediscovered: with no persona at all on the inbox's agent, nothing on this side separates the two deliveries, and the choice there is a row twice or a command nobody reports.

`commandRoute` is a pure function with a decision table, and it returns the verdict **with** the id the line reports rather than a boolean the report then re-derives from the same two ids: a boolean here and a second reading there is the #270 shape, one fact answered twice by two readings that can disagree.

**The level answers the question the issue asked.** Level is what an alert channel filters on (`emitFlowEvent` dispatches alerts for warn/error on real traffic), so it is the whole difference between a signal and a page every time someone types `/teste` at a production agent. `info` for the two an operator reads and fixes from the row, `warn` only for `no_persona`, which silently eats every command until the binding is repaired.

**The stage label sweep came with it.** `FLOW_STAGES` is read in five places and four of them derive their list from it, so a new stage reaches those for free. The fifth is `flowStageLabel`, a switch whose `default` returns the raw slug: measured while adding this one, 11 labels for 14 stages, with `vision`, `guardrail` and `memory` each added by a round that reached the four and not this one. Fixing only the stage of the day guarantees the next one is born unlabelled, so `tests/modules/flowlog-stage-labels.test.ts` sweeps the source and fails while one is missing, with a positive control proving the predicate can see an absent case and stays inside the function it was asked for.

## Validation scope

**Proven by test** (`bun check` on the master tree with this backported, rebased onto #341/#344/#340/#343: 5869 pass, 0 fail):

- `tests/modules/chatwoot-command-dropped.test.ts`, DB-backed, drives `processChatwootDelivery` for the four dropped states, the fan-out, the sparse payload and an undecryptable persona, asserting the row, its level, its detail and (for the last) that the delivery still reaches `PROCESSED`, plus two negative controls (a command that runs, and an ordinary message, write no row). Red before the fix: 4 of 6.
- `tests/modules/chatwoot-command-route.test.ts`, the decision table, including both fail-closed answers and `personaBot: 0` (equality, never truthiness).
- `tests/modules/flowlog-stage-labels.test.ts`, the label sweep and its positive control.
- Mutation battery, one at a time, each killed: dropping the `no_persona` guard (3), accepting an unattributed route as ours (1), returning the wrong `personaBot` (3), a fixed `info` level (1), emitting for an active command (3), reporting `mode` as a constant (1), removing the `command` label case (1), reporting `inactive` regardless of the route (1), keeping the stored reading's ids unused (1), and resolving the persona through `loadAgentBot` (1).

Two changes are named here rather than counted as covered, because a mutation of each leaves the suite green and saying so is the point. Polling for the expected row count is a flakiness fix: instrumented to print the first read, both multi-row tests saw every row on that read in 3 of 3 local runs, so the race does not reproduce here. And the best-effort `catch` around the persona lookup covers a transient database error this test cannot stage; what the test does prove is the narrow query, since reverting only that (keeping the catch) fails it.

**Proven live**, against the local Chatwoot fork (4.16.0), real conversations on a real inbox with a real Agent Bot fan-out, same server code either side, one worktree per half:

| | base (`main`) | this branch |
| --- | --- | --- |
| production agent | conv 75: 0 rows | conv 76: `command` info/skipped `{"mode":"production","reason":"inactive","command":"teste","routeBot":3}` |
| agent with no persona | conv 78: 0 rows | conv 77: `command` warn/skipped `{"reason":"no_persona","command":"teste","routeBot":3}` |
| fan-out: same `/teste`, two routes | conv 82: two identical `inactive` rows (`routeBot` 3 and 5) | conv 83: `inactive` from the inbox's persona (`routeBot` 3) + `other_route` (`routeBot` 5, `personaBot` 3) |

The fan-out row is the review's P2 finding, reproduced with a second Agent Bot in Chatwoot and the conversation assigned to the persona the inbox is NOT bound to. The two deliveries land 11ms apart, which is also why a dedup read cannot decide anything.

Every base half reproduces the process log line, so the deliveries reached the same code path in both trees. The conversations were removed from Chatwoot and the seeded tenant dropped afterwards.

**Not validated**: nothing on the emit path is left to reading. The one state not exercised live is `no_persona` under a fan-out (two deliveries, neither able to run the command), which is the residual double named above; it is covered by the decision table and by the DB-backed test.


