### PR TITLE
Put a refusal at the input the server named, on every form that writes

### DIFF
--- a/src/api/features/admin/admin.controller.ts
+++ b/src/api/features/admin/admin.controller.ts
@@ -311,6 +311,7 @@ export const adminController = new Elysia({
           set.status = 409;
           return {
             error: translate("errors.emailInUse", "Email already in use"),
+            field: "email",
           };
         }
         throw error;

--- a/src/api/features/auth/auth.controller.ts
+++ b/src/api/features/auth/auth.controller.ts
@@ -423,6 +423,9 @@ const baseAuthController = new Elysia({
               "errors.currentPasswordIncorrect",
               "Current password is incorrect",
             ),
+            // The form has two password boxes and this refusal is about exactly one of them. Built by
+            // hand here rather than raised as an AppError, so `refusalBody` never sees it.
+            field: "currentPassword",
           };
         }
         throw error;

--- a/src/api/features/auth/auth.controller.ts
+++ b/src/api/features/auth/auth.controller.ts
@@ -196,6 +196,9 @@ const baseAuthController = new Elysia({
         set.status = 400;
         return {
           error: translate("errors.emailInUse", "Email already in use"),
+          // The one input the operator fixes, named the way every other refusal names one (#231).
+          // Built by hand here rather than raised as an AppError, so `refusalBody` never sees it.
+          field: "email",
         };
       }
 
@@ -510,6 +513,7 @@ const baseAuthController = new Elysia({
           set.status = 409;
           return {
             error: translate("errors.emailInUse", "Email already in use"),
+            field: "email",
           };
         }
         throw error;

--- a/src/client/components/BusinessHoursForm.tsx
+++ b/src/client/components/BusinessHoursForm.tsx
@@ -8,8 +8,8 @@ import { useUnsavedChanges } from "@/client/components/Modal";
 import { Select } from "@/client/components/Select";
 import { TimezonePicker } from "@/client/components/TimezonePicker";
 import { useToast } from "@/client/components/Toast";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
-import { apiErrorMessage } from "@/client/lib/apiError";
 
 type HoursData = Awaited<
   ReturnType<(typeof api.api.v1)["business-hours"]["get"]>
@@ -84,6 +84,10 @@ export interface BusinessHoursFormProps {
 // BusinessHoursPanel (via modal) and SchedulePicker (inline create/edit).
 // When rendered inside a <Modal>, calls useUnsavedChanges so the modal's
 // discard-confirmation guard fires automatically on dirty state.
+// The keys of the body this form writes. The window and exception lists are refused per element
+// (`refused body.windows.0`), which lands on the list they belong to: see placeRefusal.
+const HOURS_FIELDS = ["name", "timezone", "windows", "exceptions"] as const;
+
 export function BusinessHoursForm({
   mode,
   initial,
@@ -101,6 +105,7 @@ export function BusinessHoursForm({
   const [windows, setWindows] = useState<Window[]>(
     initial?.windows ?? DEFAULT_WINDOWS,
   );
+  const refusal = useFieldRefusal(HOURS_FIELDS);
   const [exceptions, setExceptions] = useState<Exception[]>(
     initial?.exceptions ?? [],
   );
@@ -183,6 +188,20 @@ export function BusinessHoursForm({
   const hasInvalidWindow = windows.some(windowInvalid);
   const hasInvalidException = exceptions.some(exceptionInvalid);
 
+  // What the inputs hold right now, in the server's vocabulary, and what the write sends.
+  const currentRef = useRef({
+    name: name.trim(),
+    timezone: timezone.trim() || "UTC",
+    windows,
+    exceptions,
+  });
+  currentRef.current = {
+    name: name.trim(),
+    timezone: timezone.trim() || "UTC",
+    windows,
+    exceptions,
+  };
+
   async function save() {
     if (!name.trim()) return;
     if (hasInvalidException) {
@@ -212,27 +231,35 @@ export function BusinessHoursForm({
       windows,
       exceptions,
     };
+    const held = (e: unknown) =>
+      refusal.capture(
+        e,
+        t("hours.saveError", "Could not save."),
+        body,
+        currentRef.current,
+      );
     try {
       if (mode === "update" && initial?.id) {
         const { data, error: err } = await api.api.v1["business-hours"]({
           id: initial.id,
         }).patch(body);
         if (err || !data) throw err;
+        refusal.clear();
         showToast(t("hours.saved", "Business hours saved."), "success");
         onSaved(data.businessHours.id, data.businessHours.name);
       } else {
         const { data, error: err } =
           await api.api.v1["business-hours"].post(body);
         if (err || !data) throw err;
+        refusal.clear();
         showToast(t("hours.saved", "Business hours saved."), "success");
         onSaved(data.businessHours.id, data.businessHours.name);
       }
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("hours.saveError", "Could not save (check the timezone)."),
-        "error",
-      );
+      // The fixed sentence this replaces said "check the timezone" for every refusal this write can
+      // answer, a duplicate name included: the confident wrong pointer #224 is about.
+      const toast = held(e);
+      if (toast) showToast(toast, "error");
     } finally {
       setSaving(false);
     }
@@ -241,10 +268,18 @@ export function BusinessHoursForm({
   return (
     <div className="flex flex-col gap-4">
       <div className="grid gap-4 sm:grid-cols-2">
-        <FormField label={t("hours.name", "Name")} required>
+        <FormField
+          label={t("hours.name", "Name")}
+          required
+          error={refusal.at("name", name.trim())}
+        >
           <Input value={name} onChange={(e) => setName(e.target.value)} />
         </FormField>
-        <FormField label={t("hours.timezone", "Timezone")} group>
+        <FormField
+          label={t("hours.timezone", "Timezone")}
+          group
+          error={refusal.at("timezone", timezone.trim() || "UTC")}
+        >
           <TimezonePicker
             value={timezone}
             onChange={setTimezone}
@@ -257,6 +292,11 @@ export function BusinessHoursForm({
         <div className="flex items-center justify-between">
           <span className="font-medium text-sm text-text-secondary">
             {t("hours.windows", "Windows")}
+            {refusal.at("windows", windows) && (
+              <span className="ml-2 font-normal text-error text-xs">
+                {refusal.at("windows", windows)}
+              </span>
+            )}
           </span>
           <Button
             variant="secondary"
@@ -344,6 +384,11 @@ export function BusinessHoursForm({
         <div className="flex items-center justify-between">
           <span className="font-medium text-sm text-text-secondary">
             {t("hours.exceptions", "Holidays and closures")}
+            {refusal.at("exceptions", exceptions) && (
+              <span className="ml-2 font-normal text-error text-xs">
+                {refusal.at("exceptions", exceptions)}
+              </span>
+            )}
           </span>
           <Button
             variant="secondary"

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -437,6 +437,12 @@ export function CredentialForm({
     }
   }
 
+  // The inner inputs of a multi-field secret, by the names the server refuses them under.
+  const fieldSnapshot = () =>
+    Object.fromEntries(
+      (fields ?? []).map((f) => [f.key, fieldValues[f.key] ?? ""]),
+    );
+
   // What the inputs hold right now, in the server's vocabulary. Each write below sends a subset of
   // these, and `capture` compares only the key it was refused about.
   const currentRef = useRef<Record<string, unknown>>({});
@@ -464,7 +470,12 @@ export function CredentialForm({
     refusal.capture(
       e,
       t("vault.saveError", "Could not save the secret."),
-      sent,
+      // The per-field values ride along, and they are not on the wire: a multi-field secret is sent
+      // as ONE `value` blob, so a snapshot built from the body alone carries no `api_key` for
+      // `placeRefusal` to compare against. Without them the staleness check has nothing to check,
+      // and a value the operator replaced while the request was out gets marked as the one the
+      // server refused.
+      { ...sent, ...fieldSnapshot() },
       currentRef.current,
     );
 

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -24,6 +24,7 @@ import { McpOAuthSection } from "@/client/components/McpOAuthSection";
 import { useUnsavedChanges } from "@/client/components/Modal";
 import { Textarea } from "@/client/components/Textarea";
 import { useToast } from "@/client/components/Toast";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { providerLink } from "@/client/lib/affiliateLinks";
 import { api } from "@/client/lib/api";
 import {
@@ -208,6 +209,16 @@ export function CredentialForm({
 
   const fields = secretTypeFields(kind);
   const hasFields = !!fields && fields.length > 0;
+  // The names this form can render a sentence under. The per-field keys of a multi-field type are in
+  // the list because that is how the server refuses them: `assertNoSurroundingWhitespace` names the
+  // inner key (`api_key`), and this form draws one input per key.
+  const refusal = useFieldRefusal([
+    "name",
+    "value",
+    "baseUrl",
+    "paramName",
+    ...(fields ?? []).map((f) => f.key),
+  ]);
   const needsParamName = secretTypeNeedsParamName(kind);
   const supportsBaseUrl = secretTypeSupportsBaseUrl(kind);
   const requiresBaseUrl = secretTypeRequiresBaseUrl(kind);
@@ -426,18 +437,36 @@ export function CredentialForm({
     }
   }
 
-  function mapSaveError(
-    status: number | undefined,
-    apiMessage?: string,
-  ): string {
-    if (status === 409)
-      return t(
-        "vault.nameInUse",
-        "A secret with this name and type already exists.",
-      );
-    if (status === 400 && apiMessage) return apiMessage;
-    return t("vault.saveError", "Could not save the secret.");
-  }
+  // What the inputs hold right now, in the server's vocabulary. Each write below sends a subset of
+  // these, and `capture` compares only the key it was refused about.
+  const currentRef = useRef<Record<string, unknown>>({});
+  currentRef.current = {
+    name: name.trim(),
+    value,
+    baseUrl: baseUrl.trim() || null,
+    paramName: paramName.trim() || undefined,
+    ...Object.fromEntries(
+      (fields ?? []).map((f) => [f.key, fieldValues[f.key] ?? ""]),
+    ),
+  };
+
+  // The refusal, at the input it names.
+  //
+  // What this replaces was `mapSaveError`, which answered its OWN localized sentence for a 409 and
+  // the server's for a 400. The premise was that a 409 arrives unlocalized, and it does not: the
+  // server translates `errors.vaultNameInUse` for the request's Accept-Language, and its pt-BR
+  // sentence ("Já existe um segredo com esse nome e tipo") names the type as well, which the console
+  // copy did not. So the override was a shorter duplicate of a better sentence.
+  //
+  // The declared names include the per-field keys of a multi-field type (`api_key`, `public_key`):
+  // `assertNoSurroundingWhitespace` refuses by the inner key, and the form draws one input per key.
+  const held = (e: unknown, sent: Record<string, unknown>) =>
+    refusal.capture(
+      e,
+      t("vault.saveError", "Could not save the secret."),
+      sent,
+      currentRef.current,
+    );
 
   async function save(skipTest = false) {
     if (!canSave) return;
@@ -476,28 +505,22 @@ export function CredentialForm({
             ? buildMultiFieldValue()
             : undefined
           : value || undefined;
+        const sent = {
+          name: renaming ? name.trim() : undefined,
+          value: newValue,
+          // PUT schema: baseUrl is Optional(Nullable(String)); paramName is Optional(String).
+          baseUrl: supportsBaseUrl ? baseUrl.trim() || null : undefined,
+          paramName: needsParamName ? paramName.trim() || undefined : undefined,
+        };
         const { data, error: err } = await api.api.v1
           .vault({ id: initialId })
-          .put({
-            name: renaming ? name.trim() : undefined,
-            value: newValue,
-            // PUT schema: baseUrl is Optional(Nullable(String)); paramName is Optional(String).
-            baseUrl: supportsBaseUrl ? baseUrl.trim() || null : undefined,
-            paramName: needsParamName
-              ? paramName.trim() || undefined
-              : undefined,
-          });
+          .put(sent);
         if (err || !data) {
-          const apiErr = err as {
-            status?: number;
-            value?: { error?: string };
-          } | null;
-          showToast(
-            mapSaveError(apiErr?.status, apiErr?.value?.error),
-            "error",
-          );
+          const toast = held(err, sent);
+          if (toast) showToast(toast, "error");
           return;
         }
+        refusal.clear();
         showToast(t("vault.saved", "Secret saved."), "success");
         onSaved(data.ref, name.trim(), kind === "generic" ? null : kind);
       } else {
@@ -506,25 +529,21 @@ export function CredentialForm({
           : isManagedBlob
             ? {}
             : value;
-        const { data, error: err } = await api.api.v1.vault.post({
+        const sent = {
           name: name.trim(),
           value: newValue,
           kind: kind === "generic" ? null : kind,
           // POST schema: baseUrl/paramName are Optional(String) — no null allowed; omit when empty.
           baseUrl: supportsBaseUrl ? baseUrl.trim() || undefined : undefined,
           paramName: needsParamName ? paramName.trim() || undefined : undefined,
-        });
+        };
+        const { data, error: err } = await api.api.v1.vault.post(sent);
         if (err || !data) {
-          const apiErr = err as {
-            status?: number;
-            value?: { error?: string };
-          } | null;
-          showToast(
-            mapSaveError(apiErr?.status, apiErr?.value?.error),
-            "error",
-          );
+          const toast = held(err, sent);
+          if (toast) showToast(toast, "error");
           return;
         }
+        refusal.clear();
         showToast(t("vault.saved", "Secret saved."), "success");
         // google_oauth / mcp_oauth: stay open to show the connect section after create. Store the
         // payload so "Done" can call onSaved once the operator has (optionally) connected.
@@ -570,24 +589,20 @@ export function CredentialForm({
     setSaving(true);
     try {
       if (!existingId) {
-        const { data, error: err } = await api.api.v1.vault.post({
+        const sent = {
           name: name.trim(),
           value: buildMultiFieldValue(),
           kind,
           baseUrl: supportsBaseUrl ? baseUrl.trim() || undefined : undefined,
           paramName: needsParamName ? paramName.trim() || undefined : undefined,
-        });
+        };
+        const { data, error: err } = await api.api.v1.vault.post(sent);
         if (err || !data) {
-          const apiErr = err as {
-            status?: number;
-            value?: { error?: string };
-          } | null;
-          showToast(
-            mapSaveError(apiErr?.status, apiErr?.value?.error),
-            "error",
-          );
+          const toast = held(err, sent);
+          if (toast) showToast(toast, "error");
           return null;
         }
+        refusal.clear();
         savedOAuthPayloadRef.current = {
           ref: data.ref,
           name: name.trim(),
@@ -597,22 +612,21 @@ export function CredentialForm({
         setFieldValues({});
         return data.id;
       }
+      const sent = {
+        name: renaming ? name.trim() : undefined,
+        value: buildMultiFieldValue(),
+        baseUrl: supportsBaseUrl ? baseUrl.trim() || null : undefined,
+        paramName: needsParamName ? paramName.trim() || undefined : undefined,
+      };
       const { data, error: err } = await api.api.v1
         .vault({ id: existingId })
-        .put({
-          name: renaming ? name.trim() : undefined,
-          value: buildMultiFieldValue(),
-          baseUrl: supportsBaseUrl ? baseUrl.trim() || null : undefined,
-          paramName: needsParamName ? paramName.trim() || undefined : undefined,
-        });
+        .put(sent);
       if (err || !data) {
-        const apiErr = err as {
-          status?: number;
-          value?: { error?: string };
-        } | null;
-        showToast(mapSaveError(apiErr?.status, apiErr?.value?.error), "error");
+        const toast = held(err, sent);
+        if (toast) showToast(toast, "error");
         return null;
       }
+      refusal.clear();
       setFieldValues({});
       return existingId;
     } catch {
@@ -664,7 +678,7 @@ export function CredentialForm({
         error={
           name && !NAME_RE.test(name.trim())
             ? t("vault.invalidName", "Must be between 1 and 128 characters.")
-            : null
+            : refusal.at("name", name.trim())
         }
       >
         <Input
@@ -909,7 +923,7 @@ export function CredentialForm({
               ? t("vault.baseUrlRequired", "Base URL is required.")
               : baseUrlInvalid && baseUrl.trim()
                 ? t("common.invalidUrl", "Must be a valid http(s) URL.")
-                : null
+                : refusal.at("baseUrl", baseUrl.trim() || null)
           }
         >
           <Input
@@ -987,6 +1001,7 @@ export function CredentialForm({
                         "Stored encrypted and never shown again.",
                       )
                 }
+                error={refusal.at(f.key, fieldValues[f.key] ?? "")}
               >
                 {f.masked ? (
                   <Input
@@ -1041,6 +1056,7 @@ export function CredentialForm({
                     "Stored encrypted and never shown again.",
                   )
             }
+            error={refusal.at("value", value)}
           >
             <Input
               type="password"

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -729,15 +729,20 @@ export function CredentialForm({
             if (next) setTypeSearch("");
           }}
         >
-          {/* Locked once created, and locked again while a create is in flight: the write is about a
-              (name, kind) PAIR and the held refusal expires by the name alone, so a type changed
-              mid-save would put a 409 answered for the old pair under a new one that is free. The
-              clear on select below covers the ordinary switch, between attempts; this covers the
+          {/* Locked once created, and locked again for as long as a create is in flight: the write is
+              about a (name, kind) PAIR and the held refusal expires by the name alone, so a type
+              changed mid-save would put a 409 answered for the old pair under a new one that is
+              free. `testing` as well as `saving`, because `save()` probes the typed value first and
+              only marks itself saving afterwards — the same pair the Save button beside it uses.
+              The clear on select below covers the ordinary switch, between attempts; this covers the
               one that races the answer. */}
-          <DropdownMenuPrimitive.Trigger asChild disabled={isUpdate || saving}>
+          <DropdownMenuPrimitive.Trigger
+            asChild
+            disabled={isUpdate || testing || saving}
+          >
             <button
               type="button"
-              disabled={isUpdate || saving}
+              disabled={isUpdate || testing || saving}
               aria-label={t("vault.type", "Type")}
               className="flex w-full items-center gap-2 rounded-lg border border-border bg-bg-tertiary py-2 pr-3 pl-3 text-sm text-text-primary focus:border-border-focus focus:outline-none disabled:opacity-60"
             >

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -873,7 +873,7 @@ export function CredentialForm({
           error={
             paramNameMissing && paramNameTouched
               ? t("vault.paramNameRequired", "Parameter name is required.")
-              : null
+              : refusal.at("paramName", paramName.trim() || undefined)
           }
         >
           <Input

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -729,10 +729,15 @@ export function CredentialForm({
             if (next) setTypeSearch("");
           }}
         >
-          <DropdownMenuPrimitive.Trigger asChild disabled={isUpdate}>
+          {/* Locked once created, and locked again while a create is in flight: the write is about a
+              (name, kind) PAIR and the held refusal expires by the name alone, so a type changed
+              mid-save would put a 409 answered for the old pair under a new one that is free. The
+              clear on select below covers the ordinary switch, between attempts; this covers the
+              one that races the answer. */}
+          <DropdownMenuPrimitive.Trigger asChild disabled={isUpdate || saving}>
             <button
               type="button"
-              disabled={isUpdate}
+              disabled={isUpdate || saving}
               aria-label={t("vault.type", "Type")}
               className="flex w-full items-center gap-2 rounded-lg border border-border bg-bg-tertiary py-2 pr-3 pl-3 text-sm text-text-primary focus:border-border-focus focus:outline-none disabled:opacity-60"
             >

--- a/src/client/components/CredentialForm.tsx
+++ b/src/client/components/CredentialForm.tsx
@@ -209,16 +209,6 @@ export function CredentialForm({
 
   const fields = secretTypeFields(kind);
   const hasFields = !!fields && fields.length > 0;
-  // The names this form can render a sentence under. The per-field keys of a multi-field type are in
-  // the list because that is how the server refuses them: `assertNoSurroundingWhitespace` names the
-  // inner key (`api_key`), and this form draws one input per key.
-  const refusal = useFieldRefusal([
-    "name",
-    "value",
-    "baseUrl",
-    "paramName",
-    ...(fields ?? []).map((f) => f.key),
-  ]);
   const needsParamName = secretTypeNeedsParamName(kind);
   const supportsBaseUrl = secretTypeSupportsBaseUrl(kind);
   const requiresBaseUrl = secretTypeRequiresBaseUrl(kind);
@@ -226,6 +216,23 @@ export function CredentialForm({
   // blob created empty and populated by the connect flow. The form needs only name + baseUrl.
   const isManagedBlob = secretTypeIsManagedBlob(kind);
   const provLink = providerLink(kind);
+
+  // What this form is DRAWING, which is not what it can send. Four of these five come and go with
+  // the secret kind and the input mode: the per-key inputs of a multi-field type are how the server
+  // refuses them (`assertNoSurroundingWhitespace` names the inner key, `api_key`), and they are
+  // replaced by a single `.env` textarea the moment the operator switches to pasting — at which
+  // point a refusal about `public_key` has nowhere to land and belongs in the toast. Mirrors the
+  // conditions the JSX below renders under, and it has to keep mirroring them.
+  const refusal = useFieldRefusal([
+    "name",
+    ...(supportsBaseUrl && !langfusePaste ? ["baseUrl"] : []),
+    ...(needsParamName ? ["paramName"] : []),
+    ...(isManagedBlob || langfusePaste
+      ? []
+      : hasFields
+        ? (fields ?? []).map((f) => f.key)
+        : ["value"]),
+  ]);
 
   // For multi-field types: all fields must be either all filled or all empty (no partial).
   const allFieldsFilled =
@@ -815,6 +822,11 @@ export function CredentialForm({
                           setLangfusePaste(id === "langfuse");
                           setEnvText("");
                           setEnvError(false);
+                          // Uniqueness in the vault is the (name, kind) PAIR, and the mark expires
+                          // by the name alone. Keeping a custom name while switching type gives a
+                          // pair the server has said nothing about, under a sentence saying it is
+                          // taken.
+                          refusal.clear();
                         }}
                       >
                         <ServiceLogo

--- a/src/client/components/admin/InviteUserModal.tsx
+++ b/src/client/components/admin/InviteUserModal.tsx
@@ -45,7 +45,7 @@ export function InviteUserModal({
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(INVITE_FIELDS);
+  const refusal = useFieldRefusal(INVITE_FIELDS, modal.isOpen);
 
   // A SUPER_ADMIN must target a tenant; block submit until one is chosen.
   const noTarget = isSuperAdmin && !tenantId;

--- a/src/client/components/admin/InviteUserModal.tsx
+++ b/src/client/components/admin/InviteUserModal.tsx
@@ -20,7 +20,11 @@ const labelCls = "mb-1 block font-medium text-sm text-text-primary";
 
 // The keys of the body this modal writes. `email` is the one that matters in practice: inviting an
 // address that already has an account answers 409 "Email already in use", and it names the field.
-const INVITE_FIELDS = ["email", "role", "tenantId"] as const;
+const INVITE_FIELDS = ["email", "role"] as const;
+
+// The tenant picker is only drawn for a SUPER_ADMIN; everyone else invites into their own tenant and
+// the id still rides along in the body, so the server can refuse it by name with no picker to mark.
+const INVITE_SUPER_FIELDS = [...INVITE_FIELDS, "tenantId"] as const;
 
 export function InviteUserModal({
   modal,
@@ -45,7 +49,9 @@ export function InviteUserModal({
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(modal.isOpen ? INVITE_FIELDS : []);
+  const refusal = useFieldRefusal(
+    modal.isOpen ? (isSuperAdmin ? INVITE_SUPER_FIELDS : INVITE_FIELDS) : [],
+  );
 
   // A SUPER_ADMIN must target a tenant; block submit until one is chosen.
   const noTarget = isSuperAdmin && !tenantId;

--- a/src/client/components/admin/InviteUserModal.tsx
+++ b/src/client/components/admin/InviteUserModal.tsx
@@ -65,6 +65,8 @@ export function InviteUserModal({
     (email.trim() !== "" || role !== "AGENT" || tenantId !== defaultTenantId);
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     setEmail("");
     setRole("AGENT");
     setTenantId(defaultTenantId);

--- a/src/client/components/admin/InviteUserModal.tsx
+++ b/src/client/components/admin/InviteUserModal.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/client/components/Button";
 import { Input } from "@/client/components/Input";
@@ -8,8 +8,8 @@ import {
   type ModalController,
   useOnModalOpen,
 } from "@/client/components/Modal";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
-import type { ApiErrorPayload } from "@/client/lib/types";
 
 // Admin "invite user" modal. A SUPER_ADMIN picks the target tenant (pre-filled with the Users-tab
 // filter selection); a TENANT_ADMIN invites into its own tenant (no tenant field). There is no
@@ -17,6 +17,10 @@ import type { ApiErrorPayload } from "@/client/lib/types";
 const selectCls =
   "w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-border-focus focus:outline-none";
 const labelCls = "mb-1 block font-medium text-sm text-text-primary";
+
+// The keys of the body this modal writes. `email` is the one that matters in practice: inviting an
+// address that already has an account answers 409 "Email already in use", and it names the field.
+const INVITE_FIELDS = ["email", "role", "tenantId"] as const;
 
 export function InviteUserModal({
   modal,
@@ -41,9 +45,19 @@ export function InviteUserModal({
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const refusal = useFieldRefusal(INVITE_FIELDS);
 
   // A SUPER_ADMIN must target a tenant; block submit until one is chosen.
   const noTarget = isSuperAdmin && !tenantId;
+
+  // What the inputs hold right now, in the server's vocabulary, and what the write sends.
+  const current = {
+    email,
+    role,
+    tenantId: isSuperAdmin ? tenantId : undefined,
+  };
+  const currentRef = useRef(current);
+  currentRef.current = current;
 
   // NOTE: once the invite link is shown the work is saved, so the form is no longer dirty.
   const isDirty =
@@ -62,25 +76,28 @@ export function InviteUserModal({
   const handleSubmit = async () => {
     setError("");
     setLoading(true);
+    const body = { ...current };
+    const held = (e: unknown) =>
+      refusal.capture(
+        e,
+        t("invite.failed", "Could not create the invitation"),
+        body,
+        currentRef.current,
+      ) ?? "";
     try {
-      const { data, error: apiError } = await api.api.admin.invitations.post({
-        email,
-        role,
-        tenantId: isSuperAdmin ? tenantId : undefined,
-      });
+      const { data, error: apiError } =
+        await api.api.admin.invitations.post(body);
       if (apiError) {
-        setError(
-          (apiError.value as ApiErrorPayload)?.error ||
-            t("invite.failed", "Could not create the invitation"),
-        );
+        setError(held(apiError));
         return;
       }
+      refusal.clear();
       if (data?.invite) {
         setLink(data.invite.acceptUrl);
         onInvited();
       }
-    } catch {
-      setError(t("invite.failed", "Could not create the invitation"));
+    } catch (e) {
+      setError(held(e));
     } finally {
       setLoading(false);
     }
@@ -160,6 +177,11 @@ export function InviteUserModal({
                   </option>
                 ))}
               </select>
+              {refusal.at("tenantId", current.tenantId) && (
+                <p className="mt-1 text-error text-xs">
+                  {refusal.at("tenantId", current.tenantId)}
+                </p>
+              )}
             </div>
           )}
           <div>
@@ -175,6 +197,11 @@ export function InviteUserModal({
               disabled={loading}
               placeholder={t("auth.emailPlaceholder", "you@example.com")}
             />
+            {refusal.at("email", current.email) && (
+              <p className="mt-1 text-error text-xs">
+                {refusal.at("email", current.email)}
+              </p>
+            )}
           </div>
           <div>
             <label htmlFor="invite-role" className={labelCls}>
@@ -194,6 +221,11 @@ export function InviteUserModal({
                 {t("role.tenantAdmin", "Tenant admin")}
               </option>
             </select>
+            {refusal.at("role", current.role) && (
+              <p className="mt-1 text-error text-xs">
+                {refusal.at("role", current.role)}
+              </p>
+            )}
           </div>
           <div className="flex justify-end gap-2">
             <Button

--- a/src/client/components/admin/InviteUserModal.tsx
+++ b/src/client/components/admin/InviteUserModal.tsx
@@ -45,7 +45,7 @@ export function InviteUserModal({
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(INVITE_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? INVITE_FIELDS : []);
 
   // A SUPER_ADMIN must target a tenant; block submit until one is chosen.
   const noTarget = isSuperAdmin && !tenantId;

--- a/src/client/components/alerts/AlertChannelsSection.tsx
+++ b/src/client/components/alerts/AlertChannelsSection.tsx
@@ -63,7 +63,13 @@ function AlertChannelModal({
   const [secretRef, setSecretRef] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [error, setError] = useState("");
-  const refusal = useFieldRefusal(modal.isOpen ? ALERT_FIELDS : []);
+  const refusal = useFieldRefusal(
+    modal.isOpen
+      ? type === "webhook"
+        ? ALERT_WEBHOOK_FIELDS
+        : ALERT_FIELDS
+      : [],
+  );
   const [loading, setLoading] = useState(false);
 
   useOnModalOpen(modal, () => {
@@ -397,7 +403,12 @@ function AlertChannelModal({
 
 // The keys of the body this form writes: the route refuses by them, and `requireVaultRef` names
 // `secretRef`. `stages` and `minLevel` are chip rows and a Select with nowhere to render a sentence.
-const ALERT_FIELDS = ["name", "type", "url", "secretRef"] as const;
+const ALERT_FIELDS = ["name", "type", "url"] as const;
+
+// The signing secret belongs to a webhook, and its picker is drawn only there. The ref stays in the
+// BODY when the operator switches to Discord, though — a credential picked and then stranded — so
+// the server can still refuse it by name, on a dialog with no picker to mark.
+const ALERT_WEBHOOK_FIELDS = [...ALERT_FIELDS, "secretRef"] as const;
 
 export function AlertChannelsSection() {
   const { t } = useTranslation();

--- a/src/client/components/alerts/AlertChannelsSection.tsx
+++ b/src/client/components/alerts/AlertChannelsSection.tsx
@@ -63,7 +63,7 @@ function AlertChannelModal({
   const [secretRef, setSecretRef] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [error, setError] = useState("");
-  const refusal = useFieldRefusal(ALERT_FIELDS);
+  const refusal = useFieldRefusal(ALERT_FIELDS, modal.isOpen);
   const [loading, setLoading] = useState(false);
 
   useOnModalOpen(modal, () => {

--- a/src/client/components/alerts/AlertChannelsSection.tsx
+++ b/src/client/components/alerts/AlertChannelsSection.tsx
@@ -174,8 +174,12 @@ function AlertChannelModal({
       refusal.clear();
       onSaved();
       modal.close();
-    } catch {
-      setError(t("alerts.saveFailed", "Could not save the channel"));
+    } catch (e) {
+      // Through `held` like the branch above, and not because the sentence changes — the fallback IS
+      // this sentence. It is the CHANNEL: `error` is drawn inside the dialog, and the operator can
+      // dismiss one while its save is out (docs/modals.md), after which this line reaches nobody.
+      // `capture` is what knows the form has gone and sends the words somewhere still on screen.
+      setError(held(e));
     } finally {
       setLoading(false);
     }

--- a/src/client/components/alerts/AlertChannelsSection.tsx
+++ b/src/client/components/alerts/AlertChannelsSection.tsx
@@ -67,6 +67,8 @@ function AlertChannelModal({
   const [loading, setLoading] = useState(false);
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     const ch = modal.payload?.channel;
     setName(ch?.name ?? "");
     setType((ch?.type as "discord" | "webhook") ?? "discord");

--- a/src/client/components/alerts/AlertChannelsSection.tsx
+++ b/src/client/components/alerts/AlertChannelsSection.tsx
@@ -63,7 +63,7 @@ function AlertChannelModal({
   const [secretRef, setSecretRef] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [error, setError] = useState("");
-  const refusal = useFieldRefusal(ALERT_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? ALERT_FIELDS : []);
   const [loading, setLoading] = useState(false);
 
   useOnModalOpen(modal, () => {

--- a/src/client/components/alerts/AlertChannelsSection.tsx
+++ b/src/client/components/alerts/AlertChannelsSection.tsx
@@ -1,5 +1,5 @@
 import { BellRing, Pencil, Plus, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Badge,
@@ -20,10 +20,10 @@ import {
   useOnModalOpen,
   useToast,
 } from "@/client/components";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { flowStageLabel } from "@/client/lib/flowLabels";
-import type { ApiErrorPayload } from "@/client/lib/types";
 import { cn, formatDate } from "@/client/lib/utils";
 import { isValidHttpUrl } from "@/client/lib/validation";
 import { FLOW_STAGES } from "@/modules/flowlog/stages";
@@ -63,6 +63,7 @@ function AlertChannelModal({
   const [secretRef, setSecretRef] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [error, setError] = useState("");
+  const refusal = useFieldRefusal(ALERT_FIELDS);
   const [loading, setLoading] = useState(false);
 
   useOnModalOpen(modal, () => {
@@ -104,9 +105,34 @@ function AlertChannelModal({
     stages.size > 0 &&
     (editing ? true : url.trim().length > 0);
 
+  // What the inputs hold right now, in the server's vocabulary. `url` is omitted on an edit that
+  // leaves it blank, which is how "keep the stored one" is spelled on the wire.
+  const currentOf = () => {
+    const body: Record<string, unknown> = {
+      name,
+      type,
+      minLevel,
+      stages: allStagesChecked ? [] : [...stages],
+      secretRef: secretRef.trim() || null,
+      enabled,
+    };
+    if (!editing || url.trim()) body.url = url.trim();
+    return body;
+  };
+  const currentRef = useRef(currentOf());
+  currentRef.current = currentOf();
+
   const handleSubmit = async () => {
     setError("");
     setLoading(true);
+    const sent = currentOf();
+    const held = (e: unknown) =>
+      refusal.capture(
+        e,
+        t("alerts.saveFailed", "Could not save the channel"),
+        sent,
+        currentRef.current,
+      ) ?? "";
     try {
       const ref = secretRef.trim() || null;
       // All stages selected → persist [] (canonical "all", future-proof so a newly added stage is
@@ -140,12 +166,10 @@ function AlertChannelModal({
         ).error;
       }
       if (apiError) {
-        setError(
-          (apiError as { value?: ApiErrorPayload }).value?.error ||
-            t("alerts.saveFailed", "Could not save the channel"),
-        );
+        setError(held(apiError));
         return;
       }
+      refusal.clear();
       onSaved();
       modal.close();
     } catch {
@@ -189,6 +213,8 @@ function AlertChannelModal({
             required
             disabled={loading}
             placeholder={t("alerts.namePlaceholder", "e.g. Ops Discord")}
+            error={!!refusal.at("name", name)}
+            errorMessage={refusal.at("name", name) ?? undefined}
           />
         </div>
 
@@ -210,6 +236,11 @@ function AlertChannelModal({
               {t("alerts.type.webhook", "Generic webhook")}
             </option>
           </select>
+          {refusal.at("type", type) && (
+            <p className="mt-1 text-error text-xs">
+              {refusal.at("type", type)}
+            </p>
+          )}
         </div>
 
         <div>
@@ -227,6 +258,8 @@ function AlertChannelModal({
                 ? editing.urlMasked
                 : "https://discord.com/api/webhooks/…"
             }
+            error={!!refusal.at("url", url.trim())}
+            errorMessage={refusal.at("url", url.trim()) ?? undefined}
             helperText={
               editing
                 ? t(
@@ -311,6 +344,7 @@ function AlertChannelModal({
           <FormField
             label={t("alerts.secretRef", "Signing secret (optional)")}
             group
+            error={refusal.at("secretRef", secretRef.trim() || null)}
             description={t(
               "alerts.secretRefHint",
               "Signs each delivery (HMAC) so your endpoint can verify it. Discord ignores this.",
@@ -354,6 +388,10 @@ function AlertChannelModal({
     </Modal>
   );
 }
+
+// The keys of the body this form writes: the route refuses by them, and `requireVaultRef` names
+// `secretRef`. `stages` and `minLevel` are chip rows and a Select with nowhere to render a sentence.
+const ALERT_FIELDS = ["name", "type", "url", "secretRef"] as const;
 
 export function AlertChannelsSection() {
   const { t } = useTranslation();

--- a/src/client/components/api-keys/CreateApiKeyModal.tsx
+++ b/src/client/components/api-keys/CreateApiKeyModal.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -9,7 +9,11 @@ import {
   type ModalController,
   useOnModalOpen,
 } from "@/client/components";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
+
+// The one name this modal sends, spelled the way the route refuses it (`refused body.displayName`).
+const API_KEY_FIELDS = ["displayName"] as const;
 
 // Modal to create a per-tenant API key. On success it reveals the plaintext token ONCE
 // (copy-to-clipboard + a "shown only once" warning); the token is never retrievable again — only its
@@ -27,6 +31,12 @@ export function CreateApiKeyModal({
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const refusal = useFieldRefusal(API_KEY_FIELDS);
+  // The CURRENT value, readable from inside a request that started before it: the operator can type
+  // while the create is out, and a refusal about a name they have already replaced belongs in the
+  // banner rather than under a box that no longer holds it.
+  const nameRef = useRef(displayName);
+  nameRef.current = displayName;
 
   useOnModalOpen(modal, () => {
     setDisplayName("");
@@ -41,18 +51,25 @@ export function CreateApiKeyModal({
   const submit = async () => {
     setError("");
     setLoading(true);
+    const sent = { displayName: displayName.trim() };
+    const held = (e: unknown) =>
+      refusal.capture(
+        e,
+        t("apiKeys.createFailed", "Could not create the API key"),
+        sent,
+        { displayName: nameRef.current.trim() },
+      );
     try {
-      const { data, error: apiError } = await api.api.v1["api-keys"].post({
-        displayName: displayName.trim(),
-      });
+      const { data, error: apiError } = await api.api.v1["api-keys"].post(sent);
       if (apiError || !data) {
-        setError(t("apiKeys.createFailed", "Could not create the API key"));
+        setError(held(apiError) ?? "");
         return;
       }
+      refusal.clear();
       setToken(data.token);
       onCreated();
-    } catch {
-      setError(t("apiKeys.createFailed", "Could not create the API key"));
+    } catch (e) {
+      setError(held(e) ?? "");
     } finally {
       setLoading(false);
     }
@@ -120,6 +137,7 @@ export function CreateApiKeyModal({
               "apiKeys.nameHint",
               "A label to recognize this key later (e.g. the client or service that uses it).",
             )}
+            error={refusal.at("displayName", displayName.trim())}
           >
             <Input
               value={displayName}

--- a/src/client/components/api-keys/CreateApiKeyModal.tsx
+++ b/src/client/components/api-keys/CreateApiKeyModal.tsx
@@ -39,6 +39,8 @@ export function CreateApiKeyModal({
   nameRef.current = displayName;
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     setDisplayName("");
     setToken(null);
     setCopied(false);

--- a/src/client/components/api-keys/CreateApiKeyModal.tsx
+++ b/src/client/components/api-keys/CreateApiKeyModal.tsx
@@ -31,7 +31,7 @@ export function CreateApiKeyModal({
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(API_KEY_FIELDS);
+  const refusal = useFieldRefusal(API_KEY_FIELDS, modal.isOpen);
   // The CURRENT value, readable from inside a request that started before it: the operator can type
   // while the create is out, and a refusal about a name they have already replaced belongs in the
   // banner rather than under a box that no longer holds it.

--- a/src/client/components/api-keys/CreateApiKeyModal.tsx
+++ b/src/client/components/api-keys/CreateApiKeyModal.tsx
@@ -31,7 +31,7 @@ export function CreateApiKeyModal({
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(API_KEY_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? API_KEY_FIELDS : []);
   // The CURRENT value, readable from inside a request that started before it: the operator can type
   // while the create is out, and a refusal about a name they have already replaced belongs in the
   // banner rather than under a box that no longer holds it.

--- a/src/client/components/mcp/RegisterMcpClientModal.tsx
+++ b/src/client/components/mcp/RegisterMcpClientModal.tsx
@@ -55,6 +55,8 @@ export function RegisterMcpClientModal({
   const editingId = modal.payload?.clientId;
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     setName(modal.payload?.name ?? "");
     setRedirectUris((modal.payload?.redirectUris ?? []).join("\n"));
     setScopes(modal.payload?.scopes ?? ["mcp:read"]);

--- a/src/client/components/mcp/RegisterMcpClientModal.tsx
+++ b/src/client/components/mcp/RegisterMcpClientModal.tsx
@@ -50,7 +50,7 @@ export function RegisterMcpClientModal({
   const [firstParty, setFirstParty] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(MCP_CLIENT_FIELDS);
+  const refusal = useFieldRefusal(MCP_CLIENT_FIELDS, modal.isOpen);
 
   const editingId = modal.payload?.clientId;
 

--- a/src/client/components/mcp/RegisterMcpClientModal.tsx
+++ b/src/client/components/mcp/RegisterMcpClientModal.tsx
@@ -50,7 +50,7 @@ export function RegisterMcpClientModal({
   const [firstParty, setFirstParty] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(MCP_CLIENT_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? MCP_CLIENT_FIELDS : []);
 
   const editingId = modal.payload?.clientId;
 

--- a/src/client/components/mcp/RegisterMcpClientModal.tsx
+++ b/src/client/components/mcp/RegisterMcpClientModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -10,11 +10,20 @@ import {
   Textarea,
   useOnModalOpen,
 } from "@/client/components";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 
 // Supported MCP scopes (must match MCP_SCOPES server-side). mcp:admin is honored only for a
 // SUPER_ADMIN user at grant time, but a client MAY be allowed to request it.
 const MCP_SCOPES = ["mcp:read", "mcp:write", "mcp:admin"] as const;
+
+// The keys of the body this modal writes, which are the names the route refuses by (`refused
+// body.name`, `refused body.redirectUris.0`). The URI list is one Textarea, and an element-level
+// refusal lands on it: see placeRefusal.
+//
+// `firstParty` is not here on purpose: a Switch has nowhere to render a sentence, and a name
+// declared without a control behind it would be marked as placed and then shown to nobody.
+const MCP_CLIENT_FIELDS = ["name", "redirectUris", "scopes"] as const;
 
 export interface McpClientPayload {
   // Present when editing an existing client.
@@ -41,6 +50,7 @@ export function RegisterMcpClientModal({
   const [firstParty, setFirstParty] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const refusal = useFieldRefusal(MCP_CLIENT_FIELDS);
 
   const editingId = modal.payload?.clientId;
 
@@ -61,32 +71,45 @@ export function RegisterMcpClientModal({
     .split(/[\s,]+/)
     .map((u) => u.trim())
     .filter(Boolean);
+  // What the inputs hold right now, in the server's vocabulary. Read from a ref inside the request
+  // so a refusal about a value the operator has already replaced goes to the banner instead.
+  const current = {
+    name: name.trim(),
+    redirectUris: parsedUris,
+    scopes,
+    firstParty,
+  };
+  const currentRef = useRef(current);
+  currentRef.current = current;
   const valid =
     name.trim() !== "" && parsedUris.length > 0 && scopes.length > 0;
 
   const submit = async () => {
     setError("");
     setLoading(true);
+    const body = { ...current };
+    const held = (e: unknown) =>
+      refusal.capture(
+        e,
+        t("mcp.admin.clientSaveFailed", "Could not save the client"),
+        body,
+        currentRef.current,
+      ) ?? "";
     try {
-      const body = {
-        name: name.trim(),
-        redirectUris: parsedUris,
-        scopes,
-        firstParty,
-      };
       const { error: apiError } = editingId
         ? await api.api.v1.mcp.admin
             .clients({ clientId: editingId })
             .patch(body)
         : await api.api.v1.mcp.admin.clients.post(body);
       if (apiError) {
-        setError(t("mcp.admin.clientSaveFailed", "Could not save the client"));
+        setError(held(apiError));
         return;
       }
+      refusal.clear();
       onSaved();
       modal.close();
-    } catch {
-      setError(t("mcp.admin.clientSaveFailed", "Could not save the client"));
+    } catch (e) {
+      setError(held(e));
     } finally {
       setLoading(false);
     }
@@ -108,7 +131,11 @@ export function RegisterMcpClientModal({
             {error}
           </div>
         )}
-        <FormField label={t("mcp.admin.clientName", "Name")} required>
+        <FormField
+          label={t("mcp.admin.clientName", "Name")}
+          required
+          error={refusal.at("name", current.name)}
+        >
           <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -123,6 +150,7 @@ export function RegisterMcpClientModal({
             "mcp.admin.redirectUrisHint",
             "One per line. Exact https URLs (http allowed only for loopback); no wildcards or fragments.",
           )}
+          error={refusal.at("redirectUris", current.redirectUris)}
         >
           <Textarea
             value={redirectUris}
@@ -133,7 +161,12 @@ export function RegisterMcpClientModal({
             placeholder={"https://app.example.com/oauth/callback"}
           />
         </FormField>
-        <FormField label={t("mcp.admin.scopes", "Scopes")} required group>
+        <FormField
+          label={t("mcp.admin.scopes", "Scopes")}
+          required
+          group
+          error={refusal.at("scopes", current.scopes)}
+        >
           <div className="flex flex-col gap-1.5">
             {MCP_SCOPES.map((scope) => (
               <label

--- a/src/client/components/webhooks/WebhookSubscriptionModal.tsx
+++ b/src/client/components/webhooks/WebhookSubscriptionModal.tsx
@@ -48,7 +48,7 @@ export function WebhookSubscriptionModal({
   onSaved: () => void;
 }) {
   const { t } = useTranslation();
-  const refusal = useFieldRefusal(WEBHOOK_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? WEBHOOK_FIELDS : []);
   const enabledId = useId();
   const editing = modal.payload?.subscription;
   const [url, setUrl] = useState("");

--- a/src/client/components/webhooks/WebhookSubscriptionModal.tsx
+++ b/src/client/components/webhooks/WebhookSubscriptionModal.tsx
@@ -48,7 +48,7 @@ export function WebhookSubscriptionModal({
   onSaved: () => void;
 }) {
   const { t } = useTranslation();
-  const refusal = useFieldRefusal(WEBHOOK_FIELDS);
+  const refusal = useFieldRefusal(WEBHOOK_FIELDS, modal.isOpen);
   const enabledId = useId();
   const editing = modal.payload?.subscription;
   const [url, setUrl] = useState("");

--- a/src/client/components/webhooks/WebhookSubscriptionModal.tsx
+++ b/src/client/components/webhooks/WebhookSubscriptionModal.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/client/components/Button";
 import { CredentialPicker } from "@/client/components/CredentialPicker";
@@ -11,8 +11,8 @@ import {
   useOnModalOpen,
 } from "@/client/components/Modal";
 import { Switch } from "@/client/components/Switch";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
-import type { ApiErrorPayload } from "@/client/lib/types";
 import { cn } from "@/client/lib/utils";
 import { isValidHttpUrl } from "@/client/lib/validation";
 import { webhookEventLabel } from "@/client/lib/webhookEvents";
@@ -34,6 +34,10 @@ export interface WebhookModalPayload {
   subscription?: WebhookSubscription;
 }
 
+// The keys of the body this modal writes: the route refuses by them (`refused body.url`) and
+// `requireVaultRef` names `secretRef`.
+const WEBHOOK_FIELDS = ["url", "events", "secretRef"] as const;
+
 export function WebhookSubscriptionModal({
   modal,
   events,
@@ -44,6 +48,7 @@ export function WebhookSubscriptionModal({
   onSaved: () => void;
 }) {
   const { t } = useTranslation();
+  const refusal = useFieldRefusal(WEBHOOK_FIELDS);
   const enabledId = useId();
   const editing = modal.payload?.subscription;
   const [url, setUrl] = useState("");
@@ -62,6 +67,17 @@ export function WebhookSubscriptionModal({
     setError("");
   });
 
+  // What the inputs hold right now, in the server's vocabulary, and what the write sends. One
+  // expression, because a refusal is matched against the value that was SENT.
+  const current = {
+    url,
+    events: [...selected],
+    secretRef: secretRef.trim() || null,
+    enabled,
+  };
+  const currentRef = useRef(current);
+  currentRef.current = current;
+
   const toggleEvent = (ev: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -74,34 +90,31 @@ export function WebhookSubscriptionModal({
   const handleSubmit = async () => {
     setError("");
     setLoading(true);
+    const body = { ...current };
+    const held = (e: unknown) =>
+      refusal.capture(
+        e,
+        t("webhooks.saveFailed", "Could not save the subscription"),
+        body,
+        currentRef.current,
+      ) ?? "";
     try {
-      const eventsArr = [...selected];
-      const ref = secretRef.trim() || null;
       const apiError = editing
         ? (
             await api.api.v1.webhooks
               .subscriptions({ id: editing.id })
-              .patch({ url, events: eventsArr, secretRef: ref, enabled })
+              .patch(body)
           ).error
-        : (
-            await api.api.v1.webhooks.subscriptions.post({
-              url,
-              events: eventsArr,
-              secretRef: ref,
-              enabled,
-            })
-          ).error;
+        : (await api.api.v1.webhooks.subscriptions.post(body)).error;
       if (apiError) {
-        setError(
-          (apiError.value as ApiErrorPayload)?.error ||
-            t("webhooks.saveFailed", "Could not save the subscription"),
-        );
+        setError(held(apiError));
         return;
       }
+      refusal.clear();
       onSaved();
       modal.close();
-    } catch {
-      setError(t("webhooks.saveFailed", "Could not save the subscription"));
+    } catch (e) {
+      setError(held(e));
     } finally {
       setLoading(false);
     }
@@ -166,15 +179,26 @@ export function WebhookSubscriptionModal({
               "Must be a public HTTPS URL. Private and metadata addresses are blocked.",
             )}
           />
-          {urlInvalid && url.trim() && (
+          {urlInvalid && url.trim() ? (
             <p className="mt-1 text-error text-xs">
               {t("common.invalidUrl", "Must be a valid http(s) URL.")}
             </p>
+          ) : (
+            refusal.at("url", current.url) && (
+              <p className="mt-1 text-error text-xs">
+                {refusal.at("url", current.url)}
+              </p>
+            )
           )}
         </div>
 
         <fieldset>
           <legend className={labelCls}>{t("webhooks.events", "Events")}</legend>
+          {refusal.at("events", current.events) && (
+            <p className="mb-1 text-error text-xs">
+              {refusal.at("events", current.events)}
+            </p>
+          )}
           <div className="flex flex-col gap-1">
             {events.map((ev) => {
               const checked = selected.has(ev);
@@ -216,6 +240,7 @@ export function WebhookSubscriptionModal({
             "webhooks.secretRefHint",
             "Signs each delivery (HMAC) so your endpoint can verify it. Leave blank for unsigned.",
           )}
+          error={refusal.at("secretRef", current.secretRef)}
         >
           <CredentialPicker
             value={secretRef}

--- a/src/client/components/webhooks/WebhookSubscriptionModal.tsx
+++ b/src/client/components/webhooks/WebhookSubscriptionModal.tsx
@@ -59,6 +59,8 @@ export function WebhookSubscriptionModal({
   const [loading, setLoading] = useState(false);
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     const sub = modal.payload?.subscription;
     setUrl(sub?.url ?? "");
     setSelected(new Set(sub?.events ?? []));

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useToast } from "@/client/components/Toast";
 import {
   placeRefusal,
   readRefusal,
@@ -20,8 +21,9 @@ export interface FieldRefusal {
   // holding what the server refused, so there is no `onChange` line to forget. Forgetting the
   // argument is a type error; forgetting a `clear(field)` was invisible.
   at: (field: string, value: unknown) => string | null;
-  // Take a failed call. Returns the sentence the caller must TOAST, or null when it landed on an
-  // input and the toast must stay silent. `sent` is what this request carried and `current` is what
+  // Take a failed call. Returns the sentence the CALLER must render, or null once the operator has
+  // already been told — either because it landed on an input, or because the form was gone and this
+  // hook raised the global toast itself. `sent` is what this request carried and `current` is what
   // the inputs hold now — the placement is refused when they disagree about the refused field, or
   // when this form is already gone, because both render the mark unreadable.
   capture: (
@@ -42,16 +44,21 @@ export interface FieldRefusal {
 
 // `onScreen` is whether the FORM is showing, and it defaults to "as long as this component is".
 //
-// For a page those are the same question. For a modal they are not, and the difference is silence:
-// `useModalController` keeps the wrapper mounted when the dialog closes, so a save still in flight
-// answers into a component that is alive and a form that is gone. The mark would be written, the
-// caller told "it is on the control", and nothing on screen would say anything at all. Pass
-// `modal.isOpen` from every dialog. Measured on McpEditModal: dismiss mid-save and the banner stayed
-// empty for a refusal the server had named.
+// For a page those are the same question. Wherever the form can be hidden while its component lives
+// on, they are not, and the difference is silence: `useModalController` keeps the wrapper mounted
+// when the dialog closes, and the agent editor keeps `name` and `systemPrompt` in state while the
+// operator reads another tab. A save still in flight then answers into a component that is alive and
+// a form that is gone: the mark would be written, the caller told "it is on the control", and
+// nothing on screen would say anything at all.
+//
+// So it takes whatever makes the form visible — `modal.isOpen` from a dialog, `tab === "general"`
+// from a tab — and `capture` routes around it (see there). Measured on McpEditModal: dismiss
+// mid-save and the banner stayed empty for a refusal the server had named.
 export function useFieldRefusal(
   rendered: readonly string[],
   onScreen = true,
 ): FieldRefusal {
+  const { showToast } = useToast();
   const [held, setHeld] = useState<{
     field: string;
     message: string;
@@ -85,8 +92,9 @@ export function useFieldRefusal(
       sent: Record<string, unknown>,
       current: Record<string, unknown>,
     ) => {
+      const onForm = mounted.current && showing.current;
       const placed = placeRefusal(readRefusal(e), fields, fallback, {
-        mounted: mounted.current && showing.current,
+        mounted: onForm,
         sent,
         current,
       });
@@ -102,9 +110,22 @@ export function useFieldRefusal(
       // clear": a mark left over from a refusal the server has stopped making would sit on a control
       // while the toast says something else.
       setHeld(null);
+      // The caller's OTHER channel is inside the form for ten of the holders here: an error line
+      // drawn between the dialog's title and its buttons, which `useOnModalOpen` then clears on the
+      // next opening. Handing them a sentence for a form the operator has dismissed only moves the
+      // silence one step over — the mark used to be written where nobody looked, and the sentence
+      // would be. So when the form is gone the hook raises the global toast itself.
+      //
+      // Only for a sentence it HAS. An empty fallback is how a caller says it words this refusal
+      // better than the server does (ChannelsPage names the affordance — disconnect first — which
+      // the server cannot know about); swallowing its turn would be the new silence.
+      if (!onForm && placed.toast) {
+        showToast(placed.toast, "error");
+        return null;
+      }
       return placed.toast;
     },
-    [fields],
+    [fields, showToast],
   );
 
   const clear = useCallback(() => setHeld(null), []);

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useToast } from "@/client/components/Toast";
 import {
   placeRefusal,
@@ -42,22 +42,25 @@ export interface FieldRefusal {
   field: string | null;
 }
 
-// `onScreen` is whether the FORM is showing, and it defaults to "as long as this component is".
+// `rendered` is what the form is DRAWING RIGHT NOW, and the tense is the whole of it.
 //
-// For a page those are the same question. Wherever the form can be hidden while its component lives
-// on, they are not, and the difference is silence: `useModalController` keeps the wrapper mounted
-// when the dialog closes, and the agent editor keeps `name` and `systemPrompt` in state while the
-// operator reads another tab. A save still in flight then answers into a component that is alive and
-// a form that is gone: the mark would be written, the caller told "it is on the control", and
-// nothing on screen would say anything at all.
+// This started as a constant list plus a boolean for "is the form on screen", and the boolean grew a
+// new meaning every review round: a dialog that closed, then a tab that changed. It was always an
+// approximation of the question `placeRefusal` actually asks — is THIS name one the operator can see
+// — and it is too coarse for a form that hides some of its own controls. Measured, five of those are
+// already here: the setup token renders only where enforcement is on, the vault's per-key inputs and
+// its base URL disappear when the operator switches to pasting a `.env`, its parameter-name box
+// belongs to three of the secret kinds, and the add-content dialog draws the text box on one of its
+// two tabs. In every one of them a refusal the server named by that field was marked onto a control
+// nobody was rendering, and `capture` told the caller to keep the toast quiet.
 //
-// So it takes whatever makes the form visible — `modal.isOpen` from a dialog, `tab === "general"`
-// from a tab — and `capture` routes around it (see there). Measured on McpEditModal: dismiss
-// mid-save and the banner stayed empty for a refusal the server had named.
-export function useFieldRefusal(
-  rendered: readonly string[],
-  onScreen = true,
-): FieldRefusal {
+// So the caller answers with the list, per render, and the boolean is gone: a form that is not on
+// screen renders nothing, which is `[]`.
+//
+// Read through a ref, because the answer is needed AFTER the await and a submit handler closes over
+// the render it started in. That was the point of the boolean's ref too; it is the same fix, applied
+// to the thing that was always the real question.
+export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
   const { showToast } = useToast();
   const [held, setHeld] = useState<{
     field: string;
@@ -74,16 +77,8 @@ export function useFieldRefusal(
       mounted.current = false;
     };
   }, []);
-  // Kept in step on every render rather than read from the closure: the answer is needed AFTER the
-  // await, and a closed-over boolean is the value from the render the request started in.
-  const showing = useRef(onScreen);
-  showing.current = onScreen;
-
-  // The declared list is a literal at almost every call site (`COMPANY_FIELDS`), but a caller that
-  // builds it inline would otherwise hand `capture` a new identity on every render.
-  const key = rendered.join(" ");
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `key` IS `rendered`, by value.
-  const fields = useMemo(() => rendered.slice(), [key]);
+  const fields = useRef(rendered);
+  fields.current = rendered;
 
   const capture = useCallback(
     (
@@ -92,8 +87,10 @@ export function useFieldRefusal(
       sent: Record<string, unknown>,
       current: Record<string, unknown>,
     ) => {
-      const onForm = mounted.current && showing.current;
-      const placed = placeRefusal(readRefusal(e), fields, fallback, {
+      // The form is where the operator is looking only if it is drawing something. An empty list is
+      // a dismissed dialog, a tab left behind, a page unmounted — all the same answer.
+      const onForm = mounted.current && fields.current.length > 0;
+      const placed = placeRefusal(readRefusal(e), fields.current, fallback, {
         mounted: onForm,
         sent,
         current,
@@ -125,7 +122,7 @@ export function useFieldRefusal(
       }
       return placed.toast;
     },
-    [fields, showToast],
+    [showToast],
   );
 
   const clear = useCallback(() => setHeld(null), []);

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { placeRefusal, readRefusal } from "@/client/lib/fieldRefusal";
+import {
+  placeRefusal,
+  readRefusal,
+  sameValue,
+} from "@/client/lib/fieldRefusal";
 
 // A form's held refusal: which input the server refused, what it said about it, and the value it was
 // about.
@@ -90,9 +94,14 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
 
   const clear = useCallback(() => setHeld(null), []);
 
+  // By VALUE and not by identity, for the same reason the staleness check is: a form rebuilds its
+  // body every render, so a list or an object read twice is never `===` and the mark would never
+  // render at all. See sameValue.
   const at = useCallback(
     (field: string, value: unknown) =>
-      held?.field === field && held.value === value ? held.message : null,
+      held?.field === field && sameValue(held.value, value)
+        ? held.message
+        : null,
     [held],
   );
 

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -40,7 +40,18 @@ export interface FieldRefusal {
   field: string | null;
 }
 
-export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
+// `onScreen` is whether the FORM is showing, and it defaults to "as long as this component is".
+//
+// For a page those are the same question. For a modal they are not, and the difference is silence:
+// `useModalController` keeps the wrapper mounted when the dialog closes, so a save still in flight
+// answers into a component that is alive and a form that is gone. The mark would be written, the
+// caller told "it is on the control", and nothing on screen would say anything at all. Pass
+// `modal.isOpen` from every dialog. Measured on McpEditModal: dismiss mid-save and the banner stayed
+// empty for a refusal the server had named.
+export function useFieldRefusal(
+  rendered: readonly string[],
+  onScreen = true,
+): FieldRefusal {
   const [held, setHeld] = useState<{
     field: string;
     message: string;
@@ -56,6 +67,10 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
       mounted.current = false;
     };
   }, []);
+  // Kept in step on every render rather than read from the closure: the answer is needed AFTER the
+  // await, and a closed-over boolean is the value from the render the request started in.
+  const showing = useRef(onScreen);
+  showing.current = onScreen;
 
   // The declared list is a literal at almost every call site (`COMPANY_FIELDS`), but a caller that
   // builds it inline would otherwise hand `capture` a new identity on every render.
@@ -71,7 +86,7 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
       current: Record<string, unknown>,
     ) => {
       const placed = placeRefusal(readRefusal(e), fields, fallback, {
-        mounted: mounted.current,
+        mounted: mounted.current && showing.current,
         sent,
         current,
       });

--- a/src/client/lib/fieldRefusal.ts
+++ b/src/client/lib/fieldRefusal.ts
@@ -48,9 +48,11 @@ export type RefusalPlacement =
 // a placement can be held and never read, and they are all this: the question is not "is this input
 // one the form declared" but "will the operator actually read this".
 export interface FormAtAnswer {
-  // False once the form is gone. A modal body can unmount while its own save is in flight — this
-  // card's own comments record that the operator does exactly that — and a mark written to state
-  // nobody renders is silence, with `capture` having already reported "it is on the control".
+  // False once the form is GONE FROM THE SCREEN, which is not the same as the component being
+  // unmounted. A modal body can close while its own save is in flight — this card's own comments
+  // record that the operator does exactly that — and the wrapper around it stays mounted, so the
+  // hook takes the dialog's own `isOpen` as well. A mark written to state nobody renders is silence,
+  // with `capture` having already reported "it is on the control".
   mounted: boolean;
   // What the request carried. A refusal is about the value that was SENT.
   sent: Record<string, unknown>;

--- a/src/client/lib/fieldRefusal.ts
+++ b/src/client/lib/fieldRefusal.ts
@@ -70,6 +70,13 @@ export interface FormAtAnswer {
 // (`guardrails.output.templateMessage`), and a form that wants to catch a subtree can say so by
 // listing what it renders. Guessing that a form showing `guardrails` also shows every leaf under it
 // is how a refusal ends up marked on a control that is not about it.
+//
+// With ONE exception, and it is not a prefix rule: a trailing NUMERIC segment is an element of the
+// declared list, not a different value. The schema boundary refuses arrays per element and says so —
+// measured on this tree: `redirectUris.0`, `windows.0`, `accountIds.0`, `grants.0` — while the form
+// renders the whole list through one control. Exact matching alone means every array input in the
+// console can never receive its own refusal. A named segment stays unmatched, because `guardrails`
+// and `guardrails.output` are two different values and only the form knows which one it draws.
 export function placeRefusal(
   refusal: Refusal | null,
   rendered: readonly string[],
@@ -78,13 +85,48 @@ export function placeRefusal(
 ): RefusalPlacement {
   if (!refusal) return { toast: fallback };
   const { field, message } = refusal;
-  if (!field || !rendered.includes(field)) return { toast: message };
+  if (!field) return { toast: message };
+  const declared = rendered.includes(field)
+    ? field
+    : rendered.find((name) =>
+        new RegExp(`^${escapeName(name)}\\.\\d+$`).test(field),
+      );
+  if (declared === undefined) return { toast: message };
   if (!form.mounted) return { toast: message };
   // Only when the request carried this field. A refusal about a value this write did not change is
   // about what is stored, and the input has not moved relative to it, so there is nothing stale.
-  const carried = Object.hasOwn(form.sent, field);
-  if (carried && form.sent[field] !== form.current[field]) {
+  const carried = Object.hasOwn(form.sent, declared);
+  if (carried && !sameValue(form.sent[declared], form.current[declared])) {
     return { toast: message };
   }
-  return { at: field, message, value: form.current[field] };
+  return { at: declared, message, value: form.current[declared] };
+}
+
+// "The box still holds what the server was talking about", for a value of any shape.
+//
+// Reference identity is wrong for everything that is not a primitive, and wrong in the direction that
+// SILENCES the mechanism: a form rebuilds its request body on every render, so an array or an object
+// read twice is two values that are never `===`. Every such field would read as edited-during-the-
+// request and be sent to the toast — measured the moment the first list control was wired, and
+// invisible before it because the six fields of the reference card are all strings.
+//
+// Structural rather than deep-equal by hand: these values are request bodies, so they are JSON by
+// construction, and a shape that cannot be serialised is one this comparison should not claim to
+// answer for. It falls back to identity there rather than throwing inside a submit handler.
+export function sameValue(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+// A declared name inside a regex. The names are the server's own — columns and dotted paths — so the
+// dot is the only metacharacter any of them carries today, and escaping the set rather than the one
+// character is what keeps that true of the next name too.
+function escapeName(name: string): string {
+  return name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/client/lib/fieldRefusal.ts
+++ b/src/client/lib/fieldRefusal.ts
@@ -91,7 +91,7 @@ export function placeRefusal(
   const declared = rendered.includes(field)
     ? field
     : rendered.find((name) =>
-        new RegExp(`^${escapeName(name)}\\.\\d+$`).test(field),
+        new RegExp(`^${escapeName(name)}\\.\\d+(?:\\.|$)`).test(field),
       );
   if (declared === undefined) return { toast: message };
   if (!form.mounted) return { toast: message };

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -2286,7 +2286,6 @@
       "signedInHint": "You must be signed in to the MCP server in your browser to approve access."
     },
     "name": "Name",
-    "nameInUse": "A secret with this name already exists.",
     "namePlaceholder": "my-api-key",
     "noRefs": "Not referenced anywhere.",
     "noSearchResults": "No secrets match your search.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -2294,7 +2294,6 @@
       "signedInHint": "Você precisa estar autenticado no servidor MCP no navegador para aprovar o acesso."
     },
     "name": "Nome",
-    "nameInUse": "Já existe um segredo com esse nome.",
     "namePlaceholder": "minha-api-key",
     "noRefs": "Não referenciado em nenhum lugar.",
     "noSearchResults": "Nenhum segredo corresponde à busca.",

--- a/src/client/pages/AgentsPage.tsx
+++ b/src/client/pages/AgentsPage.tsx
@@ -27,6 +27,7 @@ import {
   useModalController,
   useToast,
 } from "@/client/components";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { providerLabel } from "@/client/lib/providerLabels";
@@ -40,6 +41,10 @@ type SortField = "updatedAt" | "createdAt" | "name";
 type StatusFilter = "all" | "active" | "inactive";
 
 const PAGE_SIZE = 20;
+
+// The one key the create body carries. The import next to it sends a whole bundle under `export`,
+// and its refusals are about elements inside that file rather than about an input on this page.
+const CREATE_AGENT_FIELDS = ["name"] as const;
 
 export function AgentsPage() {
   const { t, i18n } = useTranslation();
@@ -56,6 +61,9 @@ export function AgentsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [name, setName] = useState("");
+  const refusal = useFieldRefusal(CREATE_AGENT_FIELDS);
+  const nameRef = useRef(name);
+  nameRef.current = name;
   const [creating, setCreating] = useState(false);
   const fileInput = useRef<HTMLInputElement>(null);
   const [importing, setImporting] = useState(false);
@@ -169,19 +177,21 @@ export function AgentsPage() {
   async function create() {
     if (!name.trim()) return;
     setCreating(true);
+    const sent = { name: name.trim() };
     try {
-      const { data, error: err } = await api.api.v1.agents.post({
-        name: name.trim(),
-      });
+      const { data, error: err } = await api.api.v1.agents.post(sent);
       if (err || !data) throw err ?? new Error("no data");
+      refusal.clear();
       createModal.close();
       navigate(`/agents/${data.agent.id}`);
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("agents.createError", "Could not create the agent."),
-        "error",
+      const toast = refusal.capture(
+        e,
+        t("agents.createError", "Could not create the agent."),
+        sent,
+        { name: nameRef.current.trim() },
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setCreating(false);
     }
@@ -436,6 +446,7 @@ export function AgentsPage() {
             "agents.createHint",
             "You'll configure the prompt, model and tools next.",
           )}
+          error={refusal.at("name", name.trim())}
         >
           <Input
             value={name}

--- a/src/client/pages/AgentsPage.tsx
+++ b/src/client/pages/AgentsPage.tsx
@@ -128,6 +128,8 @@ export function AgentsPage() {
 
   function openCreate() {
     setName("");
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     createModal.open();
   }
 

--- a/src/client/pages/AgentsPage.tsx
+++ b/src/client/pages/AgentsPage.tsx
@@ -61,7 +61,7 @@ export function AgentsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [name, setName] = useState("");
-  const refusal = useFieldRefusal(CREATE_AGENT_FIELDS);
+  const refusal = useFieldRefusal(CREATE_AGENT_FIELDS, createModal.isOpen);
   const nameRef = useRef(name);
   nameRef.current = name;
   const [creating, setCreating] = useState(false);

--- a/src/client/pages/AgentsPage.tsx
+++ b/src/client/pages/AgentsPage.tsx
@@ -61,7 +61,9 @@ export function AgentsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [name, setName] = useState("");
-  const refusal = useFieldRefusal(CREATE_AGENT_FIELDS, createModal.isOpen);
+  const refusal = useFieldRefusal(
+    createModal.isOpen ? CREATE_AGENT_FIELDS : [],
+  );
   const nameRef = useRef(name);
   nameRef.current = name;
   const [creating, setCreating] = useState(false);

--- a/src/client/pages/ChannelsPage.tsx
+++ b/src/client/pages/ChannelsPage.tsx
@@ -242,9 +242,9 @@ export function ChannelsPage() {
   const [adminToken, setAdminToken] = useState("");
   // Three writes, three forms, three holders: the connect modal, the token modal, and the account
   // picker each save on their own, and a refusal about one must not mark another's input.
-  const connectRefusal = useFieldRefusal(CONNECT_FIELDS);
-  const tokenRefusal = useFieldRefusal(TOKEN_FIELDS);
-  const accountsRefusal = useFieldRefusal(ACCOUNTS_FIELDS);
+  const connectRefusal = useFieldRefusal(CONNECT_FIELDS, connectModal.isOpen);
+  const tokenRefusal = useFieldRefusal(TOKEN_FIELDS, tokenModal.isOpen);
+  const accountsRefusal = useFieldRefusal(ACCOUNTS_FIELDS, manageModal.isOpen);
   const connectRef = useRef({ baseUrl, adminToken });
   connectRef.current = { baseUrl, adminToken };
   const [connecting, setConnecting] = useState(false);

--- a/src/client/pages/ChannelsPage.tsx
+++ b/src/client/pages/ChannelsPage.tsx
@@ -565,6 +565,11 @@ export function ChannelsPage() {
       ...selected,
     ]),
   ];
+  // Readable from inside a PUT that started before it. The rows stay live while the save is out, so
+  // the list the request carried and the list the checkboxes hold are two different answers — which
+  // is the whole of what the staleness check compares.
+  const wantedRef = useRef(wantedAccountIds);
+  wantedRef.current = wantedAccountIds;
 
   async function applySelection() {
     const wanted = wantedAccountIds;
@@ -586,7 +591,7 @@ export function ChannelsPage() {
         e,
         t("channels.accountsSaveError", "Could not update the accounts."),
         { accountIds: wanted },
-        { accountIds: wanted },
+        { accountIds: wantedRef.current },
       );
       if (toast) showToast(toast, "error");
     } finally {

--- a/src/client/pages/ChannelsPage.tsx
+++ b/src/client/pages/ChannelsPage.tsx
@@ -435,6 +435,10 @@ export function ChannelsPage() {
   function openConnect() {
     setBaseUrl("");
     setAdminToken("");
+    // Every opening, not just the one driven by `?connect=`. The mark expires by VALUE, so a holder
+    // carried across a cancel comes back the moment the operator retypes the URL that was refused —
+    // an old server sentence under a box, before anything has been sent.
+    connectRefusal.clear();
     connectModal.open();
   }
 

--- a/src/client/pages/ChannelsPage.tsx
+++ b/src/client/pages/ChannelsPage.tsx
@@ -242,9 +242,13 @@ export function ChannelsPage() {
   const [adminToken, setAdminToken] = useState("");
   // Three writes, three forms, three holders: the connect modal, the token modal, and the account
   // picker each save on their own, and a refusal about one must not mark another's input.
-  const connectRefusal = useFieldRefusal(CONNECT_FIELDS, connectModal.isOpen);
-  const tokenRefusal = useFieldRefusal(TOKEN_FIELDS, tokenModal.isOpen);
-  const accountsRefusal = useFieldRefusal(ACCOUNTS_FIELDS, manageModal.isOpen);
+  const connectRefusal = useFieldRefusal(
+    connectModal.isOpen ? CONNECT_FIELDS : [],
+  );
+  const tokenRefusal = useFieldRefusal(tokenModal.isOpen ? TOKEN_FIELDS : []);
+  const accountsRefusal = useFieldRefusal(
+    manageModal.isOpen ? ACCOUNTS_FIELDS : [],
+  );
   const connectRef = useRef({ baseUrl, adminToken });
   connectRef.current = { baseUrl, adminToken };
   const [connecting, setConnecting] = useState(false);

--- a/src/client/pages/ChannelsPage.tsx
+++ b/src/client/pages/ChannelsPage.tsx
@@ -407,6 +407,8 @@ export function ChannelsPage() {
           : `https://${connectParam}`,
       );
       setAdminToken("");
+      // The component outlives the dialog, so a mark from the last session is still held here.
+      connectRefusal.clear();
       connectModal.open();
     }
     setSearchParams(
@@ -529,6 +531,8 @@ export function ChannelsPage() {
   // removing happens from the list (a hard, slot-freeing delete that returns the account to this picker).
   function openManage() {
     setSelected(new Set());
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    accountsRefusal.clear();
     manageModal.open();
     void loadReachable();
   }
@@ -584,6 +588,8 @@ export function ChannelsPage() {
 
   function openToken() {
     setNewToken("");
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    tokenRefusal.clear();
     tokenModal.open();
   }
 

--- a/src/client/pages/ChannelsPage.tsx
+++ b/src/client/pages/ChannelsPage.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/client/components";
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
 import { useAuth } from "@/client/contexts/AuthContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { chatwootInboxNewUrl } from "@/client/lib/chatwootLinks";
@@ -208,6 +209,12 @@ function ChannelsSkeleton() {
   );
 }
 
+// Three writes on this page, three forms. The names are the keys of each body, which is what the
+// route refuses by (`refused body.baseUrl`, `refused body.accountIds.0`).
+const CONNECT_FIELDS = ["baseUrl", "adminToken"] as const;
+const TOKEN_FIELDS = ["adminToken"] as const;
+const ACCOUNTS_FIELDS = ["accountIds"] as const;
+
 export function ChannelsPage() {
   const { t } = useTranslation();
   const { showToast } = useToast();
@@ -233,6 +240,13 @@ export function ChannelsPage() {
   // Connect form (base URL + admin token, entered once).
   const [baseUrl, setBaseUrl] = useState("");
   const [adminToken, setAdminToken] = useState("");
+  // Three writes, three forms, three holders: the connect modal, the token modal, and the account
+  // picker each save on their own, and a refusal about one must not mark another's input.
+  const connectRefusal = useFieldRefusal(CONNECT_FIELDS);
+  const tokenRefusal = useFieldRefusal(TOKEN_FIELDS);
+  const accountsRefusal = useFieldRefusal(ACCOUNTS_FIELDS);
+  const connectRef = useRef({ baseUrl, adminToken });
+  connectRef.current = { baseUrl, adminToken };
   const [connecting, setConnecting] = useState(false);
 
   // Every account the deployment's token can reach (from /profile), listed inline under the instance
@@ -245,6 +259,8 @@ export function ChannelsPage() {
 
   // Rotate-token modal.
   const [newToken, setNewToken] = useState("");
+  const newTokenRef = useRef(newToken);
+  newTokenRef.current = newToken;
   const [savingToken, setSavingToken] = useState(false);
 
   // Per-inbox bot existence on Chatwoot (live reconcile). "missing" = bound here but the persona's
@@ -427,15 +443,26 @@ export function ChannelsPage() {
     if (!baseUrl.trim() || !adminToken.trim()) return;
     setConnecting(true);
     try {
-      const { data, error: err } = await api.api.v1.chatwoot.deployment.post({
+      const sent = {
         baseUrl: baseUrl.trim(),
         adminToken: adminToken.trim(),
-      });
+      };
+      const { data, error: err } =
+        await api.api.v1.chatwoot.deployment.post(sent);
       if (err || !data) {
         const status =
           typeof err === "object" && err && "status" in err
             ? (err as { status?: number }).status
             : undefined;
+        // Asked first, and only for WHERE: the toast below words the 409 better than the server
+        // does (it names the affordance — disconnect first — which the server cannot know about),
+        // so the fallback here is never shown. A null answer means the sentence is already on the
+        // input and the toast must stay silent.
+        const placed = connectRefusal.capture(err, "", sent, {
+          baseUrl: connectRef.current.baseUrl.trim(),
+          adminToken: connectRef.current.adminToken.trim(),
+        });
+        if (placed === null) return;
         showToast(
           apiErrorMessage(err) ||
             (status === 409
@@ -518,11 +545,17 @@ export function ChannelsPage() {
   // Enable the newly-picked accounts. Sends the UNION of the already-active ids and the selection, so the
   // diff applier only ever CONNECTS here (it never drops an active account — removal is the explicit
   // hard-delete on the list). Connecting syncs each account's inboxes.
+  // The list the picker would send: the accounts already active, plus whatever is checked. Computed
+  // where it is also READ, so the mark keyed by this value matches what the save carried.
+  const wantedAccountIds = [
+    ...new Set([
+      ...accounts.filter((a) => !a.disconnectedAt).map((a) => a.accountId),
+      ...selected,
+    ]),
+  ];
+
   async function applySelection() {
-    const activeIds = accounts
-      .filter((a) => !a.disconnectedAt)
-      .map((a) => a.accountId);
-    const wanted = [...new Set([...activeIds, ...selected])];
+    const wanted = wantedAccountIds;
     setApplying(true);
     try {
       const { data, error: err } =
@@ -530,17 +563,20 @@ export function ChannelsPage() {
           accountIds: wanted,
         });
       if (err || !data) throw err ?? new Error("no data");
+      accountsRefusal.clear();
       setAccounts([...data.accounts]);
       await refreshInboxes();
       manageModal.close();
       setSelected(new Set());
       showToast(t("channels.accountsEnabled", "Accounts updated."), "success");
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("channels.accountsSaveError", "Could not update the accounts."),
-        "error",
+      const toast = accountsRefusal.capture(
+        e,
+        t("channels.accountsSaveError", "Could not update the accounts."),
+        { accountIds: wanted },
+        { accountIds: wanted },
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setApplying(false);
     }
@@ -555,22 +591,21 @@ export function ChannelsPage() {
     if (!newToken.trim()) return;
     setSavingToken(true);
     try {
-      const { error: err } = await api.api.v1.chatwoot.deployment.patch({
-        adminToken: newToken.trim(),
-      });
+      const sent = { adminToken: newToken.trim() };
+      const { error: err } = await api.api.v1.chatwoot.deployment.patch(sent);
       if (err) throw err;
+      tokenRefusal.clear();
       showToast(t("channels.tokenSaved", "Token updated."), "success");
       tokenModal.close();
       void load();
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t(
-            "channels.tokenSaveError",
-            "Could not update the token (check it).",
-          ),
-        "error",
+      const toast = tokenRefusal.capture(
+        e,
+        t("channels.tokenSaveError", "Could not update the token (check it)."),
+        { adminToken: newToken.trim() },
+        { adminToken: newTokenRef.current.trim() },
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setSavingToken(false);
     }
@@ -1222,7 +1257,7 @@ export function ChannelsPage() {
             error={
               baseUrlInvalid && baseUrl.trim()
                 ? t("common.invalidUrl", "Must be a valid http(s) URL.")
-                : null
+                : connectRefusal.at("baseUrl", baseUrl.trim())
             }
           >
             <Input
@@ -1238,6 +1273,7 @@ export function ChannelsPage() {
               "channels.adminTokenHint",
               "Stored encrypted, never shown again.",
             )}
+            error={connectRefusal.at("adminToken", adminToken.trim())}
           >
             <Input
               type="password"
@@ -1286,6 +1322,7 @@ export function ChannelsPage() {
               "channels.adminTokenHint",
               "Stored encrypted, never shown again.",
             )}
+            error={tokenRefusal.at("adminToken", newToken.trim())}
           >
             <Input
               type="password"
@@ -1339,6 +1376,11 @@ export function ChannelsPage() {
               {t("channels.resync", "Resync")}
             </Button>
           </div>
+          {accountsRefusal.at("accountIds", wantedAccountIds) && (
+            <p className="text-error text-xs">
+              {accountsRefusal.at("accountIds", wantedAccountIds)}
+            </p>
+          )}
           {manageRows.length === 0 ? (
             <p className="py-6 text-center text-sm text-text-muted">
               {t(

--- a/src/client/pages/LoginPage.tsx
+++ b/src/client/pages/LoginPage.tsx
@@ -9,9 +9,9 @@ import {
   Logo,
 } from "@/client/components";
 import { useAuth } from "@/client/contexts/AuthContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { useGoogleSignIn } from "@/client/hooks/useGoogleSignIn";
 import { api } from "@/client/lib/api";
-import type { ApiErrorPayload } from "@/client/lib/types";
 import { cn } from "@/client/lib/utils";
 
 // Only honor an in-app destination (a single leading slash); reject absolute or protocol-relative
@@ -34,6 +34,11 @@ export function isServerNavigation(path: string): boolean {
   );
 }
 
+// The two keys the login body carries. A wrong password answers without naming either — deliberately,
+// since naming one would say which half was right — so what lands here in practice is the schema
+// boundary refusing a malformed address.
+const LOGIN_FIELDS = ["email", "password"] as const;
+
 // biome-ignore lint/plugin/require-page-container: auth page renders its own centered layout outside <Layout>, so <PageContainer> does not apply
 export function LoginPage() {
   const { t } = useTranslation();
@@ -41,6 +46,7 @@ export function LoginPage() {
   const [searchParams] = useSearchParams();
   const redirectTo = safeLocalPath(searchParams.get("redirect"));
   const { user, login, providers, signupEnabled } = useAuth();
+  const refusal = useFieldRefusal(LOGIN_FIELDS);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -53,6 +59,10 @@ export function LoginPage() {
   // form submit cannot both pass their guards before React commits the pending
   // state update.
   const authInFlightRef = useRef(false);
+  // What the inputs hold right now, readable from inside a request that started before it. Above the
+  // early returns below, because a hook after a conditional return is not called on every render.
+  const sentRef = useRef({ email, password });
+  sentRef.current = { email, password };
   // NOTE: Covers the already-logged-in visit and the Google callback (which only flips `user`); the
   // password path navigates from its own handler.
   const resumeServerFlow = user && isServerNavigation(redirectTo);
@@ -80,19 +90,22 @@ export function LoginPage() {
     setLoading(true);
 
     try {
-      const { data, error: apiError } = await api.api.auth.login.post({
-        email,
-        password,
-      });
+      const sent = { email, password };
+      const { data, error: apiError } = await api.api.auth.login.post(sent);
 
       if (apiError) {
         setError(
-          (apiError.value as ApiErrorPayload)?.error ||
+          refusal.capture(
+            apiError,
             t("auth.loginFailed", "Login failed"),
+            sent,
+            sentRef.current,
+          ) ?? "",
         );
         return;
       }
 
+      refusal.clear();
       if (data?.user) {
         login(data.user);
         if (isServerNavigation(redirectTo)) window.location.assign(redirectTo);
@@ -171,6 +184,8 @@ export function LoginPage() {
               required
               disabled={authPending}
               placeholder={t("auth.emailPlaceholder", "you@example.com")}
+              error={!!refusal.at("email", email)}
+              errorMessage={refusal.at("email", email) ?? undefined}
             />
           </div>
 
@@ -191,6 +206,8 @@ export function LoginPage() {
               minLength={8}
               disabled={authPending}
               placeholder="••••••••"
+              error={!!refusal.at("password", password)}
+              errorMessage={refusal.at("password", password) ?? undefined}
             />
           </div>
 

--- a/src/client/pages/OAuthConsentPage.tsx
+++ b/src/client/pages/OAuthConsentPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { Badge, Button, Logo, Skeleton } from "@/client/components";
 import { useAuth } from "@/client/contexts/AuthContext";
 import { api } from "@/client/lib/api";
+import { apiErrorMessage } from "@/client/lib/apiError";
 
 // Standalone OAuth 2.1 consent screen (outside the app shell, like Login). /authorize parks a
 // pending authorization and redirects here with ?req=<id>; we fetch its details, the user approves
@@ -78,6 +79,10 @@ export function OAuthConsentPage() {
   }, [req, navigate]);
 
   const decide = async (decision: Decision) => {
+    const generic = t(
+      "oauth.consent.genericError",
+      "Something went wrong. Reconnect from the application to try again.",
+    );
     if (!details || inFlightRef.current) return;
     inFlightRef.current = true;
     setSubmitting(decision);
@@ -87,23 +92,16 @@ export function OAuthConsentPage() {
         .consent({ req })
         .post({ decision, csrfToken: details.csrfToken });
       if (apiError || !data?.redirect) {
-        setError(
-          t(
-            "oauth.consent.genericError",
-            "Something went wrong. Reconnect from the application to try again.",
-          ),
-        );
+        // The server's own words when it sent any: the consent request can be refused for a reason
+        // the person can act on (the request expired, the client was revoked), and this page has no
+        // input to attach it to — so the sentence IS the whole answer. Issue #329.
+        setError(apiErrorMessage(apiError) ?? generic);
         return;
       }
       // Hand control back to the MCP client (full navigation to its redirect URI).
       window.location.assign(data.redirect);
-    } catch {
-      setError(
-        t(
-          "oauth.consent.genericError",
-          "Something went wrong. Reconnect from the application to try again.",
-        ),
-      );
+    } catch (e) {
+      setError(apiErrorMessage(e) ?? generic);
     } finally {
       inFlightRef.current = false;
       setSubmitting(null);

--- a/src/client/pages/OAuthConsentPage.tsx
+++ b/src/client/pages/OAuthConsentPage.tsx
@@ -5,7 +5,6 @@ import { useNavigate, useSearchParams } from "react-router";
 import { Badge, Button, Logo, Skeleton } from "@/client/components";
 import { useAuth } from "@/client/contexts/AuthContext";
 import { api } from "@/client/lib/api";
-import { apiErrorMessage } from "@/client/lib/apiError";
 
 // Standalone OAuth 2.1 consent screen (outside the app shell, like Login). /authorize parks a
 // pending authorization and redirects here with ?req=<id>; we fetch its details, the user approves
@@ -79,6 +78,13 @@ export function OAuthConsentPage() {
   }, [req, navigate]);
 
   const decide = async (decision: Decision) => {
+    // The server's own sentence is NOT shown here, and this is the one screen on the sweep where that
+    // is the right answer. Measured: this endpoint's only two refusals are a bare
+    // `UnauthorizedError()` and a bare `NotFoundError()` — "Unauthorized" and "Not found" — and the
+    // second is the ordinary case (the pending authorization expired, was consumed in another tab, or
+    // the CSRF token no longer matches). Showing "Not found" would cost the only recovery action the
+    // person has and give nothing back. The better fix is on the server, where that 404 could carry a
+    // key saying what expired; until it does, the client's words are the more specific ones.
     const generic = t(
       "oauth.consent.genericError",
       "Something went wrong. Reconnect from the application to try again.",
@@ -92,16 +98,13 @@ export function OAuthConsentPage() {
         .consent({ req })
         .post({ decision, csrfToken: details.csrfToken });
       if (apiError || !data?.redirect) {
-        // The server's own words when it sent any: the consent request can be refused for a reason
-        // the person can act on (the request expired, the client was revoked), and this page has no
-        // input to attach it to — so the sentence IS the whole answer. Issue #329.
-        setError(apiErrorMessage(apiError) ?? generic);
+        setError(generic);
         return;
       }
       // Hand control back to the MCP client (full navigation to its redirect URI).
       window.location.assign(data.redirect);
-    } catch (e) {
-      setError(apiErrorMessage(e) ?? generic);
+    } catch {
+      setError(generic);
     } finally {
       inFlightRef.current = false;
       setSubmitting(null);

--- a/src/client/pages/SetupPage.tsx
+++ b/src/client/pages/SetupPage.tsx
@@ -3,9 +3,19 @@ import { useTranslation } from "react-i18next";
 import { Navigate, useNavigate, useSearchParams } from "react-router";
 import { BrandFooter, Button, Input, Logo } from "@/client/components";
 import { useAuth } from "@/client/contexts/AuthContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { setActiveTenantId } from "@/client/lib/activeTenant";
 import { api } from "@/client/lib/api";
-import type { ApiErrorPayload } from "@/client/lib/types";
+
+// The keys the setup body carries. `email` is the one that refuses in practice: an address that
+// already has an account answers 400 "Email already in use" and names it.
+const SETUP_FIELDS = [
+  "email",
+  "password",
+  "name",
+  "companyName",
+  "token",
+] as const;
 
 // biome-ignore lint/plugin/require-page-container: auth page renders its own centered layout outside <Layout>, so <PageContainer> does not apply
 export function SetupPage() {
@@ -21,6 +31,18 @@ export function SetupPage() {
   const [token, setToken] = useState(() => searchParams.get("token") ?? "");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const refusal = useFieldRefusal(SETUP_FIELDS);
+  // What the inputs hold right now, in the server's vocabulary, and what the write sends. Above the
+  // early return below, because a hook after a conditional return is not called on every render.
+  const current = {
+    email,
+    password,
+    name: name.trim() || undefined,
+    companyName: company.trim() || undefined,
+    token: token || undefined,
+  };
+  const currentRef = useRef(current);
+  currentRef.current = current;
   const inFlightRef = useRef(false);
 
   // NOTE: Drop the token from the URL once captured so it does not linger in
@@ -50,13 +72,8 @@ export function SetupPage() {
     setLoading(true);
 
     try {
-      const { data, error: apiError } = await api.api.auth.setup.post({
-        email,
-        password,
-        name: name.trim() || undefined,
-        companyName: company.trim() || undefined,
-        token: token || undefined,
-      });
+      const sent = { ...current };
+      const { data, error: apiError } = await api.api.auth.setup.post(sent);
 
       if (apiError) {
         // NOTE: 409 means setup was already completed (another replica, a
@@ -71,12 +88,17 @@ export function SetupPage() {
           return;
         }
         setError(
-          (apiError.value as ApiErrorPayload)?.error ||
+          refusal.capture(
+            apiError,
             t("setup.failed", "Setup failed"),
+            sent,
+            currentRef.current,
+          ) ?? "",
         );
         return;
       }
 
+      refusal.clear();
       if (data?.user) {
         // NOTE: Seed the active-tenant selector synchronously from the just-created tenant BEFORE
         // login()/navigate, so the SUPER_ADMIN's first dashboard paint targets a real tenant
@@ -138,6 +160,10 @@ export function SetupPage() {
               onChange={(e) => setCompany(e.target.value)}
               disabled={loading}
               placeholder={t("setup.companyPlaceholder", "Your company")}
+              error={!!refusal.at("companyName", current.companyName)}
+              errorMessage={
+                refusal.at("companyName", current.companyName) ?? undefined
+              }
               helperText={t(
                 "setup.companyHint",
                 "Names your workspace. You can change it later.",
@@ -160,6 +186,8 @@ export function SetupPage() {
               required
               disabled={loading}
               placeholder={t("auth.emailPlaceholder", "you@example.com")}
+              error={!!refusal.at("email", current.email)}
+              errorMessage={refusal.at("email", current.email) ?? undefined}
             />
           </div>
 
@@ -177,6 +205,8 @@ export function SetupPage() {
               onChange={(e) => setName(e.target.value)}
               disabled={loading}
               placeholder={t("setup.namePlaceholder", "Optional")}
+              error={!!refusal.at("name", current.name)}
+              errorMessage={refusal.at("name", current.name) ?? undefined}
             />
           </div>
 
@@ -197,6 +227,10 @@ export function SetupPage() {
               minLength={8}
               disabled={loading}
               placeholder="••••••••"
+              error={!!refusal.at("password", current.password)}
+              errorMessage={
+                refusal.at("password", current.password) ?? undefined
+              }
               helperText={t(
                 "auth.passwordMinLength",
                 "Must be at least 8 characters",
@@ -240,6 +274,8 @@ export function SetupPage() {
                 onChange={(e) => setToken(e.target.value)}
                 required
                 disabled={loading}
+                error={!!refusal.at("token", current.token)}
+                errorMessage={refusal.at("token", current.token) ?? undefined}
                 helperText={t(
                   "setup.tokenHint",
                   "Printed in the server log on first start.",

--- a/src/client/pages/SetupPage.tsx
+++ b/src/client/pages/SetupPage.tsx
@@ -9,13 +9,13 @@ import { api } from "@/client/lib/api";
 
 // The keys the setup body carries. `email` is the one that refuses in practice: an address that
 // already has an account answers 400 "Email already in use" and names it.
-const SETUP_FIELDS = [
-  "email",
-  "password",
-  "name",
-  "companyName",
-  "token",
-] as const;
+const SETUP_FIELDS = ["email", "password", "name", "companyName"] as const;
+
+// `token` only where enforcement is on. The box is drawn behind `setupTokenRequired`, but a token
+// captured from `?token=` is SENT either way, so the route can refuse it (the schema caps it at 256)
+// on a screen with no control for it. Declaring it there would place the sentence on nothing and
+// leave the button looking dead.
+const SETUP_FIELDS_WITH_TOKEN = [...SETUP_FIELDS, "token"] as const;
 
 // biome-ignore lint/plugin/require-page-container: auth page renders its own centered layout outside <Layout>, so <PageContainer> does not apply
 export function SetupPage() {
@@ -31,7 +31,9 @@ export function SetupPage() {
   const [token, setToken] = useState(() => searchParams.get("token") ?? "");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const refusal = useFieldRefusal(SETUP_FIELDS);
+  const refusal = useFieldRefusal(
+    setupTokenRequired ? SETUP_FIELDS_WITH_TOKEN : SETUP_FIELDS,
+  );
   // What the inputs hold right now, in the server's vocabulary, and what the write sends. Above the
   // early return below, because a hook after a conditional return is not called on every render.
   const current = {

--- a/src/client/pages/SignupPage.tsx
+++ b/src/client/pages/SignupPage.tsx
@@ -9,10 +9,14 @@ import {
   Logo,
 } from "@/client/components";
 import { useAuth } from "@/client/contexts/AuthContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { useGoogleSignIn } from "@/client/hooks/useGoogleSignIn";
 import { api } from "@/client/lib/api";
-import type { ApiErrorPayload } from "@/client/lib/types";
 import { cn } from "@/client/lib/utils";
+
+// The two keys the signup body carries. An address that already has an account answers 400 "Email
+// already in use" and names `email` — the whole reason this page can place anything.
+const SIGNUP_FIELDS = ["email", "password"] as const;
 
 // biome-ignore lint/plugin/require-page-container: auth page renders its own centered layout outside <Layout>, so <PageContainer> does not apply
 export function SignupPage() {
@@ -32,6 +36,11 @@ export function SignupPage() {
   // form submit cannot both pass their guards before React commits the pending
   // state update.
   const authInFlightRef = useRef(false);
+  const refusal = useFieldRefusal(SIGNUP_FIELDS);
+  // What the inputs hold right now, readable from inside a request that started before it. Above the
+  // early returns below, because a hook after a conditional return is not called on every render.
+  const sentRef = useRef({ email, password });
+  sentRef.current = { email, password };
 
   if (user) return <Navigate to="/" replace />;
   // NOTE: Public signup is opt-in (SIGNUP_ENABLED). When closed, the page is
@@ -61,19 +70,22 @@ export function SignupPage() {
     setLoading(true);
 
     try {
-      const { data, error: apiError } = await api.api.auth.signup.post({
-        email,
-        password,
-      });
+      const sent = { email, password };
+      const { data, error: apiError } = await api.api.auth.signup.post(sent);
 
       if (apiError) {
         setError(
-          (apiError.value as ApiErrorPayload)?.error ||
+          refusal.capture(
+            apiError,
             t("auth.signupFailed", "Signup failed"),
+            sent,
+            sentRef.current,
+          ) ?? "",
         );
         return;
       }
 
+      refusal.clear();
       if (data?.user) {
         login(data.user);
         navigate("/");
@@ -151,6 +163,8 @@ export function SignupPage() {
               required
               disabled={authPending}
               placeholder={t("auth.emailPlaceholder", "you@example.com")}
+              error={!!refusal.at("email", email)}
+              errorMessage={refusal.at("email", email) ?? undefined}
             />
           </div>
 
@@ -171,6 +185,8 @@ export function SignupPage() {
               minLength={8}
               disabled={authPending}
               placeholder="••••••••"
+              error={!!refusal.at("password", password)}
+              errorMessage={refusal.at("password", password) ?? undefined}
               helperText={t(
                 "auth.passwordMinLength",
                 "Must be at least 8 characters",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -2216,7 +2216,11 @@ function AgentEditor() {
       else applyBehavior(data.agent);
       markSynced(String(data.agent.updatedAt));
       bumpSync(section);
-      refusal.clear();
+      // Only for the section this holder DRAWS. One function writes both, and a Behavior save
+      // carries neither `name` nor `systemPrompt` — clearing there takes the standing refusal off
+      // the General tab without anything having answered it, so the operator comes back to a form
+      // that looks fine and is still refused.
+      if (section === "general") refusal.clear();
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
       // The backend's localized message, at the input it names when this page renders one. The

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -47,6 +47,7 @@ import { BusinessHoursForm } from "@/client/components/BusinessHoursForm";
 import type { DiscoveredMcpTool } from "@/client/components/mcp/DiscoveredMcpTools";
 import { useBreadcrumbLabel } from "@/client/contexts/BreadcrumbContext";
 import { useNavGuard } from "@/client/contexts/NavGuardContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { useTenantEvents } from "@/client/hooks/useTenantEvents";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
@@ -568,6 +569,13 @@ function AgentEditorSkeleton() {
 // the thing it clears will be repopulated, and answering that per field is how a discard ends up
 // stranding a value the form still needs. A different agent is a different form. `:tab` is NOT in
 // the key, so moving between tabs of the same agent keeps everything, which is what it is for.
+// The two names this page renders a control for, out of everything an agent write can be refused
+// about. The rest of the editor's values live in bags — `settings.tts.normalizeCredentialRef`,
+// `guardrails.output.templateMessage` — behind tabs, and placing a refusal on one of those means
+// also taking the operator to the tab that holds it, which is its own change (fazer-ai/agents#349;
+// the abstention is recorded in tests/client/field-refusal-fence.test.ts).
+const EDITOR_FIELDS = ["name", "systemPrompt"] as const;
+
 export function AgentEditorPage() {
   const { id = "" } = useParams();
   return <AgentEditor key={id} />;
@@ -611,6 +619,11 @@ function AgentEditor() {
   // Agent fields
   const [name, setName] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
+  const refusal = useFieldRefusal(EDITOR_FIELDS);
+  // What the two placeable inputs hold right now, readable from inside a save that started before
+  // them: this page's saves are long and the operator keeps typing during them.
+  const currentRef = useRef<Record<string, unknown>>({});
+  currentRef.current = { name: name.trim(), systemPrompt };
   const [enabled, setEnabled] = useState(true);
   const [agentMode, setAgentMode] = useState<"test" | "production">(
     "production",
@@ -2193,15 +2206,20 @@ function AgentEditor() {
       else applyBehavior(data.agent);
       markSynced(String(data.agent.updatedAt));
       bumpSync(section);
+      refusal.clear();
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
-      // NOTE: surface the backend's localized message when present (the prompt-size cap, the
-      // settings text caps) instead of the generic failure toast.
-      showToast(
-        apiErrorMessage(e) ||
-          t("editor.saveError", "Could not save the agent."),
-        "error",
+      // The backend's localized message, at the input it names when this page renders one. The
+      // prompt-size cap and the name are the two it can place today; a settings-bag path
+      // (`guardrails.output.templateMessage`) still answers in the toast, which is where the
+      // sentence has always gone.
+      const toast = refusal.capture(
+        e,
+        t("editor.saveError", "Could not save the agent."),
+        patch,
+        currentRef.current,
       );
+      if (toast) showToast(toast, "error");
     } finally {
       savingRef.current -= 1;
       setSavingAgent(false);
@@ -2860,6 +2878,8 @@ function AgentEditor() {
 
             {tab === "general" && (
               <GeneralTab
+                nameError={refusal.at("name", name.trim())}
+                promptError={refusal.at("systemPrompt", systemPrompt)}
                 availability={promptAvailability}
                 name={name}
                 setName={setName}

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -620,7 +620,11 @@ function AgentEditor() {
   // Agent fields
   const [name, setName] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
-  const refusal = useFieldRefusal(EDITOR_FIELDS);
+  // Gated on the TAB, for the same reason a dialog's holder is gated on `isOpen`: `GeneralTab` is
+  // only mounted while `tab === "general"`, so a save that answers after the operator has moved on —
+  // or the "Save and export" that writes General from wherever they are — would place its mark on a
+  // control nobody is rendering. Off that tab the sentence goes to the toast.
+  const refusal = useFieldRefusal(EDITOR_FIELDS, tab === "general");
   // What the two placeable inputs hold right now, readable from inside a save that started before
   // them: this page's saves are long and the operator keeps typing during them.
   const currentRef = useRef<Record<string, unknown>>({});

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -846,7 +846,7 @@ function AgentEditor() {
   const [cloneName, setCloneName] = useState("");
   // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
   // Separate from the editor's holder, because the two are on screen together.
-  const cloneRefusal = useFieldRefusal(CLONE_FIELDS);
+  const cloneRefusal = useFieldRefusal(CLONE_FIELDS, cloneModal.isOpen);
   const cloneRef = useRef("");
   cloneRef.current = cloneName;
   // The suggested name prefilled on open; the modal only warns about discarding

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -624,7 +624,7 @@ function AgentEditor() {
   // only mounted while `tab === "general"`, so a save that answers after the operator has moved on —
   // or the "Save and export" that writes General from wherever they are — would place its mark on a
   // control nobody is rendering. Off that tab the sentence goes to the toast.
-  const refusal = useFieldRefusal(EDITOR_FIELDS, tab === "general");
+  const refusal = useFieldRefusal(tab === "general" ? EDITOR_FIELDS : []);
   // What the two placeable inputs hold right now, readable from inside a save that started before
   // them: this page's saves are long and the operator keeps typing during them.
   const currentRef = useRef<Record<string, unknown>>({});
@@ -850,7 +850,7 @@ function AgentEditor() {
   const [cloneName, setCloneName] = useState("");
   // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
   // Separate from the editor's holder, because the two are on screen together.
-  const cloneRefusal = useFieldRefusal(CLONE_FIELDS, cloneModal.isOpen);
+  const cloneRefusal = useFieldRefusal(cloneModal.isOpen ? CLONE_FIELDS : []);
   const cloneRef = useRef("");
   cloneRef.current = cloneName;
   // The suggested name prefilled on open; the modal only warns about discarding

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -575,6 +575,7 @@ function AgentEditorSkeleton() {
 // also taking the operator to the tab that holds it, which is its own change (fazer-ai/agents#349;
 // the abstention is recorded in tests/client/field-refusal-fence.test.ts).
 const EDITOR_FIELDS = ["name", "systemPrompt"] as const;
+const CLONE_FIELDS = ["name"] as const;
 
 export function AgentEditorPage() {
   const { id = "" } = useParams();
@@ -843,6 +844,11 @@ function AgentEditor() {
   const fillCredModal = useModalController<VaultEntry>();
   const exportModal = useModalController();
   const [cloneName, setCloneName] = useState("");
+  // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
+  // Separate from the editor's holder, because the two are on screen together.
+  const cloneRefusal = useFieldRefusal(CLONE_FIELDS);
+  const cloneRef = useRef("");
+  cloneRef.current = cloneName;
   // The suggested name prefilled on open; the modal only warns about discarding
   // when the user actually edited it.
   const cloneNameDefaultRef = useRef("");
@@ -2449,17 +2455,22 @@ function AgentEditor() {
         .agents({ id })
         .clone.post({ name: cloneName.trim() || undefined });
       if (err || !data) throw err ?? new Error("no data");
+      cloneRefusal.clear();
       cloneModal.close();
       showToast(t("editor.cloned", "Agent cloned (disabled)."), "success");
       navigate(`/agents/${data.agent.id}`);
     } catch (e) {
       // The clone carries the source agent's settings verbatim, so a source written before the text
       // caps is refused by name — the generic message would leave the operator with a button that
-      // fails and no field to shorten.
-      showToast(
-        apiErrorMessage(e) || t("editor.cloneError", "Could not clone."),
-        "error",
+      // fails and no field to shorten. A refusal about the NEW NAME lands on the one input this
+      // dialog draws; one about the copied settings has no control here and stays a toast.
+      const toast = cloneRefusal.capture(
+        e,
+        t("editor.cloneError", "Could not clone."),
+        { name: cloneName.trim() || undefined },
+        { name: cloneRef.current.trim() || undefined },
       );
+      if (toast) showToast(toast, "error");
     }
   }
 
@@ -2696,6 +2707,8 @@ function AgentEditor() {
                     );
                     cloneNameDefaultRef.current = suggested;
                     setCloneName(suggested);
+                    // The component outlives the dialog, so a mark from the last session is still held here.
+                    cloneRefusal.clear();
                     cloneModal.open();
                   }}
                 >
@@ -3148,7 +3161,10 @@ function AgentEditor() {
               )}
             </div>
           )}
-          <FormField label={t("editor.cloneName", "New agent name")}>
+          <FormField
+            label={t("editor.cloneName", "New agent name")}
+            error={cloneRefusal.at("name", cloneName.trim() || undefined)}
+          >
             <Input
               value={cloneName}
               onChange={(e) => setCloneName(e.target.value)}

--- a/src/client/pages/agents/GeneralTab.tsx
+++ b/src/client/pages/agents/GeneralTab.tsx
@@ -39,6 +39,10 @@ interface ModelState {
 interface GeneralTabProps {
   name: string;
   setName: (v: string) => void;
+  // The server's refusal about one of these two, when it named it. Null the rest of the time — the
+  // page decides where a refusal goes, this tab only renders what it is handed.
+  nameError?: string | null;
+  promptError?: string | null;
   systemPrompt: string;
   setSystemPrompt: (v: string) => void;
   enabled: boolean;
@@ -70,6 +74,8 @@ interface GeneralTabProps {
 
 export function GeneralTab({
   name,
+  nameError,
+  promptError,
   setName,
   systemPrompt,
   setSystemPrompt,
@@ -119,6 +125,7 @@ export function GeneralTab({
             label={t("editor.name", "Name")}
             required
             className="min-w-0 flex-1"
+            error={nameError}
           >
             <Input value={name} onChange={(e) => setName(e.target.value)} />
           </FormField>
@@ -168,6 +175,9 @@ export function GeneralTab({
             agentFallback={name}
             onExpand={() => promptModal.open()}
           />
+          {promptError && (
+            <p className="mt-1 text-error text-xs">{promptError}</p>
+          )}
         </FormField>
       </Card>
 

--- a/src/client/pages/resources/AdvancedPanel.tsx
+++ b/src/client/pages/resources/AdvancedPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -10,12 +10,18 @@ import {
   useToast,
 } from "@/client/components";
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
-import { apiErrorMessage } from "@/client/lib/apiError";
 
 type Settings = NonNullable<
   Awaited<ReturnType<(typeof api.api.v1)["tenant-settings"]["get"]>>["data"]
 >;
+
+// The two blocks here are two FORMS, and the server names their credentials by the dotted path into
+// the settings bag it owns — `requireVaultRef(db, incoming, "embedding.credentialRef")`. Separate
+// hooks because they save separately: a refusal about one must not mark the other's picker.
+const EMBEDDING_FIELDS = ["embedding.credentialRef"] as const;
+const LANGFUSE_FIELDS = ["langfuse.credentialRef"] as const;
 
 // Pinned server-side (see updateEmbeddingSettings); shown read-only until flexible embeddings ship.
 const EMBEDDING_MODEL = "text-embedding-3-small";
@@ -36,12 +42,18 @@ export function AdvancedPanel() {
   // Embedding (only the credential is configurable; provider/model are pinned server-side).
   const [embCredential, setEmbCredential] = useState("");
   const [embSaving, setEmbSaving] = useState(false);
+  const embRefusal = useFieldRefusal(EMBEDDING_FIELDS);
+  const embRef = useRef(embCredential);
+  embRef.current = embCredential;
 
   const [lfEnabled, setLfEnabled] = useState(false);
   const [lfCredentialRef, setLfCredentialRef] = useState<string | null>(null);
   const [lfSendContent, setLfSendContent] = useState(false);
   const [lfDebug, setLfDebug] = useState(false);
   const [lfSaving, setLfSaving] = useState(false);
+  const lfRefusal = useFieldRefusal(LANGFUSE_FIELDS);
+  const lfRefRef = useRef(lfCredentialRef);
+  lfRefRef.current = lfCredentialRef;
 
   const apply = useCallback((s: Settings) => {
     setEmbCredential(s.embedding.credentialRef ?? "");
@@ -71,24 +83,25 @@ export function AdvancedPanel() {
 
   async function saveEmbedding() {
     setEmbSaving(true);
+    const ref = embCredential || null;
     try {
       const { error: err } = await api.api.v1["tenant-settings"].embedding.put({
-        credentialRef: embCredential || null,
+        credentialRef: ref,
       });
       if (err) throw err;
+      embRefusal.clear();
       showToast(
         t("advanced.embedding.saved", "Embedding settings saved."),
         "success",
       );
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t(
-            "advanced.embedding.saveError",
-            "Could not save embedding settings.",
-          ),
-        "error",
+      const toast = embRefusal.capture(
+        e,
+        t("advanced.embedding.saveError", "Could not save embedding settings."),
+        { "embedding.credentialRef": ref },
+        { "embedding.credentialRef": embRef.current || null },
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setEmbSaving(false);
     }
@@ -106,20 +119,23 @@ export function AdvancedPanel() {
         debug: lfDebug,
       });
       if (err || !data) throw err ?? new Error("no data");
+      lfRefusal.clear();
       setLfCredentialRef(data.langfuse.credentialRef);
       showToast(
         t("advanced.observability.saved", "Observability settings saved."),
         "success",
       );
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t(
-            "advanced.observability.saveError",
-            "Could not save observability settings.",
-          ),
-        "error",
+      const toast = lfRefusal.capture(
+        e,
+        t(
+          "advanced.observability.saveError",
+          "Could not save observability settings.",
+        ),
+        { "langfuse.credentialRef": lfCredentialRef },
+        { "langfuse.credentialRef": lfRefRef.current },
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setLfSaving(false);
     }
@@ -174,6 +190,17 @@ export function AdvancedPanel() {
                   compatibleTypes={["openai"]}
                   ariaLabel={t("advanced.embedding.credential", "Credential")}
                 />
+                {embRefusal.at(
+                  "embedding.credentialRef",
+                  embCredential || null,
+                ) && (
+                  <p className="mt-1 text-error text-xs">
+                    {embRefusal.at(
+                      "embedding.credentialRef",
+                      embCredential || null,
+                    )}
+                  </p>
+                )}
               </div>
               <Button size="sm" onClick={saveEmbedding} loading={embSaving}>
                 {t("common.save", "Save")}
@@ -218,6 +245,7 @@ export function AdvancedPanel() {
               "advanced.observability.credentialHint",
               "Public key, secret key and host are stored in the credential. Use the Vault tab to create or update it.",
             )}
+            error={lfRefusal.at("langfuse.credentialRef", lfCredentialRef)}
           >
             <CredentialPicker
               value={lfCredentialRef ?? ""}

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -33,6 +33,7 @@ import {
   useToast,
 } from "@/client/components";
 import { ServiceLogo } from "@/client/components/icons/ServiceLogo";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { credentialCompat } from "@/client/lib/credentialCompat";
@@ -480,6 +481,29 @@ function emptyForm(): Form {
 // renders a SERVICE-specific form (Asaas charges + webhook, Calendar allowlist, Drive folder), lists
 // the tools the integration exposes (label/description/args, never internal names), and reveals the
 // inbound webhook URL once after creating an Asaas instance. `onSaved` lets the caller refetch.
+// The keys of the body this modal writes. Two of them are vault refs, and `requireVaultRef` names
+// which one it refused — the reason a sentence alone cannot answer here.
+//
+// `config` is not here: it is a per-toolpack section of many controls, and a refusal about the bag
+// as a whole has no single box to sit under, so it belongs in the toast.
+const INTEGRATION_FIELDS = [
+  "name",
+  "credentialRef",
+  "inboundSecretRef",
+] as const;
+
+// The body, from the form. ONE function, because it is also what a refusal is matched against.
+function currentOf(form: Form) {
+  return {
+    name: form.name.trim(),
+    credentialRef: form.credentialRef || null,
+    config: form.config,
+    inboundAuthStrategy: form.inboundAuthStrategy,
+    inboundSecretRef: form.inboundSecretRef || null,
+    enabled: form.enabled,
+  };
+}
+
 export function IntegrationEditModal({
   modal,
   onSaved,
@@ -556,6 +580,10 @@ export function IntegrationEditModal({
   const [rotating, setRotating] = useState(false);
   const [catalog, setCatalog] = useState<CatalogEntry[]>([]);
   const [form, setForm] = useState<Form>(emptyForm());
+  // The CURRENT form, readable from inside a request that started before it.
+  const formRef = useRef(form);
+  formRef.current = form;
+  const refusal = useFieldRefusal(INTEGRATION_FIELDS);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);
@@ -767,20 +795,17 @@ export function IntegrationEditModal({
 
   async function save() {
     if (!form.name.trim() || !form.catalogType) return;
+    // The body this modal writes, minus the create-only `catalogType`. One expression, because it is
+    // also what the refusal is matched against.
+    const sent = currentOf(form);
     setSaving(true);
     try {
       if (editId) {
         const { data, error: err } = await api.api.v1.integrations
           .instances({ id: editId })
-          .patch({
-            name: form.name.trim(),
-            credentialRef: form.credentialRef || null,
-            config: form.config,
-            inboundAuthStrategy: form.inboundAuthStrategy,
-            inboundSecretRef: form.inboundSecretRef || null,
-            enabled: form.enabled,
-          });
+          .patch(sent);
         if (err || !data) throw err ?? new Error("no data");
+        refusal.clear();
         showToast(t("integrations.saved", "Integration saved."), "success");
         modal.close();
         onSaved?.(
@@ -791,14 +816,10 @@ export function IntegrationEditModal({
         const { data, error: err } =
           await api.api.v1.integrations.instances.post({
             catalogType: form.catalogType,
-            name: form.name.trim(),
-            credentialRef: form.credentialRef || null,
-            config: form.config,
-            inboundAuthStrategy: form.inboundAuthStrategy,
-            inboundSecretRef: form.inboundSecretRef || null,
-            enabled: form.enabled,
+            ...sent,
           });
         if (err || !data) throw err ?? new Error("no data");
+        refusal.clear();
         showToast(t("integrations.created", "Integration created."), "success");
         modal.close();
         onSaved?.({ id: data.id, name: form.name.trim() }, true);
@@ -811,10 +832,15 @@ export function IntegrationEditModal({
         }
       }
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) || t("integrations.saveError", "Could not save."),
-        "error",
+      // `requireVaultRef` names the ref column it refused, and this form carries TWO of them:
+      // `credentialRef` and `inboundSecretRef`. A sentence in a toast cannot say which picker.
+      const toast = refusal.capture(
+        e,
+        t("integrations.saveError", "Could not save."),
+        sent,
+        currentOf(formRef.current),
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setSaving(false);
     }
@@ -1069,14 +1095,22 @@ export function IntegrationEditModal({
               </p>
             )}
 
-            <FormField label={t("integrations.name", "Name")} required>
+            <FormField
+              label={t("integrations.name", "Name")}
+              required
+              error={refusal.at("name", form.name.trim())}
+            >
               <Input
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
               />
             </FormField>
 
-            <FormField label={t("integrations.credential", "Credential")} group>
+            <FormField
+              label={t("integrations.credential", "Credential")}
+              group
+              error={refusal.at("credentialRef", form.credentialRef || null)}
+            >
               <CredentialPicker
                 value={form.credentialRef}
                 onChange={setCredential}
@@ -1829,6 +1863,10 @@ export function IntegrationEditModal({
                     <FormField
                       label={t("integrations.inboundSecret", "Webhook secret")}
                       group
+                      error={refusal.at(
+                        "inboundSecretRef",
+                        form.inboundSecretRef || null,
+                      )}
                     >
                       <CredentialPicker
                         value={form.inboundSecretRef}

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -486,9 +486,13 @@ function emptyForm(): Form {
 //
 // `config` is not here: it is a per-toolpack section of many controls, and a refusal about the bag
 // as a whole has no single box to sit under, so it belongs in the toast.
-const INTEGRATION_FIELDS = [
-  "name",
-  "credentialRef",
+const INTEGRATION_FIELDS = ["name", "credentialRef"] as const;
+
+// The inbound secret's picker is drawn only for a strategy that HAS one. The ref survives a switch
+// to NONE in the body, so a stranded credential can still be refused by name with nothing on screen
+// holding it.
+const INTEGRATION_INBOUND_FIELDS = [
+  ...INTEGRATION_FIELDS,
   "inboundSecretRef",
 ] as const;
 
@@ -583,7 +587,13 @@ export function IntegrationEditModal({
   // The CURRENT form, readable from inside a request that started before it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(modal.isOpen ? INTEGRATION_FIELDS : []);
+  const refusal = useFieldRefusal(
+    modal.isOpen
+      ? form.inboundAuthStrategy !== "NONE"
+        ? INTEGRATION_INBOUND_FIELDS
+        : INTEGRATION_FIELDS
+      : [],
+  );
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -691,6 +691,8 @@ export function IntegrationEditModal({
   const editId = modal.payload?.id;
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     setLoadError(false);
     setAvailableCals([]);
     setCalError(false);

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -583,7 +583,7 @@ export function IntegrationEditModal({
   // The CURRENT form, readable from inside a request that started before it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(INTEGRATION_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? INTEGRATION_FIELDS : []);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);

--- a/src/client/pages/resources/IntegrationEditModal.tsx
+++ b/src/client/pages/resources/IntegrationEditModal.tsx
@@ -583,7 +583,7 @@ export function IntegrationEditModal({
   // The CURRENT form, readable from inside a request that started before it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(INTEGRATION_FIELDS);
+  const refusal = useFieldRefusal(INTEGRATION_FIELDS, modal.isOpen);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);

--- a/src/client/pages/resources/KnowledgeApprovals.tsx
+++ b/src/client/pages/resources/KnowledgeApprovals.tsx
@@ -57,7 +57,11 @@ export function KnowledgeApprovals({
   // editors invite approving the card the reviewer was not reading.
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draft, setDraft] = useState({ title: "", content: "" });
-  const refusal = useFieldRefusal(APPROVAL_FIELDS);
+  // Gated on the editor being open, because that is what the two inputs are gated on: they are drawn
+  // inside `editingId === a.id`, and a list that names them while it is null claims a control that
+  // is not there. Not a reachable failure today — Cancel is disabled while the PATCH is out, so the
+  // editor cannot close under its own save — but the claim is what the rest of this reads.
+  const refusal = useFieldRefusal(editingId ? APPROVAL_FIELDS : []);
   // The CURRENT draft, readable from inside a request that started before it.
   const draftRef = useRef(draft);
   draftRef.current = draft;
@@ -120,6 +124,10 @@ export function KnowledgeApprovals({
   }
 
   function startEdit(a: Approval) {
+    // Per editing SESSION, like a dialog's own reset: the mark expires by value, so reopening the
+    // same item — or another one whose title happens to match — would show the last request's
+    // server sentence before anything has been sent.
+    refusal.clear();
     setEditingId(a.id);
     setDraft({
       title: a.proposedTitle ?? "",

--- a/src/client/pages/resources/KnowledgeApprovals.tsx
+++ b/src/client/pages/resources/KnowledgeApprovals.tsx
@@ -7,7 +7,7 @@ import {
   Pencil,
   X,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import {
@@ -19,6 +19,7 @@ import {
   Textarea,
   useToast,
 } from "@/client/components";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { approvalEditPatch } from "@/client/lib/approvalEdit";
@@ -33,6 +34,9 @@ type Approval = NonNullable<ApprovalsData>["approvals"][number];
 // to be a top-level page). Reports the pending count up so the Components → Knowledge tab can show a
 // badge. Renders nothing once the queue is empty (the badge disappears too), so a clean knowledge
 // base has no clutter.
+// The two keys the edit patch carries, spelled the way the route refuses them.
+const APPROVAL_FIELDS = ["title", "content"] as const;
+
 export function KnowledgeApprovals({
   onCountChange,
 }: {
@@ -53,6 +57,10 @@ export function KnowledgeApprovals({
   // editors invite approving the card the reviewer was not reading.
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draft, setDraft] = useState({ title: "", content: "" });
+  const refusal = useFieldRefusal(APPROVAL_FIELDS);
+  // The CURRENT draft, readable from inside a request that started before it.
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
 
   useEffect(() => {
     let active = true;
@@ -133,13 +141,19 @@ export function KnowledgeApprovals({
         .approvals({ id: a.id })
         .patch(patch);
       if (err) {
-        showToast(
-          apiErrorMessage(err) ||
-            t("approvals.editError", "Could not save the edit."),
-          "error",
+        const toast = refusal.capture(
+          err,
+          t("approvals.editError", "Could not save the edit."),
+          { ...patch },
+          {
+            title: draftRef.current.title.trim(),
+            content: draftRef.current.content.trim(),
+          },
         );
+        if (toast) showToast(toast, "error");
         return;
       }
+      refusal.clear();
       // The endpoint reports a lost race INSIDE a 200: another reviewer approved or rejected this
       // item while the editor was open, so the revision was never stored. Checking only `error`
       // would leave the card claiming EDITED over text that no longer exists in the queue.
@@ -225,7 +239,10 @@ export function KnowledgeApprovals({
                 {/* Disabled while the save is in flight: `saveEdit` captured the draft when it was
                     clicked, so anything typed after that would be dropped by the response that
                     closes the editor. */}
-                <FormField label={t("approvals.editTitle", "Title")}>
+                <FormField
+                  label={t("approvals.editTitle", "Title")}
+                  error={refusal.at("title", draft.title.trim())}
+                >
                   <Input
                     value={draft.title}
                     disabled={busyId === a.id}
@@ -240,6 +257,7 @@ export function KnowledgeApprovals({
                     "approvals.editContentHint",
                     "This text is stored in the knowledge base exactly as written. Make it a standalone statement, with no caveats about checking it.",
                   )}
+                  error={refusal.at("content", draft.content.trim())}
                 >
                   <Textarea
                     rows={6}

--- a/src/client/pages/resources/McpEditModal.tsx
+++ b/src/client/pages/resources/McpEditModal.tsx
@@ -16,6 +16,7 @@ import {
   useToast,
 } from "@/client/components";
 import { useAuth } from "@/client/contexts/AuthContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { isValidHttpUrl } from "@/client/lib/validation";
 import {
@@ -45,6 +46,40 @@ function emptyForm() {
     enabled: true,
   };
 }
+
+type Form = ReturnType<typeof emptyForm>;
+
+// The body this modal writes, from the form it renders. ONE function, because it is also what the
+// refusal is matched against: `capture` compares the value that was SENT with the value the inputs
+// hold NOW, and two spellings of "the body" would disagree about a field nobody edited.
+function bodyOf(form: Form) {
+  const isStdio = form.transport === "stdio";
+  return {
+    name: form.name.trim(),
+    transport: form.transport,
+    url: isStdio ? null : form.url.trim() || null,
+    command: isStdio
+      ? composeStdioCommand(form.launcher, form.args.trim()) || null
+      : null,
+    credentialRef: form.credentialRef || null,
+    enabled: form.enabled,
+  };
+}
+
+// The server's own names for what this modal renders, and they are the keys of the body above — the
+// route's schema refuses by them (`refused body.name`, `refused body.transport`) and
+// `requireVaultRef` names `credentialRef`.
+//
+// `command` is declared even though no single input holds it: the launcher Select and the args Input
+// compose into it, so a refusal about the command is marked on the args field, which is the half an
+// operator can act on. See the render.
+const MCP_FIELDS = [
+  "name",
+  "transport",
+  "url",
+  "command",
+  "credentialRef",
+] as const;
 
 // Per-launcher args placeholder (the package + its flags; the launcher itself is the Select).
 function argsPlaceholder(launcher: string): string {
@@ -79,6 +114,12 @@ export function McpEditModal({
   const { showToast } = useToast();
   const { mcpStdioEnabled } = useAuth();
   const [form, setForm] = useState(emptyForm());
+  // The CURRENT form, readable from inside a request that started before it: the operator can type
+  // while the save is out, and a refusal about a value they have already replaced belongs in the
+  // banner rather than under a box that no longer holds it.
+  const formRef = useRef(form);
+  formRef.current = form;
+  const refusal = useFieldRefusal(MCP_FIELDS);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);
@@ -139,40 +180,38 @@ export function McpEditModal({
   });
 
   const isStdio = form.transport === "stdio";
+  // What the inputs hold right now, in the server's vocabulary. The marks are keyed by VALUE, so this
+  // has to be the same function the save sends — an edit takes the mark off because the box stops
+  // holding what was refused.
+  const current = bodyOf(form);
 
   async function save() {
     setFormError(null);
-    const body = {
-      name: form.name.trim(),
-      transport: form.transport,
-      url: isStdio ? null : form.url.trim() || null,
-      command: isStdio
-        ? composeStdioCommand(form.launcher, form.args.trim()) || null
-        : null,
-      credentialRef: form.credentialRef || null,
-      enabled: form.enabled,
-    };
+    const body = bodyOf(form);
     setSaving(true);
+    // Measured live, and it is why this modal is wired: a second connection under a name already
+    // taken answers 409 "mcp connection name already in use", and the banner said "check the
+    // URL/command" — the wrong input, named confidently (#329).
+    const fallback = t("mcp.saveError", "Could not save.");
+    const held = (e: unknown) =>
+      refusal.capture(e, fallback, body, bodyOf(formRef.current));
     try {
       const { data, error: err } = editId
         ? await api.api.v1["mcp-connections"]({ id: editId }).patch(body)
         : await api.api.v1["mcp-connections"].post(body);
       if (err || !data) {
-        setFormError(
-          t("mcp.saveError", "Could not save (check the URL/command)."),
-        );
+        setFormError(held(err));
         return;
       }
+      refusal.clear();
       showToast(t("mcp.saved", "MCP server saved."), "success");
       modal.close();
       onSaved?.(
         { id: data.connection.id, name: data.connection.name },
         !editId,
       );
-    } catch {
-      setFormError(
-        t("mcp.saveError", "Could not save (check the URL/command)."),
-      );
+    } catch (e) {
+      setFormError(held(e));
     } finally {
       setSaving(false);
     }
@@ -245,13 +284,20 @@ export function McpEditModal({
               </span>
             </div>
           )}
-          <FormField label={t("mcp.name", "Name")} required>
+          <FormField
+            label={t("mcp.name", "Name")}
+            required
+            error={refusal.at("name", current.name)}
+          >
             <Input
               value={form.name}
               onChange={(e) => setForm({ ...form, name: e.target.value })}
             />
           </FormField>
-          <FormField label={t("mcp.transport", "Transport")}>
+          <FormField
+            label={t("mcp.transport", "Transport")}
+            error={refusal.at("transport", current.transport)}
+          >
             <Select
               value={form.transport}
               onChange={(e) =>
@@ -312,6 +358,7 @@ export function McpEditModal({
                   "mcp.argsHint",
                   "The package to run plus its flags (the launcher is selected above). The credential's token is injected as an environment variable, never written here.",
                 )}
+                error={refusal.at("command", current.command)}
               >
                 <Input
                   value={form.args}
@@ -336,7 +383,7 @@ export function McpEditModal({
               error={
                 mcpUrlInvalid && form.url.trim()
                   ? t("common.invalidUrl", "Must be a valid http(s) URL.")
-                  : null
+                  : refusal.at("url", current.url)
               }
             >
               <Input
@@ -347,7 +394,11 @@ export function McpEditModal({
               />
             </FormField>
           )}
-          <FormField label={t("mcp.credential", "Credential")} group>
+          <FormField
+            label={t("mcp.credential", "Credential")}
+            group
+            error={refusal.at("credentialRef", current.credentialRef)}
+          >
             <CredentialPicker
               value={form.credentialRef}
               onChange={(v) => setForm({ ...form, credentialRef: v })}

--- a/src/client/pages/resources/McpEditModal.tsx
+++ b/src/client/pages/resources/McpEditModal.tsx
@@ -73,13 +73,13 @@ function bodyOf(form: Form) {
 // `command` is declared even though no single input holds it: the launcher Select and the args Input
 // compose into it, so a refusal about the command is marked on the args field, which is the half an
 // operator can act on. See the render.
-const MCP_FIELDS = [
-  "name",
-  "transport",
-  "url",
-  "command",
-  "credentialRef",
-] as const;
+const MCP_FIELDS = ["name", "transport", "credentialRef"] as const;
+
+// A stdio server is launched, the others are reached: the modal draws the command line for one and
+// the URL for the other, never both. Both stay in the BODY, so declaring both would put a refusal
+// about the one that is hidden onto a control that is not there.
+const MCP_STDIO_FIELDS = [...MCP_FIELDS, "command"] as const;
+const MCP_URL_FIELDS = [...MCP_FIELDS, "url"] as const;
 
 // Per-launcher args placeholder (the package + its flags; the launcher itself is the Select).
 function argsPlaceholder(launcher: string): string {
@@ -119,7 +119,6 @@ export function McpEditModal({
   // banner rather than under a box that no longer holds it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(modal.isOpen ? MCP_FIELDS : []);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);
@@ -182,6 +181,9 @@ export function McpEditModal({
   });
 
   const isStdio = form.transport === "stdio";
+  const refusal = useFieldRefusal(
+    modal.isOpen ? (isStdio ? MCP_STDIO_FIELDS : MCP_URL_FIELDS) : [],
+  );
   // What the inputs hold right now, in the server's vocabulary. The marks are keyed by VALUE, so this
   // has to be the same function the save sends — an edit takes the mark off because the box stops
   // holding what was refused.

--- a/src/client/pages/resources/McpEditModal.tsx
+++ b/src/client/pages/resources/McpEditModal.tsx
@@ -133,6 +133,8 @@ export function McpEditModal({
   const editId = modal.payload?.id;
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     setFormError(null);
     setLoadError(false);
     setMcpCredBaseUrl(null);

--- a/src/client/pages/resources/McpEditModal.tsx
+++ b/src/client/pages/resources/McpEditModal.tsx
@@ -119,7 +119,7 @@ export function McpEditModal({
   // banner rather than under a box that no longer holds it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(MCP_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? MCP_FIELDS : []);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);

--- a/src/client/pages/resources/McpEditModal.tsx
+++ b/src/client/pages/resources/McpEditModal.tsx
@@ -119,7 +119,7 @@ export function McpEditModal({
   // banner rather than under a box that no longer holds it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(MCP_FIELDS);
+  const refusal = useFieldRefusal(MCP_FIELDS, modal.isOpen);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -279,11 +279,15 @@ const TOOL_FIELDS = [
   "headers",
   "inputSchema",
   "query",
-  "body",
   "credentialRef",
   "expectedStatuses",
-  "ackMessage",
 ] as const;
+
+// The two this modal draws behind a switch. Both stay in the BODY when their control is gone —
+// `body` becomes an empty kv bag for a GET, `ackMessage` becomes null — so the server can still
+// refuse either by name with nothing on screen to mark.
+const TOOL_BODY_FIELDS = ["body"] as const;
+const TOOL_ACK_FIELDS = ["ackMessage"] as const;
 
 export function formFromTool(tool: Tool) {
   // NOTE: legacy rows authored programmatically may still carry pre-normalization shapes
@@ -649,7 +653,6 @@ export function ToolEditModal({
   // rather than under a box that no longer holds it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(modal.isOpen ? TOOL_FIELDS : []);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);
@@ -668,6 +671,16 @@ export function ToolEditModal({
   const aiFieldNames = form.aiFields.map((f) => f.name.trim()).filter(Boolean);
   const isWriteMethod =
     form.method === "POST" || form.method === "PUT" || form.method === "PATCH";
+
+  const refusal = useFieldRefusal(
+    modal.isOpen
+      ? [
+          ...TOOL_FIELDS,
+          ...(isWriteMethod ? TOOL_BODY_FIELDS : []),
+          ...(form.ackEnabled ? TOOL_ACK_FIELDS : []),
+        ]
+      : [],
+  );
   // What the inputs hold right now, in the server's vocabulary. The marks are keyed by VALUE, so
   // this has to be the same function the save sends. Null only while the headers are unparseable,
   // which is a client-side check the banner already answers.

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -649,7 +649,7 @@ export function ToolEditModal({
   // rather than under a box that no longer holds it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(TOOL_FIELDS, modal.isOpen);
+  const refusal = useFieldRefusal(modal.isOpen ? TOOL_FIELDS : []);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -19,6 +19,7 @@ import {
   useToast,
 } from "@/client/components";
 import { Tooltip } from "@/client/components/Tooltip";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { cn } from "@/client/lib/utils";
 import { isValidUrlTemplate } from "@/client/lib/validation";
@@ -213,6 +214,76 @@ export function parseExpectedStatuses(raw: string): number[] {
     .map((part) => Number(part))
     .filter((n) => Number.isInteger(n) && n > 0);
 }
+
+type ToolForm = ReturnType<typeof emptyForm>;
+
+// The body this modal writes, from the form it renders. ONE function, because it is also what a
+// refusal is matched against: `capture` compares the value that was SENT with the value the inputs
+// hold NOW, and two spellings of "the payload" would disagree about a field nobody edited.
+//
+// `null` when the headers are not parseable JSON, which is a client-side check with no server
+// sentence behind it.
+export function payloadOf(form: ToolForm) {
+  let headers: Record<string, unknown>;
+  try {
+    headers =
+      form.headersMode === "raw"
+        ? parseJsonOr(form.headersRaw, {})
+        : kvToObj(form.headerRows);
+  } catch {
+    return null;
+  }
+  const isWrite =
+    form.method === "POST" || form.method === "PUT" || form.method === "PATCH";
+  return {
+    // The model-facing identifier is always derived from the display name (single source of truth).
+    name: normalizeToolName(form.label.trim()),
+    label: form.label.trim(),
+    description: form.description.trim() || undefined,
+    method: form.method,
+    urlTemplate: form.urlTemplate.trim(),
+    allowedHosts: form.allowedHosts
+      .split(",")
+      .map((h) => h.trim())
+      .filter(Boolean),
+    headers,
+    // inputSchema is the AI contract only; fixed values live as literal rows in query/headers/body.
+    inputSchema: schemaFromAiFields(form.aiFields),
+    query: kvToObj(form.queryRows),
+    body: isWrite
+      ? form.bodyMode === "raw"
+        ? { mode: "raw", raw: form.bodyRaw }
+        : {
+            mode: "kv",
+            rows: form.bodyRows
+              .filter((r) => r.key.trim())
+              .map((r) => ({ key: r.key.trim(), value: r.value })),
+          }
+      : { mode: "kv", rows: [] },
+    credentialRef: form.credentialRef || null,
+    expectedStatuses: parseExpectedStatuses(form.expectedStatuses),
+    ackEnabled: form.ackEnabled,
+    ackMessage: form.ackEnabled ? form.ackMessage.trim() || null : null,
+  };
+}
+
+// The server's own names for what this modal renders, which are the keys of the body above. `name`
+// is derived from the label rather than typed, so a refusal about it is marked on the label — the
+// input the operator can actually change.
+const TOOL_FIELDS = [
+  "name",
+  "label",
+  "description",
+  "method",
+  "urlTemplate",
+  "headers",
+  "inputSchema",
+  "query",
+  "body",
+  "credentialRef",
+  "expectedStatuses",
+  "ackMessage",
+] as const;
 
 export function formFromTool(tool: Tool) {
   // NOTE: legacy rows authored programmatically may still carry pre-normalization shapes
@@ -573,6 +644,12 @@ export function ToolEditModal({
   const ackId = useId();
   const { showToast } = useToast();
   const [form, setForm] = useState(emptyForm());
+  // The CURRENT form, readable from inside a request that started before it: the operator can type
+  // during the save, and a refusal about a value they have already replaced belongs in the banner
+  // rather than under a box that no longer holds it.
+  const formRef = useRef(form);
+  formRef.current = form;
+  const refusal = useFieldRefusal(TOOL_FIELDS);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);
@@ -591,6 +668,10 @@ export function ToolEditModal({
   const aiFieldNames = form.aiFields.map((f) => f.name.trim()).filter(Boolean);
   const isWriteMethod =
     form.method === "POST" || form.method === "PUT" || form.method === "PATCH";
+  // What the inputs hold right now, in the server's vocabulary. The marks are keyed by VALUE, so
+  // this has to be the same function the save sends. Null only while the headers are unparseable,
+  // which is a client-side check the banner already answers.
+  const current = payloadOf(form) ?? ({} as Record<string, unknown>);
 
   useOnModalOpen(modal, () => {
     setFormError(null);
@@ -637,64 +718,29 @@ export function ToolEditModal({
 
   async function save() {
     setFormError(null);
-    let headers: Record<string, unknown>;
-    try {
-      headers =
-        form.headersMode === "raw"
-          ? parseJsonOr(form.headersRaw, {})
-          : kvToObj(form.headerRows);
-    } catch {
+    const payload = payloadOf(form);
+    if (payload === null) {
       setFormError(t("tools.invalidJson", "Headers must be valid JSON."));
       return;
     }
-    const payload = {
-      // The model-facing identifier is always derived from the display name (single source of truth).
-      name: normalizeToolName(form.label.trim()),
-      label: form.label.trim(),
-      description: form.description.trim() || undefined,
-      method: form.method,
-      urlTemplate: form.urlTemplate.trim(),
-      allowedHosts: form.allowedHosts
-        .split(",")
-        .map((h) => h.trim())
-        .filter(Boolean),
-      headers,
-      // inputSchema is the AI contract only; fixed values live as literal rows in query/headers/body.
-      inputSchema: schemaFromAiFields(form.aiFields),
-      query: kvToObj(form.queryRows),
-      body: isWriteMethod
-        ? form.bodyMode === "raw"
-          ? { mode: "raw", raw: form.bodyRaw }
-          : {
-              mode: "kv",
-              rows: form.bodyRows
-                .filter((r) => r.key.trim())
-                .map((r) => ({ key: r.key.trim(), value: r.value })),
-            }
-        : { mode: "kv", rows: [] },
-      credentialRef: form.credentialRef || null,
-      expectedStatuses: parseExpectedStatuses(form.expectedStatuses),
-      ackEnabled: form.ackEnabled,
-      ackMessage: form.ackEnabled ? form.ackMessage.trim() || null : null,
-    };
     setSaving(true);
+    const fallback = t("tools.saveError", "Could not save.");
+    const held = (e: unknown) =>
+      refusal.capture(e, fallback, payload, payloadOf(formRef.current) ?? {});
     try {
       const { data, error: err } = editId
         ? await api.api.v1.tools({ id: editId }).patch(payload)
         : await api.api.v1.tools.post(payload);
       if (err || !data) {
-        setFormError(
-          t("tools.saveError", "Could not save (check the name and URL)."),
-        );
+        setFormError(held(err));
         return;
       }
+      refusal.clear();
       showToast(t("tools.saved", "Tool saved."), "success");
       modal.close();
       onSaved?.({ id: data.tool.id, name: data.tool.name }, !editId);
-    } catch {
-      setFormError(
-        t("tools.saveError", "Could not save (check the name and URL)."),
-      );
+    } catch (e) {
+      setFormError(held(e));
     } finally {
       setSaving(false);
     }
@@ -781,6 +827,10 @@ export function ToolEditModal({
               "tools.nameHint",
               "How the tool is shown in the console. Spaces and accents are allowed; the identifier the AI calls is derived from it automatically.",
             )}
+            error={
+              refusal.at("label", current.label) ??
+              refusal.at("name", current.name)
+            }
           >
             <Input
               value={form.label}
@@ -799,7 +849,10 @@ export function ToolEditModal({
             )}
           </FormField>
 
-          <FormField label={t("tools.description", "Description")}>
+          <FormField
+            label={t("tools.description", "Description")}
+            error={refusal.at("description", current.description)}
+          >
             <Textarea
               value={form.description}
               onChange={(e) =>
@@ -814,6 +867,7 @@ export function ToolEditModal({
           </FormField>
 
           <FormField
+            error={refusal.at("inputSchema", current.inputSchema)}
             label={t("tools.aiFields", "AI fields")}
             group
             description={t(
@@ -828,7 +882,10 @@ export function ToolEditModal({
           </FormField>
 
           <div className="grid gap-4 sm:grid-cols-[120px_1fr]">
-            <FormField label={t("tools.method", "Method")}>
+            <FormField
+              label={t("tools.method", "Method")}
+              error={refusal.at("method", current.method)}
+            >
               <Select
                 value={form.method}
                 onChange={(e) =>
@@ -867,7 +924,7 @@ export function ToolEditModal({
                       "tools.invalidUrlTemplate",
                       "Must start with / or be a full http(s) URL.",
                     )
-                  : null
+                  : refusal.at("urlTemplate", current.urlTemplate)
               }
             >
               {credBaseUrl && (
@@ -910,6 +967,7 @@ export function ToolEditModal({
           </div>
 
           <FormField
+            error={refusal.at("credentialRef", current.credentialRef)}
             label={t("tools.credential", "Credential")}
             group
             description={
@@ -942,6 +1000,7 @@ export function ToolEditModal({
           </FormField>
 
           <FormField
+            error={refusal.at("query", current.query)}
             label={t("tools.query", "Query string")}
             group
             description={t(
@@ -961,6 +1020,7 @@ export function ToolEditModal({
           </FormField>
 
           <FormField
+            error={refusal.at("headers", current.headers)}
             label={t("tools.headers", "Headers")}
             group
             description={
@@ -1024,6 +1084,7 @@ export function ToolEditModal({
 
           {isWriteMethod && (
             <FormField
+              error={refusal.at("body", current.body)}
               label={t("tools.body", "Request body")}
               group
               description={
@@ -1103,6 +1164,7 @@ export function ToolEditModal({
               "tools.expectedStatusesHint",
               "Comma-separated, e.g. 404. Use it when this API answers with an error status for an ordinary answer — a lookup that returns 404 for 'no record'. Those responses stop counting as integration failures, so they no longer raise alerts. The AI reads the same reply either way. Leave empty and every non-2xx is treated as a failure.",
             )}
+            error={refusal.at("expectedStatuses", current.expectedStatuses)}
           >
             <Input
               value={form.expectedStatuses}
@@ -1153,14 +1215,17 @@ export function ToolEditModal({
                     "tools.ackPlaceholder",
                     "Let me look into that for you…",
                   )}
-                  error={ackInvalid}
+                  error={
+                    ackInvalid || !!refusal.at("ackMessage", current.ackMessage)
+                  }
                   errorMessage={
                     ackInvalid
                       ? t(
                           "tools.ackRequired",
                           "Add a tone example, or turn this off.",
                         )
-                      : undefined
+                      : (refusal.at("ackMessage", current.ackMessage) ??
+                        undefined)
                   }
                 />
               </div>

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -649,7 +649,7 @@ export function ToolEditModal({
   // rather than under a box that no longer holds it.
   const formRef = useRef(form);
   formRef.current = form;
-  const refusal = useFieldRefusal(TOOL_FIELDS);
+  const refusal = useFieldRefusal(TOOL_FIELDS, modal.isOpen);
   const [saving, setSaving] = useState(false);
   const [loadingForm, setLoadingForm] = useState(false);
   const [loadError, setLoadError] = useState(false);

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -674,6 +674,8 @@ export function ToolEditModal({
   const current = payloadOf(form) ?? ({} as Record<string, unknown>);
 
   useOnModalOpen(modal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     setFormError(null);
     setLoadError(false);
     setSelectedCredential(null);

--- a/src/client/pages/resources/documents/CompanyProfileCard.tsx
+++ b/src/client/pages/resources/documents/CompanyProfileCard.tsx
@@ -184,10 +184,11 @@ export function CompanyProfileCard({
         sent,
         formRef.current.draft,
       );
-      showToast(
-        toast ?? t("documents.company.saveError", "Could not save."),
-        "error",
-      );
+      // `if (toast)`, never `toast ?? fallback`: null is the hook saying the operator has already
+      // been told — the sentence is on the control, or, for a form that has left the screen, in the
+      // global toast it raised itself. Substituting a fallback there fires the second channel on top
+      // of the first, which is the noise that teaches people to stop reading toasts.
+      if (toast) showToast(toast, "error");
     } finally {
       setBusy(null);
     }

--- a/src/client/pages/resources/documents/DocumentsPanel.tsx
+++ b/src/client/pages/resources/documents/DocumentsPanel.tsx
@@ -93,7 +93,6 @@ export function DocumentsPanel() {
   const [naming, setNaming] = useState<Starter | null>(null);
   const [draftName, setDraftName] = useState("");
   const [createError, setCreateError] = useState<string | null>(null);
-  const refusal = useFieldRefusal(STARTER_FIELDS);
   const draftRef = useRef(draftName);
   draftRef.current = draftName;
   const [deleting, setDeleting] = useState(false);
@@ -123,6 +122,7 @@ export function DocumentsPanel() {
   const editModal = useModalController<{ template: DocumentTemplate }>();
   const companyModal = useModalController();
   const starterModal = useModalController();
+  const refusal = useFieldRefusal(STARTER_FIELDS, starterModal.isOpen);
   const refsModal = useModalController<{ name: string }>();
   const deleteModal = useModalController<{ id: string; name: string }>();
   const confirm = useModalController<ConfirmPayload>();

--- a/src/client/pages/resources/documents/DocumentsPanel.tsx
+++ b/src/client/pages/resources/documents/DocumentsPanel.tsx
@@ -233,6 +233,8 @@ export function DocumentsPanel() {
   // naming step and reopens would otherwise be handed that step again, prefilled with the name they
   // just abandoned (docs/modals.md).
   useOnModalOpen(starterModal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    refusal.clear();
     setNaming(null);
     setDraftName("");
     setCreateError(null);

--- a/src/client/pages/resources/documents/DocumentsPanel.tsx
+++ b/src/client/pages/resources/documents/DocumentsPanel.tsx
@@ -122,7 +122,7 @@ export function DocumentsPanel() {
   const editModal = useModalController<{ template: DocumentTemplate }>();
   const companyModal = useModalController();
   const starterModal = useModalController();
-  const refusal = useFieldRefusal(STARTER_FIELDS, starterModal.isOpen);
+  const refusal = useFieldRefusal(starterModal.isOpen ? STARTER_FIELDS : []);
   const refsModal = useModalController<{ name: string }>();
   const deleteModal = useModalController<{ id: string; name: string }>();
   const confirm = useModalController<ConfirmPayload>();

--- a/src/client/pages/resources/documents/DocumentsPanel.tsx
+++ b/src/client/pages/resources/documents/DocumentsPanel.tsx
@@ -122,7 +122,10 @@ export function DocumentsPanel() {
   const editModal = useModalController<{ template: DocumentTemplate }>();
   const companyModal = useModalController();
   const starterModal = useModalController();
-  const refusal = useFieldRefusal(starterModal.isOpen ? STARTER_FIELDS : []);
+  // The dialog has two steps and only the second draws a name box: the first is the starter list.
+  const refusal = useFieldRefusal(
+    starterModal.isOpen && naming ? STARTER_FIELDS : [],
+  );
   const refsModal = useModalController<{ name: string }>();
   const deleteModal = useModalController<{ id: string; name: string }>();
   const confirm = useModalController<ConfirmPayload>();

--- a/src/client/pages/resources/documents/DocumentsPanel.tsx
+++ b/src/client/pages/resources/documents/DocumentsPanel.tsx
@@ -26,6 +26,7 @@ import {
   useOnModalOpen,
   useToast,
 } from "@/client/components";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { mediaFetch } from "@/client/lib/media";
@@ -64,6 +65,10 @@ function companySummary(
 // `{ error }` whose `value` is the parsed body, and a refusal here is written for the operator (which
 // template has the name, which rule the name breaks) — throwing it away for a generic string is how
 // a fixable mistake becomes a dead end.
+// The keys of the create body. `name` is the one an operator can act on here — a duplicate answers
+// with which template already holds it — and the rest come from the starter, not from an input.
+const STARTER_FIELDS = ["name"] as const;
+
 export function DocumentsPanel() {
   const { t, i18n } = useTranslation();
   // The route defaults an absent locale to pt-BR, so an English console would create Portuguese
@@ -88,6 +93,9 @@ export function DocumentsPanel() {
   const [naming, setNaming] = useState<Starter | null>(null);
   const [draftName, setDraftName] = useState("");
   const [createError, setCreateError] = useState<string | null>(null);
+  const refusal = useFieldRefusal(STARTER_FIELDS);
+  const draftRef = useRef(draftName);
+  draftRef.current = draftName;
   const [deleting, setDeleting] = useState(false);
   // null = still loading, "error" = the lookup failed. Two states, because collapsing them leaves a
   // dialog claiming to be checking something it has already given up on.
@@ -237,29 +245,45 @@ export function DocumentsPanel() {
     setCreating(starter.key);
     setCreateError(null);
     try {
-      const { error: err } = await api.api.v1["document-templates"].post({
+      const sent = {
         name,
         description: starter.description,
         blocks: starter.blocks as Record<string, unknown>[],
         fields: starter.fields as Record<string, unknown>[],
         style: starter.style as unknown as Record<string, unknown>,
         numberPrefix: starter.numberPrefix,
-      });
+      };
+      const { error: err } = await api.api.v1["document-templates"].post(sent);
       if (err) {
-        // The server's own words, shown next to the field that caused them. It says which template
-        // already has the name, which a generic "could not create" cannot — and the operator is
-        // three characters away from fixing it.
-        setCreateError(apiErrorMessage(err));
+        // The server's own words, and the input they are about. It says which template already has
+        // the name, which a generic "could not create" cannot — and the operator is three characters
+        // away from fixing it. `capture` decides where it goes: the name box when the refusal is
+        // about the name, this line when it is about the starter's own blocks or style, which no
+        // control here edits.
+        setCreateError(
+          refusal.capture(
+            err,
+            t("documents.createError", "Could not create this template."),
+            sent,
+            { ...sent, name: draftRef.current.trim() },
+          ),
+        );
         return;
       }
+      refusal.clear();
       starterModal.close();
       showToast(t("documents.created", "Template created."), "success");
       void load();
-    } catch {
+    } catch (e) {
       // Eden REJECTS on a transport failure instead of answering `{ error }`, and only the second
       // was handled: offline, the button spun and then said nothing at all.
       setCreateError(
-        t("documents.createError", "Could not create this template."),
+        refusal.capture(
+          e,
+          t("documents.createError", "Could not create this template."),
+          { name },
+          { name: draftRef.current.trim() },
+        ),
       );
     } finally {
       setCreating(null);
@@ -730,7 +754,10 @@ export function DocumentsPanel() {
                 "This is what the agent's tool is called, so each template needs its own name.",
               )}
             </p>
-            <FormField label={t("documents.name", "Name")}>
+            <FormField
+              label={t("documents.name", "Name")}
+              error={refusal.at("name", draftName.trim())}
+            >
               <Input
                 autoFocus
                 value={draftName}

--- a/src/client/pages/resources/useKnowledgeManager.tsx
+++ b/src/client/pages/resources/useKnowledgeManager.tsx
@@ -153,15 +153,22 @@ export function useKnowledgeManager(opts: {
   const docEditModal = useModalController<{ id: string; title: string }>();
   const confirm = useModalController<ConfirmPayload>();
 
+  // Above the holders because one of them reads it: the add dialog's tab decides whether the text
+  // box is on screen at all.
+  const [addTab, setAddTab] = useState("texto");
+
   // Create/edit KB fields
   // Three forms here, three holders: the base (create and edit share their inputs and are never open
   // together), the "add text" document, and the document editor.
   const baseRefusal = useFieldRefusal(
-    BASE_FIELDS,
-    createModal.isOpen || editModal.isOpen,
+    createModal.isOpen || editModal.isOpen ? BASE_FIELDS : [],
   );
-  const addDocRefusal = useFieldRefusal(DOC_FIELDS, addContentModal.isOpen);
-  const editDocRefusal = useFieldRefusal(DOC_FIELDS, docEditModal.isOpen);
+  // The add dialog has two tabs and the text box belongs to one of them: on the file tab there is no
+  // control for `title` or `text`, so a refusal naming either has to go to the toast.
+  const addDocRefusal = useFieldRefusal(
+    addContentModal.isOpen && addTab === "texto" ? DOC_FIELDS : [],
+  );
+  const editDocRefusal = useFieldRefusal(docEditModal.isOpen ? DOC_FIELDS : []);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [chunkSize, setChunkSize] = useState(1000);
@@ -170,7 +177,6 @@ export function useKnowledgeManager(opts: {
   const [chunkOverlapError, setChunkOverlapError] = useState("");
 
   // Add content fields (the add form is a modal stacked over the documents list).
-  const [addTab, setAddTab] = useState("texto");
   const [docTitle, setDocTitle] = useState("");
   // What each form's inputs hold right now, readable from inside a request that started before them.
   const baseRef = useRef<Record<string, unknown>>({});

--- a/src/client/pages/resources/useKnowledgeManager.tsx
+++ b/src/client/pages/resources/useKnowledgeManager.tsx
@@ -32,6 +32,7 @@ import {
   useToast,
 } from "@/client/components";
 import { Tooltip } from "@/client/components/Tooltip";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { useTenantEvents } from "@/client/hooks/useTenantEvents";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
@@ -116,6 +117,15 @@ export interface KnowledgeManager {
 // Knowledge panel and the agent editor's Knowledge tab so a base can be created/edited/fed documents
 // without leaving the agent. `onChanged` is called after any mutation so the consumer refetches its
 // own list (the bases list itself is NOT owned here — each consumer renders its own).
+// The keys of the bodies these forms write, spelled the way the routes refuse them.
+const BASE_FIELDS = [
+  "name",
+  "description",
+  "chunkSize",
+  "chunkOverlap",
+] as const;
+const DOC_FIELDS = ["title", "text"] as const;
+
 export function useKnowledgeManager(opts: {
   onChanged: () => void | Promise<void>;
   // Optional: called with the freshly-created base so a caller (the agent editor) can auto-select it.
@@ -144,6 +154,11 @@ export function useKnowledgeManager(opts: {
   const confirm = useModalController<ConfirmPayload>();
 
   // Create/edit KB fields
+  // Three forms here, three holders: the base (create and edit share their inputs and are never open
+  // together), the "add text" document, and the document editor.
+  const baseRefusal = useFieldRefusal(BASE_FIELDS);
+  const addDocRefusal = useFieldRefusal(DOC_FIELDS);
+  const editDocRefusal = useFieldRefusal(DOC_FIELDS);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [chunkSize, setChunkSize] = useState(1000);
@@ -154,6 +169,9 @@ export function useKnowledgeManager(opts: {
   // Add content fields (the add form is a modal stacked over the documents list).
   const [addTab, setAddTab] = useState("texto");
   const [docTitle, setDocTitle] = useState("");
+  // What each form's inputs hold right now, readable from inside a request that started before them.
+  const baseRef = useRef<Record<string, unknown>>({});
+  const editDocRef = useRef<Record<string, unknown>>({});
   const [text, setText] = useState("");
   const [picked, setPicked] = useState<PickedFile[]>([]);
   const [dragOver, setDragOver] = useState(false);
@@ -206,6 +224,13 @@ export function useKnowledgeManager(opts: {
   // Doc edit (title + text); the text loads from the GET-by-id, then a PATCH re-ingests on change.
   const [editDocTitle, setEditDocTitle] = useState("");
   const [editDocText, setEditDocText] = useState("");
+  baseRef.current = {
+    name: name.trim(),
+    description: description.trim(),
+    chunkSize,
+    chunkOverlap,
+  };
+  editDocRef.current = { title: editDocTitle.trim(), text: editDocText };
   const [editDocLoading, setEditDocLoading] = useState(false);
   const [editDocOriginal, setEditDocOriginal] = useState({
     title: "",
@@ -443,6 +468,7 @@ export function useKnowledgeManager(opts: {
         description: description.trim() || undefined,
       });
       if (err || !data) throw err;
+      baseRefusal.clear();
       if (chunkSize !== 1000 || chunkOverlap !== 200) {
         await api.api.v1.knowledge
           .bases({ id: data.base.id })
@@ -453,10 +479,13 @@ export function useKnowledgeManager(opts: {
       void onChanged();
       opts.onCreated?.({ id: data.base.id, name: name.trim() });
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) || t("knowledge.createError", "Could not create."),
-        "error",
+      const toast = baseRefusal.capture(
+        e,
+        t("knowledge.createError", "Could not create."),
+        { name: name.trim(), description: description.trim() || undefined },
+        baseRef.current,
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setBusy(false);
     }
@@ -477,14 +506,23 @@ export function useKnowledgeManager(opts: {
           chunkOverlap,
         });
       if (err) throw err;
+      baseRefusal.clear();
       showToast(t("knowledge.updated", "Knowledge base updated."), "success");
       editModal.close();
       void onChanged();
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) || t("knowledge.updateError", "Could not update."),
-        "error",
+      const toast = baseRefusal.capture(
+        e,
+        t("knowledge.updateError", "Could not update."),
+        {
+          name: name.trim(),
+          description: description.trim() || null,
+          chunkSize,
+          chunkOverlap,
+        },
+        baseRef.current,
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setBusy(false);
     }
@@ -678,16 +716,19 @@ export function useKnowledgeManager(opts: {
         .documents({ id: payload.id })
         .patch({ title: editDocTitle.trim(), text: editDocText });
       if (err) throw err;
+      editDocRefusal.clear();
       showToast(t("knowledge.docUpdated", "Document updated."), "success");
       docEditModal.close();
       if (docsModal.payload) await reloadDocs(docsModal.payload.id);
       void onChanged();
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("knowledge.docUpdateError", "Could not update the document."),
-        "error",
+      const toast = editDocRefusal.capture(
+        e,
+        t("knowledge.docUpdateError", "Could not update the document."),
+        { title: editDocTitle.trim(), text: editDocText },
+        editDocRef.current,
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setBusy(false);
     }
@@ -1025,10 +1066,17 @@ export function useKnowledgeManager(opts: {
         }
       >
         <div className="flex flex-col gap-4">
-          <FormField label={t("knowledge.name", "Name")} required>
+          <FormField
+            label={t("knowledge.name", "Name")}
+            required
+            error={baseRefusal.at("name", name.trim())}
+          >
             <Input value={name} onChange={(e) => setName(e.target.value)} />
           </FormField>
-          <FormField label={t("knowledge.description", "Description")}>
+          <FormField
+            label={t("knowledge.description", "Description")}
+            error={baseRefusal.at("description", description.trim())}
+          >
             <Textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -1041,7 +1089,7 @@ export function useKnowledgeManager(opts: {
               "knowledge.chunkSizeHint",
               "Controls how large each indexed text chunk is. Smaller chunks give more precision; larger chunks preserve more context.",
             )}
-            error={chunkSizeError}
+            error={chunkSizeError ?? baseRefusal.at("chunkSize", chunkSize)}
           >
             <Input
               type="number"
@@ -1057,7 +1105,9 @@ export function useKnowledgeManager(opts: {
               "knowledge.chunkOverlapHint",
               "Number of characters shared between consecutive chunks. Helps preserve context across chunk boundaries.",
             )}
-            error={chunkOverlapError}
+            error={
+              chunkOverlapError ?? baseRefusal.at("chunkOverlap", chunkOverlap)
+            }
           >
             <Input
               type="number"
@@ -1085,10 +1135,17 @@ export function useKnowledgeManager(opts: {
         }
       >
         <div className="flex flex-col gap-4">
-          <FormField label={t("knowledge.name", "Name")} required>
+          <FormField
+            label={t("knowledge.name", "Name")}
+            required
+            error={baseRefusal.at("name", name.trim())}
+          >
             <Input value={name} onChange={(e) => setName(e.target.value)} />
           </FormField>
-          <FormField label={t("knowledge.description", "Description")}>
+          <FormField
+            label={t("knowledge.description", "Description")}
+            error={baseRefusal.at("description", description.trim())}
+          >
             <Textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
@@ -1101,7 +1158,7 @@ export function useKnowledgeManager(opts: {
               "knowledge.chunkSizeHint",
               "Controls how large each indexed text chunk is. Smaller chunks give more precision; larger chunks preserve more context.",
             )}
-            error={chunkSizeError}
+            error={chunkSizeError ?? baseRefusal.at("chunkSize", chunkSize)}
           >
             <Input
               type="number"
@@ -1117,7 +1174,9 @@ export function useKnowledgeManager(opts: {
               "knowledge.chunkOverlapHint",
               "Number of characters shared between consecutive chunks. Helps preserve context across chunk boundaries.",
             )}
-            error={chunkOverlapError}
+            error={
+              chunkOverlapError ?? baseRefusal.at("chunkOverlap", chunkOverlap)
+            }
           >
             <Input
               type="number"
@@ -1160,13 +1219,20 @@ export function useKnowledgeManager(opts: {
           />
           {addTab === "texto" && (
             <div className="flex flex-col gap-4">
-              <FormField label={t("knowledge.docTitle", "Title")}>
+              <FormField
+                label={t("knowledge.docTitle", "Title")}
+                error={addDocRefusal.at("title", docTitle.trim())}
+              >
                 <Input
                   value={docTitle}
                   onChange={(e) => setDocTitle(e.target.value)}
                 />
               </FormField>
-              <FormField label={t("knowledge.text", "Text")} required>
+              <FormField
+                label={t("knowledge.text", "Text")}
+                required
+                error={addDocRefusal.at("text", text.trim())}
+              >
                 <Textarea
                   value={text}
                   onChange={(e) => setText(e.target.value)}
@@ -1569,7 +1635,11 @@ export function useKnowledgeManager(opts: {
           </div>
         ) : (
           <div className="flex flex-col gap-4">
-            <FormField label={t("knowledge.docTitleLabel", "Title")} required>
+            <FormField
+              label={t("knowledge.docTitleLabel", "Title")}
+              required
+              error={editDocRefusal.at("title", editDocTitle.trim())}
+            >
               <Input
                 value={editDocTitle}
                 onChange={(e) => setEditDocTitle(e.target.value)}
@@ -1582,6 +1652,7 @@ export function useKnowledgeManager(opts: {
                 "knowledge.docEditHint",
                 "Editing the content re-indexes the document (it is re-embedded).",
               )}
+              error={editDocRefusal.at("text", editDocText)}
             >
               <Textarea
                 value={editDocText}

--- a/src/client/pages/resources/useKnowledgeManager.tsx
+++ b/src/client/pages/resources/useKnowledgeManager.tsx
@@ -172,6 +172,7 @@ export function useKnowledgeManager(opts: {
   // What each form's inputs hold right now, readable from inside a request that started before them.
   const baseRef = useRef<Record<string, unknown>>({});
   const editDocRef = useRef<Record<string, unknown>>({});
+  const addDocRef = useRef<Record<string, unknown>>({});
   const [text, setText] = useState("");
   const [picked, setPicked] = useState<PickedFile[]>([]);
   const [dragOver, setDragOver] = useState(false);
@@ -231,6 +232,10 @@ export function useKnowledgeManager(opts: {
     chunkOverlap,
   };
   editDocRef.current = { title: editDocTitle.trim(), text: editDocText };
+  addDocRef.current = {
+    title: docTitle.trim() || t("knowledge.docTitle", "Title"),
+    text: text.trim(),
+  };
   const [editDocLoading, setEditDocLoading] = useState(false);
   const [editDocOriginal, setEditDocOriginal] = useState({
     title: "",
@@ -359,6 +364,8 @@ export function useKnowledgeManager(opts: {
   }
 
   useOnModalOpen(createModal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    baseRefusal.clear();
     setName("");
     setDescription("");
     setChunkSize(1000);
@@ -368,6 +375,8 @@ export function useKnowledgeManager(opts: {
   });
 
   useOnModalOpen(editModal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    baseRefusal.clear();
     const b = editModal.payload;
     if (!b) return;
     setName(b.name);
@@ -379,6 +388,8 @@ export function useKnowledgeManager(opts: {
   });
 
   useOnModalOpen(addContentModal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    addDocRefusal.clear();
     setAddTab("texto");
     setDocTitle("");
     setText("");
@@ -407,6 +418,8 @@ export function useKnowledgeManager(opts: {
   });
 
   useOnModalOpen(docEditModal, () => {
+    // The component outlives the dialog, so a mark from the last session is still held here.
+    editDocRefusal.clear();
     const payload = docEditModal.payload;
     if (!payload) return;
     setEditDocTitle(payload.title);
@@ -533,13 +546,15 @@ export function useKnowledgeManager(opts: {
     if (!payload || !text.trim()) return;
     setBusy(true);
     try {
+      const sent = {
+        title: docTitle.trim() || t("knowledge.docTitle", "Title"),
+        text: text.trim(),
+      };
       const { error: err } = await api.api.v1.knowledge
         .bases({ id: payload.id })
-        .documents.post({
-          title: docTitle.trim() || t("knowledge.docTitle", "Title"),
-          text: text.trim(),
-        });
+        .documents.post(sent);
       if (err) throw err;
+      addDocRefusal.clear();
       showToast(
         t("knowledge.addedQueued", "Document queued for processing."),
         "success",
@@ -552,12 +567,17 @@ export function useKnowledgeManager(opts: {
     } catch (e) {
       // The server's own message when it sent one: a refusal that names the field and the character
       // is the whole answer, and collapsing it into "Could not add document" throws away the only
-      // part the operator can act on (issue #247).
-      showToast(
-        apiErrorMessage(e) ??
-          t("knowledge.addError", "Could not add document."),
-        "error",
+      // part the operator can act on (issue #247) — at the input it named, when this form draws one.
+      const toast = addDocRefusal.capture(
+        e,
+        t("knowledge.addError", "Could not add document."),
+        {
+          title: docTitle.trim() || t("knowledge.docTitle", "Title"),
+          text: text.trim(),
+        },
+        addDocRef.current,
       );
+      if (toast) showToast(toast, "error");
     } finally {
       setBusy(false);
     }

--- a/src/client/pages/resources/useKnowledgeManager.tsx
+++ b/src/client/pages/resources/useKnowledgeManager.tsx
@@ -1106,13 +1106,18 @@ export function useKnowledgeManager(opts: {
               rows={2}
             />
           </FormField>
+          {/* `||` and not `??`: these two hold "" when there is nothing wrong, so a nullish fallback
+              never reaches the refusal behind it. The local check tests BOUNDS only, and the schema
+              is `t.Integer` — a chunk size of 100.5 passes here and is refused there by name, which
+              is exactly the case that was landing on a reading nobody could reach. Local first
+              because it is about what the box holds now. */}
           <FormField
             label={t("knowledge.chunkSize", "Chunk size (chars)")}
             hint={t(
               "knowledge.chunkSizeHint",
               "Controls how large each indexed text chunk is. Smaller chunks give more precision; larger chunks preserve more context.",
             )}
-            error={chunkSizeError ?? baseRefusal.at("chunkSize", chunkSize)}
+            error={chunkSizeError || baseRefusal.at("chunkSize", chunkSize)}
           >
             <Input
               type="number"
@@ -1129,7 +1134,7 @@ export function useKnowledgeManager(opts: {
               "Number of characters shared between consecutive chunks. Helps preserve context across chunk boundaries.",
             )}
             error={
-              chunkOverlapError ?? baseRefusal.at("chunkOverlap", chunkOverlap)
+              chunkOverlapError || baseRefusal.at("chunkOverlap", chunkOverlap)
             }
           >
             <Input
@@ -1181,7 +1186,7 @@ export function useKnowledgeManager(opts: {
               "knowledge.chunkSizeHint",
               "Controls how large each indexed text chunk is. Smaller chunks give more precision; larger chunks preserve more context.",
             )}
-            error={chunkSizeError ?? baseRefusal.at("chunkSize", chunkSize)}
+            error={chunkSizeError || baseRefusal.at("chunkSize", chunkSize)}
           >
             <Input
               type="number"
@@ -1198,7 +1203,7 @@ export function useKnowledgeManager(opts: {
               "Number of characters shared between consecutive chunks. Helps preserve context across chunk boundaries.",
             )}
             error={
-              chunkOverlapError ?? baseRefusal.at("chunkOverlap", chunkOverlap)
+              chunkOverlapError || baseRefusal.at("chunkOverlap", chunkOverlap)
             }
           >
             <Input

--- a/src/client/pages/resources/useKnowledgeManager.tsx
+++ b/src/client/pages/resources/useKnowledgeManager.tsx
@@ -156,9 +156,12 @@ export function useKnowledgeManager(opts: {
   // Create/edit KB fields
   // Three forms here, three holders: the base (create and edit share their inputs and are never open
   // together), the "add text" document, and the document editor.
-  const baseRefusal = useFieldRefusal(BASE_FIELDS);
-  const addDocRefusal = useFieldRefusal(DOC_FIELDS);
-  const editDocRefusal = useFieldRefusal(DOC_FIELDS);
+  const baseRefusal = useFieldRefusal(
+    BASE_FIELDS,
+    createModal.isOpen || editModal.isOpen,
+  );
+  const addDocRefusal = useFieldRefusal(DOC_FIELDS, addContentModal.isOpen);
+  const editDocRefusal = useFieldRefusal(DOC_FIELDS, docEditModal.isOpen);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [chunkSize, setChunkSize] = useState(1000);

--- a/src/client/pages/settings/SettingsProfilePage.tsx
+++ b/src/client/pages/settings/SettingsProfilePage.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Badge,
@@ -10,13 +10,17 @@ import {
   useUnsavedChanges,
 } from "@/client/components";
 import { useAuth } from "@/client/contexts/AuthContext";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
 import { isAdminRole } from "@/client/lib/roles";
-import type { ApiErrorPayload } from "@/client/lib/types";
 
 // t('common.email', 'Email')
 // t('common.role', 'Role')
 // t('common.notAvailable', 'N/A')
+
+// The two keys this form patches. A wrong current password is refused by name, which is the whole
+// difference between "could not change the password" and a mark on the box that is wrong.
+const PASSWORD_FIELDS = ["currentPassword", "newPassword"] as const;
 
 export function SettingsProfilePage() {
   const { t } = useTranslation();
@@ -47,6 +51,10 @@ export function SettingsProfilePage() {
   // the endpoint still guards Google-only accounts with a clear error.
   const googleOnly = user?.hasPassword === false;
 
+  const refusal = useFieldRefusal(PASSWORD_FIELDS);
+  const sentRef = useRef({ currentPassword, newPassword });
+  sentRef.current = { currentPassword, newPassword };
+
   // Page form (no modal): arms the native beforeunload prompt while any password
   // field is filled, so a refresh/tab-close does not silently drop the entry.
   useUnsavedChanges(
@@ -63,26 +71,27 @@ export function SettingsProfilePage() {
       return;
     }
     setBusy(true);
+    const sent = { currentPassword, newPassword };
+    const held = (e2: unknown) =>
+      refusal.capture(
+        e2,
+        t("settings.passwordChangeError", "Could not change the password."),
+        sent,
+        sentRef.current,
+      ) ?? "";
     try {
-      const { error: apiError } = await api.api.auth.password.patch({
-        currentPassword,
-        newPassword,
-      });
+      const { error: apiError } = await api.api.auth.password.patch(sent);
       if (apiError) {
-        setError(
-          (apiError.value as ApiErrorPayload)?.error ||
-            t("settings.passwordChangeError", "Could not change the password."),
-        );
+        setError(held(apiError));
         return;
       }
+      refusal.clear();
       setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
       showToast(t("settings.passwordChanged", "Password changed."), "success");
-    } catch {
-      setError(
-        t("settings.passwordChangeError", "Could not change the password."),
-      );
+    } catch (e2) {
+      setError(held(e2));
     } finally {
       setBusy(false);
     }
@@ -138,6 +147,7 @@ export function SettingsProfilePage() {
             )}
             <FormField
               label={t("settings.currentPassword", "Current password")}
+              error={refusal.at("currentPassword", currentPassword)}
             >
               <Input
                 type="password"
@@ -149,7 +159,10 @@ export function SettingsProfilePage() {
                 autoComplete="current-password"
               />
             </FormField>
-            <FormField label={t("settings.newPassword", "New password")}>
+            <FormField
+              label={t("settings.newPassword", "New password")}
+              error={refusal.at("newPassword", newPassword)}
+            >
               <Input
                 type="password"
                 showPasswordToggle

--- a/src/modules/flowlog/channels.ts
+++ b/src/modules/flowlog/channels.ts
@@ -145,7 +145,7 @@ export async function createAlertChannel(
   const stages = assertStages(parsed.stages ?? []);
   const row = await runScopedOn(base, ctx, async (db) => {
     const secretRef = parsed.secretRef
-      ? await requireVaultRef(db, parsed.secretRef)
+      ? await requireVaultRef(db, parsed.secretRef, "secretRef")
       : null;
     return db.alertChannel.create({
       data: {
@@ -207,7 +207,7 @@ export async function updateAlertChannel(
   const row = await runScopedOn(base, ctx, async (db) => {
     // Canonicalized inside the tx, so the entry cannot be deleted between the check and the write.
     if (typeof data.secretRef === "string") {
-      data.secretRef = await requireVaultRef(db, data.secretRef);
+      data.secretRef = await requireVaultRef(db, data.secretRef, "secretRef");
     }
     // updateMany → count 0 for a foreign/missing id under RLS → NotFound (never a cross-tenant write).
     const res = await db.alertChannel.updateMany({ where: { id }, data });

--- a/src/modules/integrations/service.ts
+++ b/src/modules/integrations/service.ts
@@ -87,11 +87,11 @@ export async function createIntegrationInstance(
   const tenantId = ctx.tenantId as bigint;
   const created = await runScopedOn(base, ctx, async (db) => {
     const credentialRef = params.credentialRef
-      ? await requireVaultRef(db, params.credentialRef)
+      ? await requireVaultRef(db, params.credentialRef, "credentialRef")
       : null;
     const inboundSecretRef =
       minted && params.inboundSecretRef
-        ? await requireVaultRef(db, params.inboundSecretRef)
+        ? await requireVaultRef(db, params.inboundSecretRef, "inboundSecretRef")
         : null;
     return db.integrationInstance.create({
       data: {
@@ -267,10 +267,10 @@ export async function updateIntegrationInstance(
       );
     }
     const credentialRef = params.credentialRef
-      ? await requireVaultRef(db, params.credentialRef)
+      ? await requireVaultRef(db, params.credentialRef, "credentialRef")
       : null;
     const inboundSecretRef = params.inboundSecretRef
-      ? await requireVaultRef(db, params.inboundSecretRef)
+      ? await requireVaultRef(db, params.inboundSecretRef, "inboundSecretRef")
       : null;
     await db.integrationInstance.update({
       where: { id },

--- a/src/modules/mcp-connections/service.ts
+++ b/src/modules/mcp-connections/service.ts
@@ -179,6 +179,7 @@ async function assertNameFree(
     throw new ConflictError(
       "mcp connection name already in use",
       "errors.mcpNameTaken",
+      "name",
     );
   }
 }
@@ -195,7 +196,7 @@ export async function createMcpConnection(
   return runScopedOn(base, ctx, async (db) => {
     await assertNameFree(db, data.name);
     const credentialRef = data.credentialRef
-      ? await requireVaultRef(db, data.credentialRef)
+      ? await requireVaultRef(db, data.credentialRef, "credentialRef")
       : null;
     const row = await db.mcpServerConnection.create({
       data: {
@@ -241,7 +242,7 @@ export async function updateMcpConnection(
   return runScopedOn(base, ctx, async (db) => {
     if (data.name) await assertNameFree(db, data.name, id);
     const credentialRef = data.credentialRef
-      ? await requireVaultRef(db, data.credentialRef)
+      ? await requireVaultRef(db, data.credentialRef, "credentialRef")
       : null;
     await db.mcpServerConnection.update({
       where: { id },

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -137,10 +137,17 @@ export function refuseUnstorable(
     // and `message` is only the untranslated fallback, so interpolating an English sentence into a
     // pt-BR template would answer in two languages at once. What stays English either way is the
     // field name, which names the request field to change the way a schema path does.
-    throw new AppError(bad.message, 400, "errors.unstorableText", {
-      field: bad.what,
-      codePoints: bad.codePoints.join(" "),
-    });
+    throw new AppError(
+      bad.message,
+      400,
+      "errors.unstorableText",
+      { field: bad.what, codePoints: bad.codePoints.join(" ") },
+      // On the WIRE as well, and not only interpolated into the sentence. The params are what the
+      // locale template reads; `field` is what a console keys on to put the sentence under the box
+      // holding the character (#231). Without it every one of these answered `{ error }` alone and
+      // the four titles/texts this helper guards could not be placed anywhere.
+      bad.what,
+    );
   }
 }
 

--- a/src/modules/tool-definitions/service.ts
+++ b/src/modules/tool-definitions/service.ts
@@ -180,7 +180,11 @@ async function assertNameFree(
     select: { id: true },
   });
   if (existing && existing.id !== exceptId) {
-    throw new ConflictError("tool name already in use", "errors.toolNameTaken");
+    throw new ConflictError(
+      "tool name already in use",
+      "errors.toolNameTaken",
+      "name",
+    );
   }
 }
 
@@ -212,7 +216,7 @@ export async function createToolDefinition(
   return runScopedOn(base, ctx, async (db) => {
     await assertNameFree(db, data.name);
     const credentialRef = data.credentialRef
-      ? await requireVaultRef(db, data.credentialRef)
+      ? await requireVaultRef(db, data.credentialRef, "credentialRef")
       : null;
     const row = await db.toolDefinition.create({
       data: {
@@ -310,7 +314,7 @@ export async function updateToolDefinition(
       patchData.body = shapes.body as Prisma.InputJsonValue;
     if (data.credentialRef !== undefined)
       patchData.credentialRef = data.credentialRef
-        ? await requireVaultRef(db, data.credentialRef)
+        ? await requireVaultRef(db, data.credentialRef, "credentialRef")
         : null;
     if (data.enabled !== undefined) patchData.enabled = data.enabled;
     if (data.expectedStatuses !== undefined)

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -244,12 +244,19 @@ export async function resolveVaultRefByName(
 export async function requireVaultRef(
   db: ScopedDb,
   ref: string,
-  // The server's own name for the input this ref arrived in, when the caller has one — a dotted path
-  // into a bag it owns (`settings.tts.normalizeCredentialRef`). Optional because most callers refuse
-  // a column the client already named in the patch it sent; the agent's two bags are the ones that
-  // need it, where a ref can be any of eight fields across three editor tabs and the sentence alone
-  // would leave the console guessing which input to mark. See src/api/lib/refusal.ts.
-  field?: string,
+  // The server's own name for the input this ref arrived in — a column (`credentialRef`) or a dotted
+  // path into a bag it owns (`settings.tts.normalizeCredentialRef`). See src/api/lib/refusal.ts.
+  //
+  // REQUIRED, and that is the whole guard: every caller here already holds the name, and eleven of
+  // the thirteen were still omitting it. The argument for optional was that most callers "refuse a
+  // column the client already named in the patch it sent" — but what the client SENT and what the
+  // server REFUSED are different questions, which is the premise of #231. An integrations write
+  // carries `credentialRef` and `inboundSecretRef` in one body; a tool write carries `credentialRef`
+  // among sixteen keys. A refusal with no field is unplaceable by any form, however well wired.
+  //
+  // A required parameter and not a sweep: the omission is invisible at every call site, so the type
+  // is the only reader that sees the next one. Issue #320.
+  field: string,
 ): Promise<string> {
   const malformed = () =>
     new AppError(
@@ -613,6 +620,7 @@ export async function createVaultEntry(
       throw new ConflictError(
         "vault entry name and type already in use",
         "errors.vaultNameInUse",
+        "name",
       );
     }
     const blob = encryptJson(rawValue);
@@ -634,6 +642,7 @@ export async function createVaultEntry(
         throw new ConflictError(
           "vault entry name and type already in use",
           "errors.vaultNameInUse",
+          "name",
         );
       }
       throw e;
@@ -715,6 +724,7 @@ export async function createPendingVaultEntry(
       throw new ConflictError(
         "vault entry name and type already in use",
         "errors.vaultNameInUse",
+        "name",
       );
     }
     // Placeholder blob: an empty object, never a real secret. `status` discriminates it from active.
@@ -738,6 +748,7 @@ export async function createPendingVaultEntry(
         throw new ConflictError(
           "vault entry name and type already in use",
           "errors.vaultNameInUse",
+          "name",
         );
       }
       throw e;
@@ -791,6 +802,7 @@ export async function updateVaultEntry(
         throw new ConflictError(
           "vault entry name and type already in use",
           "errors.vaultNameInUse",
+          "name",
         );
       }
       data.name = newName;
@@ -834,6 +846,7 @@ export async function updateVaultEntry(
         throw new ConflictError(
           "vault entry name and type already in use",
           "errors.vaultNameInUse",
+          "name",
         );
       }
       throw e;

--- a/src/modules/webhooks/outbound/subscriptions.ts
+++ b/src/modules/webhooks/outbound/subscriptions.ts
@@ -119,7 +119,7 @@ export async function createWebhookSubscription(
   await assertUrlSafe(parsed.url);
   const row = await runScopedOn(base, ctx, async (db) => {
     const secretRef = parsed.secretRef
-      ? await requireVaultRef(db, parsed.secretRef)
+      ? await requireVaultRef(db, parsed.secretRef, "secretRef")
       : null;
     return db.webhookSubscription.create({
       data: {
@@ -178,7 +178,7 @@ export async function updateWebhookSubscription(
   const row = await runScopedOn(base, ctx, async (db) => {
     // Canonicalized inside the tx, so the entry cannot be deleted between the check and the write.
     if (typeof data.secretRef === "string") {
-      data.secretRef = await requireVaultRef(db, data.secretRef);
+      data.secretRef = await requireVaultRef(db, data.secretRef, "secretRef");
     }
     const res = await db.webhookSubscription.updateMany({
       where: { id },

--- a/tests/api/features/auth/auth.controller.test.ts
+++ b/tests/api/features/auth/auth.controller.test.ts
@@ -168,6 +168,10 @@ describe("authController", () => {
         "error",
         "Email already in use",
       );
+      // And the input it is about. The signup form has two boxes and only one of them can be fixed,
+      // so a sentence with no name sends the operator to guess (#320). Built by hand in the
+      // controller rather than raised as an AppError, which is why `refusalBody` never sees it.
+      expect(response.error?.value).toHaveProperty("field", "email");
     });
 
     test("validates email format (returns 422)", async () => {

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -11,6 +11,7 @@ import {
   NotFoundError,
 } from "@/lib/errors";
 import { SettingsTextTooLongError } from "@/modules/agents/service";
+import { refuseUnstorable } from "@/modules/rag/documents";
 import { expectWaiverLedger } from "@/tests/utils/ledger";
 import { setupPrismaMock } from "@/tests/utils/prisma-mock";
 
@@ -46,10 +47,22 @@ app.get("/__refusal/unnamed", () => {
 app.get("/__refusal/ambient-tenant", () => {
   throw new ActiveTenantNotFoundError(1234n);
 });
+// The shared refusal for a character Postgres will not store, reached by every document, approval
+// and knowledge-base write. Its field lived only in `translationParams`, so the body it answered was
+// `{ error }` alone and the console had nothing to key on — for `title` and `text`, which are the
+// two boxes those forms draw.
+app.get("/__refusal/unstorable", () => {
+  refuseUnstorable([
+    ["title", "fine"],
+    ["text", `has a ${NUL} in it`],
+  ]);
+});
 // The caller-named refusal, spelled exactly as `getTenant` spells it today.
 app.get("/__refusal/named-tenant", () => {
   throw new NotFoundError("Tenant not found", "errors.tenantNotFound");
 });
+const NUL = "\u0000";
+
 const refusal = async (
   path: string,
   lang: string,
@@ -95,6 +108,15 @@ describe("a refusal over the wire", () => {
     const { status, body } = await refusal("/__refusal/declared", "en");
     expect(status).toBe(400);
     expect(body.field).toBe("kanban.instructions");
+  });
+
+  test("the unstorable-character refusal names the field it is about", async () => {
+    // The one the client wiring for documents and approvals depends on: `DOC_FIELDS` declares
+    // `title` and `text`, and neither can be placed if the body carries no name.
+    const { status, body } = await refusal("/__refusal/unstorable", "en");
+    expect(status).toBe(400);
+    expect(body.field).toBe("text");
+    expect(body.error).toContain("U+0000");
   });
 
   test("a refusal that names no field answers the same body it answers today", async () => {

--- a/tests/client/approval-refusal-session.test.tsx
+++ b/tests/client/approval-refusal-session.test.tsx
@@ -1,0 +1,112 @@
+/// <reference lib="dom" />
+
+import { afterAll, afterEach, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+// A HELD REFUSAL BELONGS TO ONE EDITING SESSION.
+//
+// The mark expires by VALUE, which is what keeps it from needing an `onChange` line per input — and
+// it is also why cancelling an editor is not enough to end it. `startEdit` re-seeds the draft from
+// the record, so reopening the same item (or another one whose title matches) puts the previous
+// request's server sentence under a box before anything has been sent. A dialog answers this with
+// `useOnModalOpen`; an inline editor has to answer it where the session starts.
+//
+// The list is gated on the same state for consistency with that — the two boxes are drawn inside
+// `editingId === a.id` — but there is no test here for a save answering after the editor closed,
+// because there is no way to get there: Cancel is `disabled={busyId === a.id}` while the PATCH is
+// out. Leaving the record of it in the source instead of asserting a path the UI blocks.
+//
+// NOTE: assertions reduce to a string or a boolean BEFORE expect: a failing expectation holding a
+// DOM node serializes a cyclic happy-dom tree and stalls.
+
+const { KnowledgeApprovals } = await import(
+  "@/client/pages/resources/KnowledgeApprovals"
+);
+const { ToastProvider } = await import("@/client/components/Toast");
+
+const realFetch = globalThis.fetch;
+const REASON = "content contains characters that cannot be stored (U+0000)";
+
+const APPROVAL = {
+  id: "a1",
+  status: "PENDING",
+  proposedTitle: "Refund window",
+  proposedContent: "Refunds within 30 days.",
+  createdAt: new Date(0).toISOString(),
+};
+
+afterEach(cleanup);
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+function serve() {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (url.includes("/knowledge/approvals") && method === "PATCH") {
+      return new Response(JSON.stringify({ error: REASON, field: "content" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("/knowledge/approvals")) {
+      return new Response(JSON.stringify({ approvals: [APPROVAL] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+// Edits the TITLE and leaves the content as proposed, which is what makes the refusal outlive the
+// session: the server refuses `content`, and `startEdit` re-seeds that same value on the next
+// opening, so the mark — which expires by VALUE — is still about what the box holds. Retyping the
+// refused text would do it too; this is the path that needs no retyping at all.
+async function openEditorAndSave(title: string) {
+  fireEvent.click(await screen.findByRole("button", { name: /^edit$/i }));
+  fireEvent.change(screen.getByRole("textbox", { name: /title/i }), {
+    target: { value: title },
+  });
+  const save = screen.getAllByRole("button", { name: /^save$/i });
+  fireEvent.click(save[save.length - 1] as HTMLElement);
+}
+
+function mount() {
+  return render(
+    <ToastProvider>
+      <KnowledgeApprovals />
+    </ToastProvider>,
+  );
+}
+
+test("a refusal from the last session is gone when the editor reopens", async () => {
+  serve();
+  mount();
+  await openEditorAndSave("Refund window (30 days)");
+  await waitFor(() => {
+    expect(screen.queryAllByText(REASON).length).toBeGreaterThan(0);
+  });
+
+  fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+  await waitFor(() => {
+    expect(screen.queryAllByRole("textbox").length).toBe(0);
+  });
+  fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+
+  // Reopened on the same record: the draft holds what was refused, and nothing has been sent.
+  await waitFor(() => {
+    expect(screen.queryAllByRole("textbox").length).toBeGreaterThan(0);
+  });
+  expect(screen.queryAllByText(REASON).length).toBe(0);
+});

--- a/tests/client/credential-name-kind-refusal.test.tsx
+++ b/tests/client/credential-name-kind-refusal.test.tsx
@@ -31,6 +31,9 @@ afterAll(() => {
   globalThis.fetch = realFetch;
 });
 
+// Holds the write until the test lets it go, so the type picker can be tried mid-save.
+let holdWrite: Promise<void> | null = null;
+
 function refusing(body: { error: string; field?: string }) {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
@@ -47,6 +50,7 @@ function refusing(body: { error: string; field?: string }) {
       url.includes("/v1/vault") &&
       !url.includes("/test")
     ) {
+      if (holdWrite) await holdWrite;
       return new Response(JSON.stringify(body), {
         status: 409,
         headers: { "content-type": "application/json" },
@@ -141,3 +145,47 @@ test.each(["publicKey", "baseUrl"])(
     expect(marked).toBe(false);
   },
 );
+
+test("the type cannot change out from under a save that is still out", async () => {
+  // The race the clear on select cannot answer: it runs first, and the 409 for the OLD pair lands
+  // after it, reattaching a conflict under a pair the server has said nothing about. The mark
+  // expires by the name, and the name did not change.
+  refusing({ error: REASON, field: "name" });
+  let release: () => void = () => {};
+  holdWrite = new Promise<void>((r) => {
+    release = r;
+  });
+  const { container } = render(
+    <ToastProvider>
+      <CredentialForm
+        mode="create"
+        initialKind="openai"
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />
+    </ToastProvider>,
+  );
+
+  fireEvent.change(screen.getByRole("textbox", { name: /name|nome/i }), {
+    target: { value: "Alfa" },
+  });
+  const value = container.querySelector('input[type="password"]');
+  if (!value) throw new Error("no secret input rendered");
+  fireEvent.change(value, { target: { value: "sk-secret" } });
+  fireEvent.click(screen.getByRole("button", { name: /^(save|salvar)$/i }));
+
+  const picker = await screen.findByRole("button", { name: /type|tipo/i });
+  await waitFor(() => {
+    expect((picker as HTMLButtonElement).disabled).toBe(true);
+  });
+  // And it does not open, which is the half a disabled attribute alone would not prove.
+  fireEvent.pointerDown(picker, { button: 0, ctrlKey: false });
+  fireEvent.click(picker);
+  expect(screen.queryAllByRole("menuitem").length).toBe(0);
+
+  release();
+  holdWrite = null;
+  await waitFor(() => {
+    expect(screen.queryAllByText(REASON).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/client/credential-name-kind-refusal.test.tsx
+++ b/tests/client/credential-name-kind-refusal.test.tsx
@@ -31,7 +31,10 @@ afterAll(() => {
   globalThis.fetch = realFetch;
 });
 
-// Holds the write until the test lets it go, so the type picker can be tried mid-save.
+// Holds one leg of the save until the test lets it go, so the type picker can be tried while it is
+// out. Two legs, because `save()` probes the typed value BEFORE it marks itself saving: a window
+// covered by `testing` and a window covered by `saving`, and a lock on one of them is half a lock.
+let holdProbe: Promise<void> | null = null;
 let holdWrite: Promise<void> | null = null;
 
 function refusing(body: { error: string; field?: string }) {
@@ -40,6 +43,7 @@ function refusing(body: { error: string; field?: string }) {
     // The form probes before it writes; a probe that fails relabels Save and is not what this is
     // about.
     if (url.includes("/v1/vault/test")) {
+      if (holdProbe) await holdProbe;
       return new Response(JSON.stringify({ testable: true, ok: true }), {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -146,46 +150,52 @@ test.each(["publicKey", "baseUrl"])(
   },
 );
 
-test("the type cannot change out from under a save that is still out", async () => {
-  // The race the clear on select cannot answer: it runs first, and the 409 for the OLD pair lands
-  // after it, reattaching a conflict under a pair the server has said nothing about. The mark
-  // expires by the name, and the name did not change.
-  refusing({ error: REASON, field: "name" });
-  let release: () => void = () => {};
-  holdWrite = new Promise<void>((r) => {
-    release = r;
-  });
-  const { container } = render(
-    <ToastProvider>
-      <CredentialForm
-        mode="create"
-        initialKind="openai"
-        onSaved={() => {}}
-        onCancel={() => {}}
-      />
-    </ToastProvider>,
-  );
+test.each(["probe", "write"] as const)(
+  "the type cannot change out from under a save waiting on its %s",
+  async (leg) => {
+    // The race the clear on select cannot answer: it runs first, and the 409 for the OLD pair lands
+    // after it, reattaching a conflict under a pair the server has said nothing about. The mark
+    // expires by the name, and the name did not change.
+    refusing({ error: REASON, field: "name" });
+    let release: () => void = () => {};
+    const held = new Promise<void>((r) => {
+      release = r;
+    });
+    if (leg === "probe") holdProbe = held;
+    else holdWrite = held;
+    const { container } = render(
+      <ToastProvider>
+        <CredentialForm
+          mode="create"
+          initialKind="openai"
+          onSaved={() => {}}
+          onCancel={() => {}}
+        />
+      </ToastProvider>,
+    );
 
-  fireEvent.change(screen.getByRole("textbox", { name: /name|nome/i }), {
-    target: { value: "Alfa" },
-  });
-  const value = container.querySelector('input[type="password"]');
-  if (!value) throw new Error("no secret input rendered");
-  fireEvent.change(value, { target: { value: "sk-secret" } });
-  fireEvent.click(screen.getByRole("button", { name: /^(save|salvar)$/i }));
+    fireEvent.change(screen.getByRole("textbox", { name: /name|nome/i }), {
+      target: { value: "Alfa" },
+    });
+    const value = container.querySelector('input[type="password"]');
+    if (!value) throw new Error("no secret input rendered");
+    fireEvent.change(value, { target: { value: "sk-secret" } });
+    fireEvent.click(screen.getByRole("button", { name: /^(save|salvar)$/i }));
 
-  const picker = await screen.findByRole("button", { name: /type|tipo/i });
-  await waitFor(() => {
-    expect((picker as HTMLButtonElement).disabled).toBe(true);
-  });
-  // And it does not open, which is the half a disabled attribute alone would not prove.
-  fireEvent.pointerDown(picker, { button: 0, ctrlKey: false });
-  fireEvent.click(picker);
-  expect(screen.queryAllByRole("menuitem").length).toBe(0);
+    const picker = await screen.findByRole("button", { name: /type|tipo/i });
+    await waitFor(() => {
+      expect((picker as HTMLButtonElement).disabled).toBe(true);
+    });
+    // And it does not open, which is the half a disabled attribute alone would not prove.
+    fireEvent.pointerDown(picker, { button: 0, ctrlKey: false });
+    fireEvent.click(picker);
+    expect(screen.queryAllByRole("menuitem").length).toBe(0);
 
-  release();
-  holdWrite = null;
-  await waitFor(() => {
-    expect(screen.queryAllByText(REASON).length).toBeGreaterThan(0);
-  });
-});
+    release();
+    holdProbe = null;
+    holdWrite = null;
+    await waitFor(() => {
+      expect(screen.queryAllByText(REASON).length).toBeGreaterThan(0);
+    });
+  },
+);

--- a/tests/client/credential-name-kind-refusal.test.tsx
+++ b/tests/client/credential-name-kind-refusal.test.tsx
@@ -1,0 +1,143 @@
+/// <reference lib="dom" />
+
+import { afterAll, afterEach, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+// UNIQUENESS IN THE VAULT IS THE (NAME, KIND) PAIR, AND THE MARK EXPIRES BY THE NAME.
+//
+// A held refusal comes off the control when the box stops holding what the server refused, which is
+// what keeps it from needing an `onChange` line per input. `assertUniqueVaultName` refuses the pair,
+// though, so a duplicate answered for (Alfa, openai) says nothing at all about (Alfa, anthropic) —
+// and switching type while keeping the name leaves "already in use" standing under a name that is
+// free. The read is by value, so nothing about the switch expires it.
+//
+// NOTE: assertions reduce to a string or a boolean BEFORE expect: a failing expectation holding a
+// DOM node serializes a cyclic happy-dom tree and stalls.
+
+const { CredentialForm } = await import("@/client/components/CredentialForm");
+const { ToastProvider } = await import("@/client/components/Toast");
+
+const realFetch = globalThis.fetch;
+const REASON = "A secret with this name and type already exists";
+
+afterEach(cleanup);
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+function refusing(body: { error: string; field?: string }) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    // The form probes before it writes; a probe that fails relabels Save and is not what this is
+    // about.
+    if (url.includes("/v1/vault/test")) {
+      return new Response(JSON.stringify({ testable: true, ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (
+      (init?.method ?? "GET").toUpperCase() === "POST" &&
+      url.includes("/v1/vault") &&
+      !url.includes("/test")
+    ) {
+      return new Response(JSON.stringify(body), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+test("switching the type drops a name conflict the new pair never had", async () => {
+  refusing({ error: REASON, field: "name" });
+  const { container } = render(
+    <ToastProvider>
+      <CredentialForm
+        mode="create"
+        initialKind="openai"
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />
+    </ToastProvider>,
+  );
+
+  const name = screen.getByRole("textbox", { name: /name|nome/i });
+  fireEvent.change(name, { target: { value: "Alfa" } });
+  const value = container.querySelector('input[type="password"]');
+  if (!value) throw new Error("no secret input rendered");
+  fireEvent.change(value, { target: { value: "sk-secret" } });
+  fireEvent.click(screen.getByRole("button", { name: /^(save|salvar)$/i }));
+
+  await waitFor(() => {
+    expect(screen.queryAllByText(REASON).length).toBeGreaterThan(0);
+  });
+
+  // The type picker, and then a different provider. Same name, a pair the server has said nothing
+  // about.
+  const picker = screen.getByRole("button", { name: /type|tipo/i });
+  // Radix opens its menu on pointerdown, not on a synthesized click.
+  fireEvent.pointerDown(picker, { button: 0, ctrlKey: false });
+  fireEvent.click(picker);
+  fireEvent.click(
+    await screen.findByRole("menuitem", { name: /^anthropic$/i }),
+  );
+
+  await waitFor(() => {
+    expect(screen.queryAllByText(REASON).length).toBe(0);
+  });
+});
+
+// Both names the `.env` textarea stands in for. `baseUrl` has its own box for every other kind, and
+// disappears with the per-key inputs the moment the operator switches to pasting.
+test.each(["publicKey", "baseUrl"])(
+  "a %s refused in .env mode is read out, not marked on a hidden input",
+  async (field) => {
+    // Langfuse opens in paste mode: the per-key boxes are replaced by one `.env` textarea, so
+    // `publicKey` — the name `assertNoSurroundingWhitespace` refuses by — has no control on screen.
+    // Declaring it anyway placed the sentence on nothing and told `capture` to keep the toast quiet.
+    const reason = `refused: ${field}`;
+    refusing({ error: reason, field });
+    render(
+      <ToastProvider>
+        <CredentialForm
+          mode="create"
+          initialKind="langfuse"
+          onSaved={() => {}}
+          onCancel={() => {}}
+        />
+      </ToastProvider>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: /name|nome/i }), {
+      target: { value: "Alfa" },
+    });
+    const env = screen.getByRole("textbox", { name: /langfuse \.env/i });
+    fireEvent.change(env, {
+      target: {
+        value:
+          'LANGFUSE_PUBLIC_KEY="pk-lf-1"\nLANGFUSE_SECRET_KEY="sk-lf-1"\nLANGFUSE_BASE_URL="https://cloud.langfuse.com"',
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^(save|salvar)$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(reason).length).toBeGreaterThan(0);
+    });
+    // Nowhere near a control: there is no `publicKey` box in this mode.
+    const marked = screen
+      .queryAllByText(reason)
+      .some((n) => !!n.closest("label, [role='group']"));
+    expect(marked).toBe(false);
+  },
+);

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -57,12 +57,15 @@ describe("agent editor save errors", () => {
       "saveGuardrails",
       "saveTools",
     ]);
+    // The holder is often under a qualified name (`cloneRefusal`), because a page with two forms needs
+    // one per form.
+    //
     // `refusal.capture` is the same read plus a placement: it answers the server's sentence, or null
     // once that sentence is already rendered at the input it names (#320). A handler that routes
     // through it has not stopped showing what the server said — it has stopped needing a toast.
     expect(
       writers
-        .filter((h) => !/apiErrorMessage|refusal\.capture/.test(h.body))
+        .filter((h) => !/apiErrorMessage|[Rr]efusal\.capture/.test(h.body))
         .map((h) => h.name),
     ).toEqual([]);
   });

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -57,9 +57,12 @@ describe("agent editor save errors", () => {
       "saveGuardrails",
       "saveTools",
     ]);
+    // `refusal.capture` is the same read plus a placement: it answers the server's sentence, or null
+    // once that sentence is already rendered at the input it names (#320). A handler that routes
+    // through it has not stopped showing what the server said — it has stopped needing a toast.
     expect(
       writers
-        .filter((h) => !h.body.includes("apiErrorMessage"))
+        .filter((h) => !/apiErrorMessage|refusal\.capture/.test(h.body))
         .map((h) => h.name),
     ).toEqual([]);
   });

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -25,6 +25,23 @@ function handlers(src: string): { name: string; body: string }[] {
 }
 
 describe("agent editor save errors", () => {
+  // `saveAgent` writes BOTH sections and the held refusal covers one of them. A successful Behavior
+  // save carries neither `name` nor `systemPrompt`, so clearing there answers a refusal nothing
+  // answered: the operator returns to General to a form that looks clean and is still refused.
+  //
+  // Source-level for the same reason as the rest of this file — the two sections are two arguments
+  // to one function, and the distinction is invisible to anything that only watches the network.
+  test("a successful save clears the holder only for the section it draws", () => {
+    const at = SRC.indexOf("refusal.clear()");
+    expect(at).toBeGreaterThan(-1);
+    // The guard on the same line, so a `clear()` added to another branch is not answered by this one.
+    expect(SRC.slice(SRC.lastIndexOf("\n", at), at)).toContain(
+      'section === "general"',
+    );
+    // And exactly one, so the assertion above is about all of them.
+    expect(SRC.split("refusal.clear()").length - 1).toBe(1);
+  });
+
   // The tools save fires two calls (grants PUT, then agent PATCH), so it checks the bag itself before
   // the first one — otherwise the grants persist and the PATCH is refused. It has to ask the same
   // question the server asks: what does this write CHANGE. Comparing against nothing would refuse a

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -747,6 +747,8 @@ const WAIVED: Record<string, string> = {
     "Same as the Google section: the popup outcome, decided in the browser.",
   "pages/WebhooksPage.tsx :: webhooks.testFailedReason":
     "A 200 carrying the TARGET's rejection, not a refusal of ours — same class as `approvals.editGone`. `err` is null by the guard above, and the reason shown is `result.error`, which is the endpoint's own. The sweep put `apiErrorMessage(err)` here and it could only ever answer null.",
+  "pages/OAuthConsentPage.tsx :: generic":
+    'This endpoint\'s only two refusals are a bare UnauthorizedError() and a bare NotFoundError() — "Unauthorized" and "Not found". The second is the ordinary case (the pending authorization expired or was consumed elsewhere), and showing it would cost the only recovery action the person has, which the server does not know about. Same class as editor.conflictToast: the client\'s sentence is the more specific one. The sentence is `oauth.consent.genericError`, held in a local so both branches show the same one.',
   "pages/LoginPage.tsx :: auth.googleSignInFailed":
     "The Google button's own `onError`: the widget failed in the browser (script blocked, popup closed, a client id the origin does not allow) and nothing of ours was sent. The scanner reads it as the page's handler because a brace-less arrow inside JSX opens no block of its own.",
   "pages/SignupPage.tsx :: auth.googleSignInFailed":
@@ -1256,7 +1258,7 @@ describe("an error toast shows what the server said", () => {
   // The ledger may only shrink, and its size is the anchor the tree cannot supply: appending a name
   // silences a new offender AND satisfies every other rule here.
   test("the waiver ledger is pinned to its size", () => {
-    expectWaiverLedger("WAIVED", WAIVED, 10);
+    expectWaiverLedger("WAIVED", WAIVED, 11);
   });
 
   test("every toast the scanner cannot ask about is named", () => {

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -458,6 +458,73 @@ function bindingIsDead(body: string, name: string): boolean {
   return false;
 }
 
+// THE TWO CHANNELS a refusal reaches the operator through on this tree, as one trigger.
+//
+// #233 swept `showToast(…, "error")` and the fence written with it keyed on that call, so a form that
+// renders the refusal INSIDE itself — an error line in the modal, a banner over the fields — was
+// invisible to this file by construction. That is where the worst measured case lived: creating a
+// second MCP connection under a name already taken answers 409 "mcp connection name already in use"
+// and the modal says "Could not save — check the URL/command", sending the operator to the wrong
+// input entirely (#329).
+//
+// The setter is recognised by NAME because that is where a React state channel declares what it
+// holds: `set` + an optional CamelCase middle + `Err`, and then the call. `settingsTextError(` is not
+// a setter and does not match — the character after `set` has to be uppercase, or `Err` itself. Nor
+// does `setUsageErrorStatus(`, and the trailing paren is what excludes it: a name that CONTINUES past
+// the error holds something else about it, and that one holds an HTTP status.
+const ERROR_CHANNEL = /showToast\(|\bset(?:[A-Z]\w*)?Err(?:or)?\(/g;
+
+// A trigger that is actually SHOWING a sentence.
+//
+// A toast declares its level in the second argument, and the trailing comma is not optional to allow
+// for: biome writes one on every multi-line call, and requiring the quote to be last silently skipped
+// every toast the formatter had wrapped — which is most of the long ones, and they are the ones with
+// a sentence worth replacing.
+//
+// An error setter declares its level in its name, so every call qualifies but two shapes.
+//
+// The same setter is how a form CLEARS the box, and `setError("")` at the top of a submit shows
+// nothing. And a BOOLEAN error state is not a sentence at all: measured on this tree, all 34 of them
+// drive a "could not load this page" boundary after a failed READ, where there is no input to attach
+// anything to and the operator's only move is to retry. A refusal reduced to a flag by a WRITE would
+// be a real gap, and it is a different question from this one — asked and answered by the form fence
+// in tests/client/field-refusal-forms.test.ts, which requires every write to hold its refusal.
+function showsASentence(trigger: string, args: string): boolean {
+  if (trigger.startsWith("showToast")) {
+    return /["']error["'],?$/.test(args.trim());
+  }
+  return !/^\s*(?:""|''|``|null|undefined|true|false|!!?\w[\w.]*)\s*$/.test(
+    args,
+  );
+}
+
+// The names in one scope that end up carrying the server's sentence — directly, or through another
+// name that does.
+//
+// A chain and not one hop, because the shape a form reaches for is two: `const held = (e) =>
+// refusal.capture(…)` and then `const toast = held(err)`, with the toast showing `toast`. Following
+// only the first hop calls that an offender while it is the rule's own implementation. The loop runs
+// to a fixed point rather than a fixed depth: the number of hops is the form's business, not this
+// scanner's.
+function readingNames(scope: string): Set<string> {
+  const names = new Set<string>();
+  for (;;) {
+    const before = names.size;
+    for (const m of scope.matchAll(/\b([A-Za-z_$][\w$]*)\s*=([^;]*)/g)) {
+      const name = m[1] as string;
+      const rhs = m[2] as string;
+      if (names.has(name)) continue;
+      if (
+        /apiErrorMessage|[Rr]efusal\./.test(rhs) ||
+        [...names].some((r) => new RegExp(`\\b${r}\\s*\\(`).test(rhs))
+      ) {
+        names.add(name);
+      }
+    }
+    if (names.size === before) return names;
+  }
+}
+
 // Every error toast in one file, each with the verdict the rules above reach about it. One walker
 // rather than two: the filter chain was copied once, and a rule added to one copy and not the other
 // is how a fence starts claiming an invariant it does not hold — which is the defect this whole file
@@ -482,13 +549,10 @@ function verdicts(
   // Structure is read off the skeleton and TEXT off the source: the braces have to be real code, and
   // the sentence being shown is exactly the part the skeleton blanks.
   const code = codeSkeleton(src);
-  for (const m of code.matchAll(/showToast\(/g)) {
+  for (const m of code.matchAll(ERROR_CHANNEL)) {
     const open = m.index + m[0].length - 1;
     const args = callArgs(src, open);
-    // The trailing comma is not optional to allow for: biome writes one on every multi-line call, and
-    // requiring the quote to be last silently skipped every toast the formatter had wrapped — which
-    // is most of the long ones, and they are the ones with a sentence worth replacing.
-    if (!/["']error["'],?$/.test(args.trim())) continue;
+    if (!showsASentence(m[0], args)) continue;
     const at: Offender = {
       file,
       line: src.slice(0, m.index).split("\n").length,
@@ -506,7 +570,19 @@ function verdicts(
     // (CredentialForm) answers a LOCALIZED sentence for 409 and the server's own for 400, which is a
     // policy, not an oversight. A fence that only knows the helper's name calls that an offender and
     // the sweep then overrides the 409 branch.
-    if (/apiErrorMessage|refusal\.|\.value\??\.error/.test(args)) {
+    //
+    // The hook is often held under a qualified name (`embRefusal`, `lfRefusal`) because a screen with two
+    // forms needs one per form, so the capital is part of the pattern rather than a typo.
+    //
+    // `ApiErrorPayload` is the same read with a CAST in the middle —
+    // `(apiError.value as ApiErrorPayload)?.error` — which the dotted spelling above does not match.
+    // Twelve copies of it, and they are reading what the server said; what they do NOT do is place it
+    // at the input, which is a different question and is asked by the form fence.
+    if (
+      /apiErrorMessage|[Rr]efusal\.|ApiErrorPayload|\.value\??\.error/.test(
+        args,
+      )
+    ) {
       const read = args.match(/apiErrorMessage\(\s*(\w+)\s*\)/);
       const scope = enclosingHandler(code, chain);
       say(
@@ -519,18 +595,23 @@ function verdicts(
       continue;
     }
 
-    // The sentence can be computed a few lines up and shown by name — `const toast =
-    // refusal.capture(…)` then `showToast(toast, "error")`. Reading only the argument list calls that
-    // handler an offender while it is the reference implementation of the rule.
-    const named = args.trim().match(/^(\w+)\s*(?:\?\?[^,]*)?,/);
-    if (named) {
-      const assigned = new RegExp(
-        `\\b${named[1]}\\b\\s*=[^;]*(?:apiErrorMessage|refusal\\.)`,
-      );
-      if (assigned.test(src.slice(chain[0] ?? 0, m.index))) {
-        say("reads");
-        continue;
-      }
+    // The sentence can be computed a few lines up and shown by NAME — `const toast =
+    // refusal.capture(…)` then `showToast(toast, "error")` — or through a small local helper the
+    // handler calls twice, `setError(held(err))`, which is the shape a form with a resolved branch
+    // and a catch branch reaches for. Reading only the argument list calls both an offender while
+    // they are the reference implementation of the rule.
+    //
+    // Every identifier in the argument list is asked, not just a leading one: `held(err) ?? ""` and
+    // `msg ?? fallback` are the same question with different punctuation, and enumerating the
+    // punctuation is how the previous version of this branch missed the helper form entirely.
+    const carriers = readingNames(src.slice(chain[0] ?? 0, m.index));
+    if (
+      [...args.matchAll(/\b[A-Za-z_$][\w$]*/g)].some((i) =>
+        carriers.has(i[0] as string),
+      )
+    ) {
+      say("reads");
+      continue;
     }
 
     // The innermost enclosing `catch`, if the toast is in one at all.
@@ -666,6 +747,10 @@ const WAIVED: Record<string, string> = {
     "Same as the Google section: the popup outcome, decided in the browser.",
   "pages/WebhooksPage.tsx :: webhooks.testFailedReason":
     "A 200 carrying the TARGET's rejection, not a refusal of ours — same class as `approvals.editGone`. `err` is null by the guard above, and the reason shown is `result.error`, which is the endpoint's own. The sweep put `apiErrorMessage(err)` here and it could only ever answer null.",
+  "pages/LoginPage.tsx :: auth.googleSignInFailed":
+    "The Google button's own `onError`: the widget failed in the browser (script blocked, popup closed, a client id the origin does not allow) and nothing of ours was sent. The scanner reads it as the page's handler because a brace-less arrow inside JSX opens no block of its own.",
+  "pages/SignupPage.tsx :: auth.googleSignInFailed":
+    "Same widget, same page-level reading: the failure is the button's, decided before any request of ours exists.",
   "pages/agents/AgentEditorPage.tsx :: editor.conflictToast":
     "Gated on `status === 409`, and all three 409s these routes answer are the same `errors.agentModifiedElsewhere`. The client's sentence says the same thing plus the affordance the server cannot know about — the banner's `save again to overwrite` — so passing the server's through would make the toast WORSE.",
 };
@@ -1045,6 +1130,65 @@ describe("an error toast shows what the server said", () => {
     expect(deadReads(kept)).toEqual([]);
   });
 
+  test("a sentence computed by a local helper is a read", () => {
+    // The shape a form with two failure branches reaches for: one helper, called from the resolved
+    // branch and from the catch. Neither call site mentions the read, and the fence has to follow the
+    // name to find it — the previous version of this branch only understood a bare identifier
+    // followed by a comma, and called every one of these an offender.
+    const src = `
+      async function save() {
+        const held = (e: unknown) =>
+          refusal.capture(e, t("x", "Could not save."), sent, current) ?? "";
+        try {
+          const { error } = await api.thing.post(body);
+          if (error) {
+            setError(held(error));
+            return;
+          }
+        } catch (e) {
+          setError(held(e));
+        }
+      }
+    `;
+    expect(unreadRefusals(src)).toEqual([]);
+  });
+
+  test("a sentence carried through two names is still a read", () => {
+    // The shape the vault form reaches for: a helper that captures, and a `toast` holding what the
+    // helper answered. Following one hop stops at `toast` and calls this an offender.
+    const src = `
+      async function save() {
+        const held = (e: unknown, sent: Record<string, unknown>) =>
+          refusal.capture(e, fallback, sent, current);
+        const { error } = await api.thing.post(body);
+        if (error) {
+          const toast = held(error, body);
+          if (toast) showToast(toast, "error");
+          return;
+        }
+      }
+    `;
+    expect(unreadRefusals(src)).toEqual([]);
+  });
+
+  test("an unrelated local name does not make a fixed sentence a read", () => {
+    // The other direction of the same widening: the handler DOES read the sentence, somewhere, and
+    // then shows a fixed one anyway. Asking "is any identifier in this call assigned from a read"
+    // has to answer about the identifiers of THIS call.
+    const src = `
+      async function save() {
+        const reason = apiErrorMessage(err);
+        const { error } = await api.thing.post(body);
+        if (error) {
+          setError(t("x", "Could not save."));
+          return;
+        }
+        log(reason);
+      }
+    `;
+    expect(unreadRefusals(src)).toHaveLength(1);
+  });
+
   test("a handler that reads the sentence is not an offender", () => {
     const reads = `
       async function save() {
@@ -1112,7 +1256,7 @@ describe("an error toast shows what the server said", () => {
   // The ledger may only shrink, and its size is the anchor the tree cannot supply: appending a name
   // silences a new offender AND satisfies every other rule here.
   test("the waiver ledger is pinned to its size", () => {
-    expectWaiverLedger("WAIVED", WAIVED, 8);
+    expectWaiverLedger("WAIVED", WAIVED, 10);
   });
 
   test("every toast the scanner cannot ask about is named", () => {

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -158,6 +158,57 @@ export function unheldWrites(src: string): string[] {
     .map((h) => h.name);
 }
 
+// A BRANCH of a held handler that writes the form's error line without going through the holder.
+//
+// `unheldWrites` asks per handler, and a handler is answered by one `capture` anywhere inside it —
+// which is exactly how `AlertChannelsSection` passed while its `catch` wrote a fixed sentence
+// straight into the modal-local banner. The resolved-error branch was wired; the thrown one was not,
+// and Eden REJECTS on a transport failure, so the unwired branch is the one the operator hits when
+// the network is what failed. Dismiss the dialog during that and the sentence reaches nobody.
+//
+// Only branches AFTER the request went out, and only ones that write a SENTENCE.
+//
+// Both bounds are the rule, not convenience. A `setError` before the write is a pre-submit guard —
+// "Passwords do not match", "Headers must be valid JSON." — which the client decided on its own and
+// which no server was asked about; routing one through `capture` would be nonsense, and so would
+// routing the `setError("")` that clears the line at the top of a submit.
+export function unheldBranches(src: string): string[] {
+  const carriers = capturingNames(codeSkeleton(src));
+  if (carriers.size === 0) return [];
+  const out: string[] = [];
+  for (const h of handlers(src)) {
+    const uses = [...carriers].some((n) =>
+      new RegExp(`\\b${n}\\s*\\(`).test(h.code),
+    );
+    if (!uses && !/\.capture\(/.test(h.code)) continue;
+    const sent = sentAt(h.code);
+    if (sent < 0) continue;
+    for (const m of h.body.matchAll(
+      /\bset(?:[A-Z]\w*)?Err(?:or)?\(([^;]*?)\)[;,\n]/g,
+    )) {
+      if ((m.index as number) < sent) continue;
+      const arg = (m[1] as string).trim();
+      if (/^(?:""|''|``|null|undefined)$/.test(arg)) continue;
+      if (/\.capture\(/.test(arg)) continue;
+      if ([...carriers].some((n) => new RegExp(`\\b${n}\\s*\\(`).test(arg)))
+        continue;
+      out.push(`${h.name} :: ${arg.split("\n")[0]}`);
+    }
+  }
+  return out;
+}
+
+// Where the handler stops deciding for itself and starts answering the server: the offset of its
+// first write call.
+function sentAt(code: string): number {
+  let at = 0;
+  for (const line of code.split("\n")) {
+    if (WRITES.test(line) && !NOT_A_WRITE.test(line)) return at;
+    at += line.length + 1;
+  }
+  return -1;
+}
+
 // A holder that is declared and then half-used. Either half alone is silence: a holder nobody
 // captures into can only ever answer null at every `at(…)` reading it, and a holder nobody reads
 // keeps the toast quiet about a refusal it has placed nowhere.
@@ -241,40 +292,81 @@ export function readFields(src: string, holder?: string): Set<string> {
   return new Set([...src.matchAll(re)].map((m) => m[1] as string));
 }
 
-// A holder inside a modal that is not cleared when the modal opens.
+// A holder that is not cleared at EVERY opening of the dialog it belongs to.
 //
 // The component around a modal STAYS MOUNTED when the dialog closes — that is what `useOnModalOpen`
 // exists for, resetting the form on each open — so a holder written into state survives the session
 // that produced it. Reopening and typing the refused value again shows the old server sentence under
 // the box without anything having been sent. The hook's own note says a holder must not outlive its
 // form; a modal wrapper is exactly where "the form" and "the component" stop being the same thing.
+//
+// Per OPENING and per DIALOG, which the first version of this rule was neither. It pooled every
+// reset block in the file into one string and asked whether the holder's name appeared anywhere in
+// it, so one cleared opening vouched for all of them and one holder's clear vouched for the others.
+// `ChannelsPage` has three dialogs and two ways into the connect one, and the way the operator
+// actually uses — the Connect button — was the uncleared one.
+//
+// The attribution comes free from the holder itself: its second argument names the dialog whose
+// `isOpen` it answers for (`connectModal.isOpen`), and each opening names its dialog too. A holder
+// that names no dialog is a page's, and this rule has nothing to say about it — the page unmounts.
 export function uncleanedHolders(src: string): string[] {
-  if (!/useOnModalOpen\(|\.open\(/.test(src)) return [];
-  const holders = [...src.matchAll(/const (\w+) = useFieldRefusal\(/g)].map(
-    (m) => m[1] as string,
-  );
   const code = codeSkeleton(src);
-  // The `useOnModalOpen` callback, and — for a dialog opened from a click that seeds it inline, which
-  // is how the agent editor's clone dialog is written — the block around each `.open()`.
-  const resets = [
-    ...[...code.matchAll(/useOnModalOpen\(/g)].map((m) => {
-      let depth = 0;
-      for (let i = m.index; i < code.length; i++) {
-        if (code[i] === "(") depth++;
-        else if (code[i] === ")" && --depth === 0) return src.slice(m.index, i);
+  const out: string[] = [];
+  for (const m of src.matchAll(/const (\w+) = useFieldRefusal\(([^;]*?)\);/g)) {
+    const holder = m[1] as string;
+    const dialogs = [
+      ...new Set(
+        [...(m[2] as string).matchAll(/\b(\w+)\.isOpen\b/g)].map(
+          (d) => d[1] as string,
+        ),
+      ),
+    ];
+    for (const dialog of dialogs) {
+      for (const site of resetSites(src, code, dialog)) {
+        if (!new RegExp(`\\b${holder}\\.clear\\(`).test(site)) {
+          out.push(`${holder} (${dialog})`);
+        }
       }
-      return "";
-    }),
-    ...[...code.matchAll(/\.open\(/g)].map((m) => {
-      let depth = 0;
-      for (let i = m.index; i >= 0; i--) {
-        if (code[i] === "}") depth++;
-        else if (code[i] === "{" && depth-- === 0) return src.slice(i, m.index);
+    }
+  }
+  return [...new Set(out)];
+}
+
+// Where one dialog's per-session reset has to live, which is ONE of two places.
+//
+// `useOnModalOpen(dialog, …)` is the hook for it and runs on every opening by construction, so where
+// it exists it is the only site that matters and the buttons calling `.open()` are just buttons.
+// Where it does not — a dialog seeded inline from the click that opens it, which is how the agent
+// editor's clone dialog and the channels page's Connect button are written — the reset lives at each
+// `.open()` and EVERY one of them has to carry it. Asking both of a file that has the hook flags
+// every button in it; asking only the hook lets an inline dialog through with no reset at all.
+function resetSites(src: string, code: string, dialog: string): string[] {
+  const hooked: string[] = [];
+  for (const m of code.matchAll(
+    new RegExp(`useOnModalOpen\\(\\s*${dialog}\\b`, "g"),
+  )) {
+    let depth = 0;
+    for (let i = m.index as number; i < code.length; i++) {
+      if (code[i] === "(") depth++;
+      else if (code[i] === ")" && --depth === 0) {
+        hooked.push(src.slice(m.index as number, i));
+        break;
       }
-      return "";
-    }),
-  ].join("\n");
-  return holders.filter((h) => !new RegExp(`\\b${h}\\.clear\\(`).test(resets));
+    }
+  }
+  if (hooked.length > 0) return hooked;
+  const inline: string[] = [];
+  for (const m of code.matchAll(new RegExp(`\\b${dialog}\\.open\\(`, "g"))) {
+    let depth = 0;
+    for (let i = m.index as number; i >= 0; i--) {
+      if (code[i] === "}") depth++;
+      else if (code[i] === "{" && depth-- === 0) {
+        inline.push(src.slice(i, m.index as number));
+        break;
+      }
+    }
+  }
+  return inline;
 }
 
 // A holder in a file that can HIDE its form and never says when.
@@ -355,17 +447,6 @@ const NOT_A_REFUSABLE_FORM: Record<string, string> = {
     "Same section, same two calls, same reason: nothing here is a value the server can refuse by name.",
 };
 
-// A holder whose form is the PAGE, in a file that also opens a dialog for something else. The rule
-// above cannot tell the two apart — it asks per file — and clearing a page's holder when an unrelated
-// modal opens would be a line that means nothing. The page is unmounted when the operator leaves it,
-// so its holder cannot outlive its form the way a modal's does.
-const HELD_BY_THE_PAGE: Record<string, string> = {
-  "pages/admin/AdminBrandingPage.tsx :: refusal":
-    "The branding form is the page itself; the `.open()` in this file is the logo cropper, which writes no field.",
-  "pages/agents/AgentEditorPage.tsx :: refusal":
-    "The editor's own holder covers `name` and `systemPrompt`, which no dialog in this file draws — the clone dialog has its own holder (`cloneRefusal`), cleared on open. It IS hidden, by its tab, and answers for that itself: see ALWAYS_ON_SCREEN, which this entry is deliberately not in.",
-};
-
 // A holder whose form cannot be hidden, in a file that can hide something else. Separate from the
 // ledger above because the two rules ask different questions, and one entry answers only one of
 // them: the agent editor's holder is a page's for the clearing rule and a hidden form's for this
@@ -393,10 +474,6 @@ describe("a form that writes holds the refusal it gets", () => {
         `${file} is listed as partially held and holds nothing`,
       ).toBe(true);
     }
-  });
-
-  test("the page-holder ledger is pinned to its size", () => {
-    expectWaiverLedger("HELD_BY_THE_PAGE", HELD_BY_THE_PAGE, 2);
   });
 
   test("the partial ledger is pinned to its size", () => {
@@ -636,6 +713,88 @@ describe("a form that writes holds the refusal it gets", () => {
     ).toEqual([]);
   });
 
+  test("every branch of a held handler goes through the holder", () => {
+    const unheld = sources(ROOT).flatMap((f) =>
+      unheldBranches(readFileSync(f, "utf8")).map(
+        (b) => `${f.slice(`${ROOT}/`.length)} :: ${b}`,
+      ),
+    );
+    expect(
+      unheld,
+      "one wired branch answers for the handler but not for the operator: route this write through the holder too",
+    ).toEqual([]);
+  });
+
+  test("the predicate flags the branch a wired handler forgot", () => {
+    // Eden rejects on a transport failure instead of answering `{ error }`, so the branch that is
+    // easiest to leave unwired is the one a broken network lands in.
+    const src = `
+      const r = useFieldRefusal(F, m.isOpen);
+
+  const handleSubmit = async () => {
+    setError("");
+    const held = (e) => r.capture(e, fallback, sent, current);
+    try {
+      const { error } = await api.thing.post(body);
+      if (error) {
+        setError(held(error));
+        return;
+      }
+    } catch {
+      setError(t("alerts.saveFailed", "Could not save the channel"));
+    }
+  };
+    `;
+    expect(unheldBranches(src)).toEqual([
+      'handleSubmit :: t("alerts.saveFailed", "Could not save the channel")',
+    ]);
+  });
+
+  test("a check made before the request is not a refusal", () => {
+    // "Passwords do not match" and "Headers must be valid JSON." are decided here, with no server
+    // asked, and they return before anything is sent.
+    const src = `
+      const r = useFieldRefusal(F, m.isOpen);
+
+  const handleSubmit = async () => {
+    if (a !== b) {
+      setError(t("auth.passwordsNoMatch", "Passwords do not match"));
+      return;
+    }
+    const held = (e) => r.capture(e, fallback, sent, current);
+    const { error } = await api.thing.post(body);
+    if (error) setError(held(error));
+  };
+    `;
+    expect(unheldBranches(src)).toEqual([]);
+  });
+
+  test("a handler with no holder at all is another rule's business", () => {
+    // `unheldWrites` names those. Asking twice would report one defect as two.
+    const src = `
+      const r = useFieldRefusal(F, m.isOpen);
+
+  const other = async () => {
+    await api.thing.post(body);
+    setError("nope");
+  };
+    `;
+    expect(unheldBranches(src)).toEqual([]);
+  });
+
+  test("clearing the line is not a write", () => {
+    const src = `
+      const r = useFieldRefusal(F, m.isOpen);
+
+  const save = async () => {
+    setError("");
+    setFormError(null);
+    setError(r.capture(e, f, sent, current));
+  };
+    `;
+    expect(unheldBranches(src)).toEqual([]);
+  });
+
   test("no holder is declared and half-used", () => {
     const half = sources(ROOT).flatMap((f) =>
       halfUsedHolders(readFileSync(f, "utf8")).map(
@@ -661,13 +820,14 @@ describe("a form that writes holds the refusal it gets", () => {
   });
 
   test("a holder inside a modal is cleared when the modal opens", () => {
-    const uncleaned = sources(ROOT)
-      .flatMap((f) =>
-        uncleanedHolders(readFileSync(f, "utf8")).map(
-          (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
-        ),
-      )
-      .filter((h) => !(h in HELD_BY_THE_PAGE));
+    // No ledger under this one, and that is the rule earning its keep: it used to need two waivers
+    // saying "this holder belongs to the page, not to the dialog in the same file", and now the
+    // holder says which dialog it belongs to and the ones that name none are simply not asked.
+    const uncleaned = sources(ROOT).flatMap((f) =>
+      uncleanedHolders(readFileSync(f, "utf8")).map(
+        (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
+      ),
+    );
     expect(
       uncleaned,
       "the component outlives the dialog, so a mark from the last session is still held when it reopens: clear the holder in useOnModalOpen",
@@ -721,30 +881,87 @@ describe("a form that writes holds the refusal it gets", () => {
 
   test("the predicate flags a modal holder that is never cleared", () => {
     const src = `
-      const refusal = useFieldRefusal(F);
+      const refusal = useFieldRefusal(F, modal.isOpen);
       useOnModalOpen(modal, () => {
         setName("");
       });
     `;
-    expect(uncleanedHolders(src)).toEqual(["refusal"]);
+    expect(uncleanedHolders(src)).toEqual(["refusal (modal)"]);
+  });
+
+  test("one cleared opening does not vouch for another", () => {
+    // The shape the pooled version could not see, and it is the one the operator uses: the deep-link
+    // path clears, the button beside it does not, and the mark comes back on the value it refused.
+    const src = `
+      const connectRefusal = useFieldRefusal(F, connectModal.isOpen);
+      useEffect(() => {
+        connectRefusal.clear();
+        connectModal.open();
+      }, [x]);
+
+      function openConnect() {
+        setBaseUrl("");
+        connectModal.open();
+      }
+    `;
+    expect(uncleanedHolders(src)).toEqual(["connectRefusal (connectModal)"]);
+  });
+
+  test("the buttons of a hooked dialog are not reset sites", () => {
+    // `useOnModalOpen` runs on every opening, so where it exists it IS the per-session reset and the
+    // `.open()` calls scattered through the JSX have nothing to carry.
+    const src = `
+      const refusal = useFieldRefusal(F, modal.isOpen);
+      useOnModalOpen(modal, () => {
+        setName("");
+        refusal.clear();
+      });
+      <Button onClick={() => modal.open({})} />
+      <Button onClick={() => modal.open({ channel: ch })} />
+    `;
+    expect(uncleanedHolders(src)).toEqual([]);
+  });
+
+  test("one holder's clear does not vouch for another dialog's", () => {
+    const src = `
+      const a = useFieldRefusal(F, aModal.isOpen);
+      const b = useFieldRefusal(F, bModal.isOpen);
+      useOnModalOpen(aModal, () => {
+        a.clear();
+      });
+      useOnModalOpen(bModal, () => {
+        setName("");
+      });
+    `;
+    expect(uncleanedHolders(src)).toEqual(["b (bModal)"]);
+  });
+
+  test("a holder that names no dialog is not this rule's business", () => {
+    // A page's holder. The page unmounts when the operator leaves it, so it cannot outlive its form
+    // the way a modal's does, and clearing it when an unrelated dialog opens would mean nothing.
+    const src = `
+      const refusal = useFieldRefusal(BRANDING_FIELDS);
+      cropper.open();
+    `;
+    expect(uncleanedHolders(src)).toEqual([]);
   });
 
   test("a dialog seeded from a click is asked the same question", () => {
     // The agent editor's clone dialog has no `useOnModalOpen`: it seeds its input and opens in one
     // onClick, and the holder survives the close exactly the same way.
     const src = `
-      const cloneRefusal = useFieldRefusal(F);
+      const cloneRefusal = useFieldRefusal(F, cloneModal.isOpen);
       onClick={() => {
         setCloneName(suggested);
         cloneModal.open();
       }}
     `;
-    expect(uncleanedHolders(src)).toEqual(["cloneRefusal"]);
+    expect(uncleanedHolders(src)).toEqual(["cloneRefusal (cloneModal)"]);
   });
 
   test("a modal holder cleared on open is not flagged", () => {
     const src = `
-      const refusal = useFieldRefusal(F);
+      const refusal = useFieldRefusal(F, modal.isOpen);
       useOnModalOpen(modal, () => {
         setName("");
         refusal.clear();

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -223,6 +223,33 @@ export function uncleanedHolders(src: string): string[] {
   return holders.filter((h) => !new RegExp(`\\b${h}\\.clear\\(`).test(resets));
 }
 
+// A holder in a file with a dialog that never says whether its form is on SCREEN.
+//
+// The other half of the same confusion: `useModalController` keeps the wrapper mounted when the
+// dialog closes, so the hook's mounted check answers `true` for a form the operator has already
+// dismissed. `capture` then reports "it is on the control", the caller keeps the banner quiet, and a
+// refusal the server named reaches nobody. Silence is the one outcome this mechanism must never
+// produce, so the dialog's own `isOpen` is the second argument.
+export function holdersBlindToTheDialog(src: string): string[] {
+  if (!/useOnModalOpen\(|\.open\(/.test(src)) return [];
+  return [...src.matchAll(/const (\w+) = useFieldRefusal\(([^;]*?)\);/g)]
+    .filter((m) => topLevelArgCount(m[2] as string) < 2)
+    .map((m) => m[1] as string);
+}
+
+// How many arguments a call carries, counting only the commas that belong to IT.
+function topLevelArgCount(args: string): number {
+  if (!args.trim()) return 0;
+  let depth = 0;
+  let n = 1;
+  for (const c of args) {
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") depth--;
+    else if (c === "," && depth === 0) n++;
+  }
+  return n;
+}
+
 export function silentDeclarations(src: string): string[] {
   const read = readFields(src);
   return declaredFields(src).filter((name) => !read.has(name));
@@ -440,6 +467,37 @@ describe("a form that writes holds the refusal it gets", () => {
       uncleaned,
       "the component outlives the dialog, so a mark from the last session is still held when it reopens: clear the holder in useOnModalOpen",
     ).toEqual([]);
+  });
+
+  test("a holder in a file with a dialog says whether its form is showing", () => {
+    const blind = sources(ROOT)
+      .flatMap((f) =>
+        holdersBlindToTheDialog(readFileSync(f, "utf8")).map(
+          (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
+        ),
+      )
+      .filter((h) => !(h in HELD_BY_THE_PAGE));
+    expect(
+      blind,
+      "the wrapper stays mounted when the dialog closes, so a save answering after that places a mark nobody renders: pass the dialog's isOpen",
+    ).toEqual([]);
+  });
+
+  test("the predicate flags a holder that takes only its field list", () => {
+    const src = `
+      const refusal = useFieldRefusal(FIELDS);
+      useOnModalOpen(modal, () => {});
+    `;
+    expect(holdersBlindToTheDialog(src)).toEqual(["refusal"]);
+  });
+
+  test("a holder given the dialog's own state is not flagged", () => {
+    // The argument can be an expression: one form reached from two dialogs answers for both.
+    const src = `
+      const refusal = useFieldRefusal(FIELDS, a.isOpen || b.isOpen);
+      useOnModalOpen(modal, () => {});
+    `;
+    expect(holdersBlindToTheDialog(src)).toEqual([]);
   });
 
   test("the predicate flags a modal holder that is never cleared", () => {

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -440,11 +440,19 @@ export function uncleanedHolders(src: string): string[] {
   const out: string[] = [];
   for (const m of src.matchAll(/const (\w+) = useFieldRefusal\(([^;]*?)\);/g)) {
     const holder = m[1] as string;
+    // DIALOGS, and deliberately not every state a holder is gated on.
+    //
+    // An inline editor needs the same per-session clear — `startEdit` re-seeds the form from a
+    // record, so a mark from the last request stops being about anything on screen — and this rule
+    // is not the place to demand it. Asking every gating state means asking the vault's
+    // manual/`.env` toggle too, and clearing there would DELETE a correct mark: switching views does
+    // not change the value the server refused. Separating "opens a session" from "switches a view"
+    // needs to know what the setter re-seeds, which two attempts at a heuristic got wrong in
+    // opposite directions. KnowledgeApprovals' clear is proved by a test instead.
+    const guard = codeSkeleton(m[2] as string);
     const dialogs = [
       ...new Set(
-        [...(m[2] as string).matchAll(/\b(\w+)\.isOpen\b/g)].map(
-          (d) => d[1] as string,
-        ),
+        [...guard.matchAll(/\b(\w+)\.isOpen\b/g)].map((d) => d[1] as string),
       ),
     ];
     for (const dialog of dialogs) {
@@ -495,22 +503,29 @@ function resetSites(src: string, code: string, dialog: string): string[] {
   return inline;
 }
 
-// A holder in a file that can HIDE part of its form and hands the hook a bare constant.
+// A holder that hands the hook a bare constant, which is the claim "every one of these is drawn,
+// always".
 //
-// `rendered` is what the form is DRAWING, so a file that draws conditionally has to say so in the
-// argument. A bare `const FIELDS` says "all of these, always", which is a claim, and in a file with
-// a dialog, a tab, or a mode toggle it is a false one. Measured five times before this rule existed:
-// a dismissed dialog, a tab left behind, the setup token, the vault's `.env` toggle, and the
-// add-content tabs — each of them a refusal marked onto a control nobody was rendering, with
-// `capture` telling the caller to keep the toast quiet.
+// `rendered` is what the form is DRAWING, so the default is an expression and a bare list is the
+// exception. The first two versions of this rule had it the other way round — they tried to work out
+// whether the FILE hides anything, first from a list of shapes (a dialog, a tab) and then from the
+// JSX around each reading — and each version missed the shape the next round found: an inline editor
+// opened by `editingId === a.id`, whose two inputs are as absent as any dialog's while it is closed.
+// Detecting a conditional render from source text is a real static-analysis question and string
+// matching kept answering it with one more exclusion.
 //
-// The test is on the ARGUMENT, not on the file: a conditional expression is the form answering, and
-// what it answers with is the caller's business.
+// Inverting it costs a ledger of eight and buys the property the shape list never had: a form added
+// next week either says what it draws or writes down why it always draws everything. See
+// ALWAYS_ON_SCREEN.
 export function holdersBlindToTheScreen(src: string): string[] {
-  if (!/useOnModalOpen\(|\.open\(|\btab === "|\bTabs\b/.test(src)) return [];
-  return [...src.matchAll(/const (\w+) = useFieldRefusal\(([^;]*?)\);/g)]
-    .filter((m) => /^\s*[A-Za-z_$][\w$]*\s*$/.test(m[2] as string))
-    .map((m) => m[1] as string);
+  return declarations(src)
+    .filter((d) => /^\s*[A-Za-z_$][\w$]*\s*$/.test(argOf(src, d.holder)))
+    .map((d) => d.holder);
+}
+
+function argOf(src: string, holder: string): string {
+  const m = new RegExp(`const ${holder} = useFieldRefusal\\(`).exec(src);
+  return m ? argumentOf(src, m.index + m[0].length - 1) : "";
 }
 
 // A reading that CANNOT run, because the `??` in front of it never falls through.
@@ -563,6 +578,19 @@ const NOT_A_REFUSABLE_FORM: Record<string, string> = {
 // them: the agent editor's holder is a page's for the clearing rule and a hidden form's for this
 // one. Waiving it in both was how the tab case survived the round that found the modal case.
 const ALWAYS_ON_SCREEN: Record<string, string> = {
+  "components/BusinessHoursForm.tsx :: refusal":
+    "The schedule editor IS the screen it is on, and its four controls are drawn together. The windows and exceptions lists grow and shrink; the controls that hold them do not.",
+  "pages/LoginPage.tsx :: refusal":
+    "Two boxes, both always drawn. The page unmounts on a successful login, which the mounted check already answers.",
+  "pages/SignupPage.tsx :: refusal": "Same two boxes, same reason.",
+  "pages/settings/SettingsProfilePage.tsx :: refusal":
+    "The password form is a section of the page, drawn whenever the page is.",
+  "pages/resources/documents/CompanyProfileCard.tsx :: refusal":
+    "The profile fields are the card's body; the card is either mounted or it is not.",
+  "pages/resources/AdvancedPanel.tsx :: embRefusal":
+    "One credential picker, drawn with the panel.",
+  "pages/resources/AdvancedPanel.tsx :: lfRefusal":
+    "The Langfuse credential picker, likewise. The enable switch hides the SETTINGS below it, not the picker this holder names.",
   "pages/admin/AdminBrandingPage.tsx :: refusal":
     "The branding form is drawn unconditionally by the page. The only thing this file hides is the logo cropper, which writes no field.",
 };
@@ -1065,18 +1093,18 @@ describe("a form that writes holds the refusal it gets", () => {
       .filter((h) => !(h in ALWAYS_ON_SCREEN));
     expect(
       blind,
-      "a bare constant claims every field is drawn, always, and this file hides some of them: hand the hook the list it is DRAWING",
+      "a bare constant claims every one of these is drawn, always: hand the hook the list it is DRAWING, or name the form in ALWAYS_ON_SCREEN",
     ).toEqual([]);
   });
 
   test("the always-on-screen ledger is pinned to its size", () => {
-    expectWaiverLedger("ALWAYS_ON_SCREEN", ALWAYS_ON_SCREEN, 1);
+    expectWaiverLedger("ALWAYS_ON_SCREEN", ALWAYS_ON_SCREEN, 8);
   });
 
   test("the predicate flags a holder that claims every field, always", () => {
     const src = `
       const refusal = useFieldRefusal(FIELDS);
-      useOnModalOpen(modal, () => {});
+      {modal.isOpen && <FormField error={refusal.at("name", v)} />}
     `;
     expect(holdersBlindToTheScreen(src)).toEqual(["refusal"]);
   });
@@ -1086,9 +1114,10 @@ describe("a form that writes holds the refusal it gets", () => {
     // while the operator reads another tab, and a save started before the switch answers after it.
     const src = `
       const refusal = useFieldRefusal(EDITOR_FIELDS);
-      {tab === "general" && <GeneralTab />}
+      {tab === "general" ? (
+        <FormField error={refusal.at("name", v)} />
+      ) : null}
     `;
-
     expect(holdersBlindToTheScreen(src)).toEqual(["refusal"]);
   });
 
@@ -1097,9 +1126,34 @@ describe("a form that writes holds the refusal it gets", () => {
     // for that too. What it answers with is the caller's business.
     const src = `
       const refusal = useFieldRefusal(a.isOpen || b.isOpen ? FIELDS : []);
-      useOnModalOpen(modal, () => {});
+      {a.isOpen && <FormField error={refusal.at("name", v)} />}
     `;
     expect(holdersBlindToTheScreen(src)).toEqual([]);
+  });
+
+  test("a page's form is flagged too, and answers in the ledger", () => {
+    // The inversion: a bare list is the exception, not the default. A form that really does draw all
+    // of them says so once, by name, in ALWAYS_ON_SCREEN — which is a sentence someone wrote, not a
+    // shape a regex guessed.
+    const src = `
+      const refusal = useFieldRefusal(BRANDING_FIELDS);
+      <FormField error={refusal.at("name", v)} />
+    `;
+    expect(holdersBlindToTheScreen(src)).toEqual(["refusal"]);
+  });
+
+  test("an inline editor guards its readings like any dialog", () => {
+    // The shape the file-shape list missed: no dialog, no tab, and the two inputs are as absent as
+    // any modal's while `editingId` is null.
+    const src = `
+      const refusal = useFieldRefusal(APPROVAL_FIELDS);
+      {editingId === a.id ? (
+        <Input error={refusal.at("title", draft.title)} />
+      ) : (
+        <p>{a.title}</p>
+      )}
+    `;
+    expect(holdersBlindToTheScreen(src)).toEqual(["refusal"]);
   });
 
   test("a per-control list is an answer too", () => {
@@ -1108,7 +1162,7 @@ describe("a form that writes holds the refusal it gets", () => {
         "name",
         ...(needsParamName ? ["paramName"] : []),
       ]);
-      useOnModalOpen(modal, () => {});
+      {needsParamName && <Input error={refusal.at("paramName", v)} />}
     `;
     expect(holdersBlindToTheScreen(src)).toEqual([]);
   });

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { codeSkeleton } from "@/tests/client/error-toast-reason.test";
 import { expectWaiverLedger } from "@/tests/utils/ledger";
 
 // THE GUARD AGAINST THE NEXT FORM THAT SENDS A FIELD REFUSAL TO A BANNER.
@@ -43,14 +44,125 @@ const WRITES = /\.(?:post|put|patch)\s*\(/;
 const NOT_A_WRITE = /\b(?:list|preview|test|extract|transcribe|discover)\b/;
 
 export function writesAForm(src: string): boolean {
-  if (!RENDERS_A_CONTROL.test(src)) return false;
-  for (const line of src.split("\n")) {
-    if (!WRITES.test(line)) continue;
-    if (NOT_A_WRITE.test(line)) continue;
-    if (!/\bapi\b/.test(line) && !/^\s*\./.test(line)) continue;
-    return true;
+  return RENDERS_A_CONTROL.test(src) && writeHandlers(src).length > 0;
+}
+
+// One function of a component, by name. Both spellings this tree uses — `async function save()` and
+// `const submit = async () => {` — at the component's own indentation, so a callback nested inside
+// one is part of its body rather than a handler of its own.
+//
+// Named and not merely located, because the whole point is to say WHICH handler is unheld: a file
+// with six forms is not answered by "this file calls the hook somewhere", which is what the previous
+// version of this fence asked and what let `useKnowledgeManager`'s add-text form through with a
+// holder that was read and never written.
+const HANDLER_HEAD =
+  /\n {2}(?:export )?(?:async function (\w+)|const (\w+) = (?:async )?(?:\([^)]*\)|\w+) =>|function (\w+))/g;
+
+export function handlers(src: string): { name: string; body: string }[] {
+  // Bounded by its own closing brace, not by where the next handler starts. Slicing to the next head
+  // makes the LAST handler of a nested component swallow everything after it, and this file's whole
+  // subject is per-handler attribution: measured, that made `ChannelsPage`'s `select` — which awaits
+  // a callback and no request at all — read as a write of the function three declarations below it.
+  const code = codeSkeleton(src);
+  return [...src.matchAll(HANDLER_HEAD)].map((m) => {
+    const open = code.indexOf("{", m.index + (m[0] as string).length - 3);
+    let depth = 0;
+    let end = src.length;
+    for (let i = open; i >= 0 && i < code.length; i++) {
+      const c = code[i];
+      if (c === "{") depth++;
+      else if (c === "}" && --depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+    return {
+      name: (m[1] ?? m[2] ?? m[3]) as string,
+      body: src.slice(m.index, end),
+    };
+  });
+}
+
+// The handlers that write a form's values back. `POST` is also how this API asks two questions whose
+// answer is a list (the model catalog, the voice catalog) and how it runs a connection test — none of
+// those carry a form's values, so none of them can refuse one.
+export function writeHandlers(src: string): string[] {
+  return handlers(src)
+    .filter((h) =>
+      h.body
+        .split("\n")
+        .some((line) => WRITES.test(line) && !NOT_A_WRITE.test(line)),
+    )
+    .map((h) => h.name);
+}
+
+// The names that carry a capture, directly or through another name. A form with two failure branches
+// writes one helper and calls it twice — `const held = (e, sent) => refusal.capture(…)` — and the
+// helper lives at component scope, outside every handler body.
+function capturingNames(src: string): Set<string> {
+  const names = new Set<string>();
+  for (;;) {
+    const before = names.size;
+    for (const m of src.matchAll(/\b([A-Za-z_$][\w$]*)\s*=([^;]*)/g)) {
+      const name = m[1] as string;
+      const rhs = m[2] as string;
+      if (names.has(name)) continue;
+      if (
+        /\.capture\(/.test(rhs) ||
+        [...names].some((r) => new RegExp(`\\b${r}\\s*\\(`).test(rhs))
+      ) {
+        names.add(name);
+      }
+    }
+    if (names.size === before) return names;
   }
-  return false;
+}
+
+// A write handler that sends a value this form DECLARED and does not route its failure through a
+// refusal holder.
+//
+// Declared is what bounds it, and the bound is the rule rather than a convenience: the fence's whole
+// subject is "a refusal naming an input this form renders reaches that input", so a handler that
+// sends nothing the form named cannot receive one. That is what separates a submit from the actions
+// beside it — `revoke.post()` carries no body at all, `toggleEnabled` sends the one switch of a list
+// row, `saveGuardrails` sends the settings bag whose paths this page deliberately does not declare
+// (see PARTIALLY_HELD). Asking every write instead flagged twenty-five handlers, of which one was a
+// form.
+export function unheldWrites(src: string): string[] {
+  if (!RENDERS_A_CONTROL.test(src)) return [];
+  const declared = declaredFields(src);
+  if (declared.length === 0) return [];
+  const sends = new RegExp(
+    `\\b(?:${declared.map((f) => f.split(".").pop()).join("|")})\\b`,
+  );
+  const carriers = capturingNames(src);
+  return handlers(src)
+    .filter((h) => {
+      const writes = h.body
+        .split("\n")
+        .some((line) => WRITES.test(line) && !NOT_A_WRITE.test(line));
+      if (!writes || !sends.test(h.body)) return false;
+      if (/\.capture\(/.test(h.body)) return false;
+      return ![...carriers].some((n) =>
+        new RegExp(`\\b${n}\\s*\\(`).test(h.body),
+      );
+    })
+    .map((h) => h.name);
+}
+
+// A holder that is declared and then half-used. Either half alone is silence: a holder nobody
+// captures into can only ever answer null at every `at(…)` reading it, and a holder nobody reads
+// keeps the toast quiet about a refusal it has placed nowhere.
+export function halfUsedHolders(src: string): string[] {
+  const out: string[] = [];
+  for (const m of src.matchAll(/const (\w+) = useFieldRefusal\(/g)) {
+    const name = m[1] as string;
+    const captures = new RegExp(`\\b${name}\\.capture\\(`).test(src);
+    const reads = new RegExp(`\\b${name}\\.at\\(`).test(src);
+    if (!captures || !reads)
+      out.push(`${name} (${captures ? "never read" : "never captured"})`);
+  }
+  return out;
 }
 
 // The names a file declares it can render, from the `as const` list every form keeps next to its
@@ -75,6 +187,42 @@ export function readFields(src: string): Set<string> {
   );
 }
 
+// A holder inside a modal that is not cleared when the modal opens.
+//
+// The component around a modal STAYS MOUNTED when the dialog closes — that is what `useOnModalOpen`
+// exists for, resetting the form on each open — so a holder written into state survives the session
+// that produced it. Reopening and typing the refused value again shows the old server sentence under
+// the box without anything having been sent. The hook's own note says a holder must not outlive its
+// form; a modal wrapper is exactly where "the form" and "the component" stop being the same thing.
+export function uncleanedHolders(src: string): string[] {
+  if (!/useOnModalOpen\(|\.open\(/.test(src)) return [];
+  const holders = [...src.matchAll(/const (\w+) = useFieldRefusal\(/g)].map(
+    (m) => m[1] as string,
+  );
+  const code = codeSkeleton(src);
+  // The `useOnModalOpen` callback, and — for a dialog opened from a click that seeds it inline, which
+  // is how the agent editor's clone dialog is written — the block around each `.open()`.
+  const resets = [
+    ...[...code.matchAll(/useOnModalOpen\(/g)].map((m) => {
+      let depth = 0;
+      for (let i = m.index; i < code.length; i++) {
+        if (code[i] === "(") depth++;
+        else if (code[i] === ")" && --depth === 0) return src.slice(m.index, i);
+      }
+      return "";
+    }),
+    ...[...code.matchAll(/\.open\(/g)].map((m) => {
+      let depth = 0;
+      for (let i = m.index; i >= 0; i--) {
+        if (code[i] === "}") depth++;
+        else if (code[i] === "{" && depth-- === 0) return src.slice(i, m.index);
+      }
+      return "";
+    }),
+  ].join("\n");
+  return holders.filter((h) => !new RegExp(`\\b${h}\\.clear\\(`).test(resets));
+}
+
 export function silentDeclarations(src: string): string[] {
   const read = readFields(src);
   return declaredFields(src).filter((name) => !read.has(name));
@@ -87,6 +235,17 @@ const NOT_A_REFUSABLE_FORM: Record<string, string> = {
     "Its POSTs are the OAuth dance itself — authorize and disconnect — with no value of the operator's in the body. The fields it renders are the connected account, read-only.",
   "components/McpOAuthSection.tsx":
     "Same section, same two calls, same reason: nothing here is a value the server can refuse by name.",
+};
+
+// A holder whose form is the PAGE, in a file that also opens a dialog for something else. The rule
+// above cannot tell the two apart — it asks per file — and clearing a page's holder when an unrelated
+// modal opens would be a line that means nothing. The page is unmounted when the operator leaves it,
+// so its holder cannot outlive its form the way a modal's does.
+const HELD_BY_THE_PAGE: Record<string, string> = {
+  "pages/admin/AdminBrandingPage.tsx :: refusal":
+    "The branding form is the page itself; the `.open()` in this file is the logo cropper, which writes no field.",
+  "pages/agents/AgentEditorPage.tsx :: refusal":
+    "The editor's own holder covers `name` and `systemPrompt` on the General TAB, not a dialog. The dialog in this file is the clone one, and it has its own holder (`cloneRefusal`) cleared on open.",
 };
 
 // A form that holds SOME of its refusals, with what is left. Neither rule above can see this — rule
@@ -109,6 +268,10 @@ describe("a form that writes holds the refusal it gets", () => {
     }
   });
 
+  test("the page-holder ledger is pinned to its size", () => {
+    expectWaiverLedger("HELD_BY_THE_PAGE", HELD_BY_THE_PAGE, 2);
+  });
+
   test("the partial ledger is pinned to its size", () => {
     expectWaiverLedger("PARTIALLY_HELD", PARTIALLY_HELD, 1);
   });
@@ -117,7 +280,10 @@ describe("a form that writes holds the refusal it gets", () => {
     expect(
       writesAForm(`
         <FormField label="x"><Input value={v} /></FormField>
-        const { error } = await api.api.v1.tools.post(body);
+
+  async function save() {
+    const { error } = await api.api.v1.tools.post(body);
+  }
       `),
     ).toBe(true);
   });
@@ -128,15 +294,82 @@ describe("a form that writes holds the refusal it gets", () => {
     expect(
       writesAForm(`
         <Select value={v} />
-        const { data } = await api.api.v1.agents.models.list.post({ provider });
+
+  async function loadVoices() {
+    const { data } = await api.api.v1.agents.models.list.post({ provider });
+  }
       `),
     ).toBe(false);
   });
 
   test("a screen with no control is not a form", () => {
     expect(
-      writesAForm(`const { error } = await api.api.v1.agents.post(body);`),
+      writesAForm(`
+  async function save() {
+    const { error } = await api.api.v1.agents.post(body);
+  }
+      `),
     ).toBe(false);
+  });
+
+  test("a handler ends at its own brace, not at the next declaration", () => {
+    // A nested component's last handler used to swallow everything after it, which read a callback
+    // that awaits nothing as a write of the function three declarations below.
+    const src = `
+  async function select(next: string | null) {
+    await onChange(next);
+  }
+
+  function Other() {
+    return null;
+  }
+
+  async function save() {
+    await api.api.v1.tools.post(body);
+  }
+    `;
+    expect(writeHandlers(src)).toEqual(["save"]);
+  });
+
+  test("an unheld handler is named, even next to a held one", () => {
+    // The shape the file-level rule could not see: two forms in one file, one wired.
+    const src = `
+      const A = ["x", "y"] as const;
+      const a = useFieldRefusal(A);
+      <FormField error={a.at("x", v)} />
+
+  async function saveA() {
+    const { error } = await api.thing.post({ x });
+    if (error) setErr(a.capture(error, f, sent, current));
+  }
+
+  async function saveB() {
+    const { error } = await api.other.post({ y });
+    if (error) setErr("nope");
+  }
+
+  async function revoke() {
+    const { error } = await api.thing({ id }).revoke.post();
+    if (error) setErr("nope");
+  }
+    `;
+    expect(unheldWrites(src)).toEqual(["saveB"]);
+  });
+
+  test("a holder that is read and never captured is flagged", () => {
+    const src = `
+      const addDocRefusal = useFieldRefusal(DOC_FIELDS);
+      <FormField error={addDocRefusal.at("title", v)} />
+    `;
+    expect(halfUsedHolders(src)).toEqual(["addDocRefusal (never captured)"]);
+  });
+
+  test("a holder that is captured and never read is flagged too", () => {
+    const src = `
+      const r = useFieldRefusal(F);
+      setError(r.capture(e, f, sent, current));
+    `;
+    expect(halfUsedHolders(src)).toEqual(["r (never read)"]);
   });
 
   test("a declared name with no control behind it is flagged", () => {
@@ -157,16 +390,29 @@ describe("a form that writes holds the refusal it gets", () => {
     expect(silentDeclarations(src)).toEqual([]);
   });
 
-  test("every form that writes holds its refusal", () => {
-    const unheld = sources(ROOT)
-      .filter((f) => {
-        const src = readFileSync(f, "utf8");
-        return writesAForm(src) && !src.includes("useFieldRefusal");
-      })
-      .map((f) => f.slice(`${ROOT}/`.length));
+  test("every handler that writes a form holds its refusal", () => {
+    const unheld = sources(ROOT).flatMap((f) => {
+      const file = f.slice(`${ROOT}/`.length);
+      if (file in NOT_A_REFUSABLE_FORM) return [];
+      return unheldWrites(readFileSync(f, "utf8")).map(
+        (h) => `${file} :: ${h}`,
+      );
+    });
     expect(
-      unheld.filter((f) => !(f in NOT_A_REFUSABLE_FORM)),
-      "these write a form and send every refusal to a banner: wire useFieldRefusal, or name the reason not to",
+      unheld,
+      "these write a form and send every refusal to a banner: route the failure through refusal.capture, or name the reason not to",
+    ).toEqual([]);
+  });
+
+  test("no holder is declared and half-used", () => {
+    const half = sources(ROOT).flatMap((f) =>
+      halfUsedHolders(readFileSync(f, "utf8")).map(
+        (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
+      ),
+    );
+    expect(
+      half,
+      "a holder that is only read places nothing, and one that is only captured shows nothing",
     ).toEqual([]);
   });
 
@@ -180,6 +426,54 @@ describe("a form that writes holds the refusal it gets", () => {
       silent,
       "a declared name with no `at(…)` behind it swallows its refusal: render it, or stop declaring it",
     ).toEqual([]);
+  });
+
+  test("a holder inside a modal is cleared when the modal opens", () => {
+    const uncleaned = sources(ROOT)
+      .flatMap((f) =>
+        uncleanedHolders(readFileSync(f, "utf8")).map(
+          (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
+        ),
+      )
+      .filter((h) => !(h in HELD_BY_THE_PAGE));
+    expect(
+      uncleaned,
+      "the component outlives the dialog, so a mark from the last session is still held when it reopens: clear the holder in useOnModalOpen",
+    ).toEqual([]);
+  });
+
+  test("the predicate flags a modal holder that is never cleared", () => {
+    const src = `
+      const refusal = useFieldRefusal(F);
+      useOnModalOpen(modal, () => {
+        setName("");
+      });
+    `;
+    expect(uncleanedHolders(src)).toEqual(["refusal"]);
+  });
+
+  test("a dialog seeded from a click is asked the same question", () => {
+    // The agent editor's clone dialog has no `useOnModalOpen`: it seeds its input and opens in one
+    // onClick, and the holder survives the close exactly the same way.
+    const src = `
+      const cloneRefusal = useFieldRefusal(F);
+      onClick={() => {
+        setCloneName(suggested);
+        cloneModal.open();
+      }}
+    `;
+    expect(uncleanedHolders(src)).toEqual(["cloneRefusal"]);
+  });
+
+  test("a modal holder cleared on open is not flagged", () => {
+    const src = `
+      const refusal = useFieldRefusal(F);
+      useOnModalOpen(modal, () => {
+        setName("");
+        refusal.clear();
+      });
+    `;
+    expect(uncleanedHolders(src)).toEqual([]);
   });
 
   test("the abstention ledger is pinned to its size", () => {

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -58,7 +58,15 @@ export function writesAForm(src: string): boolean {
 const HANDLER_HEAD =
   /\n {2}(?:export )?(?:async function (\w+)|const (\w+) = (?:async )?(?:\([^)]*\)|\w+) =>|function (\w+))/g;
 
-export function handlers(src: string): { name: string; body: string }[] {
+export function handlers(src: string): {
+  name: string;
+  body: string;
+  // The same span with comments and string CONTENTS blanked out, offsets preserved. Every question
+  // this file asks of a handler is about what it runs, and prose is where those words appear
+  // innocently: `useKnowledgeManager`'s reindex button sends no body at all, and read raw it looked
+  // like a form write because a comment inside it says "Same text as the banner".
+  code: string;
+}[] {
   // Bounded by its own closing brace, not by where the next handler starts. Slicing to the next head
   // makes the LAST handler of a nested component swallow everything after it, and this file's whole
   // subject is per-handler attribution: measured, that made `ChannelsPage`'s `select` — which awaits
@@ -79,6 +87,7 @@ export function handlers(src: string): { name: string; body: string }[] {
     return {
       name: (m[1] ?? m[2] ?? m[3]) as string,
       body: src.slice(m.index, end),
+      code: code.slice(m.index, end),
     };
   });
 }
@@ -88,22 +97,24 @@ export function handlers(src: string): { name: string; body: string }[] {
 // those carry a form's values, so none of them can refuse one.
 export function writeHandlers(src: string): string[] {
   return handlers(src)
-    .filter((h) =>
-      h.body
-        .split("\n")
-        .some((line) => WRITES.test(line) && !NOT_A_WRITE.test(line)),
-    )
+    .filter((h) => writes(h.code))
     .map((h) => h.name);
+}
+
+function writes(code: string): boolean {
+  return code
+    .split("\n")
+    .some((line) => WRITES.test(line) && !NOT_A_WRITE.test(line));
 }
 
 // The names that carry a capture, directly or through another name. A form with two failure branches
 // writes one helper and calls it twice — `const held = (e, sent) => refusal.capture(…)` — and the
 // helper lives at component scope, outside every handler body.
-function capturingNames(src: string): Set<string> {
+function capturingNames(code: string): Set<string> {
   const names = new Set<string>();
   for (;;) {
     const before = names.size;
-    for (const m of src.matchAll(/\b([A-Za-z_$][\w$]*)\s*=([^;]*)/g)) {
+    for (const m of code.matchAll(/\b([A-Za-z_$][\w$]*)\s*=([^;]*)/g)) {
       const name = m[1] as string;
       const rhs = m[2] as string;
       if (names.has(name)) continue;
@@ -135,16 +146,13 @@ export function unheldWrites(src: string): string[] {
   const sends = new RegExp(
     `\\b(?:${declared.map((f) => f.split(".").pop()).join("|")})\\b`,
   );
-  const carriers = capturingNames(src);
+  const carriers = capturingNames(codeSkeleton(src));
   return handlers(src)
     .filter((h) => {
-      const writes = h.body
-        .split("\n")
-        .some((line) => WRITES.test(line) && !NOT_A_WRITE.test(line));
-      if (!writes || !sends.test(h.body)) return false;
-      if (/\.capture\(/.test(h.body)) return false;
+      if (!writes(h.code) || !sends.test(h.code)) return false;
+      if (/\.capture\(/.test(h.code)) return false;
       return ![...carriers].some((n) =>
-        new RegExp(`\\b${n}\\s*\\(`).test(h.body),
+        new RegExp(`\\b${n}\\s*\\(`).test(h.code),
       );
     })
     .map((h) => h.name);
@@ -165,26 +173,72 @@ export function halfUsedHolders(src: string): string[] {
   return out;
 }
 
-// The names a file declares it can render, from the `as const` list every form keeps next to its
-// component. Read from the source rather than imported because the point is to compare the
-// declaration against the RENDER, and only the source has both.
-export function declaredFields(src: string): string[] {
-  const at = src.indexOf("useFieldRefusal(");
-  if (at === -1) return [];
-  const arg = src.slice(at + "useFieldRefusal(".length).match(/^\s*(\w+)/);
-  if (!arg) return [];
-  const list = new RegExp(`${arg[1]}\\s*=\\s*\\[([^\\]]*)\\]`).exec(src);
-  if (!list) return [];
-  return [...(list[1] as string).matchAll(/["']([^"']+)["']/g)].map(
-    (m) => m[1] as string,
-  );
+// EVERY holder in the file with the names it declares, not the first one that happens to appear.
+//
+// A file with one form is the easy case and it is not the common one here: `ChannelsPage` keeps
+// three holders, `useKnowledgeManager` three, `AdvancedPanel` two, and the agent editor two. Reading
+// only the first meant the fence agreed with itself about one form per file and asked nothing at all
+// of the rest — a declared name with no control behind it, in any of them, passed. Attributed per
+// holder for the same reason `unheldWrites` names its handler: "this file declares a name it never
+// renders" is not a finding anyone can act on.
+//
+// Read from the source rather than imported because the point is to compare the declaration against
+// the RENDER, and only the source has both.
+export function declarations(
+  src: string,
+): { holder: string; fields: string[] }[] {
+  return [...src.matchAll(/const (\w+) = useFieldRefusal\(/g)].map((m) => ({
+    holder: m[1] as string,
+    fields: declaredArg(
+      src.slice((m.index as number) + (m[0] as string).length),
+      src,
+    ),
+  }));
 }
 
-// The names the file actually reads back onto a control.
-export function readFields(src: string): Set<string> {
-  return new Set(
-    [...src.matchAll(/\.at\(\s*["']([^"']+)["']/g)].map((m) => m[1] as string),
-  );
+// The first argument's names, however it is spelled. Both spellings are in the tree: the `as const`
+// list beside the component, and — where the list depends on what the form is drawing — an array
+// built inline (`CredentialForm`, whose multi-field types contribute one name per input). The inline
+// one was skipped entirely by the identifier-only version.
+//
+// A computed element contributes nothing, which is the honest answer rather than a hole: a spread of
+// `fields.map(f => f.key)` is read back by an `at(f.key, …)` the source cannot see either, so both
+// sides of the comparison drop it together.
+function declaredArg(rest: string, src: string): string[] {
+  const lead = rest.match(/^\s*/)?.[0].length ?? 0;
+  const arg = rest.slice(lead);
+  if (arg.startsWith("[")) {
+    let depth = 0;
+    for (let i = 0; i < arg.length; i++) {
+      if (arg[i] === "[") depth++;
+      else if (arg[i] === "]" && --depth === 0)
+        return literals(arg.slice(1, i));
+    }
+    return [];
+  }
+  const ident = arg.match(/^([A-Za-z_$][\w$]*)/)?.[1];
+  if (!ident) return [];
+  const list = new RegExp(`${ident}\\s*=\\s*\\[([^\\]]*)\\]`).exec(src);
+  return list ? literals(list[1] as string) : [];
+}
+
+function literals(list: string): string[] {
+  return [...list.matchAll(/["']([^"']+)["']/g)].map((m) => m[1] as string);
+}
+
+// Every name declared anywhere in the file, which is what "did this handler send something the form
+// named" asks: any holder's control can receive it.
+export function declaredFields(src: string): string[] {
+  return [...new Set(declarations(src).flatMap((d) => d.fields))];
+}
+
+// The names read back onto a control — by ONE holder when asked for one, since a name `refusal`
+// declares is not rendered by `cloneRefusal.at(…)` two forms away.
+export function readFields(src: string, holder?: string): Set<string> {
+  const re = holder
+    ? new RegExp(`\\b${holder}\\.at\\(\\s*["']([^"']+)["']`, "g")
+    : /\.at\(\s*["']([^"']+)["']/g;
+  return new Set([...src.matchAll(re)].map((m) => m[1] as string));
 }
 
 // A holder inside a modal that is not cleared when the modal opens.
@@ -223,15 +277,21 @@ export function uncleanedHolders(src: string): string[] {
   return holders.filter((h) => !new RegExp(`\\b${h}\\.clear\\(`).test(resets));
 }
 
-// A holder in a file with a dialog that never says whether its form is on SCREEN.
+// A holder in a file that can HIDE its form and never says when.
 //
 // The other half of the same confusion: `useModalController` keeps the wrapper mounted when the
 // dialog closes, so the hook's mounted check answers `true` for a form the operator has already
 // dismissed. `capture` then reports "it is on the control", the caller keeps the banner quiet, and a
 // refusal the server named reaches nobody. Silence is the one outcome this mechanism must never
-// produce, so the dialog's own `isOpen` is the second argument.
-export function holdersBlindToTheDialog(src: string): string[] {
-  if (!/useOnModalOpen\(|\.open\(/.test(src)) return [];
+// produce, so what makes the form visible is the second argument.
+//
+// A dialog is not the only way to hide a form, and asking only about dialogs is how the agent
+// editor got through the round that added this rule: its `name` and `systemPrompt` live in
+// `GeneralTab`, mounted only while `tab === "general"`, and its holder had been waived as a page's
+// because the file's dialog belongs to something else. A tab test in the file asks the same
+// question of every holder in it.
+export function holdersBlindToTheScreen(src: string): string[] {
+  if (!/useOnModalOpen\(|\.open\(|\btab === "/.test(src)) return [];
   return [...src.matchAll(/const (\w+) = useFieldRefusal\(([^;]*?)\);/g)]
     .filter((m) => topLevelArgCount(m[2] as string) < 2)
     .map((m) => m[1] as string);
@@ -251,8 +311,10 @@ function topLevelArgCount(args: string): number {
 }
 
 export function silentDeclarations(src: string): string[] {
-  const read = readFields(src);
-  return declaredFields(src).filter((name) => !read.has(name));
+  return declarations(src).flatMap(({ holder, fields }) => {
+    const read = readFields(src, holder);
+    return fields.filter((n) => !read.has(n)).map((n) => `${holder}.${n}`);
+  });
 }
 
 // A form that writes and does not hold its refusal, with the reason. Asserted in both directions, so
@@ -272,7 +334,16 @@ const HELD_BY_THE_PAGE: Record<string, string> = {
   "pages/admin/AdminBrandingPage.tsx :: refusal":
     "The branding form is the page itself; the `.open()` in this file is the logo cropper, which writes no field.",
   "pages/agents/AgentEditorPage.tsx :: refusal":
-    "The editor's own holder covers `name` and `systemPrompt` on the General TAB, not a dialog. The dialog in this file is the clone one, and it has its own holder (`cloneRefusal`) cleared on open.",
+    "The editor's own holder covers `name` and `systemPrompt`, which no dialog in this file draws — the clone dialog has its own holder (`cloneRefusal`), cleared on open. It IS hidden, by its tab, and answers for that itself: see ALWAYS_ON_SCREEN, which this entry is deliberately not in.",
+};
+
+// A holder whose form cannot be hidden, in a file that can hide something else. Separate from the
+// ledger above because the two rules ask different questions, and one entry answers only one of
+// them: the agent editor's holder is a page's for the clearing rule and a hidden form's for this
+// one. Waiving it in both was how the tab case survived the round that found the modal case.
+const ALWAYS_ON_SCREEN: Record<string, string> = {
+  "pages/admin/AdminBrandingPage.tsx :: refusal":
+    "The branding form is drawn unconditionally by the page. The only thing this file hides is the logo cropper, which writes no field.",
 };
 
 // A form that holds SOME of its refusals, with what is left. Neither rule above can see this — rule
@@ -358,6 +429,22 @@ describe("a form that writes holds the refusal it gets", () => {
     expect(writeHandlers(src)).toEqual(["save"]);
   });
 
+  test("a declared name inside a COMMENT is not a form write", () => {
+    // Measured on `useKnowledgeManager`: the reindex button sends no body at all, and the only
+    // mention of a declared name inside it is a comment that says "Same text as the banner".
+    const src = `
+      const F = ["title", "text"] as const;
+      const r = useFieldRefusal(F, m.isOpen);
+      <FormField error={r.at("title", v)} /><FormField error={r.at("text", w)} />
+
+  async function reindex(id: string) {
+    // Same text as the banner, from the same function.
+    const { error } = await api.bases({ id }).reindex.post();
+  }
+    `;
+    expect(unheldWrites(src)).toEqual([]);
+  });
+
   test("an unheld handler is named, even next to a held one", () => {
     // The shape the file-level rule could not see: two forms in one file, one wired.
     const src = `
@@ -405,7 +492,48 @@ describe("a form that writes holds the refusal it gets", () => {
       const refusal = useFieldRefusal(FIELDS);
       <FormField error={refusal.at("name", current.name)} />
     `;
-    expect(silentDeclarations(src)).toEqual(["allowedHosts"]);
+    expect(silentDeclarations(src)).toEqual(["refusal.allowedHosts"]);
+  });
+
+  test("the second holder of a file is asked the same question", () => {
+    // The shape the first-call-only version could not see: two forms, and the one that is wrong is
+    // not the one declared first.
+    const src = `
+      const A = ["name"] as const;
+      const B = ["name", "slug"] as const;
+      const a = useFieldRefusal(A, x.isOpen);
+      const b = useFieldRefusal(B, y.isOpen);
+      <FormField error={a.at("name", u)} />
+      <FormField error={b.at("name", v)} />
+    `;
+    expect(silentDeclarations(src)).toEqual(["b.slug"]);
+  });
+
+  test("a name read by ANOTHER holder does not answer for this one", () => {
+    // Two forms with a `name` each is the normal case here — a modal over the panel that opened it —
+    // and a file-wide reading let one form's control vouch for the other's declaration.
+    const src = `
+      const A = ["name"] as const;
+      const B = ["name"] as const;
+      const a = useFieldRefusal(A, x.isOpen);
+      const b = useFieldRefusal(B, y.isOpen);
+      <FormField error={a.at("name", u)} />
+    `;
+    expect(silentDeclarations(src)).toEqual(["b.name"]);
+  });
+
+  test("an inline field list is read, not skipped", () => {
+    // `CredentialForm` builds its list from the secret type it is drawing. The identifier-only
+    // version returned nothing for it, so the whole form was outside the fence.
+    const src = `
+      const refusal = useFieldRefusal([
+        "name",
+        "value",
+        ...(fields ?? []).map((f) => f.key),
+      ]);
+      <FormField error={refusal.at("name", u)} />
+    `;
+    expect(silentDeclarations(src)).toEqual(["refusal.value"]);
   });
 
   test("a declared name that is read is not flagged", () => {
@@ -469,18 +597,22 @@ describe("a form that writes holds the refusal it gets", () => {
     ).toEqual([]);
   });
 
-  test("a holder in a file with a dialog says whether its form is showing", () => {
+  test("a holder in a file that hides a form says when its own is showing", () => {
     const blind = sources(ROOT)
       .flatMap((f) =>
-        holdersBlindToTheDialog(readFileSync(f, "utf8")).map(
+        holdersBlindToTheScreen(readFileSync(f, "utf8")).map(
           (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
         ),
       )
-      .filter((h) => !(h in HELD_BY_THE_PAGE));
+      .filter((h) => !(h in ALWAYS_ON_SCREEN));
     expect(
       blind,
-      "the wrapper stays mounted when the dialog closes, so a save answering after that places a mark nobody renders: pass the dialog's isOpen",
+      "the component outlives the form when a dialog closes or a tab changes, so a save answering after that places a mark nobody renders: pass what makes the form visible",
     ).toEqual([]);
+  });
+
+  test("the always-on-screen ledger is pinned to its size", () => {
+    expectWaiverLedger("ALWAYS_ON_SCREEN", ALWAYS_ON_SCREEN, 1);
   });
 
   test("the predicate flags a holder that takes only its field list", () => {
@@ -488,7 +620,17 @@ describe("a form that writes holds the refusal it gets", () => {
       const refusal = useFieldRefusal(FIELDS);
       useOnModalOpen(modal, () => {});
     `;
-    expect(holdersBlindToTheDialog(src)).toEqual(["refusal"]);
+    expect(holdersBlindToTheScreen(src)).toEqual(["refusal"]);
+  });
+
+  test("a form behind a tab is asked the same question as one behind a dialog", () => {
+    // No dialog in sight, and the form is hidden just as completely: `GeneralTab` is not mounted
+    // while the operator reads another tab, and a save started before the switch answers after it.
+    const src = `
+      const refusal = useFieldRefusal(EDITOR_FIELDS);
+      {tab === "general" && <GeneralTab />}
+    `;
+    expect(holdersBlindToTheScreen(src)).toEqual(["refusal"]);
   });
 
   test("a holder given the dialog's own state is not flagged", () => {
@@ -497,7 +639,7 @@ describe("a form that writes holds the refusal it gets", () => {
       const refusal = useFieldRefusal(FIELDS, a.isOpen || b.isOpen);
       useOnModalOpen(modal, () => {});
     `;
-    expect(holdersBlindToTheDialog(src)).toEqual([]);
+    expect(holdersBlindToTheScreen(src)).toEqual([]);
   });
 
   test("the predicate flags a modal holder that is never cleared", () => {

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { expectWaiverLedger } from "@/tests/utils/ledger";
+
+// THE GUARD AGAINST THE NEXT FORM THAT SENDS A FIELD REFUSAL TO A BANNER.
+//
+// #231 put the refused field on the wire, #232 built the state that renders it at the control, and
+// this sweep wired the console. What comes back without a guard is the form written next week: it
+// will read the server's sentence (the other fence in this directory sees to that) and drop it into
+// a toast or an error line, which is far from the input and, on a long form, leaves the operator
+// counting down the fields to work out which one the server meant.
+//
+// Two rules, because a form can fail this in two directions and only one of them is visible:
+//
+//   1. a form that WRITES holds its refusal — `useFieldRefusal`, or a named reason not to;
+//   2. every name a form DECLARES is read back by an `at(…)` call in the same file. A declared name
+//      with no control behind it is worse than not declaring it: `placeRefusal` marks it as placed
+//      and the caller then keeps the toast silent, so the refusal reaches nobody at all. Measured
+//      while wiring ToolEditModal, which declared `allowedHosts` and renders no such input.
+
+const ROOT = "src/client";
+
+function sources(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) out.push(...sources(path));
+    else if (/\.tsx?$/.test(path)) out.push(path);
+  }
+  return out;
+}
+
+// A control the operator types or picks into. The pickers are named too: a credential or a business
+// hours selection is refused by the server like any other value.
+const RENDERS_A_CONTROL =
+  /<(?:FormField|Input|Textarea|Select|CredentialPicker)\b/;
+
+// A WRITE, and only a write. `POST` is also how this API asks two questions whose answer is a list
+// (the model catalog, the voice catalog) and how it runs a connection test — none of those carry a
+// form's values, so none of them can refuse one.
+const WRITES = /\.(?:post|put|patch)\s*\(/;
+const NOT_A_WRITE = /\b(?:list|preview|test|extract|transcribe|discover)\b/;
+
+export function writesAForm(src: string): boolean {
+  if (!RENDERS_A_CONTROL.test(src)) return false;
+  for (const line of src.split("\n")) {
+    if (!WRITES.test(line)) continue;
+    if (NOT_A_WRITE.test(line)) continue;
+    if (!/\bapi\b/.test(line) && !/^\s*\./.test(line)) continue;
+    return true;
+  }
+  return false;
+}
+
+// The names a file declares it can render, from the `as const` list every form keeps next to its
+// component. Read from the source rather than imported because the point is to compare the
+// declaration against the RENDER, and only the source has both.
+export function declaredFields(src: string): string[] {
+  const at = src.indexOf("useFieldRefusal(");
+  if (at === -1) return [];
+  const arg = src.slice(at + "useFieldRefusal(".length).match(/^\s*(\w+)/);
+  if (!arg) return [];
+  const list = new RegExp(`${arg[1]}\\s*=\\s*\\[([^\\]]*)\\]`).exec(src);
+  if (!list) return [];
+  return [...(list[1] as string).matchAll(/["']([^"']+)["']/g)].map(
+    (m) => m[1] as string,
+  );
+}
+
+// The names the file actually reads back onto a control.
+export function readFields(src: string): Set<string> {
+  return new Set(
+    [...src.matchAll(/\.at\(\s*["']([^"']+)["']/g)].map((m) => m[1] as string),
+  );
+}
+
+export function silentDeclarations(src: string): string[] {
+  const read = readFields(src);
+  return declaredFields(src).filter((name) => !read.has(name));
+}
+
+// A form that writes and does not hold its refusal, with the reason. Asserted in both directions, so
+// an entry describing code that no longer exists fails too.
+const NOT_A_REFUSABLE_FORM: Record<string, string> = {
+  "components/GoogleOAuthSection.tsx":
+    "Its POSTs are the OAuth dance itself — authorize and disconnect — with no value of the operator's in the body. The fields it renders are the connected account, read-only.",
+  "components/McpOAuthSection.tsx":
+    "Same section, same two calls, same reason: nothing here is a value the server can refuse by name.",
+};
+
+// A form that holds SOME of its refusals, with what is left. Neither rule above can see this — rule
+// 1 is satisfied by the hook being called at all — so it is a declaration, pinned by size, and the
+// only thing keeping the sweep honest about where it stopped.
+const PARTIALLY_HELD: Record<string, string> = {
+  "pages/agents/AgentEditorPage.tsx":
+    "Holds `name` and `systemPrompt`, the two values it renders a control for directly. Everything else it writes lives in bags (`settings.tts.normalizeCredentialRef`, `guardrails.output.templateMessage`) behind eight tabs, so placing one of those means also taking the operator to the tab that holds it — the deep-link TEXT_CAP_TARGETS already maps for config-health warnings. Left to fazer-ai/agents#349.",
+};
+
+describe("a form that writes holds the refusal it gets", () => {
+  test("every partially held form still holds something", () => {
+    // Both directions: an entry describing a file that stopped calling the hook is describing code
+    // that no longer exists, and an entry for a file that got fully wired should be deleted.
+    for (const file of Object.keys(PARTIALLY_HELD)) {
+      expect(
+        readFileSync(join(ROOT, file), "utf8").includes("useFieldRefusal"),
+        `${file} is listed as partially held and holds nothing`,
+      ).toBe(true);
+    }
+  });
+
+  test("the partial ledger is pinned to its size", () => {
+    expectWaiverLedger("PARTIALLY_HELD", PARTIALLY_HELD, 1);
+  });
+
+  test("the predicate sees a form that writes", () => {
+    expect(
+      writesAForm(`
+        <FormField label="x"><Input value={v} /></FormField>
+        const { error } = await api.api.v1.tools.post(body);
+      `),
+    ).toBe(true);
+  });
+
+  test("a POST that asks for a list is not a write", () => {
+    // The model and voice catalogs are POSTed because the query is a body, not because anything of
+    // the operator's is being stored. A form next to one of those has nothing to place.
+    expect(
+      writesAForm(`
+        <Select value={v} />
+        const { data } = await api.api.v1.agents.models.list.post({ provider });
+      `),
+    ).toBe(false);
+  });
+
+  test("a screen with no control is not a form", () => {
+    expect(
+      writesAForm(`const { error } = await api.api.v1.agents.post(body);`),
+    ).toBe(false);
+  });
+
+  test("a declared name with no control behind it is flagged", () => {
+    const src = `
+      const FIELDS = ["name", "allowedHosts"] as const;
+      const refusal = useFieldRefusal(FIELDS);
+      <FormField error={refusal.at("name", current.name)} />
+    `;
+    expect(silentDeclarations(src)).toEqual(["allowedHosts"]);
+  });
+
+  test("a declared name that is read is not flagged", () => {
+    const src = `
+      const FIELDS = ["name"] as const;
+      const refusal = useFieldRefusal(FIELDS);
+      <FormField error={refusal.at("name", current.name)} />
+    `;
+    expect(silentDeclarations(src)).toEqual([]);
+  });
+
+  test("every form that writes holds its refusal", () => {
+    const unheld = sources(ROOT)
+      .filter((f) => {
+        const src = readFileSync(f, "utf8");
+        return writesAForm(src) && !src.includes("useFieldRefusal");
+      })
+      .map((f) => f.slice(`${ROOT}/`.length));
+    expect(
+      unheld.filter((f) => !(f in NOT_A_REFUSABLE_FORM)),
+      "these write a form and send every refusal to a banner: wire useFieldRefusal, or name the reason not to",
+    ).toEqual([]);
+  });
+
+  test("no form declares a name it never renders", () => {
+    const silent = sources(ROOT).flatMap((f) =>
+      silentDeclarations(readFileSync(f, "utf8")).map(
+        (name) => `${f.slice(`${ROOT}/`.length)} :: ${name}`,
+      ),
+    );
+    expect(
+      silent,
+      "a declared name with no `at(…)` behind it swallows its refusal: render it, or stop declaring it",
+    ).toEqual([]);
+  });
+
+  test("the abstention ledger is pinned to its size", () => {
+    expectWaiverLedger("NOT_A_REFUSABLE_FORM", NOT_A_REFUSABLE_FORM, 2);
+  });
+});

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -669,8 +669,6 @@ const ALWAYS_ON_SCREEN: Record<string, string> = {
     "One credential picker, drawn with the panel.",
   "pages/resources/AdvancedPanel.tsx :: lfRefusal":
     "The Langfuse credential picker, likewise. The enable switch hides the SETTINGS below it, not the picker this holder names.",
-  "pages/admin/AdminBrandingPage.tsx :: refusal":
-    "The branding form is drawn unconditionally by the page. The only thing this file hides is the logo cropper, which writes no field.",
 };
 
 // A form that holds SOME of its refusals, with what is left. Neither rule above can see this — rule
@@ -1229,8 +1227,26 @@ describe("a form that writes holds the refusal it gets", () => {
     ).toEqual([]);
   });
 
+  test("every always-on-screen entry describes a holder that still exists", () => {
+    // Both directions, like the other ledgers here: an entry for a holder that has since started
+    // answering with an expression is describing code that is not there any more, and it would go on
+    // waiving whatever took its place. The branding page's holder became conditional the round this
+    // assertion was written, and nothing else noticed.
+    const flagged = new Set(
+      sources(ROOT).flatMap((f) =>
+        holdersBlindToTheScreen(readFileSync(f, "utf8")).map(
+          (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
+        ),
+      ),
+    );
+    expect(
+      Object.keys(ALWAYS_ON_SCREEN).filter((k) => !flagged.has(k)),
+      "these are waived and no longer flagged: delete the entry",
+    ).toEqual([]);
+  });
+
   test("the always-on-screen ledger is pinned to its size", () => {
-    expectWaiverLedger("ALWAYS_ON_SCREEN", ALWAYS_ON_SCREEN, 8);
+    expectWaiverLedger("ALWAYS_ON_SCREEN", ALWAYS_ON_SCREEN, 7);
   });
 
   test("the predicate flags a holder that claims every field, always", () => {

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -209,6 +209,92 @@ function sentAt(code: string): number {
   return -1;
 }
 
+// A caller that does not believe the hook's null.
+//
+// `capture` answers one question — is there anything left for YOU to say — and null is "no": the
+// sentence is on the control, or the form had left the screen and the hook raised the global toast
+// itself. Substituting a fallback for that null fires the second channel on top of the first, and
+// the two spellings of the mistake are the same operator experience: a message under the box AND a
+// toast repeating it, or two identical toasts. Measured on `CompanyProfileCard`, whose catch read
+// `toast ?? t("…saveError")`.
+export function distrustedNulls(src: string): string[] {
+  const code = codeSkeleton(src);
+  const carriers = capturingNames(code);
+  const ends: number[] = [];
+  for (const m of code.matchAll(/\.capture\(/g)) {
+    const open = (m.index as number) + ".capture".length;
+    ends.push(open + argumentOf(code, open).length + 2);
+  }
+  for (const n of carriers) {
+    for (const m of code.matchAll(new RegExp(`\\b${n}\\b`, "g"))) {
+      const after = (m.index as number) + n.length;
+      ends.push(
+        code[after] === "("
+          ? after + argumentOf(code, after).length + 2
+          : after,
+      );
+    }
+  }
+  const out: string[] = [];
+  for (const end of ends) {
+    const rest = code.slice(end);
+    const op = rest.match(/^\s*(\?\?|\|\|)\s*/);
+    if (!op) continue;
+    const at = end + (op[0] as string).length;
+    const width = (code.slice(at).split(/[,;)]/)[0] ?? "").length;
+    // Read from the SOURCE and not the skeleton, because the operand is the words themselves and the
+    // skeleton is exactly what blanks them out.
+    const right = src.slice(at, at + width);
+    // `?? ""` is a TYPE coercion, not a second sentence: the state it feeds is `string`, and an
+    // empty one renders nothing. What this rule is about is a caller answering the hook's "they have
+    // already been told" with words of its own.
+    if (/^\s*(?:""|''|``|null|undefined)\s*$/.test(right)) continue;
+    out.push(`${op[1]} ${right.trim().slice(0, 40)}`);
+  }
+  return [...new Set(out)];
+}
+
+// A staleness check that compares a value with itself.
+//
+// `capture` takes what the request CARRIED and what the inputs hold NOW, and refuses to mark a
+// control that has moved on. Handing it the same expression twice makes that comparison a tautology
+// — always "unchanged", always placed — while the render reads the live value and finds no mark for
+// it. The refusal then reaches neither channel. Measured on `ChannelsPage`'s account picker, whose
+// rows stay live while the PUT is out.
+export function tautologicalStaleness(src: string): string[] {
+  const code = codeSkeleton(src);
+  const out: string[] = [];
+  for (const m of code.matchAll(/\.capture\(/g)) {
+    const args = splitArgs(
+      argumentOf(code, (m.index as number) + ".capture".length),
+    );
+    if (args.length < 4) continue;
+    const [, , sent, current] = args as [string, string, string, string];
+    if (sent.trim() && sent.trim() === current.trim()) out.push(sent.trim());
+  }
+  return out;
+}
+
+// A call's arguments, split on the commas that belong to IT.
+function splitArgs(args: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let last = 0;
+  for (let i = 0; i < args.length; i++) {
+    const c = args[i];
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") depth--;
+    else if (c === "," && depth === 0) {
+      out.push(args.slice(last, i));
+      last = i + 1;
+    }
+  }
+  out.push(args.slice(last));
+  return out
+    .map((a) => a.trim())
+    .filter((a, i, all) => a || i < all.length - 1);
+}
+
 // A holder that is declared and then half-used. Either half alone is silence: a holder nobody
 // captures into can only ever answer null at every `at(…)` reading it, and a holder nobody reads
 // keeps the toast quiet about a refusal it has placed nowhere.
@@ -851,6 +937,83 @@ describe("a form that writes holds the refusal it gets", () => {
   };
     `;
     expect(unheldBranches(src)).toEqual([]);
+  });
+
+  test("no caller substitutes a sentence for the hook's null", () => {
+    const distrusted = sources(ROOT).flatMap((f) =>
+      distrustedNulls(readFileSync(f, "utf8")).map(
+        (d) => `${f.slice(`${ROOT}/`.length)} :: ${d}`,
+      ),
+    );
+    expect(
+      distrusted,
+      "null is the hook saying the operator has already been told: `if (toast) showToast(toast)`, never `toast ?? fallback`",
+    ).toEqual([]);
+  });
+
+  test("the predicate flags a fallback substituted for null", () => {
+    const src = `
+      const r = useFieldRefusal(m.isOpen ? F : []);
+  const save = async () => {
+    try {
+      await api.thing.post(body);
+    } catch (e) {
+      const toast = r.capture(e, fallback, sent, current);
+      showToast(toast ?? t("company.saveError", "Could not save."), "error");
+    }
+  };
+    `;
+    expect(distrustedNulls(src)).toEqual(['?? t("company.saveError"']);
+  });
+
+  test("coercing null to an empty string is not a second sentence", () => {
+    // The auth pages feed a `string` state, and `""` renders nothing. Only words are a second
+    // channel.
+    const src = `
+      const r = useFieldRefusal(m.isOpen ? F : []);
+  const submit = async () => {
+    const held = (e) => r.capture(e, fallback, sent, current);
+    setError(held(apiError) ?? "");
+  };
+    `;
+    expect(distrustedNulls(src)).toEqual([]);
+  });
+
+  test("guarding on the sentence is not distrusting the null", () => {
+    const src = `
+      const r = useFieldRefusal(m.isOpen ? F : []);
+  const save = async () => {
+    const toast = r.capture(e, fallback, sent, current);
+    if (toast) showToast(toast, "error");
+  };
+    `;
+    expect(distrustedNulls(src)).toEqual([]);
+  });
+
+  test("no staleness check compares a value with itself", () => {
+    const tautological = sources(ROOT).flatMap((f) =>
+      tautologicalStaleness(readFileSync(f, "utf8")).map(
+        (a) => `${f.slice(`${ROOT}/`.length)} :: ${a}`,
+      ),
+    );
+    expect(
+      tautological,
+      "`sent` and `current` are the request's value and the box's value: handing over the same one makes the check a tautology and the mark unreadable",
+    ).toEqual([]);
+  });
+
+  test("the predicate flags sent and current being one snapshot", () => {
+    const src = `
+      r.capture(e, fallback, { accountIds: wanted }, { accountIds: wanted });
+    `;
+    expect(tautologicalStaleness(src)).toEqual(["{ accountIds: wanted }"]);
+  });
+
+  test("a live read against the snapshot is not flagged", () => {
+    const src = `
+      r.capture(e, fallback, { accountIds: wanted }, { accountIds: ref.current });
+    `;
+    expect(tautologicalStaleness(src)).toEqual([]);
   });
 
   test("no holder is declared and half-used", () => {

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -235,46 +235,86 @@ export function halfUsedHolders(src: string): string[] {
 //
 // Read from the source rather than imported because the point is to compare the declaration against
 // the RENDER, and only the source has both.
-export function declarations(
-  src: string,
-): { holder: string; fields: string[] }[] {
+export function declarations(src: string): {
+  holder: string;
+  fields: string[];
+}[] {
   return [...src.matchAll(/const (\w+) = useFieldRefusal\(/g)].map((m) => ({
     holder: m[1] as string,
     fields: declaredArg(
-      src.slice((m.index as number) + (m[0] as string).length),
+      argumentOf(src, (m.index as number) + (m[0] as string).length - 1),
       src,
     ),
   }));
 }
 
-// The first argument's names, however it is spelled. Both spellings are in the tree: the `as const`
-// list beside the component, and — where the list depends on what the form is drawing — an array
-// built inline (`CredentialForm`, whose multi-field types contribute one name per input). The inline
-// one was skipped entirely by the identifier-only version.
+// The text between a call's parentheses, balanced. Not a lazy match up to the next `);`, because the
+// argument is an expression now and expressions nest.
+function argumentOf(src: string, open: number): string {
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") {
+      if (--depth === 0) return src.slice(open + 1, i);
+    }
+  }
+  return "";
+}
+
+// Every name the argument can ever produce, whichever branch it takes.
 //
-// A computed element contributes nothing, which is the honest answer rather than a hole: a spread of
+// The argument is an EXPRESSION now — `modal.isOpen ? MCP_FIELDS : []`, `required ? WITH_TOKEN :
+// BASE`, an array built one control at a time — so reading it as "one identifier, or one inline
+// array" answers `[]` for almost every holder in the tree, and a rule that is handed nothing asks
+// nothing. That is what this rule was written to catch and what it silently stopped seeing the
+// moment the hook's argument changed shape: a fence with no findings and a fence with no vision are
+// the same green.
+//
+// So: every string literal in the expression, plus every SCREAMING_CASE identifier in it that names
+// a list in this file, resolved one level down so `[...SETUP_FIELDS, "token"]` contributes both. A
+// computed element contributes nothing, which is the honest answer rather than a hole — a spread of
 // `fields.map(f => f.key)` is read back by an `at(f.key, …)` the source cannot see either, so both
 // sides of the comparison drop it together.
-function declaredArg(rest: string, src: string): string[] {
-  const lead = rest.match(/^\s*/)?.[0].length ?? 0;
-  const arg = rest.slice(lead);
-  if (arg.startsWith("[")) {
-    let depth = 0;
-    for (let i = 0; i < arg.length; i++) {
-      if (arg[i] === "[") depth++;
-      else if (arg[i] === "]" && --depth === 0)
-        return literals(arg.slice(1, i));
-    }
-    return [];
+function declaredArg(arg: string, src: string): string[] {
+  const out = new Set(literalsInLists(arg));
+  for (const m of arg.matchAll(/\b([A-Z][A-Z0-9_]*)\b/g)) {
+    for (const name of resolveList(m[1] as string, src, 0)) out.add(name);
   }
-  const ident = arg.match(/^([A-Za-z_$][\w$]*)/)?.[1];
-  if (!ident) return [];
-  const list = new RegExp(`${ident}\\s*=\\s*\\[([^\\]]*)\\]`).exec(src);
-  return list ? literals(list[1] as string) : [];
+  return [...out];
+}
+
+// A SCREAMING_CASE list declared in this file, following a spread into another one.
+function resolveList(ident: string, src: string, depth: number): string[] {
+  if (depth > 2) return [];
+  const at = src.search(new RegExp(`\\b${ident}\\s*=\\s*\\[`));
+  if (at < 0) return [];
+  const body = argumentOf(src, src.indexOf("[", at));
+  const out = new Set(literals(body));
+  for (const m of body.matchAll(/\.\.\.([A-Z][A-Z0-9_]*)\b/g)) {
+    for (const name of resolveList(m[1] as string, src, depth + 1)) {
+      out.add(name);
+    }
+  }
+  return [...out];
 }
 
 function literals(list: string): string[] {
   return [...list.matchAll(/["']([^"']+)["']/g)].map((m) => m[1] as string);
+}
+
+// Only the literals inside an ARRAY, because the expression also holds the condition that chooses
+// between them: `addTab === "texto" ? DOC_FIELDS : []` names a tab, not a field, and reading it as
+// one had the fence demanding a control for `texto`.
+function literalsInLists(arg: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < arg.length; i++) {
+    if (arg[i] !== "[") continue;
+    const body = argumentOf(arg, i);
+    out.push(...literals(body));
+    i += body.length + 1;
+  }
+  return out;
 }
 
 // Every name declared anywhere in the file, which is what "did this handler send something the form
@@ -369,37 +409,22 @@ function resetSites(src: string, code: string, dialog: string): string[] {
   return inline;
 }
 
-// A holder in a file that can HIDE its form and never says when.
+// A holder in a file that can HIDE part of its form and hands the hook a bare constant.
 //
-// The other half of the same confusion: `useModalController` keeps the wrapper mounted when the
-// dialog closes, so the hook's mounted check answers `true` for a form the operator has already
-// dismissed. `capture` then reports "it is on the control", the caller keeps the banner quiet, and a
-// refusal the server named reaches nobody. Silence is the one outcome this mechanism must never
-// produce, so what makes the form visible is the second argument.
+// `rendered` is what the form is DRAWING, so a file that draws conditionally has to say so in the
+// argument. A bare `const FIELDS` says "all of these, always", which is a claim, and in a file with
+// a dialog, a tab, or a mode toggle it is a false one. Measured five times before this rule existed:
+// a dismissed dialog, a tab left behind, the setup token, the vault's `.env` toggle, and the
+// add-content tabs — each of them a refusal marked onto a control nobody was rendering, with
+// `capture` telling the caller to keep the toast quiet.
 //
-// A dialog is not the only way to hide a form, and asking only about dialogs is how the agent
-// editor got through the round that added this rule: its `name` and `systemPrompt` live in
-// `GeneralTab`, mounted only while `tab === "general"`, and its holder had been waived as a page's
-// because the file's dialog belongs to something else. A tab test in the file asks the same
-// question of every holder in it.
+// The test is on the ARGUMENT, not on the file: a conditional expression is the form answering, and
+// what it answers with is the caller's business.
 export function holdersBlindToTheScreen(src: string): string[] {
-  if (!/useOnModalOpen\(|\.open\(|\btab === "/.test(src)) return [];
+  if (!/useOnModalOpen\(|\.open\(|\btab === "|\bTabs\b/.test(src)) return [];
   return [...src.matchAll(/const (\w+) = useFieldRefusal\(([^;]*?)\);/g)]
-    .filter((m) => topLevelArgCount(m[2] as string) < 2)
+    .filter((m) => /^\s*[A-Za-z_$][\w$]*\s*$/.test(m[2] as string))
     .map((m) => m[1] as string);
-}
-
-// How many arguments a call carries, counting only the commas that belong to IT.
-function topLevelArgCount(args: string): number {
-  if (!args.trim()) return 0;
-  let depth = 0;
-  let n = 1;
-  for (const c of args) {
-    if (c === "(" || c === "[" || c === "{") depth++;
-    else if (c === ")" || c === "]" || c === "}") depth--;
-    else if (c === "," && depth === 0) n++;
-  }
-  return n;
 }
 
 // A reading that CANNOT run, because the `??` in front of it never falls through.
@@ -676,6 +701,39 @@ describe("a form that writes holds the refusal it gets", () => {
     expect(silentDeclarations(src)).toEqual(["b.name"]);
   });
 
+  test("a list chosen by a condition is read on both branches", () => {
+    // The shape almost every holder has now, and the one an identifier-or-array reader answers `[]`
+    // for — which would leave the whole sweep green and blind.
+    const src = `
+      const A = ["name", "slug"] as const;
+      const r = useFieldRefusal(modal.isOpen ? A : []);
+      <FormField error={r.at("name", u)} />
+    `;
+    expect(silentDeclarations(src)).toEqual(["r.slug"]);
+  });
+
+  test("a condition's own strings are not fields", () => {
+    // `addTab === "texto"` names a tab. Reading the expression's literals flat had the fence
+    // demanding a control for it.
+    const src = `
+      const DOC = ["title"] as const;
+      const r = useFieldRefusal(m.isOpen && addTab === "texto" ? DOC : []);
+      <FormField error={r.at("title", u)} />
+    `;
+    expect(silentDeclarations(src)).toEqual([]);
+  });
+
+  test("a list spread into another contributes both", () => {
+    const src = `
+      const BASE = ["email", "password"] as const;
+      const WITH_TOKEN = [...BASE, "token"] as const;
+      const r = useFieldRefusal(required ? WITH_TOKEN : BASE);
+      <FormField error={r.at("email", u)} />
+      <FormField error={r.at("password", v)} />
+    `;
+    expect(silentDeclarations(src)).toEqual(["r.token"]);
+  });
+
   test("an inline field list is read, not skipped", () => {
     // `CredentialForm` builds its list from the secret type it is drawing. The identifier-only
     // version returned nothing for it, so the whole form was outside the fence.
@@ -834,7 +892,7 @@ describe("a form that writes holds the refusal it gets", () => {
     ).toEqual([]);
   });
 
-  test("a holder in a file that hides a form says when its own is showing", () => {
+  test("a holder in a file that hides controls answers with what it draws", () => {
     const blind = sources(ROOT)
       .flatMap((f) =>
         holdersBlindToTheScreen(readFileSync(f, "utf8")).map(
@@ -844,7 +902,7 @@ describe("a form that writes holds the refusal it gets", () => {
       .filter((h) => !(h in ALWAYS_ON_SCREEN));
     expect(
       blind,
-      "the component outlives the form when a dialog closes or a tab changes, so a save answering after that places a mark nobody renders: pass what makes the form visible",
+      "a bare constant claims every field is drawn, always, and this file hides some of them: hand the hook the list it is DRAWING",
     ).toEqual([]);
   });
 
@@ -852,7 +910,7 @@ describe("a form that writes holds the refusal it gets", () => {
     expectWaiverLedger("ALWAYS_ON_SCREEN", ALWAYS_ON_SCREEN, 1);
   });
 
-  test("the predicate flags a holder that takes only its field list", () => {
+  test("the predicate flags a holder that claims every field, always", () => {
     const src = `
       const refusal = useFieldRefusal(FIELDS);
       useOnModalOpen(modal, () => {});
@@ -867,13 +925,26 @@ describe("a form that writes holds the refusal it gets", () => {
       const refusal = useFieldRefusal(EDITOR_FIELDS);
       {tab === "general" && <GeneralTab />}
     `;
+
     expect(holdersBlindToTheScreen(src)).toEqual(["refusal"]);
   });
 
-  test("a holder given the dialog's own state is not flagged", () => {
-    // The argument can be an expression: one form reached from two dialogs answers for both.
+  test("a holder that answers with an expression is not flagged", () => {
+    // One form reached from two dialogs answers for both, and a form that hides one control answers
+    // for that too. What it answers with is the caller's business.
     const src = `
-      const refusal = useFieldRefusal(FIELDS, a.isOpen || b.isOpen);
+      const refusal = useFieldRefusal(a.isOpen || b.isOpen ? FIELDS : []);
+      useOnModalOpen(modal, () => {});
+    `;
+    expect(holdersBlindToTheScreen(src)).toEqual([]);
+  });
+
+  test("a per-control list is an answer too", () => {
+    const src = `
+      const refusal = useFieldRefusal([
+        "name",
+        ...(needsParamName ? ["paramName"] : []),
+      ]);
       useOnModalOpen(modal, () => {});
     `;
     expect(holdersBlindToTheScreen(src)).toEqual([]);

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -310,6 +310,35 @@ function topLevelArgCount(args: string): number {
   return n;
 }
 
+// A reading that CANNOT run, because the `??` in front of it never falls through.
+//
+// `at(…)` answers `string | null`, so it reads naturally as the fallback of a local validation
+// error — and it is dead there whenever that local error is a state initialized to `""`, since an
+// empty string is not nullish. Nothing about this is visible: the name is declared, the reading is
+// written, the fence's other rule sees an `at(…)` and is satisfied, and the refusal is placed onto a
+// holder whose one reader can never return it. `capture` has already told the caller "it is on the
+// control", so the toast stays quiet too. Measured on `useKnowledgeManager`: the chunk-size box
+// checks BOUNDS locally and the schema is `t.Integer`, so a size of 100.5 is refused by name and
+// answered with nothing at all.
+//
+// The left operand is the whole test. `refusal.at(a) ?? refusal.at(b)` — one control drawn for two
+// names, which ToolEditModal does — falls through exactly as intended.
+export function deadReadings(src: string): string[] {
+  const neverNullish = new Set(
+    [...src.matchAll(/const \[(\w+),[^\]]*\]\s*=\s*useState\(\s*["'`]/g)].map(
+      (m) => m[1] as string,
+    ),
+  );
+  if (neverNullish.size === 0) return [];
+  return [
+    ...codeSkeleton(src).matchAll(
+      /\b([A-Za-z_$][\w$]*)\s*\?\?\s*([A-Za-z_$][\w$]*)\.at\(/g,
+    ),
+  ]
+    .filter((m) => neverNullish.has(m[1] as string))
+    .map((m) => `${m[2]}.at behind ${m[1]}`);
+}
+
 export function silentDeclarations(src: string): string[] {
   return declarations(src).flatMap(({ holder, fields }) => {
     const read = readFields(src, holder);
@@ -484,6 +513,54 @@ describe("a form that writes holds the refusal it gets", () => {
       setError(r.capture(e, f, sent, current));
     `;
     expect(halfUsedHolders(src)).toEqual(["r (never read)"]);
+  });
+
+  test("no reading sits behind a fallback that never falls through", () => {
+    const dead = sources(ROOT).flatMap((f) =>
+      deadReadings(readFileSync(f, "utf8")).map(
+        (d) => `${f.slice(`${ROOT}/`.length)} :: ${d}`,
+      ),
+    );
+    expect(
+      dead,
+      'a local error state initialized to "" is never nullish, so the refusal behind `??` is unreachable and the toast is already quiet: use `||`',
+    ).toEqual([]);
+  });
+
+  test("the predicate flags a refusal behind an empty-string local error", () => {
+    const src = `
+      const [chunkSizeError, setChunkSizeError] = useState("");
+      <FormField error={chunkSizeError ?? r.at("chunkSize", v)} />
+    `;
+    expect(deadReadings(src)).toEqual(["r.at behind chunkSizeError"]);
+  });
+
+  test("the same reading behind a truthy fallback is fine", () => {
+    const src = `
+      const [chunkSizeError, setChunkSizeError] = useState("");
+      <FormField error={chunkSizeError || r.at("chunkSize", v)} />
+    `;
+    expect(deadReadings(src)).toEqual([]);
+  });
+
+  test("a local error that CAN be null keeps its fallback", () => {
+    // The filter's own control: the rule is about a state that is never nullish, not about `??`.
+    // A nullable local error is the shape this pattern is written for.
+    const src = `
+      const [touched, setTouched] = useState("");
+      const localError = invalid ? "Must be a number." : null;
+      <FormField error={localError ?? r.at("chunkSize", v)} />
+    `;
+    expect(deadReadings(src)).toEqual([]);
+  });
+
+  test("one control drawn for two names still falls through", () => {
+    // `at(…)` answers null when it is not the refused name, which is exactly what `??` is for.
+    const src = `
+      const [x, setX] = useState("");
+      <FormField error={r.at("label", a) ?? r.at("name", b)} />
+    `;
+    expect(deadReadings(src)).toEqual([]);
   });
 
   test("a declared name with no control behind it is flagged", () => {

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -528,6 +528,84 @@ function argOf(src: string, holder: string): string {
   return m ? argumentOf(src, m.index + m[0].length - 1) : "";
 }
 
+// A field whose control is drawn BEHIND A GUARD, declared as though it always were.
+//
+// This is the per-control half of the rule above, and it took three review rounds to state because I
+// kept trying to state it about the file: a dialog, then a tab, then an inline editor, then a mode
+// toggle inside a form that is itself on screen. The thing being asked about was never the file. It
+// is one JSX conditional, in the idiom this codebase writes it in — `{expr && (`, `{expr ? (` — with
+// the expression carrying no parens or braces of its own, which is what keeps the search from
+// walking out to the component body and calling every arrow and type annotation a guard.
+//
+// The demand is that the DECLARATION mention the STATE the guard turns on — `type` for
+// `type === "webhook"`, `form.ackEnabled` for itself — which is exactly what a caller writes anyway
+// (`type === "webhook" ? ALERT_WEBHOOK_FIELDS : ALERT_FIELDS`). Mentioning it rather than repeating
+// the whole condition, because the two are not always spellable the same way: an inline editor's
+// guard is `editingId === a.id`, per row, and the holder above the rows has only `editingId`. What
+// makes this checkable at all is that it never has to decide whether one expression implies another.
+//
+// Run over the tree it named eighteen guarded controls, six of which were declared unconditionally —
+// two the review found and four it had not reached.
+const JSX_GUARD = /\{\s*[^{}()]*?(?:&&|\?)\s*$/;
+
+export function guardOf(
+  src: string,
+  holder: string,
+  field: string,
+): string | null {
+  const code = codeSkeleton(src);
+  const re = new RegExp(
+    `\\b${holder}\\.at\\(\\s*["']${field}["']|\\b${holder}\\.at\\(\\s*\\n\\s*["']${field}["']`,
+    "g",
+  );
+  for (const m of src.matchAll(re)) {
+    const at = m.index as number;
+    const opens: number[] = [];
+    for (let i = 0; i < at; i++) {
+      const c = code[i];
+      if (c === "(" || c === "{") opens.push(i);
+      else if (c === ")" || c === "}") opens.pop();
+    }
+    // Innermost first: an outer guard is about the screen, and the one this control answers to is
+    // the nearest one.
+    for (const o of opens.reverse()) {
+      const from = Math.max(0, o - 120);
+      const g = JSX_GUARD.exec(code.slice(from, o));
+      if (!g) continue;
+      return src
+        .slice(from + (g.index as number), o)
+        .replace(/\s+/g, " ")
+        .trim();
+    }
+  }
+  return null;
+}
+
+// The state a guard turns on: the leading identifier chain, past any `!`. `form.ackEnabled` and not
+// `form`, because half this tree's guards hang off one `form` object and the root alone would let
+// any of them vouch for any other.
+function stateOf(guard: string): string {
+  return (
+    /^\{\s*!*\s*([A-Za-z_$][\w$]*(?:\??\.[A-Za-z_$][\w$]*)*)/.exec(
+      guard,
+    )?.[1] ?? guard
+  );
+}
+
+export function guardedButUnconditional(src: string): string[] {
+  const out: string[] = [];
+  for (const d of declarations(src)) {
+    const arg = argOf(src, d.holder).replace(/\s+/g, " ");
+    for (const field of d.fields) {
+      const guard = guardOf(src, d.holder, field);
+      if (!guard) continue;
+      if (!arg.includes(stateOf(guard)))
+        out.push(`${d.holder}.${field} <- ${guard}`);
+    }
+  }
+  return out;
+}
+
 // A reading that CANNOT run, because the `??` in front of it never falls through.
 //
 // `at(…)` answers `string | null`, so it reads naturally as the fallback of a local validation
@@ -729,6 +807,60 @@ describe("a form that writes holds the refusal it gets", () => {
       setError(r.capture(e, f, sent, current));
     `;
     expect(halfUsedHolders(src)).toEqual(["r (never read)"]);
+  });
+
+  test("a control drawn behind a guard is declared behind the same one", () => {
+    const blind = sources(ROOT).flatMap((f) =>
+      guardedButUnconditional(readFileSync(f, "utf8")).map(
+        (h) => `${f.slice(`${ROOT}/`.length)} :: ${h}`,
+      ),
+    );
+    expect(
+      blind,
+      "this control is only drawn under that condition, so declaring it always puts the server's sentence on nothing and keeps the toast quiet: mirror the guard in the list",
+    ).toEqual([]);
+  });
+
+  test("the predicate flags a field drawn behind a switch", () => {
+    const src = `
+      const F = ["name", "secretRef"] as const;
+      const r = useFieldRefusal(m.isOpen ? F : []);
+      <Input error={r.at("name", n)} />
+      {type === "webhook" && (
+        <CredentialPicker error={r.at("secretRef", s)} />
+      )}
+    `;
+    expect(guardedButUnconditional(src)).toEqual([
+      'r.secretRef <- {type === "webhook" &&',
+    ]);
+  });
+
+  test("a declaration that mirrors the guard is not flagged", () => {
+    const src = `
+      const F = ["name"] as const;
+      const WF = [...F, "secretRef"] as const;
+      const r = useFieldRefusal(type === "webhook" ? WF : F);
+      <Input error={r.at("name", n)} />
+      {type === "webhook" && (
+        <CredentialPicker error={r.at("secretRef", s)} />
+      )}
+    `;
+    expect(guardedButUnconditional(src)).toEqual([]);
+  });
+
+  test("the badge idiom is not a guard", () => {
+    // `{r.at(x) && (<span/>)}` guards on the refusal itself and says nothing about whether the
+    // control is drawn. It needs no clause of its own: the pattern only accepts a condition that
+    // ends the text before the delimiter, and here the reading it would flag sits past a `<span>`.
+    // Measured — an explicit exclusion for it was dead in both directions.
+    const src = `
+      const F = ["windows"] as const;
+      const r = useFieldRefusal(F);
+      {r.at("windows", w) && (
+        <span className="text-error">{r.at("windows", w)}</span>
+      )}
+    `;
+    expect(guardedButUnconditional(src)).toEqual([]);
   });
 
   test("no reading sits behind a fallback that never falls through", () => {

--- a/tests/client/field-refusal-forms.test.tsx
+++ b/tests/client/field-refusal-forms.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, expect, test } from "bun:test";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -37,13 +38,20 @@ afterEach(() => {
 });
 
 // Everything the tree needs to render answers 200; the one write under test answers the refusal.
-function refusing(body: { error: string; field?: string }, status = 409) {
+// `hold` keeps that answer in flight until the test lets it go, which is how the operator dismissing
+// a dialog mid-save is reproduced.
+function refusing(
+  body: { error: string; field?: string },
+  status = 409,
+  hold?: Promise<void>,
+) {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(
       typeof input === "string" || input instanceof URL ? input : input.url,
     );
     const method = (init?.method ?? "GET").toUpperCase();
     if (method === "POST" && url.includes("/api/v1/mcp-connections")) {
+      if (hold) await hold;
       return new Response(JSON.stringify(body), {
         status,
         headers: { "Content-Type": "application/json" },
@@ -64,14 +72,15 @@ function refusing(body: { error: string; field?: string }, status = 409) {
   }) as typeof fetch;
 }
 
-function OpenMcpModal() {
+function OpenMcpModal({ onReady }: { onReady?: (close: () => void) => void }) {
   const modal = useModalController<{ id?: string }>();
   const opened = useRef(false);
   useEffect(() => {
     if (opened.current) return;
     opened.current = true;
     modal.open({});
-  }, [modal]);
+    onReady?.(() => modal.close());
+  }, [modal, onReady]);
   return (
     <McpEditModal
       modal={modal as unknown as Parameters<typeof McpEditModal>[0]["modal"]}
@@ -79,13 +88,13 @@ function OpenMcpModal() {
   );
 }
 
-function mount() {
+function mount(onReady?: (close: () => void) => void) {
   return render(
     <MemoryRouter>
       <ThemeProvider>
         <AuthProvider>
           <ToastProvider>
-            <OpenMcpModal />
+            <OpenMcpModal onReady={onReady} />
           </ToastProvider>
         </AuthProvider>
       </ThemeProvider>
@@ -144,4 +153,40 @@ test("a refusal about no input at all still reaches the operator", async () => {
   await waitFor(() => {
     expect(screen.queryAllByText(reason).length).toBeGreaterThan(0);
   });
+});
+
+test("a refusal that lands after the dialog is dismissed is still read out", () => {
+  // The half a mounted check could not answer. `useModalController` keeps this wrapper mounted when
+  // the dialog closes, so the save that was in flight comes back to a live component and a form the
+  // operator has already dismissed — and the error line it would be written to is drawn between the
+  // dialog's title and its buttons. Placing the mark there, or handing the caller a sentence for
+  // that line, are two spellings of the same silence.
+  let release: () => void = () => {};
+  const held = new Promise<void>((r) => {
+    release = r;
+  });
+  const reason = "mcp connection name already in use";
+  refusing({ error: reason, field: "name" }, 409, held);
+  // Closed through the controller rather than by Escape: the dialog's own Cancel is disabled while
+  // the save is out, and Escape on a dirty form raises the discard prompt first. Both paths end at
+  // this call, which is the state the refusal has to answer into.
+  let close: () => void = () => {};
+  mount((c) => {
+    close = c;
+  });
+
+  return (async () => {
+    await fillAndSave("Servidor Gama", "https://mcp.example.com/sse");
+    act(() => close());
+    await waitFor(() => {
+      expect(screen.queryAllByRole("dialog").length).toBe(0);
+    });
+    release();
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(reason).length).toBeGreaterThan(0);
+    });
+    // On the screen the operator is looking at, not under a control that is gone.
+    expect(fieldShowing(reason)).toBeNull();
+  })();
 });

--- a/tests/client/field-refusal-forms.test.tsx
+++ b/tests/client/field-refusal-forms.test.tsx
@@ -1,0 +1,147 @@
+/// <reference lib="dom" />
+
+import { afterEach, expect, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useEffect, useRef } from "react";
+import { MemoryRouter } from "react-router";
+
+// THE REFUSAL THAT REACHES THE INPUT IT NAMES, ON THE FORMS THAT WRITE.
+//
+// #232 built the mechanism and wired one card as the reference. This file holds the sweep's own
+// proof, on the screen the defect was MEASURED on: creating a second MCP connection under a name
+// already taken answers 409 "mcp connection name already in use", and the modal answered "Could not
+// save (check the URL/command)" — the wrong input, named confidently (#329).
+//
+// Both halves are asserted, because the rule is that exactly one channel fires: the sentence lands
+// at the control the server named, and the form's own error line stays empty. A message rendered at
+// the input AND repeated in the banner is the noise that teaches people to stop reading either.
+
+const { McpEditModal } = await import("@/client/pages/resources/McpEditModal");
+const { ToastProvider, useModalController } = await import(
+  "@/client/components"
+);
+const { AuthProvider } = await import("@/client/contexts/AuthContext");
+const { ThemeProvider } = await import("@/client/contexts/ThemeContext");
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+});
+
+// Everything the tree needs to render answers 200; the one write under test answers the refusal.
+function refusing(body: { error: string; field?: string }, status = 409) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(
+      typeof input === "string" || input instanceof URL ? input : input.url,
+    );
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (method === "POST" && url.includes("/api/v1/mcp-connections")) {
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url.includes("/api/auth/me")) {
+      return new Response(
+        JSON.stringify({
+          user: { id: "1", email: "a@b.co", role: "TENANT_ADMIN", name: "A" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return new Response("{}", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+function OpenMcpModal() {
+  const modal = useModalController<{ id?: string }>();
+  const opened = useRef(false);
+  useEffect(() => {
+    if (opened.current) return;
+    opened.current = true;
+    modal.open({});
+  }, [modal]);
+  return (
+    <McpEditModal
+      modal={modal as unknown as Parameters<typeof McpEditModal>[0]["modal"]}
+    />
+  );
+}
+
+function mount() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <AuthProvider>
+          <ToastProvider>
+            <OpenMcpModal />
+          </ToastProvider>
+        </AuthProvider>
+      </ThemeProvider>
+    </MemoryRouter>,
+  );
+}
+
+async function fillAndSave(name: string, url: string) {
+  const nameBox = await screen.findByRole("textbox", { name: /name|nome/i });
+  fireEvent.change(nameBox, { target: { value: name } });
+  const urlBox = screen.getByRole("textbox", { name: /url/i });
+  fireEvent.change(urlBox, { target: { value: url } });
+  fireEvent.click(screen.getByRole("button", { name: /^(save|salvar)$/i }));
+}
+
+// The field the sentence was rendered INTO, by the input that shares its FormField. Asserting only
+// that the text is on screen somewhere passes with the sentence sitting in the banner, which is the
+// state this whole sweep is replacing.
+function fieldShowing(text: string): HTMLElement | null {
+  for (const node of screen.queryAllByText(text)) {
+    const field = node.closest("label, [role='group']");
+    const control = field?.querySelector("input, select, textarea");
+    if (control) return control as HTMLElement;
+  }
+  return null;
+}
+
+test("a name already taken marks the name input, not the URL", async () => {
+  const reason = "mcp connection name already in use";
+  refusing({ error: reason, field: "name" });
+  mount();
+  await fillAndSave("Servidor Alfa", "https://mcp.example.com/sse");
+
+  await waitFor(() => {
+    expect(fieldShowing(reason)).not.toBeNull();
+  });
+  // AT the name, and nowhere else: the control the sentence renders under is the one holding the
+  // value the server refused.
+  expect((fieldShowing(reason) as HTMLInputElement).value).toBe(
+    "Servidor Alfa",
+  );
+  // The sentence the operator was being sent to the wrong input by.
+  expect(
+    screen.queryAllByText(/check the URL\/command|URL\/comando/i).length,
+  ).toBe(0);
+});
+
+test("a refusal about no input at all still reaches the operator", async () => {
+  // The other direction: a refusal the form has no control for must not be swallowed by the
+  // mechanism that places the ones it does. Silence is what a scheme like this breaks first.
+  const reason = "this tenant cannot create more MCP connections";
+  refusing({ error: reason });
+  mount();
+  await fillAndSave("Servidor Beta", "https://mcp.example.com/sse");
+
+  await waitFor(() => {
+    expect(screen.queryAllByText(reason).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/client/field-refusal.test.ts
+++ b/tests/client/field-refusal.test.ts
@@ -158,6 +158,42 @@ describe("placeRefusal", () => {
       want: { at: "redirectUris", message: "not a URL", value: ["nope"] },
     },
     {
+      // All the way INSIDE the element, because that is how the schema names it when the elements
+      // are objects: `variants.0.weight` is asserted on the API side
+      // (tests/api/v1/write-body-required.test.ts), and business hours answers `windows.0.day`.
+      // Stopping at the index means every list of objects in the console — service windows, date
+      // exceptions, tool grants — still could not receive its own refusal.
+      name: "a field inside an element of a rendered list is that list",
+      refusal: { message: "must be a weekday", field: "windows.0.day" },
+      form: {
+        mounted: true,
+        sent: { windows: [{ day: 9 }] },
+        current: { windows: [{ day: 9 }] },
+      },
+      rendered: ["windows"],
+      want: {
+        at: "windows",
+        message: "must be a weekday",
+        value: [{ day: 9 }],
+      },
+    },
+    {
+      // Nested lists too: the exceptions of a schedule each hold their own ranges.
+      name: "a list inside an element of a rendered list is still that list",
+      refusal: { message: "bad time", field: "exceptions.0.ranges.1.start" },
+      form: {
+        mounted: true,
+        sent: { exceptions: [{ ranges: [{}, { start: "x" }] }] },
+        current: { exceptions: [{ ranges: [{}, { start: "x" }] }] },
+      },
+      rendered: ["exceptions"],
+      want: {
+        at: "exceptions",
+        message: "bad time",
+        value: [{ ranges: [{}, { start: "x" }] }],
+      },
+    },
+    {
       // And the index is the whole of the exception: a NAMED segment under a rendered list is a
       // different value, and the form has not said it draws it.
       name: "a named child of a rendered list is not that list",

--- a/tests/client/field-refusal.test.ts
+++ b/tests/client/field-refusal.test.ts
@@ -79,7 +79,12 @@ describe("readRefusal", () => {
 });
 
 describe("placeRefusal", () => {
-  const RENDERED = ["name", "document", "guardrails.output.templateMessage"];
+  const RENDERED = [
+    "name",
+    "document",
+    "guardrails.output.templateMessage",
+    "redirectUris",
+  ];
   const FALLBACK = "Could not save.";
 
   // A form that is on screen and whose inputs still hold exactly what the request carried: the
@@ -138,6 +143,26 @@ describe("placeRefusal", () => {
       name: "a parent of a rendered path is not a rendered path either",
       refusal: { message: "too long", field: "guardrails.output" },
       want: { toast: "too long" },
+    },
+    {
+      // The schema boundary refuses an array PER ELEMENT (`refused body.redirectUris.0`), and one
+      // control renders the whole list. Without this the array inputs of the console — redirect
+      // URIs, service windows, account ids, tool grants — could never receive their own refusal.
+      name: "an element of a rendered list is that list",
+      refusal: { message: "not a URL", field: "redirectUris.0" },
+      form: {
+        mounted: true,
+        sent: { redirectUris: ["nope"] },
+        current: { redirectUris: ["nope"] },
+      },
+      want: { at: "redirectUris", message: "not a URL", value: ["nope"] },
+    },
+    {
+      // And the index is the whole of the exception: a NAMED segment under a rendered list is a
+      // different value, and the form has not said it draws it.
+      name: "a named child of a rendered list is not that list",
+      refusal: { message: "not a URL", field: "redirectUris.first" },
+      want: { toast: "not a URL" },
     },
     {
       name: "a refusal about no input is a toast, in the server's words",

--- a/tests/client/hooks/useFieldRefusal.test.tsx
+++ b/tests/client/hooks/useFieldRefusal.test.tsx
@@ -1,0 +1,57 @@
+/// <reference lib="dom" />
+
+import { afterEach, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
+
+// WHETHER THE FORM IS ON SCREEN, WHICH IS NOT WHETHER THE COMPONENT IS MOUNTED.
+//
+// `placeRefusal` refuses to place a mark on a form that is gone, and the hook answered that question
+// with a mounted ref. For a page the two are the same. For a modal they are not: `useModalController`
+// keeps the wrapper mounted when the dialog closes, so a save still in flight came back to a live
+// component and a form nobody could see — the mark was written, `capture` reported "it is on the
+// control", and the banner stayed empty. Silence is the one outcome this mechanism must never reach.
+
+const FIELDS = ["name"] as const;
+const eden = (value: unknown) => ({ value });
+const REFUSAL = eden({ error: "name already in use", field: "name" });
+const FORM = { name: "Alfa" };
+
+afterEach(cleanup);
+
+test("a refusal about a rendered input lands on the control while the form shows", () => {
+  const { result } = renderHook(() => useFieldRefusal(FIELDS, true));
+  let toast: string | null = "unset";
+  act(() => {
+    toast = result.current.capture(REFUSAL, "Could not save.", FORM, FORM);
+  });
+  expect(toast).toBeNull();
+  expect(result.current.at("name", "Alfa")).toBe("name already in use");
+});
+
+test("the same refusal goes to the toast once the dialog has closed", () => {
+  const { result } = renderHook(() => useFieldRefusal(FIELDS, false));
+  let toast: string | null = "unset";
+  act(() => {
+    toast = result.current.capture(REFUSAL, "Could not save.", FORM, FORM);
+  });
+  // The server's own words, in the channel that is still on screen.
+  expect(toast).toBe("name already in use");
+  expect(result.current.at("name", "Alfa")).toBeNull();
+});
+
+test("the answer follows the dialog, not the render the request started in", () => {
+  // The whole reason it is a ref: the operator dismisses the modal DURING the save, so the value the
+  // handler closed over says "open" and the only true answer is the current one.
+  const { result, rerender } = renderHook(
+    ({ open }: { open: boolean }) => useFieldRefusal(FIELDS, open),
+    { initialProps: { open: true } },
+  );
+  const capture = result.current.capture;
+  rerender({ open: false });
+  let toast: string | null = "unset";
+  act(() => {
+    toast = capture(REFUSAL, "Could not save.", FORM, FORM);
+  });
+  expect(toast).toBe("name already in use");
+});

--- a/tests/client/hooks/useFieldRefusal.test.tsx
+++ b/tests/client/hooks/useFieldRefusal.test.tsx
@@ -6,17 +6,16 @@ import type { ReactNode } from "react";
 import { ToastProvider } from "@/client/components/Toast";
 import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 
-// WHETHER THE FORM IS ON SCREEN, WHICH IS NOT WHETHER THE COMPONENT IS MOUNTED.
+// WHAT THE FORM IS DRAWING, WHICH IS NOT WHAT IT CAN SEND.
 //
-// `placeRefusal` refuses to place a mark on a form that is gone, and the hook answered that question
-// with a mounted ref. For a page the two are the same. For a modal they are not: `useModalController`
-// keeps the wrapper mounted when the dialog closes, so a save still in flight came back to a live
-// component and a form nobody could see — the mark was written, `capture` reported "it is on the
-// control", and the banner stayed empty. Silence is the one outcome this mechanism must never reach.
+// `placeRefusal` refuses to put a mark where nobody is looking, and the hook answered that with a
+// mounted ref, then with a boolean for "the form is on screen". Both were approximations of the
+// question the caller can actually answer: is THIS name one the operator can see right now. The
+// list is per render, and a form that is not on screen renders nothing.
 //
-// And answering "put it in your other channel" was only half a fix, because for ten of the holders
-// here that channel is an error line INSIDE the dialog. So the hook raises the global toast itself
-// once the form is gone, which is what these tests read: the sentence on screen, not the return.
+// Answering "put it in your other channel" was only half of it, because for ten of the holders here
+// that channel is an error line INSIDE the dialog. So the hook raises the global toast itself once
+// nothing is drawn, which is what these tests read: the sentence on screen, not the return.
 
 const FIELDS = ["name"] as const;
 const eden = (value: unknown) => ({ value });
@@ -29,10 +28,8 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 
 afterEach(cleanup);
 
-test("a refusal about a rendered input lands on the control while the form shows", () => {
-  const { result } = renderHook(() => useFieldRefusal(FIELDS, true), {
-    wrapper,
-  });
+test("a refusal about a drawn input lands on the control", () => {
+  const { result } = renderHook(() => useFieldRefusal(FIELDS), { wrapper });
   let toast: string | null = "unset";
   act(() => {
     toast = result.current.capture(REFUSAL, "Could not save.", FORM, FORM);
@@ -43,10 +40,8 @@ test("a refusal about a rendered input lands on the control while the form shows
   expect(screen.queryAllByText("name already in use").length).toBe(0);
 });
 
-test("the same refusal is toasted once the dialog has closed", () => {
-  const { result } = renderHook(() => useFieldRefusal(FIELDS, false), {
-    wrapper,
-  });
+test("the same refusal is toasted once the form draws nothing", () => {
+  const { result } = renderHook(() => useFieldRefusal([]), { wrapper });
   let toast: string | null = "unset";
   act(() => {
     toast = result.current.capture(REFUSAL, "Could not save.", FORM, FORM);
@@ -58,11 +53,30 @@ test("the same refusal is toasted once the dialog has closed", () => {
   expect(screen.queryAllByText("name already in use").length).toBe(1);
 });
 
-test("the answer follows the dialog, not the render the request started in", () => {
-  // The whole reason it is a ref: the operator dismisses the modal DURING the save, so the value the
-  // handler closed over says "open" and the only true answer is the current one.
+test("a name the form has stopped drawing is toasted, not marked", () => {
+  // The half a single on-screen boolean could never answer: the form is right there, and this one
+  // control is not. The vault swaps its per-key inputs for a `.env` textarea, the setup screen draws
+  // its token box only where enforcement is on, the add-content dialog keeps its text box on one of
+  // two tabs. A mark on any of those is written and never rendered.
+  const { result } = renderHook(() => useFieldRefusal(["name"]), { wrapper });
+  let toast: string | null = "unset";
+  act(() => {
+    toast = result.current.capture(
+      eden({ error: "no surrounding whitespace", field: "public_key" }),
+      "Could not save.",
+      { public_key: " pk " },
+      { public_key: " pk " },
+    );
+  });
+  expect(toast).toBe("no surrounding whitespace");
+  expect(screen.queryAllByText("no surrounding whitespace").length).toBe(0);
+});
+
+test("the answer follows the render, not the one the request started in", () => {
+  // The whole reason it is a ref: the operator dismisses the modal DURING the save, so the list the
+  // handler closed over still names every input and the only true answer is the current one.
   const { result, rerender } = renderHook(
-    ({ open }: { open: boolean }) => useFieldRefusal(FIELDS, open),
+    ({ open }: { open: boolean }) => useFieldRefusal(open ? FIELDS : []),
     { initialProps: { open: true }, wrapper },
   );
   const capture = result.current.capture;
@@ -78,9 +92,7 @@ test("a caller that words the refusal itself keeps its turn", () => {
   // one — it names the affordance, disconnect first, which the server cannot know about. The hook
   // has no words of its own here, so raising an empty toast and reporting "told them" would be a
   // new silence in place of the old one.
-  const { result } = renderHook(() => useFieldRefusal(FIELDS, false), {
-    wrapper,
-  });
+  const { result } = renderHook(() => useFieldRefusal([]), { wrapper });
   let toast: string | null = "unset";
   act(() => {
     toast = result.current.capture({ value: {} }, "", FORM, FORM);

--- a/tests/client/hooks/useFieldRefusal.test.tsx
+++ b/tests/client/hooks/useFieldRefusal.test.tsx
@@ -1,7 +1,9 @@
 /// <reference lib="dom" />
 
 import { afterEach, expect, test } from "bun:test";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ToastProvider } from "@/client/components/Toast";
 import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 
 // WHETHER THE FORM IS ON SCREEN, WHICH IS NOT WHETHER THE COMPONENT IS MOUNTED.
@@ -11,33 +13,49 @@ import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 // keeps the wrapper mounted when the dialog closes, so a save still in flight came back to a live
 // component and a form nobody could see — the mark was written, `capture` reported "it is on the
 // control", and the banner stayed empty. Silence is the one outcome this mechanism must never reach.
+//
+// And answering "put it in your other channel" was only half a fix, because for ten of the holders
+// here that channel is an error line INSIDE the dialog. So the hook raises the global toast itself
+// once the form is gone, which is what these tests read: the sentence on screen, not the return.
 
 const FIELDS = ["name"] as const;
 const eden = (value: unknown) => ({ value });
 const REFUSAL = eden({ error: "name already in use", field: "name" });
 const FORM = { name: "Alfa" };
 
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ToastProvider>{children}</ToastProvider>
+);
+
 afterEach(cleanup);
 
 test("a refusal about a rendered input lands on the control while the form shows", () => {
-  const { result } = renderHook(() => useFieldRefusal(FIELDS, true));
+  const { result } = renderHook(() => useFieldRefusal(FIELDS, true), {
+    wrapper,
+  });
   let toast: string | null = "unset";
   act(() => {
     toast = result.current.capture(REFUSAL, "Could not save.", FORM, FORM);
   });
   expect(toast).toBeNull();
   expect(result.current.at("name", "Alfa")).toBe("name already in use");
+  // The other channel stays quiet: exactly one of the two fires.
+  expect(screen.queryAllByText("name already in use").length).toBe(0);
 });
 
-test("the same refusal goes to the toast once the dialog has closed", () => {
-  const { result } = renderHook(() => useFieldRefusal(FIELDS, false));
+test("the same refusal is toasted once the dialog has closed", () => {
+  const { result } = renderHook(() => useFieldRefusal(FIELDS, false), {
+    wrapper,
+  });
   let toast: string | null = "unset";
   act(() => {
     toast = result.current.capture(REFUSAL, "Could not save.", FORM, FORM);
   });
-  // The server's own words, in the channel that is still on screen.
-  expect(toast).toBe("name already in use");
+  // Nothing left for the caller to render — its error line is inside the dialog that just closed —
+  // and the server's own words on the screen the operator is actually looking at.
+  expect(toast).toBeNull();
   expect(result.current.at("name", "Alfa")).toBeNull();
+  expect(screen.queryAllByText("name already in use").length).toBe(1);
 });
 
 test("the answer follows the dialog, not the render the request started in", () => {
@@ -45,13 +63,28 @@ test("the answer follows the dialog, not the render the request started in", () 
   // handler closed over says "open" and the only true answer is the current one.
   const { result, rerender } = renderHook(
     ({ open }: { open: boolean }) => useFieldRefusal(FIELDS, open),
-    { initialProps: { open: true } },
+    { initialProps: { open: true }, wrapper },
   );
   const capture = result.current.capture;
   rerender({ open: false });
+  act(() => {
+    capture(REFUSAL, "Could not save.", FORM, FORM);
+  });
+  expect(screen.queryAllByText("name already in use").length).toBe(1);
+});
+
+test("a caller that words the refusal itself keeps its turn", () => {
+  // An empty fallback is how ChannelsPage says it has a better sentence than the server for this
+  // one — it names the affordance, disconnect first, which the server cannot know about. The hook
+  // has no words of its own here, so raising an empty toast and reporting "told them" would be a
+  // new silence in place of the old one.
+  const { result } = renderHook(() => useFieldRefusal(FIELDS, false), {
+    wrapper,
+  });
   let toast: string | null = "unset";
   act(() => {
-    toast = capture(REFUSAL, "Could not save.", FORM, FORM);
+    toast = result.current.capture({ value: {} }, "", FORM, FORM);
   });
-  expect(toast).toBe("name already in use");
+  expect(toast).toBe("");
+  expect(screen.queryAllByRole("status").length).toBe(0);
 });

--- a/tests/client/pages/KnowledgeDocsBlock.test.tsx
+++ b/tests/client/pages/KnowledgeDocsBlock.test.tsx
@@ -41,6 +41,9 @@ let docsCalls = 0;
 let reindexResponse: Record<string, unknown> = {};
 // What the add-a-text-document POST answers. Null means it is not being exercised.
 let addDocResponse: { status: number; body: unknown } | null = null;
+// Keeps the add-a-document answer in flight until a test lets it go, so the operator can move away
+// from the form while its own write is still out.
+let holdAddDoc: Promise<void> | null = null;
 let onKnowledgeDocument:
   | ((e: {
       knowledgeBaseId: string;
@@ -126,6 +129,7 @@ function installFetchStub() {
       return json(await nextDocs());
     }
     if (url.includes("/documents") && method === "POST" && addDocResponse) {
+      if (holdAddDoc) await holdAddDoc;
       return new Response(JSON.stringify(addDocResponse.body), {
         status: addDocResponse.status,
         headers: { "content-type": "application/json" },
@@ -756,6 +760,39 @@ describe("knowledge: a refusal the server phrased reaches the operator", () => {
     fireEvent.focus(chip);
     await waitFor(() => expect(shows(/Unsupported file type/i)).toBe(true));
     expect(shows(/whatever the API said/)).toBe(false);
+  });
+
+  // The dialog has two tabs and the text box belongs to one of them. The tabs stay live while the
+  // POST is out, so the operator can be looking at the file tab when the refusal lands — and a
+  // refusal naming `text` would then be marked onto a control that is not rendered, with `capture`
+  // reporting it placed and the toast staying quiet. Nothing on screen, on a dialog whose Add button
+  // had just spun.
+  test("a text refusal answered on the file tab still reaches the operator", async () => {
+    addDocResponse = null;
+    await openModal();
+    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    fireEvent.change(await screen.findByRole("textbox", { name: /text/i }), {
+      target: { value: "some text" },
+    });
+    // Held until the operator has moved to the other tab, which is the whole point.
+    let release: () => void = () => {};
+    holdAddDoc = new Promise<void>((r) => {
+      release = r;
+    });
+    addDocResponse = {
+      status: 400,
+      body: {
+        error: "text contains characters that cannot be stored (U+0000)",
+        field: "text",
+      },
+    };
+    const buttons = screen.getAllByRole("button", { name: /^add$/i });
+    fireEvent.click(buttons[buttons.length - 1] as HTMLElement);
+    fireEvent.click(screen.getByRole("tab", { name: /^file$/i }));
+    release();
+
+    await waitFor(() => expect(shows(/U\+0000/)).toBe(true));
+    holdAddDoc = null;
   });
 });
 

--- a/tests/client/pages/SetupPage.test.tsx
+++ b/tests/client/pages/SetupPage.test.tsx
@@ -48,27 +48,33 @@ mock.module("react-i18next", () => ({
 }));
 
 const { SetupPage } = await import("@/client/pages/SetupPage");
+const { ToastProvider } = await import("@/client/components/Toast");
 
 function LocationProbe() {
   const location = useLocation();
   return <div data-testid="location-search">{location.search}</div>;
 }
 
+// The provider is not decoration here: `useFieldRefusal` reaches for the global toast when the form
+// it is holding for has left the screen, so a holder outside a ToastProvider is one that cannot keep
+// its promise that exactly one channel fires. The app mounts every route inside one.
 function renderAt(path: string) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route
-          path="/setup"
-          element={
-            <>
-              <SetupPage />
-              <LocationProbe />
-            </>
-          }
-        />
-      </Routes>
-    </MemoryRouter>,
+    <ToastProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/setup"
+            element={
+              <>
+                <SetupPage />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
   );
 }
 

--- a/tests/client/pages/SetupPage.test.tsx
+++ b/tests/client/pages/SetupPage.test.tsx
@@ -1,7 +1,13 @@
 /// <reference lib="dom" />
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 
@@ -118,4 +124,54 @@ describe("SetupPage", () => {
       expect(screen.getByTestId("location-search").textContent).toBe("");
     });
   });
+});
+
+test("a refusal about the hidden setup token is read out, not swallowed", async () => {
+  // The token box is drawn only where enforcement is on, but a token captured from `?token=` is SENT
+  // either way, and the route caps it at 256 characters. Declaring `token` unconditionally put the
+  // server's sentence on a control this screen is not rendering, and `capture` — believing it had
+  // placed it — kept the toast quiet. The button just stopped doing anything.
+  authState.setupTokenRequired = false;
+  const realFetch = globalThis.fetch;
+  const reason = "The value sent in token is not valid.";
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(
+      typeof input === "string" || input instanceof URL ? input : input.url,
+    );
+    if (
+      (init?.method ?? "GET").toUpperCase() === "POST" &&
+      url.includes("/setup")
+    ) {
+      return new Response(JSON.stringify({ error: reason, field: "token" }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("{}", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    renderAt("/setup?token=abc123");
+    for (const [label, value] of [
+      ["Company name", "ACME"],
+      ["Name", "Ana"],
+      ["Email", "ana@acme.co"],
+      ["Password", "hunter2hunter2"],
+      ["Confirm Password", "hunter2hunter2"],
+    ] as const) {
+      fireEvent.change(screen.getByLabelText(label), { target: { value } });
+    }
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create admin account" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(reason).length).toBeGreaterThan(0);
+    });
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });

--- a/tests/modules/vault/ref-write-boundary.test.ts
+++ b/tests/modules/vault/ref-write-boundary.test.ts
@@ -88,11 +88,12 @@ const uniq = (p: string) => `${p}-${process.pid}-${++seq}`;
 interface Boundary {
   // What the operator sees in the API, so a failure names the field rather than the test row.
   field: string;
-  // The name the REFUSAL puts on the wire (#231/#245), when this boundary names one. Absent for the
-  // six columns of #124: the patch key the client sent already is the name, and extending #245's
-  // sweep to them is its own change. Asserted in both directions so "these were checked" cannot be
-  // read into a boundary that answers without one.
-  wireField?: string;
+  // The name the REFUSAL puts on the wire (#231/#245), and every boundary here names one. The six
+  // columns of #124 were the holdout, on the argument that "the patch key the client sent already is
+  // the name" — which is what the client SENT, not what the server REFUSED, and an integrations
+  // write carries two ref keys in one body. A refusal with no field is unplaceable by any form
+  // (#320), so `requireVaultRef` now takes the name as a required argument.
+  wireField: string;
   create: (ref: string) => Promise<bigint>;
   update: (id: bigint, ref: string) => Promise<unknown>;
   read: (id: bigint) => Promise<string | null>;
@@ -101,6 +102,7 @@ interface Boundary {
 const boundaries: Boundary[] = [
   {
     field: "integrationInstance.inboundSecretRef",
+    wireField: "inboundSecretRef",
     create: async (ref) =>
       (
         await createIntegrationInstance(
@@ -126,6 +128,7 @@ const boundaries: Boundary[] = [
   },
   {
     field: "integrationInstance.credentialRef",
+    wireField: "credentialRef",
     create: async (ref) =>
       (
         await createIntegrationInstance(
@@ -150,6 +153,7 @@ const boundaries: Boundary[] = [
   },
   {
     field: "toolDefinition.credentialRef",
+    wireField: "credentialRef",
     create: async (ref) => {
       const dto = await createToolDefinition(
         ctx(),
@@ -176,6 +180,7 @@ const boundaries: Boundary[] = [
   },
   {
     field: "mcpServerConnection.credentialRef",
+    wireField: "credentialRef",
     create: async (ref) => {
       const dto = await createMcpConnection(
         ctx(),
@@ -201,6 +206,7 @@ const boundaries: Boundary[] = [
   },
   {
     field: "alertChannel.secretRef",
+    wireField: "secretRef",
     create: async (ref) => {
       const dto = await createAlertChannel(
         ctx(),
@@ -226,6 +232,7 @@ const boundaries: Boundary[] = [
   },
   {
     field: "webhookSubscription.secretRef",
+    wireField: "secretRef",
     create: async (ref) => {
       const dto = await createWebhookSubscription(
         ctx(),
@@ -682,14 +689,12 @@ describe.skipIf(!dbUp)("vault ref write boundary", () => {
         expect(await b.read(id)).toBe(pendingRef);
       });
 
-      test("says which field it refused, or says nothing at all", async () => {
-        // The refusal is the only thing the console can key on: the sentence is localized and the
-        // agent keeps eight of these across three tabs, so without a name there is nothing to put
-        // the message next to. Both directions, so an entry that quietly stops naming one fails.
+      test("names the input it refused, by the server's own name for it", async () => {
+        // The name is the only thing the console can key on: the sentence is localized and the agent
+        // keeps eight of these across three tabs, so without one there is nothing to put the message
+        // next to. Asserted by VALUE, so a boundary that starts naming a different input fails too.
         const raised = await b.create("live-key").catch((e: unknown) => e);
-        expect((raised as { field?: string }).field).toBe(
-          b.wireField as string,
-        );
+        expect((raised as { field?: string }).field).toBe(b.wireField);
       });
 
       test("refuses a bare NAME and a dead ref on update too", async () => {


### PR DESCRIPTION
Fixes #320
Fixes #329

#231 put the refused field on the wire, #232 built the state that renders it at the control and wired one card as the reference, and #233 made every error toast show the sentence the server sent. What was left is where that sentence lands, and one place it still did not reach at all.

## What was broken

### A refusal about one input went to a banner, on every form but one

Counted on `main`: **24 components** render a form control and write it back, and exactly one — `CompanyProfileCard` — held the refusal. The other 23 sent it to a toast or to an error line at the top of the modal, which is far from the input and, on a form of sixteen fields, leaves the operator counting down to work out which one the server meant.

### A refusal rendered into local error state kept a fixed sentence (#329)

The sweep in #233 keyed on `showToast(…, "error")`, so a form that renders its own error line was invisible to it by construction. Re-measured here by rule rather than by grep, on `main`:

| shape | count |
| --- | --- |
| shows a FIXED sentence where the server sent one | **7** |
| reads the wire by hand, `(apiError.value as ApiErrorPayload)?.error \|\| …` | 12 |
| a boolean flag after a failed READ ("could not load this page") | 34 |

The 7 are the defect. The worst of them is the one #329 measured live: creating a second MCP connection under a name already taken answers `409 mcp connection name already in use`, and the modal said **"Could not save (check the URL/command)"** — the wrong input, named confidently. `tools.saveError` did the same with "check the name and URL", and `hours.saveError` said "check the timezone" for every refusal a business-hours write can answer, a duplicate name included.

### The server knew the field and did not say so, on 23 refusals

This is the half that makes the other two possible, and it is not something the console can fix.

`requireVaultRef` takes the name of the input a `vault:<id>` arrived in. **Eleven of its thirteen call sites omitted it**, while every one of them held the name: `data.credentialRef`, `params.inboundSecretRef`, `parsed.secretRef`. The argument for optional was that most callers "refuse a column the client already named in the patch it sent" — but what the client SENT and what the server REFUSED are different questions, which is the premise of #231. An integrations write carries `credentialRef` **and** `inboundSecretRef` in one body; a tool write carries `credentialRef` among sixteen keys.

`ConflictError` had the same shape: **nine** uniqueness refusals that name a column in their own sentence (`tenant slug already in use`, `mcp connection name already in use`, `vault entry name and type already in use`) sent no field. So did three hand-built `{ error: "Email already in use" }` bodies in the auth and admin controllers.

And one **shared** producer, found in the last review round: `refuseUnstorable` — reached by every document, approval and knowledge-base write — passed the field only in `translationParams`, which is what the locale template reads. Its body went out as `{ error }` alone, so the two names it refuses by, `title` and `text`, could not be placed on the boxes those forms draw. A call-site sweep does not find this one; only asking the wire does.

The fence in `tests/api/lib/refusal-callsites.test.ts` cannot see any of these: it reads the CODE of the arguments, and these refusals spell the name in prose.

## What this changes

**On the server**, the field becomes an argument the caller cannot forget: `requireVaultRef(db, ref, field)` takes it as a **required** parameter, so the compiler is the guard and the next call site is born naming its input. The nine conflicts, the three email bodies and `refuseUnstorable` name theirs. Measured over real HTTP against the running app, in pt-BR, same probe on both codes:

| refusal | before | after |
| --- | --- | --- |
| duplicate MCP name (409) | `{"error":"Este nome de conexão MCP já está em uso."}` | `{"error":"…","field":"name"}` |
| malformed `credentialRef` (400) | `{"error":"\"vault:nao-e-um-id\" não é uma referência do cofre…"}` | `{"error":"…","field":"credentialRef"}` |
| blank `name` (422, schema) | `{"error":"O valor enviado em name não é válido.","field":"name"}` | unchanged (#255 already named it) |

**On the client**, all 24 form components route their submit through `capture` and pass `error={refusal.at(name, value)}` to each control — 100 call sites. The refusal reaches exactly one channel: the input when the form draws it, the global toast when it does not.

The hook's argument is **what the form is drawing right now**, and getting there took the review loop four tries. It began as a constant list plus a boolean for "is the form on screen", and that boolean grew a new meaning every round: a dialog dismissed mid-save, then a tab left behind. It was always an approximation of the question `placeRefusal` actually asks — is THIS name one the operator can see — and too coarse for a form that hides some of its own controls. Eighteen controls in this tree are drawn behind a JSX guard; eight of them were declared as though they always were:

| field | drawn only when |
| --- | --- |
| `token` (setup) | `setupTokenRequired` |
| `publicKey` / `secretKey` / `value` (vault) | not pasting a `.env` |
| `baseUrl` (vault) | the kind supports it, and not pasting |
| `paramName` (vault) | the kind needs one |
| `text` / `title` (add content) | the text tab is showing |
| `secretRef` (alerts) | `type === "webhook"` |
| `inboundSecretRef` | auth is not `NONE` |
| `body` / `ackMessage` (tool) | the method writes / ack is on |
| `tenantId` (invite) | the inviter is a SUPER_ADMIN |
| `command` (MCP) | the transport is stdio |
| `name` (starter) | the naming step is showing |
| `brandColor` | the mode is SIMPLE |

Three more mechanism defects the wiring exposed, none visible before a real form was on the other end:

- **`placeRefusal` matched exactly, and the schema boundary refuses an array PER ELEMENT** — and, where the elements are objects, all the way inside: `variants.0.weight`, `windows.0.day`, `exceptions.0.ranges.1.start`. A numeric segment now resolves to the declared list and everything after it belongs to that element; a *named* segment still does not, because `guardrails` and `guardrails.output` are two different values.
- **The value comparison was reference identity.** A form rebuilds its request body every render, so an array or an object read twice is never `===`: every such field read as edited-during-the-request and went to the toast. `sameValue` compares structurally.
- **The "other channel" is inside the dialog for ten of the holders.** Handing a caller a sentence for a form the operator has dismissed only moves the silence one step: the mark used to be written where nobody looks, and the sentence would be. The hook raises the global toast itself once the form draws nothing — and only for a sentence it has, since an empty fallback is how `ChannelsPage` says it words a refusal better than the server does.

`CredentialForm`'s `mapSaveError` is gone. It answered its own localized sentence for a 409 on the premise that the server's arrives untranslated, and it does not: the server translates `errors.vaultNameInUse` for the request's Accept-Language, and its pt-BR sentence ("Já existe um segredo com esse nome e tipo") names the type as well, which the console copy did not.

## The guards

`tests/client/error-toast-reason.test.ts` now reads **both** channels — `showToast(…, "error")` and an error state a form renders itself — through one walker, so the shape that escaped #233 cannot escape again. It follows a sentence through a chain of names (`const held = e => refusal.capture(…)`, then `const toast = held(err)`), which is what a form with two failure branches writes.

`tests/client/field-refusal-fence.test.ts` is new. Each rule in it exists because a review round found the defect it now blocks:

| rule | what it blocks |
| --- | --- |
| `unheldWrites` | a form that writes and sends its refusal to a banner |
| `unheldBranches` | one wired branch answering for a handler, while the `catch` writes a fixed sentence |
| `silentDeclarations` | a name declared with no `at(…)` behind it — marked as placed, shown to nobody |
| `holdersBlindToTheScreen` | a bare constant list, which claims every field is drawn always |
| `guardedButUnconditional` | a control drawn behind a JSX guard the declaration does not mirror |
| `uncleanedHolders` | a dialog's holder outliving the session that produced it |
| `deadReadings` | an `at(…)` behind a `??` whose left operand is a `useState("")` and never falls through |
| `distrustedNulls` | a caller substituting its own sentence for the hook's "already told them" |
| `tautologicalStaleness` | `sent` and `current` handed the same snapshot |
| `halfUsedHolders` | a holder only read, or only captured |

Three of those rules first shipped in a form that asked about the FILE — does it have a dialog, a tab, an inline editor — and each version missed the shape the next round found. `guardedButUnconditional` is the one that states the question: one JSX conditional in the idiom this repo writes it in, with the expression carrying no parens or braces of its own. Run over the tree it named the eighteen guarded controls above, six of them declared unconditionally — two the review found and four it had not reached.

Every rule carries fixtures for the shapes it must and must not flag, so a scan that stops matching fails instead of passing empty. Three waiver ledgers are pinned by size **and** asserted in both directions, so an entry describing code that changed fails rather than going on waiving whatever replaced it.

## What of the report does not hold

#329 counted 22 sites setting an error state to a fixed sentence. Measured by rule, **7** show a fixed sentence; 12 of the remaining 15 already read the wire by hand and were a simplification rather than a defect, and the rest are boolean load flags after a failed READ, where "could not load this page" is the honest answer and there is no input to attach anything to.

## Validation scope

**Proved by test**
- 6132 tests pass on the whole tree.
- The fences above, each with fixtures, both re-run against the derived Free tree.
- DOM tests that mount the real components against a refusing server: `McpEditModal` (the sentence renders under the control holding the refused value, and the banner stays empty); the same modal dismissed mid-save (the sentence reaches the toast instead of a form that is gone); `SetupPage` with token enforcement off (a refusal about the hidden token is read out); `CredentialForm` in `.env` mode and across a type change; `KnowledgeApprovals` reopening an editor; the add-content dialog answered on the file tab.
- A wire test through the real app for `refuseUnstorable`, because the DOM tests for that path manufactured `field: "text"` in a fetch mock and the producer was never sending it.
- Every fix in the fourteen review rounds is killed by at least one mutation; the mutations are named in the round commits.

**Proved live**
- The wire table above: the app running locally, a seeded throwaway tenant, the same probe run against the code with and without the producer change, over HTTP with `Accept-Language: pt-BR`. The tenant was deleted afterwards.
- The browser half, on the real console in pt-BR: with `Servidor Alfa` already registered, saving a second one under that name renders "Este nome de conexão MCP já está em uso." **inside the Nome field** (it is also part of the input's accessible name, so a screen reader announces it), the modal footer stays empty, and the URL field carries no mark. The only console entry is the expected 409 — no unhandled rejection.

**Not validated**
- `AdminBrandingPage`, `CreateTenantModal`, `EditTenantModal` and the tenant-admin service are Pro-side files with no counterpart in this repo, so their wiring is not exercisable here.
- The **agent editor is partially held**: `name` and `systemPrompt`, the two values it renders a control for directly. Everything else it writes lives in a settings bag behind one of eight tabs, and placing one of those means also taking the operator to the tab that holds it. Split out as #349; the abstention is pinned in `PARTIALLY_HELD` so it costs an edit rather than passing as a clean scan.
- `guardedButUnconditional` asks that a declaration mention the STATE its guard turns on, not that the two conditions are equivalent. A declaration that names the right state under the wrong comparison would pass it.
- The gate on `KnowledgeApprovals`' editor is consistency with the model, not a reachable failure: Cancel is disabled while the PATCH is out, so that editor cannot close under its own save.
- No per-locale review of the sentences the server now sends where the console used to word its own.
