### PR TITLE
Say an outbound delivery died where the operator reads it, instead of counting it in a process log

### DIFF
--- a/src/client/lib/flowLabels.ts
+++ b/src/client/lib/flowLabels.ts
@@ -36,6 +36,8 @@ export function flowStageLabel(stage: string, t: TFunction): string {
       return t("logs.stage.handoff", "Handoff");
     case "memory":
       return t("logs.stage.memory", "Memory");
+    case "webhook":
+      return t("logs.stage.webhook", "Outbound webhook");
     default:
       return stage;
   }

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1579,7 +1579,8 @@
       "stt": "Transcription",
       "tool": "Tool call",
       "tts": "Audio synthesis",
-      "vision": "Image reading"
+      "vision": "Image reading",
+      "webhook": "Outbound webhook"
     },
     "steps": "{{n}} steps",
     "subtitle": "Per-step execution flow for each agent turn: transcription, generation, audio, delivery and handoffs.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1585,7 +1585,8 @@
       "stt": "Transcrição",
       "tool": "Chamada de ferramenta",
       "tts": "Síntese de áudio",
-      "vision": "Leitura de imagem"
+      "vision": "Leitura de imagem",
+      "webhook": "Webhook de saída"
     },
     "steps": "{{n}} etapas",
     "subtitle": "Fluxo de execução passo a passo de cada turno do agente: transcrição, geração, áudio, entrega e transferências.",

--- a/src/modules/flowlog/stages.ts
+++ b/src/modules/flowlog/stages.ts
@@ -1,8 +1,11 @@
 // Closed vocabulary for the execution-flow log, kept dependency-free so the schema layer and the
 // read/controller layers can validate without importing the emit machinery.
 
-// One stage per pipeline step a turn can run through. Stored as a validated String on ExecutionLog
-// (never a Prisma enum — adding a stage must not require a migration).
+// One stage per step the operator can be asked to explain. Most are pipeline steps a turn runs
+// through; `route` and `command` sit BEFORE the turn (#318, #317) and `webhook` is not a turn at all
+// (#325), which is why the vocabulary is the operator's question and not the pipeline's shape.
+// Stored as a validated String on ExecutionLog (never a Prisma enum — adding a stage must not
+// require a migration).
 export const FLOW_STAGES = [
   // The step BEFORE any of the others: the delivery is matched to the agent that answers this
   // inbox. It writes only when there is none — an inbox nobody bound consumes the message and
@@ -25,6 +28,12 @@ export const FLOW_STAGES = [
   "split", // humanized balloon delivery
   "handoff", // an ownership gate closed: a takeover, or the conversation left the bot
   "memory", // a closed attendance folded into the contact's memory (compaction)
+  // NOT a turn step, and the only stage here that is not: an outbound webhook delivery the bus gave
+  // up on. It happens on a worker tick long after whatever produced the event, so it hangs off no
+  // conversation and no contact. It is in this vocabulary because the vocabulary is what an alert
+  // channel subscribes to and what the Logs page filters by, and a dropped event that reaches
+  // neither is a loss nobody is told about (issue #325).
+  "webhook",
 ] as const;
 export type FlowStage = (typeof FLOW_STAGES)[number];
 
@@ -41,5 +50,7 @@ export function isFlowLevel(s: string): s is FlowLevel {
 
 export type FlowStatus = "ok" | "error" | "skipped";
 
-// inbox = real customer traffic; playground = operator test turns (never alerts).
+// The two worlds an alert has to tell apart, and the split is real-vs-test, never turn-vs-not:
+// inbox = production, including the system work that serves it (a `webhook` line has no turn and
+// still pages); playground = operator test turns, which never alert.
 export type FlowSource = "inbox" | "playground";

--- a/src/modules/flowlog/webhook.ts
+++ b/src/modules/flowlog/webhook.ts
@@ -1,0 +1,64 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+import { emitFlowEvent } from "./service";
+
+// AN OUTBOUND DELIVERY THE BUS GAVE UP ON, AND THE ONE LINE THAT SAYS SO.
+//
+// A delivery that reaches `DEAD` is an event the operator asked to receive and never will. Before
+// issue #325 the only trace was the tick's summary line (`… dead=%d`), which counts the deaths
+// without naming any of them and is not a channel anyone subscribes to: measured against the real
+// worker with an enabled channel at `minLevel: warn` and no stage allowlist, two deliveries died —
+// one on the eighth attempt, one on a URL the SSRF guard refused — and produced 0 `ExecutionLog`
+// rows and 0 `AlertDelivery` rows. The only way to see a dead delivery was to read the deliveries
+// table directly, which #305 answered is not a surface we can promise to keep.
+//
+// `error`, never `warn`. The two are the difference between "look when you can" and "something
+// failed", and a DEAD delivery is a permanent loss of data the receiver was told it would get.
+// It is also the level a channel gets by DEFAULT (`AlertChannel.minLevel` defaults to `error`, and
+// `info` is not even a value it accepts), so anything softer would reach nobody who had not gone
+// and widened their channel first — which is the state this issue reports.
+//
+// A broken receiver produces one death per event, so the flood risk is real and already handled one
+// layer down: `dispatchAlertsForEvent` bumps `count` on a PENDING delivery for the same
+// (channel, stage, level) instead of inserting another, and the alert worker drains that on a
+// debounced window. A burst of a thousand dead deliveries is one alert that says a thousand.
+//
+// `detail` carries what the operator needs to FIND the delivery (its id, the subscription and the
+// event name) and what tells them how it died (`attempts`, which is 8 on an exhausted budget and 1
+// on a refused URL). The payload never travels: it is the customer's data, and a dead-letter alert
+// is read by whoever runs the tenant, not by whoever the event was about. The error string is
+// already sanitized where it is stored (`sanitizeErrorMessage`, issue #243) and is sanitized again
+// on the way into the row.
+export function emitDeliveryDead(args: {
+  tenantId: bigint;
+  deliveryId: bigint;
+  subscriptionId: bigint;
+  event: string;
+  // The attempt count AFTER this one, i.e. what the row now stores. Named rather than derived so
+  // the two roads to DEAD report the same number the deliveries table does.
+  attempts: number;
+  error: string;
+  base?: PrismaClient;
+}): void {
+  emitFlowEvent(
+    {
+      tenantId: args.tenantId,
+      // A delivery is not a turn and has no conversation to hang off, so this correlates the one
+      // line with itself. It is still required: `turnId` is what the Logs page groups by.
+      turnId: crypto.randomUUID(),
+      source: "inbox",
+      base: args.base,
+    },
+    {
+      stage: "webhook",
+      level: "error",
+      status: "error",
+      detail: {
+        deliveryId: String(args.deliveryId),
+        subscriptionId: String(args.subscriptionId),
+        event: args.event,
+        attempts: args.attempts,
+      },
+      errorMessage: args.error,
+    },
+  );
+}

--- a/src/modules/webhooks/outbound/worker.ts
+++ b/src/modules/webhooks/outbound/worker.ts
@@ -5,6 +5,7 @@ import config from "@/config";
 import { sanitizeErrorMessage } from "@/lib/redact";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
+import { emitDeliveryDead } from "@/modules/flowlog/webhook";
 import { tryResolveVaultSecret } from "@/modules/vault/service";
 import { nextBackoffMs } from "./service";
 import { outboundHeaders } from "./signing";
@@ -181,6 +182,37 @@ async function finalizeDelivered(
   );
 }
 
+// THE ONLY WRITE OF DEAD, and it is one function for that reason rather than for tidiness. There
+// are two roads here — the retry budget running out, and a URL the SSRF guard refuses on sight —
+// and issue #325 is what happens when a road forgets to tell anybody: both of them wrote the row
+// and returned, and the operator's only trace was a counter in a process log. A third road will be
+// added one day; going through here is what makes it announce itself without anyone remembering to.
+async function finalizeDead(
+  base: PrismaClient,
+  d: ClaimedDelivery,
+  attempts: number,
+  error: string,
+): Promise<DeliveryOutcome> {
+  await runScopedOn(base, sysCtx(d.tenantId), (db) =>
+    db.outboundWebhookDelivery.update({
+      where: { id: d.id },
+      data: { status: "DEAD", attempts, lastError: error },
+    }),
+  );
+  // Fire-and-forget, and AFTER the write: the row is the fact, the line is the notification, and a
+  // failed notification must never leave a delivery claimed forever.
+  emitDeliveryDead({
+    tenantId: d.tenantId,
+    deliveryId: d.id,
+    subscriptionId: d.subscriptionId,
+    event: d.event,
+    attempts,
+    error,
+    base,
+  });
+  return "dead";
+}
+
 // Retryable failure: increment attempts, schedule next attempt with full-jitter backoff, or
 // give up (DEAD) once MAX_ATTEMPTS is reached. The row's tenant scopes the update via RLS.
 async function finalizeFailure(
@@ -190,15 +222,8 @@ async function finalizeFailure(
   now: () => number,
 ): Promise<DeliveryOutcome> {
   const attemptsAfter = d.attempts + 1;
-  if (attemptsAfter >= MAX_ATTEMPTS) {
-    await runScopedOn(base, sysCtx(d.tenantId), (db) =>
-      db.outboundWebhookDelivery.update({
-        where: { id: d.id },
-        data: { status: "DEAD", attempts: attemptsAfter, lastError: error },
-      }),
-    );
-    return "dead";
-  }
+  if (attemptsAfter >= MAX_ATTEMPTS)
+    return finalizeDead(base, d, attemptsAfter, error);
   const nextAttemptAt = new Date(now() + nextBackoffMs(attemptsAfter));
   await runScopedOn(base, sysCtx(d.tenantId), (db) =>
     db.outboundWebhookDelivery.update({
@@ -228,17 +253,7 @@ async function deliverClaimed(
   try {
     await assertSafe(d.url);
   } catch (err) {
-    await runScopedOn(base, sysCtx(d.tenantId), (db) =>
-      db.outboundWebhookDelivery.update({
-        where: { id: d.id },
-        data: {
-          status: "DEAD",
-          attempts: d.attempts + 1,
-          lastError: errMsg(err),
-        },
-      }),
-    );
-    return "dead";
+    return finalizeDead(base, d, d.attempts + 1, errMsg(err));
   }
 
   // Per-tenant signing secret, resolved through a tenant-scoped read (RLS active, not the

--- a/tests/lib/storable-write-sweep.test.ts
+++ b/tests/lib/storable-write-sweep.test.ts
@@ -348,13 +348,16 @@ const ERROR_COLUMN_LINES: Record<string, [number, ErrorSite | string]> = {
   "src/modules/flowlog/alert-worker.ts": [4, "guarded + cleared"],
   "src/modules/flowlog/read.ts": [4, "read"],
   "src/modules/flowlog/service.ts": [2, "guarded"],
+  "src/modules/flowlog/webhook.ts": [1, "flow-event"],
   "src/modules/guardrails/gate.ts": [2, "flow-event"],
   "src/modules/guardrails/health.ts": [4, "read"],
   "src/modules/memory/compact.ts": [1, "flow-event"],
   "src/modules/scheduler/service.ts": [4, "guarded + cleared"],
   "src/modules/stt/service.ts": [2, "flow-event"],
   "src/modules/vision/service.ts": [2, "flow-event"],
-  "src/modules/webhooks/outbound/worker.ts": [4, "guarded + cleared"],
+  // Was 4 until issue #325 collapsed the two DEAD writes into `finalizeDead`; the line that went
+  // is the duplicate, not a guard.
+  "src/modules/webhooks/outbound/worker.ts": [3, "guarded + cleared"],
 };
 
 // The other half of the same ledger, and the half that covers the two columns the scan above cannot

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -181,6 +181,7 @@ const FLOWLOG_READERS: Record<string, number> = {
   "tests/modules/tts-normalize-observability.test.ts": 1,
   "tests/modules/tts.test.ts": 2,
   "tests/modules/vision-retry.test.ts": 1,
+  "tests/modules/webhooks-outbound-dead-alert.test.ts": 1,
 };
 
 // Lives beside the rest of the flowlog family rather than in tests/tooling/, which the manifest

--- a/tests/modules/webhooks-outbound-dead-alert.test.ts
+++ b/tests/modules/webhooks-outbound-dead-alert.test.ts
@@ -1,0 +1,338 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { assertSafeOutboundUrl } from "@/lib/ssrf";
+import { createAlertChannel } from "@/modules/flowlog/channels";
+import { processOutboundBatch } from "@/modules/webhooks/outbound/worker";
+
+// ── A DEAD DELIVERY HAS TO SAY SO WHERE THE OPERATOR READS (issue #325) ──
+// Integration, real DB, real RLS: the claim runs cross-tenant under asSuperAdmin and the outcome
+// under the tenant scope, exactly as the worker does in production. Only the network and the SSRF
+// guard are injectable, and the SSRF test uses the REAL guard because the URL it refuses is the
+// second road to DEAD — the one that needs no retries at all.
+//
+// The effect asserted is the row an operator can see (`ExecutionLog`) and the alert it feeds
+// (`AlertDelivery`), never the worker's own return value: the tick summary already counted these
+// deaths before this issue, and counting is exactly what did not reach anybody.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const passthroughSafe = async (u: string) => new URL(u);
+const never = (async () => {
+  throw new Error("fetch must not be reached");
+}) as unknown as typeof fetch;
+const responds = (status: number) =>
+  (async () => ({ status }) as Response) as unknown as typeof fetch;
+
+// A secret-looking string in the payload, so a leak of the body into the log line is detectable
+// rather than argued about.
+const PAYLOAD_MARKER = "sk-live-PAYLOAD-MUST-NOT-LEAK-325";
+
+let tenantId = 0n;
+let liveSub = 0n;
+let blockedSub = 0n;
+let allStagesChannel = 0n;
+let webhookOnlyChannel = 0n;
+let otherStageChannel = 0n;
+
+async function seedDelivery(
+  subscriptionId: bigint,
+  attempts: number,
+): Promise<bigint> {
+  const row = await suDb.outboundWebhookDelivery.create({
+    data: {
+      tenantId,
+      subscriptionId,
+      event: "conversion",
+      payload: { value: 42, token: PAYLOAD_MARKER },
+      status: "PENDING",
+      attempts,
+    },
+  });
+  return row.id;
+}
+
+// The emit is fire-and-forget, so the row lands after the worker returned. Poll for the expected
+// count instead of sleeping a fixed amount: a fixed sleep is either flaky or slow, and this says
+// which of the two it is when it fails.
+async function webhookRows(expected: number, waitMs = 3000) {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    // flowlog-scope: tenant-wide — the subject is HOW MANY lines the tick wrote, so scoping the
+    // read to a turn would answer a different question and pass while a second row existed. The
+    // tenant is this file's own and `clearRows` empties it before each case.
+    const rows = await suDb.executionLog.findMany({
+      where: { tenantId, stage: "webhook" },
+      orderBy: { id: "asc" },
+    });
+    if (rows.length >= expected) return rows;
+    if (Date.now() > deadline) return rows;
+    await Bun.sleep(50);
+  }
+}
+
+async function alertRows(expected: number, waitMs = 3000) {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    const rows = await suDb.alertDelivery.findMany({
+      where: { tenantId },
+      orderBy: { id: "asc" },
+    });
+    if (rows.length >= expected) return rows;
+    if (Date.now() > deadline) return rows;
+    await Bun.sleep(50);
+  }
+}
+
+async function clearRows() {
+  await suDb.$executeRawUnsafe(
+    `DELETE FROM execution_logs WHERE tenant_id = ${tenantId}`,
+  );
+  await suDb.$executeRawUnsafe(
+    `DELETE FROM alert_deliveries WHERE tenant_id = ${tenantId}`,
+  );
+}
+
+describe.skipIf(!dbUp)("a dead outbound delivery reaches the operator", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "WHD", slug: `whd-${process.pid}` },
+    });
+    tenantId = t.id;
+    liveSub = (
+      await suDb.webhookSubscription.create({
+        data: {
+          tenantId,
+          url: "https://example.com/receiver",
+          events: ["conversion"],
+          enabled: true,
+        },
+      })
+    ).id;
+    blockedSub = (
+      await suDb.webhookSubscription.create({
+        data: {
+          tenantId,
+          // Refused by the real SSRF guard (plain http), so it dies without a single attempt.
+          url: "http://example.com/insecure",
+          events: ["conversion"],
+          enabled: true,
+        },
+      })
+    ).id;
+    allStagesChannel = (
+      await suDb.alertChannel.create({
+        data: {
+          tenantId,
+          name: "all",
+          type: "webhook",
+          url: "enc",
+          enabled: true,
+          minLevel: "error",
+          stages: [],
+        },
+      })
+    ).id;
+    webhookOnlyChannel = (
+      await suDb.alertChannel.create({
+        data: {
+          tenantId,
+          name: "webhook-only",
+          type: "webhook",
+          url: "enc",
+          enabled: true,
+          minLevel: "error",
+          stages: ["webhook"],
+        },
+      })
+    ).id;
+    otherStageChannel = (
+      await suDb.alertChannel.create({
+        data: {
+          tenantId,
+          name: "generate-only",
+          type: "webhook",
+          url: "enc",
+          enabled: true,
+          minLevel: "error",
+          stages: ["generate"],
+        },
+      })
+    ).id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const tbl of [
+        "alert_deliveries",
+        "alert_channels",
+        "execution_logs",
+        "outbound_webhook_deliveries",
+        "webhook_subscriptions",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${tbl} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  test("attempts exhausted: the row names the subscription, the event and the last error", async () => {
+    await clearRows();
+    const id = await seedDelivery(liveSub, 7);
+    const summary = await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl: responds(500),
+      assertSafe: passthroughSafe,
+    });
+    expect(summary.dead).toBe(1);
+    const rows = await webhookRows(1);
+    expect(rows).toHaveLength(1);
+    const row = rows[0] as (typeof rows)[number];
+    expect(row.level).toBe("error");
+    expect(row.status).toBe("error");
+    expect(row.source).toBe("inbox");
+    expect(row.conversationId).toBeNull();
+    const detail = row.detail as Record<string, unknown>;
+    expect(detail.deliveryId).toBe(String(id));
+    expect(detail.subscriptionId).toBe(String(liveSub));
+    expect(detail.event).toBe("conversion");
+    expect(detail.attempts).toBe(8);
+    expect(row.errorMessage).toContain("non-2xx response: 500");
+  });
+
+  test("a blocked URL dies on the first attempt, and says so too", async () => {
+    await clearRows();
+    const id = await seedDelivery(blockedSub, 0);
+    const summary = await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl: never,
+      assertSafe: assertSafeOutboundUrl,
+    });
+    expect(summary.dead).toBe(1);
+    const rows = await webhookRows(1);
+    expect(rows).toHaveLength(1);
+    const row = rows[0] as (typeof rows)[number];
+    expect(row.level).toBe("error");
+    const detail = row.detail as Record<string, unknown>;
+    expect(detail.deliveryId).toBe(String(id));
+    // The whole point of this second road: no retry budget was spent, so an operator reading
+    // `attempts` must not conclude the receiver was tried eight times.
+    expect(detail.attempts).toBe(1);
+    expect(row.errorMessage).toContain("Blocked outbound URL");
+  });
+
+  test("the delivery payload never reaches the log line", async () => {
+    await clearRows();
+    await seedDelivery(liveSub, 7);
+    await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl: responds(500),
+      assertSafe: passthroughSafe,
+    });
+    const rows = await webhookRows(1);
+    expect(rows).toHaveLength(1);
+    const serialized = JSON.stringify(rows[0], (_k, v) =>
+      typeof v === "bigint" ? String(v) : v,
+    );
+    expect(serialized).not.toContain(PAYLOAD_MARKER);
+  });
+
+  test("the alert reaches an all-stages channel and a channel that asked for this stage, and not one narrowed to another", async () => {
+    await clearRows();
+    await seedDelivery(liveSub, 7);
+    await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl: responds(500),
+      assertSafe: passthroughSafe,
+    });
+    const alerts = await alertRows(2);
+    const byChannel = new Map(alerts.map((a) => [String(a.channelId), a]));
+    expect(byChannel.has(String(allStagesChannel))).toBe(true);
+    expect(byChannel.has(String(webhookOnlyChannel))).toBe(true);
+    expect(byChannel.has(String(otherStageChannel))).toBe(false);
+    const one = byChannel.get(String(allStagesChannel)) as NonNullable<
+      ReturnType<typeof byChannel.get>
+    >;
+    expect(one.stage).toBe("webhook");
+    expect(one.level).toBe("error");
+    expect(one.summary).not.toContain(PAYLOAD_MARKER);
+  });
+
+  test("an operator can subscribe a channel to this stage by name", async () => {
+    // The point of putting this in `FLOW_STAGES` rather than giving the worker its own path: the
+    // vocabulary is what the channel picker offers and what `assertStages` accepts, so the operator
+    // can ask for dead deliveries WITHOUT taking every other error with them. A stage the worker
+    // owned privately could only ever reach a channel that had asked for everything.
+    const ch = await createAlertChannel(
+      { tenantId, userId: null, role: "TENANT_ADMIN" },
+      {
+        name: `subscribable-${process.pid}`,
+        type: "webhook",
+        url: "https://example.com/alerts",
+        minLevel: "error",
+        stages: ["webhook"],
+      },
+      suDb,
+    );
+    expect(ch.stages).toEqual(["webhook"]);
+    await suDb.alertChannel.delete({ where: { id: BigInt(ch.id) } });
+  });
+
+  test("negative control: a delivered delivery writes no line", async () => {
+    await clearRows();
+    await seedDelivery(liveSub, 0);
+    const summary = await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl: responds(200),
+      assertSafe: passthroughSafe,
+    });
+    expect(summary.delivered).toBe(1);
+    expect(await webhookRows(0, 700)).toHaveLength(0);
+  });
+
+  test("negative control: a retried delivery writes no line — the budget is not spent yet", async () => {
+    await clearRows();
+    await seedDelivery(liveSub, 0);
+    const summary = await processOutboundBatch({
+      base: appDb,
+      tenantId,
+      fetchImpl: responds(503),
+      assertSafe: passthroughSafe,
+    });
+    expect(summary.retried).toBe(1);
+    expect(summary.dead).toBe(0);
+    expect(await webhookRows(0, 700)).toHaveLength(0);
+  });
+});

--- a/tests/modules/webhooks-outbound-dead-fence.test.ts
+++ b/tests/modules/webhooks-outbound-dead-fence.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+// ── EVERY ROAD TO DEAD GOES THROUGH THE ONE THAT ANNOUNCES IT (issue #325) ──
+// The fix collapsed two DEAD writes into `finalizeDead`, which writes the row AND emits the line.
+// That is the correction; this is what keeps it. The two sites did not disagree because anyone
+// decided they should — they were written a year apart and neither had a line to forget, so a third
+// one added the same way would be silent again and nothing would say so.
+//
+// A source sweep, because the alternative (a runtime assertion) can only fire on a path a test
+// already drives, and the whole failure mode here is the path nobody thought to drive.
+
+const OUTBOUND_DIR = "src/modules/webhooks/outbound";
+
+// A write of the DEAD status, in the two spellings TypeScript accepts for a Prisma enum column: the
+// string literal the codebase uses, and the generated enum member. Reads (`where: { status: … }`)
+// are deliberately NOT matched — asking which deliveries are dead is a question, not a death, and
+// #305 will add exactly such a reader.
+const DEAD_WRITE =
+  /(?<!where:\s*\{[^}]{0,80})status:\s*(?:"DEAD"|'DEAD'|WebhookDeliveryStatus\.DEAD)/;
+
+const FUNCTION_DECL = /(?:async\s+)?function\s+([A-Za-z0-9_$]+)\s*\(/;
+
+// Exported for its own positive control: a sweep that finds nothing passes identically whether the
+// codebase is clean or the predicate is broken, so the predicate has to be shown finding something.
+export function deadWriteFunctions(source: string): string[] {
+  const lines = source.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] as string;
+    if (line.trimStart().startsWith("//")) continue;
+    if (!DEAD_WRITE.test(line)) continue;
+    let enclosing = "<top level>";
+    for (let j = i; j >= 0; j--) {
+      const m = FUNCTION_DECL.exec(lines[j] as string);
+      if (m) {
+        enclosing = m[1] as string;
+        break;
+      }
+    }
+    out.push(enclosing);
+  }
+  return out;
+}
+
+describe("the DEAD write fence", () => {
+  test("positive control: the predicate sees a stray write, and names the function it is in", () => {
+    const fixture = `
+async function finalizeDead(base, d) {
+  await db.outboundWebhookDelivery.update({ data: { status: "DEAD" } });
+}
+async function someNewPath(base, d) {
+  await db.outboundWebhookDelivery.update({ data: { status: "DEAD" } });
+}
+`;
+    expect(deadWriteFunctions(fixture)).toEqual([
+      "finalizeDead",
+      "someNewPath",
+    ]);
+  });
+
+  test("positive control: the enum spelling counts too, and a read does not", () => {
+    const write = `function f() { await u({ data: { status: WebhookDeliveryStatus.DEAD } }); }`;
+    expect(deadWriteFunctions(write)).toEqual(["f"]);
+    const read = `function g() { await m({ where: { status: "DEAD" } }); }`;
+    expect(deadWriteFunctions(read)).toEqual([]);
+  });
+
+  test("positive control: a commented-out write is not a write", () => {
+    expect(
+      deadWriteFunctions(`function f() {\n  // status: "DEAD"\n}`),
+    ).toEqual([]);
+  });
+
+  test("every DEAD write in the outbound module is inside finalizeDead", async () => {
+    const files = [...new Bun.Glob("*.ts").scanSync(OUTBOUND_DIR)].map(
+      (f) => `${OUTBOUND_DIR}/${f}`,
+    );
+    expect(files.length).toBeGreaterThan(0);
+    const sites: string[] = [];
+    for (const f of files) {
+      const source = await Bun.file(f).text();
+      for (const fn of deadWriteFunctions(source)) sites.push(`${f}:${fn}`);
+    }
+    // Read at assertion time from the real tree, never from a snapshot.
+    expect(sites).toEqual([
+      "src/modules/webhooks/outbound/worker.ts:finalizeDead",
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #325

## What happens

An outbound delivery that reaches `DEAD` is an event the operator asked to receive and never will, and until now nothing said so anywhere they look. The worker tick logs `reaped=… claimed=… delivered=… retried=… dead=%d`, which counts the deaths without naming any of them and is not a channel anyone subscribes to.

Measured against the real worker and a real Postgres, with an alert channel enabled at `minLevel: warn` and no stage allowlist — that is, an operator who asked for everything:

| road to DEAD | delivery row | `ExecutionLog` | `AlertDelivery` |
| --- | --- | --- | --- |
| retry budget exhausted | `DEAD`, attempts 8, `non-2xx response: 500` | 0 | 0 |
| URL the SSRF guard refuses | `DEAD`, **attempts 1**, `Blocked outbound URL: protocol … not allowed` | 0 | 0 |

## What the report understates

**There are two roads to DEAD, and the issue names one.** Besides the exhausted retry budget, `deliverClaimed` writes `DEAD` directly when `assertSafeOutboundUrl` refuses the subscription's URL — no attempt, no backoff, dead on sight. It is the likelier one in practice, because it is what an operator's typo in a subscription URL produces, and it is the one where `attempts` reads `1` rather than `8`. Both were silent; a fix that covered only the first would have left the faster one exactly as it was.

## The decision the issue records, and why it goes to the flow log

The issue lists three options and asks for a decision rather than a call site. Two of them fall to measurement.

**The objection to the flow log no longer holds.** It rests on the vocabulary's comment, "one stage per pipeline step a turn can run through". That comment stopped describing `FLOW_STAGES` when `route` landed for #318 and again when `command` landed for #317: both are pre-turn, both are emitted with a synthesized `turnId` and `source: "inbox"`. This change stops asserting it and says what the vocabulary is actually for — the question an operator can be asked to explain — with `webhook` named in place as the one entry that is not a turn step at all.

**A private path for the worker (option b) is worse for the operator, in two measured ways.** `dispatchAlertsForEvent` matches a channel with `ch.stages.length > 0 && !ch.stages.includes(ev.stage)`, so an alert carrying no stage reaches only channels that asked for everything: anyone who narrowed their channel would silently never hear about a dead delivery. And there would be no row on the Logs page, so the alert would arrive with nothing for the operator to open.

**An event on the bus (option c)** the issue already answers itself: the bus is the thing that just failed.

What the flow log buys instead, for no extra code: `FLOW_STAGES` has **six** readers (`/stages`, the MCP stage list, two MCP tool enums, `assertStages`, the console's channel picker, the Logs filter) and every one of them derives its list from the vocabulary, so a channel can subscribe to `webhook` **and nothing else** the moment the entry exists. There is a test for exactly that, through the real `createAlertChannel`, because it is the operator-facing half of this decision.

## The fix

`finalizeDead` is now the only write of `DEAD`, and it writes the row and emits the line together. That is deliberately construction rather than convention: the two sites did not disagree because anyone decided they should, they were written apart and neither had a line to forget, and a third one added the same way would be silent again. A source sweep (`tests/modules/webhooks-outbound-dead-fence.test.ts`, with positive controls for both spellings of the enum, for a read, and for a commented-out write) fails while any `DEAD` write sits outside it.

The line is `error`, not `warn`. Level is what a channel filters on, `AlertChannel.minLevel` defaults to `error` and does not even accept `info`, so anything softer would reach nobody who had not already gone and widened their channel — which is the state this issue reports. The flood risk that argues for `warn` is handled a layer down: `dispatchAlertsForEvent` bumps `count` on a PENDING delivery for the same (channel, stage, level) instead of inserting another, so a thousand dead deliveries are one alert that says a thousand.

`detail` carries what finds the delivery (`deliveryId`, `subscriptionId`, `event`) and what says how it died (`attempts`, 8 on an exhausted budget and 1 on a refused URL). The payload never travels.

## Validation scope

**Proven by test** (`bun check`: 6058 pass, 0 fail):

- `tests/modules/webhooks-outbound-dead-alert.test.ts`, DB-backed against the real worker under real RLS: both roads to DEAD, the row's level, source, null conversation and every `detail` field, the alert reaching an all-stages channel and a `["webhook"]` channel while missing a `["generate"]` one, an operator subscribing to the stage through `createAlertChannel`, that the payload never reaches the line, and two negative controls (a delivered and a retried delivery write nothing). The SSRF case uses the **real** guard, not a stub. Red before the fix: 4 of 6.
- `tests/modules/webhooks-outbound-dead-fence.test.ts`, the DEAD-write sweep and its positive controls.
- Mutation battery, one at a time, each killed: the emit removed (4 tests), `level` to `warn` (3), `source` to `playground` (2), a constant `attempts` (1), the wrong stage (4), the SSRF site restored to its pre-fix direct write (2 — the fence and the second road), the payload into `detail` (1), the label case removed (1), emitting on a retry too (1), and the stage removed from `FLOW_STAGES` (2 — the label sweep's reverse half and the subscribability test).

**Proven live**, real HTTP on both ends: a `Bun.serve` receiver that answers 500, real `fetch`, and the operator's alert channel is a second real server that records what it is POSTed. Same script, one worktree per half.

| | base (`2715507d`) | this branch |
| --- | --- | --- |
| receiver hit | 1 POST, 500 | 1 POST, 500 |
| delivery | `DEAD`, attempts 8, `non-2xx response: 500` | `DEAD`, attempts 8, same error |
| `ExecutionLog` | 0 | 1 — `webhook` / `error`, `{"event":"conversion","attempts":8,"deliveryId":…,"subscriptionId":…}` |
| **the operator's channel** | **0 POSTs** | **1 POST**: `{"version":1,"type":"alert","stage":"webhook","level":"error","count":1,"summary":"[webhook] non-2xx response: 500"}` |
| second road (`ftp://`, real guard) | `DEAD` attempts 1, **0 POSTs** | `DEAD` attempts 1, **1 POST**, summary `[webhook] Blocked outbound URL: protocol ftp: not allowed` |

Both halves reach the same delivery state — identical receiver hits, identical `attempts`, identical `lastError` — so the measured difference is only what reaches the operator. The payload marker seeded into the delivery body appears in neither alert.

The live second road uses a refused *scheme* rather than a private address on purpose: `config.ssrf.allowPrivateTargets` is auto-true in development, so plain http and private targets pass the guard there (which is also why the local receiver above is reachable at all). The test covers that road under the real guard with the test configuration, where the http refusal is the one that fires.

**The burst, measured** rather than argued, because `error` on a per-event failure is the choice that most deserves a number: 25 deliveries against the same broken receiver, one tick, `DELIVERY_CONCURRENCY = 10`.

```
dead: 25/25   ExecutionLog(webhook): 25   AlertDelivery: 1 row, count = 25
```

One alert that says twenty-five. The row-per-death is what the Logs page needs to show which events were lost; the single alert is what keeps a broken receiver from paging twenty-five times. The race `dispatchAlertsForEvent` documents ("a rare race may insert two rows") did not fire here, which is a measurement and not a guarantee.

**Not validated**: nothing on the emit path is left to reading. One thing is named rather than counted as covered: the alert channel's own delivery is exercised live with the SSRF check relaxed, because a local receiver cannot be reached otherwise — the signing and retry behaviour of that worker is unchanged by this PR and has its own tests.
