### PR TITLE
Charge a job's failures to the unit of work that had them, not to the next one

### DIFF
--- a/src/graph/ingest-job.ts
+++ b/src/graph/ingest-job.ts
@@ -67,6 +67,10 @@ export async function armIngest(params: ArmIngestParams): Promise<void> {
     tenantId: params.tenantId,
     kind: "INGEST_MESSAGE",
     dedupeKey: dedupeKey(params.graphThreadId, params.messageId),
+    // The key names ONE message, so a re-arm is that same append being armed again, never a second
+    // one. The row is also deleted on DONE (JOB_DELETE_ON_DONE), so a completed ingest leaves nothing
+    // for a later arm to inherit in the first place.
+    rearm: "same-work",
     // Now: the fast tick drains this lane, and what waits behind a queued ingestion is the next
     // turn's context rather than a customer reading a reply.
     runAt: new Date(),

--- a/src/graph/ingest-job.ts
+++ b/src/graph/ingest-job.ts
@@ -67,9 +67,9 @@ export async function armIngest(params: ArmIngestParams): Promise<void> {
     tenantId: params.tenantId,
     kind: "INGEST_MESSAGE",
     dedupeKey: dedupeKey(params.graphThreadId, params.messageId),
-    // The key names ONE message, so a re-arm is that same append being armed again, never a second
-    // one. The row is also deleted on DONE (JOB_DELETE_ON_DONE), so a completed ingest leaves nothing
-    // for a later arm to inherit in the first place.
+    // NOTE: The key names ONE message, so a re-arm is that same append being armed again, never a
+    // second one. The row is also deleted on DONE (JOB_DELETE_ON_DONE), so a completed ingest
+    // leaves nothing for a later arm to inherit in the first place.
     rearm: "same-work",
     // Now: the fast tick drains this lane, and what waits behind a queued ingestion is the next
     // turn's context rather than a customer reading a reply.

--- a/src/modules/appointments/reminders.ts
+++ b/src/modules/appointments/reminders.ts
@@ -104,9 +104,9 @@ export async function enqueueAppointmentReminders(
       tenantId: args.tenantId,
       kind: "APPOINTMENT_REMINDER",
       dedupeKey: `${reminderPrefix(args.eventId)}${j.offsetHours}`,
-      // Armed when a customer books or reschedules, so the row being reused means the appointment
-      // MOVED: the previous arm was cancelled (cancelAppointmentReminders) and this is a different
-      // send, at a different time, for a start the previous one no longer describes.
+      // NOTE: Armed when a customer books or reschedules, so the row being reused means the
+      // appointment MOVED: the previous arm was cancelled (cancelAppointmentReminders) and this is
+      // a different send, at a different time, for a start the previous one no longer describes.
       rearm: "new-work",
       runAt: j.runAt,
       payload: {

--- a/src/modules/appointments/reminders.ts
+++ b/src/modules/appointments/reminders.ts
@@ -104,6 +104,10 @@ export async function enqueueAppointmentReminders(
       tenantId: args.tenantId,
       kind: "APPOINTMENT_REMINDER",
       dedupeKey: `${reminderPrefix(args.eventId)}${j.offsetHours}`,
+      // Armed when a customer books or reschedules, so the row being reused means the appointment
+      // MOVED: the previous arm was cancelled (cancelAppointmentReminders) and this is a different
+      // send, at a different time, for a start the previous one no longer describes.
+      rearm: "new-work",
       runAt: j.runAt,
       payload: {
         threadId: args.threadId,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -219,6 +219,11 @@ export async function armRedirectChatFollowUp(
     tenantId: p.tenantId,
     kind: "REDIRECT_FOLLOWUP",
     dedupeKey: followUpDedupeKey(p.widgetThreadId),
+    // The key is the widget THREAD, reused by every idle period this lead ever has, and this call is
+    // what a LEAD MESSAGE triggers: the ladder pending from the previous silence is superseded, and
+    // what is being armed is the ladder for the silence starting now. Without the reset, a ladder
+    // that dead-lettered once would leave every later idle period on that thread with one attempt.
+    rearm: "new-work",
     runAt: minutesFromNow(
       redirectDelayMinutes(
         p.cfg.chatFollowupDelayValue,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -219,10 +219,11 @@ export async function armRedirectChatFollowUp(
     tenantId: p.tenantId,
     kind: "REDIRECT_FOLLOWUP",
     dedupeKey: followUpDedupeKey(p.widgetThreadId),
-    // The key is the widget THREAD, reused by every idle period this lead ever has, and this call is
-    // what a LEAD MESSAGE triggers: the ladder pending from the previous silence is superseded, and
-    // what is being armed is the ladder for the silence starting now. Without the reset, a ladder
-    // that dead-lettered once would leave every later idle period on that thread with one attempt.
+    // NOTE: The key is the widget THREAD, reused by every idle period this lead ever has, and this
+    // call is what a LEAD MESSAGE triggers: the ladder pending from the previous silence is
+    // superseded, and what is being armed is the ladder for the silence starting now. Without the
+    // reset, a ladder that dead-lettered once would leave every later idle period on that thread
+    // with one attempt.
     rearm: "new-work",
     runAt: minutesFromNow(
       redirectDelayMinutes(

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -92,9 +92,10 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         where: { kind: "DEBOUNCE", dedupeKey },
         select: { status: true, payload: true },
       });
-      // A live PENDING row is the burst this message joins; anything else (no row, DONE, DEAD, or a
-      // claim in flight) means the previous flush is finished business and this message opens a new
-      // burst. Every question below reads that one fact, so they cannot answer it differently.
+      // NOTE: A live PENDING row is the burst this message joins; anything else (no row, DONE,
+      // DEAD, or a claim in flight) means the previous flush is finished business and this message
+      // opens a new burst. Every question below reads that one fact, so they cannot answer it
+      // differently.
       const continuingBurst = existing?.status === "PENDING";
       const prevBurst = continuingBurst
         ? readBurstStart(existing.payload)
@@ -122,9 +123,9 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         dedupeKey,
         runAt: new Date(runAtMs),
         payload,
-        // A new burst is new work; a message joining the burst already open is the SAME flush being
-        // pushed out, and one waiting on its backoff must not be handed five more attempts by every
-        // message the contact types.
+        // NOTE: A new burst is new work; a message joining the burst already open is the SAME flush
+        // being pushed out, and one waiting on its backoff must not be handed five more attempts by
+        // every message the contact types.
         //
         // The key is the THREAD, reused by every burst this contact ever sends, so before this a
         // flush that dead-lettered left every later burst on that thread with one attempt (#339).

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -2,6 +2,7 @@ import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { withEntityLock } from "@/lib/locks";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import { upsertJobRow } from "@/modules/scheduler/service";
 import { type DebounceConfig, readDebounceConfig } from "./settings";
 
 // Debounce arming + config resolution. Arming re-uses the durable scheduler row (one live row per
@@ -91,16 +92,18 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         where: { kind: "DEBOUNCE", dedupeKey },
         select: { status: true, payload: true },
       });
-      const prevBurst =
-        existing?.status === "PENDING"
-          ? readBurstStart(existing.payload)
-          : null;
+      // A live PENDING row is the burst this message joins; anything else (no row, DONE, DEAD, or a
+      // claim in flight) means the previous flush is finished business and this message opens a new
+      // burst. Every question below reads that one fact, so they cannot answer it differently.
+      const continuingBurst = existing?.status === "PENDING";
+      const prevBurst = continuingBurst
+        ? readBurstStart(existing.payload)
+        : null;
       const burstStartedAt = prevBurst ?? nowMs;
       // High-water message id across the burst's arms (a fresh burst starts over, like burstStartedAt).
-      const prevLast =
-        existing?.status === "PENDING"
-          ? readLastMessageId(existing.payload)
-          : null;
+      const prevLast = continuingBurst
+        ? readLastMessageId(existing.payload)
+        : null;
       const lastCandidate = Math.max(prevLast ?? 0, params.lastMessageId ?? 0);
       const lastMessageId = lastCandidate > 0 ? lastCandidate : null;
       const runAtMs = Math.min(
@@ -113,24 +116,19 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         burstStartedAt,
         ...(lastMessageId !== null ? { lastMessageId } : {}),
       } satisfies Prisma.InputJsonObject;
-      await db.schedulerJob.upsert({
-        where: {
-          tenantId_kind_dedupeKey: { tenantId, kind: "DEBOUNCE", dedupeKey },
-        },
-        create: {
-          tenantId,
-          kind: "DEBOUNCE",
-          dedupeKey,
-          runAt: new Date(runAtMs),
-          status: "PENDING",
-          payload,
-        },
-        update: {
-          runAt: new Date(runAtMs),
-          status: "PENDING",
-          lastError: null,
-          payload,
-        },
+      await upsertJobRow(db, {
+        tenantId,
+        kind: "DEBOUNCE",
+        dedupeKey,
+        runAt: new Date(runAtMs),
+        payload,
+        // A new burst is new work; a message joining the burst already open is the SAME flush being
+        // pushed out, and one waiting on its backoff must not be handed five more attempts by every
+        // message the contact types.
+        //
+        // The key is the THREAD, reused by every burst this contact ever sends, so before this a
+        // flush that dead-lettered left every later burst on that thread with one attempt (#339).
+        rearm: continuingBurst ? "same-work" : "new-work",
       });
       return new Date(runAtMs);
     }),

--- a/src/modules/flowlog/retention.ts
+++ b/src/modules/flowlog/retention.ts
@@ -66,8 +66,8 @@ export async function ensureFlowlogSweep(
     tenantId,
     kind: "FLOWLOG_SWEEP",
     dedupeKey: "flowlog-sweep",
-    // One perpetual row per tenant, same shape as the follow-up sweep: a completed pass clears the
-    // budget (issue #287), and a boot re-arming it must not.
+    // NOTE: One perpetual row per tenant, same shape as the follow-up sweep: a completed pass
+    // clears the budget (issue #287), and a boot re-arming it must not.
     rearm: "same-work",
     runAt: new Date(Date.now() + SWEEP_INTERVAL_MS),
     base,

--- a/src/modules/flowlog/retention.ts
+++ b/src/modules/flowlog/retention.ts
@@ -66,6 +66,9 @@ export async function ensureFlowlogSweep(
     tenantId,
     kind: "FLOWLOG_SWEEP",
     dedupeKey: "flowlog-sweep",
+    // One perpetual row per tenant, same shape as the follow-up sweep: a completed pass clears the
+    // budget (issue #287), and a boot re-arming it must not.
+    rearm: "same-work",
     runAt: new Date(Date.now() + SWEEP_INTERVAL_MS),
     base,
   });

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -192,6 +192,12 @@ async function sweepHandler(
       kind: "FOLLOWUP",
       dedupeKey: `followup:${t.thread_id}`,
       runAt: new Date(),
+      // A CLOCK arms this, not the world: the sweep re-enqueues every eligible thread once a minute,
+      // and a thread stays eligible until its follow-up actually goes out. So a re-arm here is the
+      // same episode being pushed again, and clearing the budget would hand a follow-up that keeps
+      // failing five fresh attempts every minute forever. A follow-up that DID go out completes,
+      // which is what clears the count for the next episode.
+      rearm: "same-work",
       payload: { threadId: t.thread_id },
       base,
     });
@@ -542,6 +548,11 @@ export async function ensureTenantSweep(
     tenantId,
     kind: "FOLLOWUP_SWEEP",
     dedupeKey: "sweep",
+    // One perpetual row per tenant: this call bootstraps or self-heals it, and every pass reschedules
+    // itself, so there is only ever one unit of work. Its budget is cleared by each completed pass
+    // (issue #287); clearing it HERE would mean a restart loop, or an operator saving an agent,
+    // resetting the count of a sweep that is genuinely broken.
+    rearm: "same-work",
     runAt: new Date(Date.now() + SWEEP_INTERVAL_MS),
     base,
   });

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -192,11 +192,11 @@ async function sweepHandler(
       kind: "FOLLOWUP",
       dedupeKey: `followup:${t.thread_id}`,
       runAt: new Date(),
-      // A CLOCK arms this, not the world: the sweep re-enqueues every eligible thread once a minute,
-      // and a thread stays eligible until its follow-up actually goes out. So a re-arm here is the
-      // same episode being pushed again, and clearing the budget would hand a follow-up that keeps
-      // failing five fresh attempts every minute forever. A follow-up that DID go out completes,
-      // which is what clears the count for the next episode.
+      // NOTE: A CLOCK arms this, not the world: the sweep re-enqueues every eligible thread once a
+      // minute, and a thread stays eligible until its follow-up actually goes out. So a re-arm here
+      // is the same episode being pushed again, and clearing the budget would hand a follow-up that
+      // keeps failing five fresh attempts every minute forever. A follow-up that DID go out
+      // completes, which is what clears the count for the next episode.
       rearm: "same-work",
       payload: { threadId: t.thread_id },
       base,
@@ -548,10 +548,10 @@ export async function ensureTenantSweep(
     tenantId,
     kind: "FOLLOWUP_SWEEP",
     dedupeKey: "sweep",
-    // One perpetual row per tenant: this call bootstraps or self-heals it, and every pass reschedules
-    // itself, so there is only ever one unit of work. Its budget is cleared by each completed pass
-    // (issue #287); clearing it HERE would mean a restart loop, or an operator saving an agent,
-    // resetting the count of a sweep that is genuinely broken.
+    // NOTE: One perpetual row per tenant: this call bootstraps or self-heals it, and every pass
+    // reschedules itself, so there is only ever one unit of work. Its budget is cleared by each
+    // completed pass (issue #287); clearing it HERE would mean a restart loop, or an operator
+    // saving an agent, resetting the count of a sweep that is genuinely broken.
     rearm: "same-work",
     runAt: new Date(Date.now() + SWEEP_INTERVAL_MS),
     base,

--- a/src/modules/memory/compact.ts
+++ b/src/modules/memory/compact.ts
@@ -115,7 +115,7 @@ export async function armCompaction(
       // This dedupeKey is the THREAD, so the same row is reused by every attendance this contact ever
       // has. Each attendance is new work and gets its own retry budget; otherwise failures accumulate
       // across months and one bad day retires compaction for that contact permanently.
-      resetAttempts: true,
+      rearm: "new-work",
       payload: {
         instanceId: String(p.instanceId),
         contactInboxId: p.contactInboxId,

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -205,6 +205,9 @@ export async function createDocument(
     kind: "RAG_INGEST",
     dedupeKey: `doc:${doc.id}`,
     runAt: new Date(),
+    // A document that was just created: no row can exist under this key yet, so the answer is only
+    // ever about the insert. It is still stated, because a field nobody has to answer is a default.
+    rearm: "new-work",
     payload: { documentId: String(doc.id) },
     base,
   });
@@ -355,6 +358,10 @@ export async function updateDocument(
       kind: "RAG_INGEST",
       dedupeKey: `doc:${id}`,
       runAt: new Date(),
+      // The document's CONTENT changed, so this is a different index of a different text. The key is
+      // the document and lives as long as it does, so without the reset an ingest that failed once
+      // would follow the document through every edit it ever gets.
+      rearm: "new-work",
       payload: { documentId: String(id) },
       base,
     });
@@ -400,6 +407,10 @@ export async function retryDocument(
     kind: "RAG_INGEST",
     dedupeKey: `doc:${id}`,
     runAt: new Date(),
+    // An operator asked for this, on a document sitting in FAILED or UNINDEXED. FAILED is reached by
+    // exhausting the budget, so without the reset the retry button is worth exactly one attempt, and
+    // every press after the first fails straight back to DEAD.
+    rearm: "new-work",
     payload: { documentId: String(id) },
     base,
   });
@@ -518,6 +529,10 @@ export async function reindexKnowledgeBase(
       kind: "RAG_INGEST",
       dedupeKey: `doc:${d.id}`,
       runAt: new Date(),
+      // Same as the single-document retry, in bulk: an operator asked for the whole base to be
+      // indexed again, and a document that failed on a previous embedding provider is exactly the one
+      // this is for.
+      rearm: "new-work",
       payload: { documentId: String(d.id) },
       base,
     });

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -205,8 +205,9 @@ export async function createDocument(
     kind: "RAG_INGEST",
     dedupeKey: `doc:${doc.id}`,
     runAt: new Date(),
-    // A document that was just created: no row can exist under this key yet, so the answer is only
-    // ever about the insert. It is still stated, because a field nobody has to answer is a default.
+    // NOTE: A document that was just created: no row can exist under this key yet, so the answer is
+    // only ever about the insert. It is still stated, because a field nobody has to answer is a
+    // default.
     rearm: "new-work",
     payload: { documentId: String(doc.id) },
     base,
@@ -358,9 +359,9 @@ export async function updateDocument(
       kind: "RAG_INGEST",
       dedupeKey: `doc:${id}`,
       runAt: new Date(),
-      // The document's CONTENT changed, so this is a different index of a different text. The key is
-      // the document and lives as long as it does, so without the reset an ingest that failed once
-      // would follow the document through every edit it ever gets.
+      // NOTE: The document's CONTENT changed, so this is a different index of a different text. The
+      // key is the document and lives as long as it does, so without the reset an ingest that
+      // failed once would follow the document through every edit it ever gets.
       rearm: "new-work",
       payload: { documentId: String(id) },
       base,
@@ -407,9 +408,9 @@ export async function retryDocument(
     kind: "RAG_INGEST",
     dedupeKey: `doc:${id}`,
     runAt: new Date(),
-    // An operator asked for this, on a document sitting in FAILED or UNINDEXED. FAILED is reached by
-    // exhausting the budget, so without the reset the retry button is worth exactly one attempt, and
-    // every press after the first fails straight back to DEAD.
+    // NOTE: An operator asked for this, on a document sitting in FAILED or UNINDEXED. FAILED is
+    // reached by exhausting the budget, so without the reset the retry button is worth exactly one
+    // attempt, and every press after the first fails straight back to DEAD.
     rearm: "new-work",
     payload: { documentId: String(id) },
     base,
@@ -529,9 +530,9 @@ export async function reindexKnowledgeBase(
       kind: "RAG_INGEST",
       dedupeKey: `doc:${d.id}`,
       runAt: new Date(),
-      // Same as the single-document retry, in bulk: an operator asked for the whole base to be
-      // indexed again, and a document that failed on a previous embedding provider is exactly the one
-      // this is for.
+      // NOTE: Same as the single-document retry, in bulk: an operator asked for the whole base to
+      // be indexed again, and a document that failed on a previous embedding provider is exactly
+      // the one this is for.
       rearm: "new-work",
       payload: { documentId: String(d.id) },
       base,

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -32,8 +32,10 @@ import {
 // the GUC is transaction-local (set_config(...,true)) so it never leaks to the next request on a
 // pooled connection. Each job's EFFECT and status update run under the job's OWN tenant scope
 // (runScoped), so RLS still fences the work. `attempts` grows only on failure/crash and is CLEARED
-// by a completed pass (rescheduleJob), so the cap bounds CONSECUTIVE failures rather than the row's
-// lifetime — issue #287; the reaper bounds crash loops by pushing exhausted jobs to DEAD.
+// by a completed pass, whichever way it ends: rescheduleJob (issue #287) and completeJob (#339). So
+// the cap bounds CONSECUTIVE failures rather than the row's lifetime; the reaper bounds crash loops
+// by pushing exhausted jobs to DEAD. What a completed pass cannot reach is a row whose LAST pass
+// failed, and there the budget outlives the work only if the next arm says it should: see `Rearm`.
 
 const MAX_ATTEMPTS = 5;
 
@@ -87,65 +89,100 @@ export interface ClaimedJob {
   claimSeq: number;
 }
 
-export interface EnqueueParams {
+// What a re-arm of an existing row MEANS, answered by whoever arms it, because nothing the row
+// itself carries can answer it (issue #339).
+//
+// It decides ONE thing: whether the failure budget of the pass that came before survives into this
+// arm. It only ever matters on a row whose last pass FAILED, since a pass that completed clears the
+// count on its way out (completeJob, rescheduleJob).
+//
+//   "new-work":  this arm stands for a unit of work the row has not run yet. The trigger is the
+//                WORLD changing: a contact wrote, an operator asked for a re-index, an appointment
+//                was booked. Carrying the previous unit's failures into this one is how four
+//                transient blips spread over months make the next attendance dead-letter on its
+//                first, and that contact never compacts again.
+//
+//   "same-work": this arm is the SAME unit being pushed again. The trigger is a CLOCK: a sweep that
+//                re-enqueues every eligible thread each minute, a boot that re-arms the per-tenant
+//                sweeps, a key that names one message. Clearing here would hand a genuinely broken
+//                job five fresh attempts on a schedule, which is the cap doing nothing at all.
+//
+// There is deliberately no default. The rule is real but it is not derivable: the same status means
+// opposite things to different callers (a DEAD row re-armed by armCompaction is a new attendance,
+// the same row re-armed by the follow-up sweep is the same broken follow-up), and per kind does not
+// separate them either, since FOLLOWUP's key is the thread and the sweep arms it for both. The
+// knowledge is the caller's, so the caller is the one asked.
+export type Rearm = "new-work" | "same-work";
+
+export interface JobRowParams {
   tenantId: bigint;
-  // Written to the dedicated String column, never into `payload`. See ClaimedJob.payloadSecret.
-  payloadSecret?: string | null;
   kind: SchedulerJobKind;
   dedupeKey: string;
   runAt: Date;
   payload?: Record<string, unknown>;
-  // Start this row's retry budget over. Off by default, because most kinds key their dedupeKey to
-  // one unit of work (a conversation's follow-up, a document's ingest) and a re-arm there is the
-  // SAME work being retried. A kind whose key is permanent — one row per contact thread, reused by
-  // every attendance forever — needs it: without it, four transient failures spread over months make
-  // the next attendance dead-letter on its first, and that thread never compacts again.
-  resetAttempts?: boolean;
+  // Written to the dedicated String column, never into `payload`. See ClaimedJob.payloadSecret.
+  payloadSecret?: string | null;
+  rearm: Rearm;
+}
+
+export interface EnqueueParams extends JobRowParams {
   base?: PrismaClient;
+}
+
+// The ONE place a scheduler_jobs row comes into existence, and the reason it takes a ScopedDb rather
+// than being folded into enqueueJob: armDebounce has to write inside its own advisory-lock
+// transaction, so it cannot call something that opens a second one. It used to hand-copy this block
+// instead, which is exactly how DEBOUNCE ended up with no answer to the `rearm` question at all.
+// tests/modules/scheduler-row-writers.test.ts is the fence that keeps a third copy from appearing.
+export async function upsertJobRow(
+  db: ScopedDb,
+  params: JobRowParams,
+): Promise<bigint> {
+  const row = await db.schedulerJob.upsert({
+    where: {
+      tenantId_kind_dedupeKey: {
+        tenantId: params.tenantId,
+        kind: params.kind,
+        dedupeKey: params.dedupeKey,
+      },
+    },
+    create: {
+      tenantId: params.tenantId,
+      kind: params.kind,
+      dedupeKey: params.dedupeKey,
+      runAt: params.runAt,
+      payload: (params.payload ?? {}) as Prisma.InputJsonValue,
+      payloadSecret: params.payloadSecret ?? null,
+      status: "PENDING",
+    },
+    update: {
+      runAt: params.runAt,
+      status: "PENDING",
+      lastError: null,
+      // Re-arming with a payload is authoritative (the latest enqueue wins): this resets a stale
+      // payload on a reused row, e.g. the follow-up sweep restarting a sequence at step 0 on a row
+      // a prior run had advanced to a later step. A payload-less re-enqueue preserves the existing.
+      ...(params.payload !== undefined
+        ? { payload: params.payload as Prisma.InputJsonValue }
+        : {}),
+      // Re-armed together with the payload it belongs to: the two halves describe one message, and
+      // a re-enqueue that refreshed only the JSON would leave a body from the previous arming.
+      ...(params.payload !== undefined
+        ? { payloadSecret: params.payloadSecret ?? null }
+        : {}),
+      ...(params.rearm === "new-work" ? { attempts: 0 } : {}),
+    },
+    select: { id: true },
+  });
+  return row.id;
 }
 
 // One live row per (tenant, kind, dedupeKey): a re-enqueue re-arms run_at and resets to PENDING.
 export async function enqueueJob(params: EnqueueParams): Promise<bigint> {
   const base = params.base ?? basePrisma;
-  return runScopedOn(base, sysCtx(params.tenantId), async (db) => {
-    const row = await db.schedulerJob.upsert({
-      where: {
-        tenantId_kind_dedupeKey: {
-          tenantId: params.tenantId,
-          kind: params.kind,
-          dedupeKey: params.dedupeKey,
-        },
-      },
-      create: {
-        tenantId: params.tenantId,
-        kind: params.kind,
-        dedupeKey: params.dedupeKey,
-        runAt: params.runAt,
-        payload: (params.payload ?? {}) as Prisma.InputJsonValue,
-        payloadSecret: params.payloadSecret ?? null,
-        status: "PENDING",
-      },
-      update: {
-        runAt: params.runAt,
-        status: "PENDING",
-        lastError: null,
-        // Re-arming with a payload is authoritative (the latest enqueue wins) — this resets a stale
-        // payload on a reused row, e.g. the follow-up sweep restarting a sequence at step 0 on a row
-        // a prior run had advanced to a later step. A payload-less re-enqueue preserves the existing.
-        ...(params.payload !== undefined
-          ? { payload: params.payload as Prisma.InputJsonValue }
-          : {}),
-        // Re-armed together with the payload it belongs to: the two halves describe one message, and
-        // a re-enqueue that refreshed only the JSON would leave a body from the previous arming.
-        ...(params.payload !== undefined
-          ? { payloadSecret: params.payloadSecret ?? null }
-          : {}),
-        ...(params.resetAttempts ? { attempts: 0 } : {}),
-      },
-      select: { id: true },
-    });
-    return row.id;
-  });
+  return runScopedOn(base, sysCtx(params.tenantId), (db) =>
+    upsertJobRow(db, params),
+  );
 }
 
 // A customer reply (or opt-out) makes a pending proactive job moot: CAS-cancel the live PENDING
@@ -634,7 +671,18 @@ export async function completeJob(
         })
       : db.schedulerJob.updateMany({
           where: { id, status: "CLAIMED", claimSeq },
-          data: { status: "DONE" },
+          // `attempts` is cleared for the same reason rescheduleJob clears it (issue #287): reaching
+          // here means the handler neither threw nor reported failure, so the pass proved the job
+          // works and the budget it spent was for a state it is no longer in. DONE is simply the
+          // other ending of that same pass, and leaving the count on the row is what made a kind
+          // whose dedupeKey is permanent (one row per thread, per document, reused forever) inherit
+          // failures across months of healthy work and retire on the fifth (issue #339).
+          //
+          // `lastError` deliberately stays: a DONE row is the RECORD that the work happened, the last
+          // error is part of that record, and nothing reads it as state here. The two future-dated
+          // PENDING states that `lastError` does tell apart (backoff vs stood down) are rescheduleJob's
+          // problem, and a re-arm clears it before the row is claimable again anyway.
+          data: { status: "DONE", attempts: 0 },
         }),
   );
   return { applied: count > 0 };
@@ -659,7 +707,8 @@ export async function completeJob(
 // the same work again and fails again. Consecutive failures are never interleaved with a completed
 // pass, so a genuinely failing FOLLOWUP step or MEMORY_COMPACT still burns its five and dies. What
 // this does exempt is a job that fails INTERMITTENTLY, which is a job that works, and one that
-// dies for good in silence is the worse of the two outcomes.
+// dies for good in silence is the worse of the two outcomes. completeJob clears it for the same
+// reason, on the other ending of the same pass (issue #339).
 //
 // An optional
 // `payload` REPLACES the row's payload (used to advance a multi-step follow-up's stepIndex on the

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -159,14 +159,16 @@ export async function upsertJobRow(
       runAt: params.runAt,
       status: "PENDING",
       lastError: null,
-      // Re-arming with a payload is authoritative (the latest enqueue wins): this resets a stale
-      // payload on a reused row, e.g. the follow-up sweep restarting a sequence at step 0 on a row
-      // a prior run had advanced to a later step. A payload-less re-enqueue preserves the existing.
+      // NOTE: Re-arming with a payload is authoritative (the latest enqueue wins): this resets a
+      // stale payload on a reused row, e.g. the follow-up sweep restarting a sequence at step 0 on
+      // a row a prior run had advanced to a later step. A payload-less re-enqueue preserves the
+      // existing.
       ...(params.payload !== undefined
         ? { payload: params.payload as Prisma.InputJsonValue }
         : {}),
-      // Re-armed together with the payload it belongs to: the two halves describe one message, and
-      // a re-enqueue that refreshed only the JSON would leave a body from the previous arming.
+      // NOTE: Re-armed together with the payload it belongs to: the two halves describe one
+      // message, and a re-enqueue that refreshed only the JSON would leave a body from the previous
+      // arming.
       ...(params.payload !== undefined
         ? { payloadSecret: params.payloadSecret ?? null }
         : {}),
@@ -671,17 +673,19 @@ export async function completeJob(
         })
       : db.schedulerJob.updateMany({
           where: { id, status: "CLAIMED", claimSeq },
-          // `attempts` is cleared for the same reason rescheduleJob clears it (issue #287): reaching
-          // here means the handler neither threw nor reported failure, so the pass proved the job
-          // works and the budget it spent was for a state it is no longer in. DONE is simply the
-          // other ending of that same pass, and leaving the count on the row is what made a kind
-          // whose dedupeKey is permanent (one row per thread, per document, reused forever) inherit
-          // failures across months of healthy work and retire on the fifth (issue #339).
+          // NOTE: `attempts` is cleared for the same reason rescheduleJob clears it (issue #287):
+          // reaching here means the handler neither threw nor reported failure, so the pass proved
+          // the job works and the budget it spent was for a state it is no longer in. DONE is
+          // simply the other ending of that same pass, and leaving the count on the row is what
+          // made a kind whose dedupeKey is permanent (one row per thread, per document, reused
+          // forever) inherit failures across months of healthy work and retire on the fifth (issue
+          // #339).
           //
-          // `lastError` deliberately stays: a DONE row is the RECORD that the work happened, the last
-          // error is part of that record, and nothing reads it as state here. The two future-dated
-          // PENDING states that `lastError` does tell apart (backoff vs stood down) are rescheduleJob's
-          // problem, and a re-arm clears it before the row is claimable again anyway.
+          // `lastError` deliberately stays: a DONE row is the RECORD that the work happened, the
+          // last error is part of that record, and nothing reads it as state here. The two future-
+          // dated PENDING states that `lastError` does tell apart (backoff vs stood down) are
+          // rescheduleJob's problem, and a re-arm clears it before the row is claimable again
+          // anyway.
           data: { status: "DONE", attempts: 0 },
         }),
   );

--- a/src/modules/webhooks/outbound/heartbeat.ts
+++ b/src/modules/webhooks/outbound/heartbeat.ts
@@ -34,9 +34,9 @@ async function ensureTenantHeartbeat(
     tenantId,
     kind: "HEARTBEAT",
     dedupeKey: HEARTBEAT_DEDUPE_KEY,
-    // One perpetual row per tenant, re-armed by every subscription mutation. Reconciliation is not
-    // new work: a heartbeat that keeps failing would otherwise get five fresh attempts each time a
-    // subscription is toggled. A pass that ran clears the count on its own.
+    // NOTE: One perpetual row per tenant, re-armed by every subscription mutation. Reconciliation
+    // is not new work: a heartbeat that keeps failing would otherwise get five fresh attempts each
+    // time a subscription is toggled. A pass that ran clears the count on its own.
     rearm: "same-work",
     runAt: new Date(Date.now() + config.heartbeat.intervalMs),
     base,

--- a/src/modules/webhooks/outbound/heartbeat.ts
+++ b/src/modules/webhooks/outbound/heartbeat.ts
@@ -34,6 +34,10 @@ async function ensureTenantHeartbeat(
     tenantId,
     kind: "HEARTBEAT",
     dedupeKey: HEARTBEAT_DEDUPE_KEY,
+    // One perpetual row per tenant, re-armed by every subscription mutation. Reconciliation is not
+    // new work: a heartbeat that keeps failing would otherwise get five fresh attempts each time a
+    // subscription is toggled. A pass that ran clears the count on its own.
+    rearm: "same-work",
     runAt: new Date(Date.now() + config.heartbeat.intervalMs),
     base,
   });

--- a/tests/lib/storable-write-sweep.test.ts
+++ b/tests/lib/storable-write-sweep.test.ts
@@ -253,6 +253,7 @@ describe.skipIf(!dbUp)("error text reaches every column that holds it", () => {
 
   test("a failing job with a NUL still schedules its retry", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "sweep-failjob",
@@ -285,6 +286,7 @@ describe.skipIf(!dbUp)("error text reaches every column that holds it", () => {
 
   test("a NUL in the message still dead-letters the last attempt", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "sweep-failjob-dead",
@@ -343,7 +345,6 @@ const ERROR_COLUMN_LINES: Record<string, [number, ErrorSite | string]> = {
   "src/modules/contact-auth/service.ts": [1, "flow-event"],
   "src/modules/conversations/error.ts": [3, "guarded + cleared"],
   "src/modules/conversations/service.ts": [12, "read"],
-  "src/modules/debounce/service.ts": [1, "cleared"],
   "src/modules/flowlog/alert-worker.ts": [4, "guarded + cleared"],
   "src/modules/flowlog/read.ts": [4, "read"],
   "src/modules/flowlog/service.ts": [2, "guarded"],

--- a/tests/modules/chatwoot-reset.test.ts
+++ b/tests/modules/chatwoot-reset.test.ts
@@ -1753,6 +1753,7 @@ describe.skipIf(!dbUp)(
     test("a reschedule during the cleanup keeps its reminders", async () => {
       const threadId = `${tenantId}:${instanceId}:${CONV_ID}`;
       await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind: "APPOINTMENT_REMINDER",
         dedupeKey: "reminder:evt-1:60",
@@ -1767,6 +1768,7 @@ describe.skipIf(!dbUp)(
         if (!rearmed && String(input).includes("/kanban/tasks/")) {
           rearmed = true;
           await enqueueJob({
+            rearm: "same-work",
             tenantId,
             kind: "APPOINTMENT_REMINDER",
             dedupeKey: "reminder:evt-1:60",
@@ -1802,6 +1804,7 @@ describe.skipIf(!dbUp)(
     test("a redirect ladder re-armed during the cleanup survives", async () => {
       const threadId = `${tenantId}:${instanceId}:${CONV_ID}`;
       await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind: "REDIRECT_FOLLOWUP",
         dedupeKey: `redirect-followup:${threadId}`,
@@ -1816,6 +1819,7 @@ describe.skipIf(!dbUp)(
         if (!rearmed && String(input).includes("/kanban/tasks/")) {
           rearmed = true;
           await enqueueJob({
+            rearm: "same-work",
             tenantId,
             kind: "REDIRECT_FOLLOWUP",
             dedupeKey: `redirect-followup:${threadId}`,

--- a/tests/modules/debounce.test.ts
+++ b/tests/modules/debounce.test.ts
@@ -328,6 +328,7 @@ describe.skipIf(!dbUp)("debounce", () => {
     );
     const past = new Date(Date.now() - 60_000);
     await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dbc-wr",
@@ -1549,6 +1550,122 @@ describe.skipIf(!dbUp)("debounce", () => {
     expect(sent).toEqual([]);
     expect(calls.getMessages).toBe(0);
     expect(await watermarkOf(806)).toBe(12);
+  });
+
+  // Issue #339. The DEBOUNCE dedupeKey is the THREAD, so one physical row serves every burst this
+  // contact ever sends. A flush that dead-lettered (five consecutive failures) left the row carrying
+  // five attempts, and the re-arm only ever wrote status/run_at/payload, so the NEXT burst, days
+  // later, got exactly one attempt before being retired again, forever.
+  //
+  // A fresh burst is not a guess here: it is the same thing `burstStartedAt` already keys off, a row
+  // that is not PENDING, and both are asserted so the two cannot drift apart.
+  test("a burst after a dead-lettered flush starts with the whole budget", async () => {
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId}`,
+    );
+    const thread = threadOf(702);
+    const cfg = {
+      enabled: true,
+      windowSeconds: 15,
+      maxMessagesPerBurst: 20,
+      maxWindowSeconds: 60,
+    };
+    const t0 = new Date(Date.now() - 600_000);
+    await armDebounce({
+      tenantId,
+      threadId: thread,
+      agentBotId: 9,
+      cfg,
+      base: appDb,
+      now: t0,
+    });
+    const armed = await suDb.schedulerJob.findFirstOrThrow({
+      where: {
+        tenantId,
+        kind: "DEBOUNCE",
+        dedupeKey: debounceDedupeKey(thread),
+      },
+      select: { id: true },
+    });
+    await suDb.schedulerJob.update({
+      where: { id: armed.id },
+      data: { attempts: 5, status: "DEAD" },
+    });
+
+    const t1 = new Date(t0.getTime() + 300_000);
+    await armDebounce({
+      tenantId,
+      threadId: thread,
+      agentBotId: 9,
+      cfg,
+      base: appDb,
+      now: t1,
+    });
+    const row = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id: armed.id },
+      select: { status: true, attempts: true, payload: true },
+    });
+    expect(row.status).toBe("PENDING");
+    expect(row.attempts).toBe(0);
+    expect((row.payload as { burstStartedAt: number }).burstStartedAt).toBe(
+      t1.getTime(),
+    );
+  });
+
+  // The control for the test above, and the reason the answer is not just "always clear it": while a
+  // burst is still open, a re-arm is the SAME flush being pushed out by another message. A flush that
+  // failed and is waiting on its backoff must not be handed five more attempts by every message the
+  // contact types.
+  test("re-arming inside a burst keeps the attempts that burst has spent", async () => {
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId}`,
+    );
+    const thread = threadOf(703);
+    const cfg = {
+      enabled: true,
+      windowSeconds: 15,
+      maxMessagesPerBurst: 20,
+      maxWindowSeconds: 60,
+    };
+    const t0 = new Date(Date.now() - 10_000);
+    await armDebounce({
+      tenantId,
+      threadId: thread,
+      agentBotId: 9,
+      cfg,
+      base: appDb,
+      now: t0,
+    });
+    const armed = await suDb.schedulerJob.findFirstOrThrow({
+      where: {
+        tenantId,
+        kind: "DEBOUNCE",
+        dedupeKey: debounceDedupeKey(thread),
+      },
+      select: { id: true },
+    });
+    // The flush failed twice: failJob re-pends with a backoff, so the row is PENDING and the burst
+    // is still the same one.
+    await suDb.schedulerJob.update({
+      where: { id: armed.id },
+      data: { attempts: 2 },
+    });
+    await armDebounce({
+      tenantId,
+      threadId: thread,
+      agentBotId: 9,
+      cfg,
+      base: appDb,
+      now: new Date(t0.getTime() + 5_000),
+    });
+    const row = await suDb.schedulerJob.findUniqueOrThrow({
+      where: { id: armed.id },
+      select: { attempts: true, payload: true },
+    });
+    expect(row.attempts).toBe(2);
+    expect((row.payload as { burstStartedAt: number }).burstStartedAt).toBe(
+      t0.getTime(),
+    );
   });
 
   test("armDebounce keeps the burst's highest lastMessageId across re-arms", async () => {

--- a/tests/modules/rag-documents.test.ts
+++ b/tests/modules/rag-documents.test.ts
@@ -231,6 +231,40 @@ describe.skipIf(!dbUp)("rag documents", () => {
     expect(doc.error).toBeNull();
   });
 
+  // Issue #339. A document's ingest job is keyed `doc:<id>`, so one row serves the document for as
+  // long as it exists. FAILED is reached by EXHAUSTING the budget, which is precisely the state the
+  // retry button is for: without a fresh budget the retry is worth one attempt, and every press
+  // after the first dead-letters again on the first blip.
+  test("retryDocument gives the ingest its whole budget back", async () => {
+    const created = await createDocument({
+      ctx: ctxOf(t1),
+      knowledgeBaseId: kb1,
+      title: "Retry Budget Test",
+      text: "Failed five times",
+      sourceType: "text",
+      base: appDb,
+    });
+    await suDb.schedulerJob.updateMany({
+      where: { kind: "RAG_INGEST", dedupeKey: `doc:${created.id}` },
+      data: { status: "DEAD", attempts: 5 },
+    });
+    await runScopedOn(appDb, ctx(t1), (db) =>
+      db.knowledgeDocument.updateMany({
+        where: { id: created.id },
+        data: { status: "FAILED", error: "embeddings unavailable" },
+      }),
+    );
+
+    await retryDocument(ctxOf(t1), created.id, appDb);
+
+    const job = await suDb.schedulerJob.findFirstOrThrow({
+      where: { kind: "RAG_INGEST", dedupeKey: `doc:${created.id}` },
+      select: { status: true, attempts: true },
+    });
+    expect(job.status).toBe("PENDING");
+    expect(job.attempts).toBe(0);
+  });
+
   test("retryDocument re-queues an UNINDEXED document", async () => {
     const created = await createDocument({
       ctx: ctxOf(t1),

--- a/tests/modules/scheduler-claim-token.test.ts
+++ b/tests/modules/scheduler-claim-token.test.ts
@@ -73,6 +73,7 @@ async function staleAndCurrent(
   dedupeKey: string,
 ): Promise<{ id: bigint; stale: ClaimedJob; current: ClaimedJob }> {
   const id = await enqueueJob({
+    rearm: "same-work",
     tenantId,
     kind: "WEBHOOK_RETRY",
     dedupeKey,
@@ -84,6 +85,7 @@ async function staleAndCurrent(
   expect(stale).toBeDefined();
 
   await enqueueJob({
+    rearm: "same-work",
     tenantId,
     kind: "WEBHOOK_RETRY",
     dedupeKey,
@@ -196,6 +198,7 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
 
   test("the reaper does not issue a token, so the run it declared dead stays out", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "tok-reap",
@@ -237,6 +240,7 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
       if (!armedDuring) {
         armedDuring = true;
         await enqueueJob({
+          rearm: "same-work",
           tenantId: job.tenantId,
           kind: "HEARTBEAT",
           dedupeKey: "tok-handler",
@@ -249,6 +253,7 @@ describe.skipIf(!dbUp)("scheduler claim token", () => {
     });
 
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "HEARTBEAT",
       dedupeKey: "tok-handler",

--- a/tests/modules/scheduler-lanes.test.ts
+++ b/tests/modules/scheduler-lanes.test.ts
@@ -167,6 +167,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
     const ids = new Map<bigint, SchedulerJobKind>();
     for (const kind of ALL_KINDS) {
       const id = await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind,
         dedupeKey: `lane-${kind}`,
@@ -244,6 +245,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
     });
 
     await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "HEARTBEAT",
       dedupeKey: "drain-first",
@@ -251,6 +253,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
       base: appDb,
     });
     await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FLOWLOG_SWEEP",
       dedupeKey: "drain-second",
@@ -318,6 +321,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
 
     for (let i = 0; i < N; i++) {
       await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind: "APPOINTMENT_REMINDER",
         dedupeKey: `bound-costly-${i}`,
@@ -325,6 +329,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
         base: appDb,
       });
       await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind: "HEARTBEAT",
         dedupeKey: `bound-cheap-${i}`,
@@ -403,6 +408,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
     });
     try {
       const foreign = await enqueueJob({
+        rearm: "same-work",
         tenantId: other.id,
         kind: "WEBHOOK_RETRY",
         dedupeKey: "foreign",
@@ -441,6 +447,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
   // change that a function was covered and its call site was not.
   test("the shared tick drains both halves of its lane", async () => {
     const fixed = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-tick-fixed",
@@ -448,6 +455,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
       base: appDb,
     });
     const traffic = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "INGEST_MESSAGE",
       dedupeKey: "dk-tick-traffic",
@@ -504,6 +512,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
 
     for (const key of ["reject-a", "reject-b"]) {
       await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind: "WEBHOOK_RETRY",
         dedupeKey: key,

--- a/tests/modules/scheduler-row-writers.test.ts
+++ b/tests/modules/scheduler-row-writers.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+// Who may bring a `scheduler_jobs` row into existence, enforced per call site.
+//
+// Issue #339. A row's failure budget survives the unit of work that spent it, so whoever arms the
+// row has to say what the re-arm MEANS — new work, or the same work pushed again. `enqueueJob` asks
+// that as a required field, so the compiler asks it of every one of its call sites. What the compiler
+// cannot see is a writer that never calls `enqueueJob` at all, and that was not hypothetical:
+// `armDebounce` had its own hand-copied upsert (same status/run_at/last_error block, no budget
+// question), which is why DEBOUNCE — a dedupeKey that is the THREAD, reused by every burst that
+// contact ever has — silently kept a dead-lettered flush's five attempts forever.
+//
+// So the fence is on the WRITE, not on the caller: one module creates the row, its params carry the
+// question, and a second writer added later fails here instead of inheriting a default nobody chose.
+
+const OWNER = "src/modules/scheduler/service.ts";
+
+// The spellings that CREATE a row, as text. Prisma's `upsert` counts because its `create` branch
+// does; `update`/`updateMany`/`delete` do not, and neither does a plain read.
+const CREATES_A_ROW = [
+  /\bschedulerJob\s*\.\s*upsert\s*\(/,
+  /\bschedulerJob\s*\.\s*create\s*\(/,
+  /\bschedulerJob\s*\.\s*createMany\s*\(/,
+  /\bINSERT\s+INTO\s+scheduler_jobs\b/i,
+];
+
+export function createsASchedulerRow(source: string): boolean {
+  return CREATES_A_ROW.some((re) => re.test(source));
+}
+
+async function tsFilesUnder(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await tsFilesUnder(full)));
+    else if (entry.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+describe("who may create a scheduler job row", () => {
+  // A fence with no offender left passes over an empty set just as happily as over a correct one,
+  // so the predicate is proved on fixtures BEFORE it is trusted on the tree — both directions, and
+  // with the second spelling of the same thing written by hand (a formatter breaking the call across
+  // lines is what a `\s*`-less pattern misses).
+  test("the predicate catches every spelling of creating a row", () => {
+    for (const offender of [
+      `await db.schedulerJob.upsert({ where: {}, create: {}, update: {} });`,
+      `await db.schedulerJob\n  .create({ data: {} });`,
+      `await db.schedulerJob.createMany({ data: [] });`,
+      "await db.$executeRaw`INSERT INTO scheduler_jobs (tenant_id) VALUES (1)`",
+    ]) {
+      expect(createsASchedulerRow(offender)).toBe(true);
+    }
+  });
+
+  test("the predicate ignores reading or updating one", () => {
+    for (const innocent of [
+      `await db.schedulerJob.updateMany({ where: {}, data: {} });`,
+      `await db.schedulerJob.findFirst({ where: {} });`,
+      `await db.schedulerJob.deleteMany({ where: {} });`,
+      "await db.$executeRaw`UPDATE scheduler_jobs SET status = 'DONE'`",
+    ]) {
+      expect(createsASchedulerRow(innocent)).toBe(false);
+    }
+  });
+
+  test("exactly one module creates a scheduler job row", async () => {
+    const root = join(import.meta.dir, "..", "..");
+    const files = await tsFilesUnder(join(root, "src"));
+    // Positive control on the SWEEP as well as on the predicate: a sweep that walked the wrong
+    // directory would report an empty offender set and pass.
+    expect(files.length).toBeGreaterThan(200);
+    const writers: string[] = [];
+    for (const file of files) {
+      if (createsASchedulerRow(await Bun.file(file).text())) {
+        writers.push(relative(root, file));
+      }
+    }
+    expect(writers.sort()).toEqual([OWNER]);
+  });
+});

--- a/tests/modules/scheduler.test.ts
+++ b/tests/modules/scheduler.test.ts
@@ -92,6 +92,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
 
   test("enqueue is idempotent per (tenant, kind, dedupeKey)", async () => {
     const id1 = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-idem",
@@ -99,6 +100,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
       base: appDb,
     });
     const id2 = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-idem",
@@ -114,6 +116,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
 
   test("re-enqueue with a payload overwrites it; without one preserves it", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FOLLOWUP",
       dedupeKey: "dk-payload",
@@ -123,6 +126,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
     });
     // The follow-up sweep restarts a sequence: re-enqueue with the step-0 payload must reset it.
     await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FOLLOWUP",
       dedupeKey: "dk-payload",
@@ -138,6 +142,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
 
     // A payload-less re-enqueue preserves the existing payload (e.g. the SWEEP heartbeat).
     await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FOLLOWUP",
       dedupeKey: "dk-payload",
@@ -158,6 +163,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // buys nothing.
   test("the shared lane claims neither debounce nor compaction jobs", async () => {
     const shared = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-lane-shared",
@@ -165,6 +171,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
       base: appDb,
     });
     const debounce = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "DEBOUNCE",
       dedupeKey: "dk-lane-debounce",
@@ -172,6 +179,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
       base: appDb,
     });
     const compaction = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "MEMORY_COMPACT",
       dedupeKey: "dk-lane-compaction",
@@ -202,6 +210,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // Staged at the boundary that matters: the batch is smaller than the ingestion backlog.
   test("a batch full of ingestion still leaves room for a due reminder", async () => {
     const reminder = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "APPOINTMENT_REMINDER",
       dedupeKey: "dk-share-reminder",
@@ -214,6 +223,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
     for (let i = 0; i < 8; i++) {
       ingest.push(
         await enqueueJob({
+          rearm: "same-work",
           tenantId,
           kind: "INGEST_MESSAGE",
           dedupeKey: `dk-share-ingest-${i}`,
@@ -243,6 +253,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // on id + CLAIMED).
   test("an excluded id is left PENDING, not claimed", async () => {
     const busy = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "MEMORY_COMPACT",
       dedupeKey: "dk-lane-busy",
@@ -250,6 +261,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
       base: appDb,
     });
     const free = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "MEMORY_COMPACT",
       dedupeKey: "dk-lane-free",
@@ -272,6 +284,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
 
   test("claim → complete", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-complete",
@@ -292,6 +305,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // already carried, so it passed either way and pinned nothing.
   test("reschedule re-pends and clears the failure budget a completed pass earned", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-resched",
@@ -321,6 +335,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // what bounds that work, not the scheduler's budget.
   test("the merging reschedule clears the budget too", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "APPOINTMENT_REMINDER",
       dedupeKey: "dk-resched-patch",
@@ -355,6 +370,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // Measured before the fix: DEAD after the fifth, with four healthy passes in between.
   test("a perpetual job outlives more lifetime failures than the cap", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FLOWLOG_SWEEP",
       dedupeKey: "dk-perpetual",
@@ -396,6 +412,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // with a backoff and the next claim fails again.
   test("consecutive failures still dead-letter at the cap", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FLOWLOG_SWEEP",
       dedupeKey: "dk-consecutive",
@@ -423,8 +440,139 @@ describe.skipIf(!dbUp)("scheduler", () => {
     expect(status).toBe("DEAD");
   });
 
+  // Issue #339, and the other half of #287. `rescheduleJob` clears the budget a completed pass
+  // earned; DONE is the same pass with a different ending, and it did not. Every kind whose
+  // dedupeKey names a permanent identity (a thread, a document) finishes its work with this call, so
+  // the budget one attendance spent was still on the row when the next one re-armed it.
+  test("completing a job clears the failure budget the pass earned", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "WEBHOOK_RETRY",
+      dedupeKey: "dk-complete-budget",
+      runAt: past(),
+      rearm: "same-work",
+      base: appDb,
+    });
+    await suDb.schedulerJob.update({ where: { id }, data: { attempts: 3 } });
+    await claimDueJobs(10, appDb, new Date(), tenantId);
+    await completeJob(tenantId, id, await seqOf(id), "WEBHOOK_RETRY", appDb);
+    const s = await statusOf(id);
+    expect(s.status).toBe("DONE");
+    expect(s.attempts).toBe(0);
+  });
+
+  // The defect #339 reports, in the shape that produces it: MEMORY_COMPACT's dedupeKey is the
+  // THREAD, so one physical row serves every attendance that contact ever has. A transient failure
+  // in one of them was inherited by the next, and the fifth, months later with healthy attendances in
+  // between, retired compaction for that contact for good.
+  //
+  // The re-arm here declares "same-work" ON PURPOSE, which is the declaration that keeps the budget:
+  // the row survives because the passes COMPLETED, not because the caller asked for a clean slate.
+  test("a row re-armed by new work outlives more lifetime failures than the cap", async () => {
+    const key = "dk-rearmed-lifetime";
+    for (let attendance = 0; attendance < 8; attendance++) {
+      const id = await enqueueJob({
+        tenantId,
+        kind: "MEMORY_COMPACT",
+        dedupeKey: key,
+        runAt: past(),
+        rearm: "same-work",
+        base: appDb,
+      });
+      await claimDueCompactionJobs(10, appDb, new Date(), tenantId);
+      const before = await statusOf(id);
+      await failJob(
+        tenantId,
+        id,
+        await seqOf(id),
+        before.attempts,
+        "blip",
+        appDb,
+      );
+      expect((await statusOf(id)).status).toBe("PENDING");
+      // The retry succeeds, which is what a transient blip looks like: the attendance compacted.
+      await suDb.schedulerJob.update({
+        where: { id },
+        data: { runAt: past() },
+      });
+      await claimDueCompactionJobs(10, appDb, new Date(), tenantId);
+      await completeJob(tenantId, id, await seqOf(id), "MEMORY_COMPACT", appDb);
+      expect((await statusOf(id)).status).toBe("DONE");
+    }
+    const row = await suDb.schedulerJob.findFirstOrThrow({
+      where: { tenantId, kind: "MEMORY_COMPACT", dedupeKey: key },
+      select: { status: true, attempts: true },
+    });
+    expect(row.status).toBe("DONE");
+    expect(row.attempts).toBe(0);
+  });
+
+  // What a re-arm MEANS is the caller's knowledge, and it is the only thing left deciding the budget
+  // once a completed pass clears it: the row still carries a count when its LAST pass failed. Both
+  // directions are asserted here, because a field that only ever reads one way is a field nothing
+  // measures.
+  test("a re-arm declares whether the budget survives it", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "WEBHOOK_RETRY",
+      dedupeKey: "dk-rearm-declares",
+      runAt: past(),
+      rearm: "same-work",
+      base: appDb,
+    });
+    await suDb.schedulerJob.update({ where: { id }, data: { attempts: 3 } });
+    await enqueueJob({
+      tenantId,
+      kind: "WEBHOOK_RETRY",
+      dedupeKey: "dk-rearm-declares",
+      runAt: past(),
+      rearm: "same-work",
+      base: appDb,
+    });
+    expect((await statusOf(id)).attempts).toBe(3);
+    await enqueueJob({
+      tenantId,
+      kind: "WEBHOOK_RETRY",
+      dedupeKey: "dk-rearm-declares",
+      runAt: past(),
+      rearm: "new-work",
+      base: appDb,
+    });
+    expect((await statusOf(id)).attempts).toBe(0);
+  });
+
+  // A DEAD row re-armed for new work is the case `rearm` exists for, and the one a completed pass
+  // cannot reach: five consecutive failures retired it, and every later unit of work would get ONE
+  // attempt instead of five until something cleared the count.
+  test("new work gets the whole budget on a row that dead-lettered", async () => {
+    const id = await enqueueJob({
+      tenantId,
+      kind: "MEMORY_COMPACT",
+      dedupeKey: "dk-dead-rearm",
+      runAt: past(),
+      rearm: "new-work",
+      base: appDb,
+    });
+    await suDb.schedulerJob.update({
+      where: { id },
+      data: { attempts: 5, status: "DEAD" },
+    });
+    await enqueueJob({
+      tenantId,
+      kind: "MEMORY_COMPACT",
+      dedupeKey: "dk-dead-rearm",
+      runAt: past(),
+      rearm: "new-work",
+      base: appDb,
+    });
+    const s = await statusOf(id);
+    expect(s.status).toBe("PENDING");
+    expect(s.attempts).toBe(0);
+  });
+
   test("reschedule with a payload REPLACES the row payload (step advance)", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FOLLOWUP",
       dedupeKey: "dk-resched-payload",
@@ -468,6 +616,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
 
   test("fail retries until the cap, then DEAD", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-fail",
@@ -499,6 +648,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
       ["dk-retire-dead", "DEAD"],
     ] as const) {
       ids[key] = await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind: "FOLLOWUP",
         dedupeKey: key,
@@ -542,6 +692,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   test("the retirement predicate agrees with the retirement read, in both forms", async () => {
     const claimOf = async (dedupeKey: string): Promise<ClaimedJob> => {
       const id = await enqueueJob({
+        rearm: "same-work",
         tenantId,
         kind: "FOLLOWUP",
         dedupeKey,
@@ -610,6 +761,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // the fence inside the claim would answer "keep going" every single time.
   test("the retirement read answers inside a pinned transaction, on a pool of one", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FOLLOWUP",
       dedupeKey: "dk-pool-one",
@@ -658,6 +810,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
   // one, so swapping it in at a call site does not change the ordinary path.
   test("the strict probe still answers when the read succeeds", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "FOLLOWUP",
       dedupeKey: "dk-strict-ok",
@@ -674,6 +827,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
 
   test("reaper requeues a stranded CLAIMED job", async () => {
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-reap",
@@ -703,6 +857,7 @@ describe.skipIf(!dbUp)("scheduler", () => {
       return { outcome: "done" };
     });
     const id = await enqueueJob({
+      rearm: "same-work",
       tenantId,
       kind: "WEBHOOK_RETRY",
       dedupeKey: "dk-run",


### PR DESCRIPTION
Fixes #339.

## What breaks

A scheduler job's failure budget (`MAX_ATTEMPTS = 5`) outlives the unit of work that spent it, in two
different ways, and the row is retired for work that never failed five times.

**A pass that COMPLETED did not clear the count.** #287 made `rescheduleJob` clear it, with the
argument that reaching it means the handler neither threw nor reported failure, so the pass proved
the job works. `completeJob` is the same pass with the other ending, and it wrote `status: "DONE"`
and nothing else. Every kind whose `dedupeKey` names a permanent identity finishes its work through
that call, so one transient blip per attendance, per re-index, per burst accumulated on the row until
the fifth retired it. Measured on the base, with a healthy pass between every failure:

```
a row re-armed by new work outlives more lifetime failures than the cap  ->  DEAD on attendance 5
```

**And the arm that re-uses the row could not say what it meant.** `enqueueJob` took an optional
`resetAttempts`, exactly one of its twelve call sites passed it, and nothing made the next one
decide. Worse, one writer was not a call site at all: `armDebounce` wrote
the row with its own hand-copied upsert (same `status`/`run_at`/`last_error` block, no budget
question). `DEBOUNCE`'s key is the THREAD, reused by every burst a contact ever sends, so a flush
that dead-lettered left every later burst on that thread with one attempt, permanently.

## The fix

One line closes the issue: `completeJob` clears `attempts`, for the reason `rescheduleJob` already
does. That is what kills "five failures months apart", because months apart means completed passes in
between.

What a completed pass cannot reach is a row whose LAST pass failed, and there the answer is the
caller's knowledge, not a rule. Both derivations were tried on #337 and both were refuted by
measurement (status means opposite things to different callers; per kind does not separate a new
follow-up episode from the same one). So the question is asked, and it is required:

```ts
export type Rearm = "new-work" | "same-work";
```

`"new-work"` when the WORLD is what armed the row (a contact wrote, an operator asked for a re-index,
an appointment was booked); `"same-work"` when a CLOCK did (a sweep that re-enqueues every eligible
thread each minute, a boot re-arming the per-tenant sweeps, a key that names one message). There is
no default, so a call site added later does not compile until it answers.

### Every site, classified

| arming site | kind | the key names | declared |
| --- | --- | --- | --- |
| `armIngest` | `INGEST_MESSAGE` | one message | `same-work` |
| `armRedirectChatFollowUp` | `REDIRECT_FOLLOWUP` | the widget thread | `new-work` |
| `armCompaction` | `MEMORY_COMPACT` | the thread | `new-work` |
| `sweepHandler` | `FOLLOWUP` | the thread | `same-work` |
| `ensureTenantSweep` | `FOLLOWUP_SWEEP` | the tenant | `same-work` |
| `enqueueAppointmentReminders` | `APPOINTMENT_REMINDER` | one event's offset | `new-work` |
| `createDocument` | `RAG_INGEST` | the document | `new-work` |
| `updateDocument` (re-ingest) | `RAG_INGEST` | the document | `new-work` |
| `retryDocument` | `RAG_INGEST` | the document | `new-work` |
| `reindexKnowledgeBase` | `RAG_INGEST` | the document | `new-work` |
| `ensureFlowlogSweep` | `FLOWLOG_SWEEP` | the tenant | `same-work` |
| `ensureTenantHeartbeat` | `HEARTBEAT` | the tenant | `same-work` |
| `armDebounce` | `DEBOUNCE` | the thread | computed per arm |

`armDebounce` is the one that cannot answer statically, and it does not have to guess: a live PENDING
row means this message is joining a burst already open, which is the same fact `burstStartedAt`
already keys off, so both read it from the same place and cannot drift.

Two of these were user-visible on their own. `retryDocument` is the operator's retry button on a
document sitting in FAILED, and FAILED is reached by exhausting the budget: without the reset the
button was worth exactly one attempt, and every press after the first dead-lettered on the first
blip. `armDebounce` is above.

### The fence

The compiler covers every `enqueueJob` call site, because the field is required. What it cannot see
is a writer that never calls `enqueueJob`, which is precisely what `armDebounce` was. So the row now
has ONE writer (`upsertJobRow`, taking a `ScopedDb` so `armDebounce` can use it inside its own
advisory-lock transaction rather than opening a second one), and
`tests/modules/scheduler-row-writers.test.ts` sweeps `src/` for anything that creates a
`scheduler_jobs` row and fails unless the set is exactly that module. It was RED on the base, naming
`src/modules/debounce/service.ts`.

## Validation scope

**Proved by test, red first.** Four new tests in `tests/modules/scheduler.test.ts`, two in
`tests/modules/debounce.test.ts`, and the writer fence, all run against the base before a line of
`src/` was touched:

```
(fail) scheduler > completing a job clears the failure budget the pass earned
(fail) scheduler > a row re-armed by new work outlives more lifetime failures than the cap
(fail) scheduler > a re-arm declares whether the budget survives it
(fail) scheduler > new work gets the whole budget on a row that dead-lettered
(fail) debounce  > a burst after a dead-lettered flush starts with the whole budget
(fail) who may create a scheduler job row > exactly one module creates a scheduler job row
```

`debounce > re-arming inside a burst keeps the attempts that burst has spent` is the control and was
GREEN on the base: it pins the direction that must NOT change. The one in
`tests/modules/rag-documents.test.ts` was written after the fix and is proved by mutation instead
(below), not by a base run.

All of them are DB-backed against a real Postgres, and what they assert is the row itself (`status`,
`attempts`), not a return value. The lifetime test declares `"same-work"` on purpose, so it proves
the row survives because the passes COMPLETED, not because the caller asked for a clean slate.

**Mutation, one at a time, tree restored and diffed against the saved patch after each.**

| mutation | tests that fell |
| --- | --- |
| `completeJob` keeps `attempts` | 2 |
| `upsertJobRow` ignores `"new-work"` | 5 |
| `armDebounce` always `"same-work"` | 1 (the dead-lettered burst) |
| `armDebounce` always `"new-work"` | 1 (the control) |
| `retryDocument` declares `"same-work"` | 1 |
| `armCompaction` declares `"same-work"` | 1 (the existing #287-era test) |

**Not validated.** Six of the thirteen declarations have no behavioural test of their own: the four
`same-work` sweeps and boots, `armIngest`, and the `new-work` arms other than `retryDocument` and
`armCompaction`. Flipping any of them changes behaviour only on a row whose last pass failed and that
is then re-armed from that specific entry point, and driving `sweepHandler` alone needs the whole
conversation/agent/inbox fixture. What holds them is the compiler (the answer cannot be omitted) and
the reason written at each site, not a measurement. The four kinds #339 names are all pinned.

**No live exercise, and why.** Nothing here talks to an external system: the change is the semantics
of one Postgres table, and the tests above run against a real one. There is no Chatwoot, provider or
storage call anywhere in the path.

**One ledger line moved.** `tests/lib/storable-write-sweep.test.ts` counts the lines that name an
error column per file, and `src/modules/debounce/service.ts` dropped from 1 to 0. That is the
duplicated writer disappearing, not a write disappearing: `armDebounce` still clears `lastError`, now
through the line in `upsertJobRow` that was already counted under `src/modules/scheduler/service.ts`
(whose count is unchanged at 4). The entry was removed rather than edited down.

**Out of scope, found on the way.** The upsert sets `status: "PENDING"` unconditionally, so the
follow-up sweep resurrects a DEAD `FOLLOWUP` row a minute later, forever: for that kind the cap does
not retire anything, it only changes the retry cadence from a backoff to once per sweep. That
predates this change and is untouched by it.
