### PR TITLE
Refuse a test run whose database-backed half would silently skip

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,9 @@ DB_POOL_MAX=30
 # dev DB — it does destructive, unscoped ops (e.g. `DELETE FROM scheduler_jobs`) and creates/drops
 # tenants, which would wipe live dev data on every `bun test` if pointed at the dev DB. Provision
 # it once with `bun db:test:setup` (creates the DB, bootstraps the app role, runs migrations).
-# Unset both = the integration tests skip (e.g. CI without a database).
+# Unset both = the suite REFUSES to start, because every database-backed test would be skipped and
+# the run would still exit 0. To run the rest without a database on purpose, say so:
+# ALLOW_NO_DB=1 bun test (see tests/db-gate.ts).
 # - TEST_APP_DATABASE_URL: app-role (non-superuser) connection, exercises RLS.
 # - TEST_MIGRATION_DATABASE_URL: superuser connection for the suite's setup/teardown. tests/setup.ts
 #   redirects MIGRATION_DATABASE_URL to this at preload (guarding the name ends in `_test`), so the

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -44,4 +44,4 @@ Lives in a separate `langgraph` Postgres schema (outside Prisma). `thread_id` is
 
 ## Verifying isolation
 
-[`tests/lib/tenancy.integration.test.ts`](../tests/lib/tenancy.integration.test.ts) proves fail-closed, scoped reads, RLS overriding an explicit cross-tenant `WHERE`, blocked cross-tenant writes, and `asSuperAdmin` visibility against a real Postgres. It reads `TEST_APP_DATABASE_URL` (the app role) and skips when no DB is reachable.
+[`tests/lib/tenancy.integration.test.ts`](../tests/lib/tenancy.integration.test.ts) proves fail-closed, scoped reads, RLS overriding an explicit cross-tenant `WHERE`, blocked cross-tenant writes, and `asSuperAdmin` visibility against a real Postgres. It reads `TEST_APP_DATABASE_URL` (the app role) and skips when no DB is reachable, though the suite no longer starts at all in that state unless the run declares `ALLOW_NO_DB=1` (see [`tests/db-gate.ts`](../tests/db-gate.ts)).

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -71,6 +71,28 @@ function oneLine(err: unknown): string {
   return collapsed.length > 200 ? `${collapsed.slice(0, 200)}...` : collapsed;
 }
 
+// WHAT TO PROBE, AND WHAT TO CALL IT WHEN IT FAILS. The two are not the same string. The preload
+// DERIVES the URLs it hands the suite (`MIGRATION_DATABASE_URL` is overwritten from
+// TEST_MIGRATION_DATABASE_URL, and the app URL has its database name swapped in), so a refusal that
+// names the derived variable sends the reader to edit a value that is overwritten again on the next
+// run. The label is therefore always the variable a `.env` actually holds, while the probe still
+// runs against the derived URL, which is the one the guarded files will use.
+export function probeTargets(env: { [k: string]: string | undefined }): {
+  variable: string;
+  url: string;
+}[] {
+  return [
+    {
+      variable: "TEST_MIGRATION_DATABASE_URL",
+      url: env.MIGRATION_DATABASE_URL as string,
+    },
+    {
+      variable: "TEST_APP_DATABASE_URL",
+      url: env.TEST_APP_DATABASE_URL as string,
+    },
+  ];
+}
+
 // An endpoint that ACCEPTS the connection and then says nothing is not a slow database, it is a
 // refusal that never arrives: measured against a listener that accepts and stays silent, the preload
 // was still hanging at 45s with no output at all. A deadline is what keeps this a gate rather than a

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -1,0 +1,52 @@
+// WHY A RUN WITHOUT A DATABASE MUST NOT BE GREEN.
+//
+// 154 `describe` blocks in this suite are guarded by `describe.skipIf(!dbUp)`, and `dbUp` is a
+// CONNECTION ATTEMPT made by each file against TEST_MIGRATION_DATABASE_URL / TEST_APP_DATABASE_URL.
+// When those are unset or the database does not answer, every one of those blocks is skipped, the
+// run exits 0, and the line a reader checks says `0 fail`. Measured on one file, with the variable
+// pointed at a database that does not exist: `0 pass, 10 skip, 0 fail`, exit 0. Measured on a real
+// full-suite run in a tree where the variables were never set: `3839 pass, 2008 skip, 0 fail` out of
+// 5847 across 409 files, a third of the suite, silent (issue #351).
+//
+// The trigger is configuration, not carelessness: a fresh clone of this repository has no `.env`, so
+// the first suite run from one skips the DB-backed half and says nothing. The guard itself is right
+// (a contributor without a database has to be able to run the rest), so what this adds is the
+// distinction the guard never had: NO DATABASE AND THAT IS DELIBERATE, versus NO DATABASE AND NOBODY
+// NOTICED. The first is a flag someone sets once. The second is now a failure before the first test
+// runs, which is the only place it can still be read as one.
+//
+// PREVENTIVE, NOT A TALLY. Counting skips after the fact would report the same fact one run too
+// late, and against a number nobody reads; refusing to start names what is missing while the reader
+// is still looking at the command they typed.
+
+export const DB_GATE_OPT_OUT = "ALLOW_NO_DB";
+
+const HOW = [
+  `  - in a worktree: cp ../main/.env .env`,
+  `  - first time on this machine: bun run db:test:setup`,
+  `  - deliberately without a database: ${DB_GATE_OPT_OUT}=1 bun test`,
+].join("\n");
+
+// The half of the decision that needs no I/O, so it can be proved with fixtures rather than with a
+// database that has to be absent to test the absence.
+export function missingDbConfig(env: {
+  [k: string]: string | undefined;
+}): string | null {
+  if (env[DB_GATE_OPT_OUT] === "1") return null;
+  const missing = (
+    ["TEST_MIGRATION_DATABASE_URL", "TEST_APP_DATABASE_URL"] as const
+  ).filter((k) => !env[k]);
+  if (missing.length === 0) return null;
+  return [
+    `${missing.join(" and ")} ${missing.length === 1 ? "is" : "are"} not set, so every database-backed test in this suite would be SKIPPED and the run would still exit 0.`,
+    HOW,
+  ].join("\n");
+}
+
+export function unreachableDb(url: string, err: unknown): string {
+  return [
+    `the test database did not answer, so every database-backed test in this suite would be SKIPPED and the run would still exit 0.`,
+    `  ${new URL(url).pathname.replace(/^\//, "")}: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`,
+    HOW,
+  ].join("\n");
+}

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -1,7 +1,7 @@
 // WHY A RUN WITHOUT A DATABASE MUST NOT BE GREEN.
 //
-// 154 `describe` blocks in this suite are guarded by `describe.skipIf(!dbUp)`, and `dbUp` is a
-// CONNECTION ATTEMPT made by each file against TEST_MIGRATION_DATABASE_URL / TEST_APP_DATABASE_URL.
+// More than 150 `describe` blocks in this suite are guarded by `describe.skipIf(!dbUp)`, and `dbUp`
+// is a CONNECTION ATTEMPT each file makes against TEST_MIGRATION_DATABASE_URL / TEST_APP_DATABASE_URL.
 // When those are unset or the database does not answer, every one of those blocks is skipped, the
 // run exits 0, and the line a reader checks says `0 fail`. Measured on one file, with the variable
 // pointed at a database that does not exist: `0 pass, 10 skip, 0 fail`, exit 0. Measured on a real
@@ -43,10 +43,54 @@ export function missingDbConfig(env: {
   ].join("\n");
 }
 
-export function unreachableDb(url: string, err: unknown): string {
+// Named after the VARIABLE, not after the database: both connections point at the same database and
+// differ only in the role they authenticate as, so the database name alone cannot say which of the
+// two failed.
+export function unreachableDb(
+  variable: string,
+  url: string,
+  err: unknown,
+): string {
   return [
     `the test database did not answer, so every database-backed test in this suite would be SKIPPED and the run would still exit 0.`,
-    `  ${new URL(url).pathname.replace(/^\//, "")}: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`,
+    `  ${variable} (${new URL(url).pathname.replace(/^\//, "")}): ${oneLine(err)}`,
     HOW,
   ].join("\n");
+}
+
+// COLLAPSED, not truncated to the first line. Every driver error that matters here arrives as a
+// multi-line block whose FIRST line is empty: Prisma's is
+// "\nInvalid `prisma.$queryRaw()` invocation:\n\n\nRaw query failed. Code: `28P01`. Message: `...`",
+// so taking line one prints the variable, the database, and then nothing at all. Measured on the
+// four failures a reader actually hits (bad password, closed port, unknown host, missing database),
+// none of which echo the connection string, so no credential travels in here.
+function oneLine(err: unknown): string {
+  const collapsed = (err instanceof Error ? err.message : String(err))
+    .replace(/\s+/g, " ")
+    .trim();
+  return collapsed.length > 200 ? `${collapsed.slice(0, 200)}...` : collapsed;
+}
+
+// An endpoint that ACCEPTS the connection and then says nothing is not a slow database, it is a
+// refusal that never arrives: measured against a listener that accepts and stays silent, the preload
+// was still hanging at 45s with no output at all. A deadline is what keeps this a gate rather than a
+// second way to stall. 10s is far above a `SELECT 1` on a loaded machine and far below any OS-level
+// socket timeout, which is the wait it replaces.
+export const PROBE_DEADLINE_MS = 10_000;
+
+export function withDeadline<T>(
+  work: Promise<T>,
+  ms: number,
+  what: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    work,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`${what} did not answer within ${ms / 1000}s`)),
+        ms,
+      );
+    }),
+  ]).finally(() => clearTimeout(timer));
 }

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -107,6 +107,20 @@ export function probeTargets(env: { [k: string]: string | undefined }): {
 // socket timeout, which is the wait it replaces.
 export const PROBE_DEADLINE_MS = 10_000;
 
+// The driver's own limits, which is what actually CANCELS the work. `Promise.race` alone stops the
+// waiting without stopping the query, leaving a client checked out of the pool. These two cover the
+// two phases (handshake, then query); the race below stays as the backstop for anything they do not
+// honour, and is given headroom so the driver's own error is the one a reader sees.
+export function probePoolConfig(url: string) {
+  return {
+    connectionString: url,
+    connectionTimeoutMillis: PROBE_DEADLINE_MS,
+    query_timeout: PROBE_DEADLINE_MS,
+  };
+}
+
+export const PROBE_BACKSTOP_MS = PROBE_DEADLINE_MS + 2_000;
+
 export function withDeadline<T>(
   work: Promise<T>,
   ms: number,

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -21,12 +21,15 @@
 
 export const DB_GATE_OPT_OUT = "ALLOW_NO_DB";
 
-// Every line here has to be runnable FROM THE STATE THAT PRINTED IT. `bun run db:test:setup` on its
-// own is not: it reads the same two variables this gate just found missing, so on a fresh clone it
-// fails at its own first check. The order below is the one a fresh clone actually needs, measured by
-// following it from a clone with no `.env`.
+// Every line here has to be runnable FROM THE STATE THAT PRINTED IT, as one paste. `bun run
+// db:test:setup` on its own is not: it reads the same two variables this gate just found missing, so
+// on a fresh clone it fails at its own first check. `--wait` is not decoration either: plain
+// `up -d` returns when the container STARTS, and the setup script connects with no retry, so the
+// chained command loses the race against a cold Postgres (measured, `read ECONNRESET`). The whole
+// line was run from a clone with no `.env`, against a cold container, and ends with a suite that
+// runs.
 const HOW = [
-  `  - fresh clone: cp .env.example .env && docker compose up -d && bun run db:test:setup`,
+  `  - fresh clone: cp .env.example .env && docker compose up -d --wait && bun run db:test:setup`,
   `  - in a worktree, with the database already up: cp ../main/.env .env`,
   `  - deliberately without a database: ${DB_GATE_OPT_OUT}=1 bun test`,
 ].join("\n");

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -21,9 +21,13 @@
 
 export const DB_GATE_OPT_OUT = "ALLOW_NO_DB";
 
+// Every line here has to be runnable FROM THE STATE THAT PRINTED IT. `bun run db:test:setup` on its
+// own is not: it reads the same two variables this gate just found missing, so on a fresh clone it
+// fails at its own first check. The order below is the one a fresh clone actually needs, measured by
+// following it from a clone with no `.env`.
 const HOW = [
-  `  - in a worktree: cp ../main/.env .env`,
-  `  - first time on this machine: bun run db:test:setup`,
+  `  - fresh clone: cp .env.example .env && docker compose up -d && bun run db:test:setup`,
+  `  - in a worktree, with the database already up: cp ../main/.env .env`,
   `  - deliberately without a database: ${DB_GATE_OPT_OUT}=1 bun test`,
 ].join("\n");
 

--- a/tests/lib/db-gate.test.ts
+++ b/tests/lib/db-gate.test.ts
@@ -151,12 +151,12 @@ describe("what the probe is called when it fails", () => {
   // The label is not the value: the migration probe must still run against the DERIVED URL, which
   // is the one the guarded files connect with.
   test("the migration probe is labelled by its source and runs on the derived URL", () => {
-    const [migration] = probeTargets({
+    const migration = probeTargets({
       ...derived,
       MIGRATION_DATABASE_URL: "postgresql://su@localhost/derived_test",
-    });
-    expect(migration.variable).toBe("TEST_MIGRATION_DATABASE_URL");
-    expect(migration.url).toContain("derived_test");
+    }).find((t) => t.variable === "TEST_MIGRATION_DATABASE_URL");
+    expect(migration).toBeDefined();
+    expect(migration?.url).toContain("derived_test");
   });
 });
 

--- a/tests/lib/db-gate.test.ts
+++ b/tests/lib/db-gate.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   DB_GATE_OPT_OUT,
   missingDbConfig,
+  PROBE_BACKSTOP_MS,
+  PROBE_DEADLINE_MS,
+  probePoolConfig,
   probeTargets,
   unreachableDb,
   withDeadline,
@@ -157,6 +160,22 @@ describe("what the probe is called when it fails", () => {
     }).find((t) => t.variable === "TEST_MIGRATION_DATABASE_URL");
     expect(migration).toBeDefined();
     expect(migration?.url).toContain("derived_test");
+  });
+});
+
+// Racing a promise stops the WAITING, not the work: the query keeps a client checked out of the
+// pool. The driver's own limits are what cancel it, so they have to actually be passed, and the
+// outer backstop has to sit above them or it fires first and the cancellation never happens.
+describe("what cancels a probe that will not answer", () => {
+  test("the driver is given both limits, not just a connection string", () => {
+    const config = probePoolConfig("postgresql://u@localhost/x_test");
+    expect(config.connectionString).toContain("x_test");
+    expect(config.connectionTimeoutMillis).toBe(PROBE_DEADLINE_MS);
+    expect(config.query_timeout).toBe(PROBE_DEADLINE_MS);
+  });
+
+  test("the backstop leaves the driver room to speak first", () => {
+    expect(PROBE_BACKSTOP_MS).toBeGreaterThan(PROBE_DEADLINE_MS);
   });
 });
 

--- a/tests/lib/db-gate.test.ts
+++ b/tests/lib/db-gate.test.ts
@@ -185,9 +185,13 @@ describe("the gate, as a run", () => {
   const appUrl = process.env.TEST_APP_DATABASE_URL as string;
 
   async function run(env: Record<string, string>) {
+    // The opt-out is stripped from the INHERITED environment and only ever set by a caller that
+    // means it. Otherwise a parent run started with ALLOW_NO_DB=1 would hand it to every child,
+    // and the refusal these tests are watching for would never happen.
+    const { [DB_GATE_OPT_OUT]: _optOut, ...inherited } = process.env;
     const proc = Bun.spawn(["bun", "test", noop], {
       cwd: repoRoot,
-      env: { ...process.env, ...env },
+      env: { ...inherited, ...env },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -199,18 +203,25 @@ describe("the gate, as a run", () => {
     return { code, output: `${out}\n${err}` };
   }
 
-  test("an app role that cannot log in stops the run, even with a healthy migration role", async () => {
-    const broken = new URL(appUrl);
-    broken.username = "no_such_role_351";
-    broken.password = "no_such_password";
-    const { code, output } = await run({
-      TEST_MIGRATION_DATABASE_URL: suUrl,
-      TEST_APP_DATABASE_URL: broken.toString(),
-    });
-    expect(code).not.toBe(0);
-    expect(output).toContain("TEST_APP_DATABASE_URL");
-    expect(output).toContain("would still exit 0");
-  }, 60_000);
+  // The one test here that needs a live database, so it is guarded like every other one in this
+  // suite. Under ALLOW_NO_DB=1 there is no app URL to break, and a run that DECLARED it has no
+  // database is exactly the run this may be silent in.
+  test.skipIf(process.env[DB_GATE_OPT_OUT] === "1")(
+    "an app role that cannot log in stops the run, even with a healthy migration role",
+    async () => {
+      const broken = new URL(appUrl);
+      broken.username = "no_such_role_351";
+      broken.password = "no_such_password";
+      const { code, output } = await run({
+        TEST_MIGRATION_DATABASE_URL: suUrl,
+        TEST_APP_DATABASE_URL: broken.toString(),
+      });
+      expect(code).not.toBe(0);
+      expect(output).toContain("TEST_APP_DATABASE_URL");
+      expect(output).toContain("would still exit 0");
+    },
+    60_000,
+  );
 
   test("the opt-out disarms the probe too, not only the variable check", async () => {
     const { code, output } = await run({

--- a/tests/lib/db-gate.test.ts
+++ b/tests/lib/db-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DB_GATE_OPT_OUT,
   missingDbConfig,
+  probeTargets,
   unreachableDb,
   withDeadline,
 } from "../db-gate";
@@ -128,6 +129,34 @@ describe("the database gate's decision", () => {
       expect(msg).toContain("db:test:setup");
       expect(msg).toContain(DB_GATE_OPT_OUT);
     }
+  });
+});
+
+// A refusal that names a variable the reader cannot change is a refusal they cannot act on: the
+// preload OVERWRITES `MIGRATION_DATABASE_URL` from `TEST_MIGRATION_DATABASE_URL` on every run, so
+// editing the former in a `.env` changes nothing and the same error comes back.
+describe("what the probe is called when it fails", () => {
+  const derived = {
+    TEST_MIGRATION_DATABASE_URL: "postgresql://su@localhost/x_test",
+    MIGRATION_DATABASE_URL: "postgresql://su@localhost/x_test",
+    TEST_APP_DATABASE_URL: "postgresql://app@localhost/x_test",
+  };
+
+  test("every label is a variable a .env actually holds", () => {
+    for (const { variable } of probeTargets(derived)) {
+      expect(variable.startsWith("TEST_")).toBe(true);
+    }
+  });
+
+  // The label is not the value: the migration probe must still run against the DERIVED URL, which
+  // is the one the guarded files connect with.
+  test("the migration probe is labelled by its source and runs on the derived URL", () => {
+    const [migration] = probeTargets({
+      ...derived,
+      MIGRATION_DATABASE_URL: "postgresql://su@localhost/derived_test",
+    });
+    expect(migration.variable).toBe("TEST_MIGRATION_DATABASE_URL");
+    expect(migration.url).toContain("derived_test");
   });
 });
 

--- a/tests/lib/db-gate.test.ts
+++ b/tests/lib/db-gate.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { DB_GATE_OPT_OUT, missingDbConfig, unreachableDb } from "../db-gate";
+import {
+  DB_GATE_OPT_OUT,
+  missingDbConfig,
+  unreachableDb,
+  withDeadline,
+} from "../db-gate";
 
 // The gate itself runs at PRELOAD, before any test file, which is the one place it can refuse a run
 // instead of reporting on one. That also puts it out of reach of a test: by the time this file
@@ -54,29 +59,169 @@ describe("the database gate's decision", () => {
     expect(missingDbConfig({})).toContain("would still exit 0");
     expect(
       unreachableDb(
+        "MIGRATION_DATABASE_URL",
         "postgresql://u@localhost/x_test",
         new Error("ECONNREFUSED"),
       ),
     ).toContain("would still exit 0");
   });
 
-  test("an unreachable database is named, with the driver's first line", () => {
+  // The exact shape Prisma produces, measured: the message OPENS with a newline, so a first-line
+  // trim prints the variable and the database and then stops, which is the one thing a reader
+  // cannot act on.
+  test("the driver's reason survives, on one line", () => {
     const msg = unreachableDb(
+      "TEST_APP_DATABASE_URL",
       "postgresql://u@localhost/secretaria_v4_test",
-      new Error('database "secretaria_v4_test" does not exist\n  at pg'),
+      new Error(
+        '\nInvalid `prisma.$queryRaw()` invocation:\n\n\nRaw query failed. Code: `28P01`. Message: `password authentication failed for user "fazerai_app"`',
+      ),
     );
-    expect(msg).toContain("secretaria_v4_test");
-    expect(msg).toContain("does not exist");
-    expect(msg).not.toContain("  at pg");
+    const line = msg
+      .split("\n")
+      .find((l) => l.includes("TEST_APP_DATABASE_URL")) as string;
+    expect(line).toContain("password authentication failed");
+    expect(line).toContain("secretaria_v4_test");
+  });
+
+  test("a long driver error does not run away with the output", () => {
+    const line = unreachableDb(
+      "MIGRATION_DATABASE_URL",
+      "postgresql://u@localhost/x_test",
+      new Error("x".repeat(5_000)),
+    )
+      .split("\n")
+      .find((l) => l.includes("MIGRATION_DATABASE_URL")) as string;
+    expect(line.length).toBeLessThan(300);
+    expect(line).toContain("...");
+  });
+
+  // The two connections point at the SAME database under different roles, so the database name says
+  // nothing about which one failed. Only the variable does, and it is the variable a reader has to
+  // go and fix.
+  test("the refusal names which of the two connections failed", () => {
+    expect(
+      unreachableDb(
+        "TEST_APP_DATABASE_URL",
+        "postgresql://u@localhost/secretaria_v4_test",
+        new Error('role "fazerai_app" does not exist'),
+      ),
+    ).toContain("TEST_APP_DATABASE_URL");
+    expect(
+      unreachableDb(
+        "MIGRATION_DATABASE_URL",
+        "postgresql://u@localhost/secretaria_v4_test",
+        new Error("ECONNREFUSED"),
+      ),
+    ).not.toContain("TEST_APP_DATABASE_URL");
   });
 
   test("every refusal says how to fix it", () => {
     for (const msg of [
       missingDbConfig({}) ?? "",
-      unreachableDb("postgresql://u@localhost/x_test", new Error("boom")),
+      unreachableDb(
+        "MIGRATION_DATABASE_URL",
+        "postgresql://u@localhost/x_test",
+        new Error("boom"),
+      ),
     ]) {
       expect(msg).toContain("db:test:setup");
       expect(msg).toContain(DB_GATE_OPT_OUT);
     }
   });
+});
+
+// An endpoint that accepts the connection and then never answers is the case the deadline exists
+// for: measured against a listener that accepts and stays silent, the preload was still hanging at
+// 45s. A gate that stalls instead of refusing is not a gate.
+describe("the probe's deadline", () => {
+  test("a promise that never settles is rejected, naming what did not answer", async () => {
+    const never = new Promise<never>(() => {});
+    await expect(
+      withDeadline(never, 20, "TEST_APP_DATABASE_URL"),
+    ).rejects.toThrow("TEST_APP_DATABASE_URL did not answer within 0.02s");
+  });
+
+  test("an answer inside the deadline passes through, value and all", async () => {
+    await expect(
+      withDeadline(Promise.resolve("pong"), 5_000, "MIGRATION_DATABASE_URL"),
+    ).resolves.toBe("pong");
+  });
+
+  // The timer has to be cleared on the winning path too: a pending timeout keeps the event loop
+  // alive, so a probe that answered would still hold the run open for the whole deadline. Measured
+  // from the outside, because a leaked timer is invisible to the process holding it (Bun's
+  // `process.getActiveResourcesInfo` returns an empty list, so asserting on it proves nothing).
+  test("the timer does not outlive a settled probe", async () => {
+    const module = new URL("../db-gate.ts", import.meta.url).pathname;
+    const started = Date.now();
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "-e",
+        `const { withDeadline } = await import(${JSON.stringify(module)});
+         await withDeadline(Promise.resolve(1), 30_000, "MIGRATION_DATABASE_URL");`,
+      ],
+      { stdout: "ignore", stderr: "pipe" },
+    );
+    const code = await proc.exited;
+    expect(code).toBe(0);
+    // Without the clearTimeout this process stays alive for the full 30s deadline.
+    expect(Date.now() - started).toBeLessThan(10_000);
+  });
+});
+
+// The gate itself is a PRELOAD, so the two tests above it prove the decision and these two prove
+// the thing that actually ships: a real `bun test` invocation, with a real broken environment,
+// refusing to run. This is where the app-role half was missing, and a unit test could not have
+// caught it, because the shape of the bug was "the preload asks a different question than the
+// guarded files do".
+describe("the gate, as a run", () => {
+  const noop = new URL("../utils/db-gate-noop.ts", import.meta.url).pathname;
+  const repoRoot = new URL("../..", import.meta.url).pathname;
+
+  // Both URLs are the ones this very run is using, which the gate above already proved reachable.
+  const suUrl = process.env.MIGRATION_DATABASE_URL as string;
+  const appUrl = process.env.TEST_APP_DATABASE_URL as string;
+
+  async function run(env: Record<string, string>) {
+    const proc = Bun.spawn(["bun", "test", noop], {
+      cwd: repoRoot,
+      env: { ...process.env, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [code, err, out] = await Promise.all([
+      proc.exited,
+      new Response(proc.stderr).text(),
+      new Response(proc.stdout).text(),
+    ]);
+    return { code, output: `${out}\n${err}` };
+  }
+
+  test("an app role that cannot log in stops the run, even with a healthy migration role", async () => {
+    const broken = new URL(appUrl);
+    broken.username = "no_such_role_351";
+    broken.password = "no_such_password";
+    const { code, output } = await run({
+      TEST_MIGRATION_DATABASE_URL: suUrl,
+      TEST_APP_DATABASE_URL: broken.toString(),
+    });
+    expect(code).not.toBe(0);
+    expect(output).toContain("TEST_APP_DATABASE_URL");
+    expect(output).toContain("would still exit 0");
+  }, 60_000);
+
+  test("the opt-out disarms the probe too, not only the variable check", async () => {
+    const { code, output } = await run({
+      [DB_GATE_OPT_OUT]: "1",
+      TEST_MIGRATION_DATABASE_URL: "postgresql://u:p@127.0.0.1:1/nothing_test",
+      TEST_APP_DATABASE_URL: "postgresql://u:p@127.0.0.1:1/nothing_test",
+    });
+    expect(code).toBe(0);
+    // The run got past the preload and executed the noop file, which is the whole claim: the
+    // opt-out has to skip the PROBE, not merely the variable check that precedes it.
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+  }, 60_000);
 });

--- a/tests/lib/db-gate.test.ts
+++ b/tests/lib/db-gate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { DB_GATE_OPT_OUT, missingDbConfig, unreachableDb } from "../db-gate";
+
+// The gate itself runs at PRELOAD, before any test file, which is the one place it can refuse a run
+// instead of reporting on one. That also puts it out of reach of a test: by the time this file
+// executes, the gate has already passed. So the DECISION is a pure function and this proves it with
+// fixtures, in both directions: a fence with no offender left passes over an empty set just as
+// happily as over a correct one (issue #351).
+
+describe("the database gate's decision", () => {
+  const configured = {
+    TEST_MIGRATION_DATABASE_URL: "postgresql://u@localhost/x_test",
+    TEST_APP_DATABASE_URL: "postgresql://a@localhost/x_test",
+  };
+
+  test("a configured run is not stopped", () => {
+    expect(missingDbConfig(configured)).toBeNull();
+  });
+
+  test("each missing variable is named, and both when both are gone", () => {
+    const noSu = missingDbConfig({
+      TEST_APP_DATABASE_URL: configured.TEST_APP_DATABASE_URL,
+    });
+    expect(noSu).toContain("TEST_MIGRATION_DATABASE_URL");
+    expect(noSu).not.toContain("TEST_APP_DATABASE_URL is");
+    const noApp = missingDbConfig({
+      TEST_MIGRATION_DATABASE_URL: configured.TEST_MIGRATION_DATABASE_URL,
+    });
+    expect(noApp).toContain("TEST_APP_DATABASE_URL");
+    expect(missingDbConfig({})).toContain(
+      "TEST_MIGRATION_DATABASE_URL and TEST_APP_DATABASE_URL",
+    );
+  });
+
+  // An EMPTY string is the shape a shell hands over when someone clears the variable, and it is not
+  // the same falsy as absent for every predicate one could write here.
+  test("an empty variable counts as missing", () => {
+    expect(
+      missingDbConfig({ ...configured, TEST_MIGRATION_DATABASE_URL: "" }),
+    ).toContain("TEST_MIGRATION_DATABASE_URL");
+  });
+
+  test("the opt-out is what makes a deliberate run without a database silent", () => {
+    expect(missingDbConfig({ [DB_GATE_OPT_OUT]: "1" })).toBeNull();
+    // Only the exact value. A variable left at "0" or "false" by a shell profile is not a decision
+    // anyone made about this run.
+    expect(missingDbConfig({ [DB_GATE_OPT_OUT]: "0" })).not.toBeNull();
+    expect(missingDbConfig({ [DB_GATE_OPT_OUT]: "true" })).not.toBeNull();
+  });
+
+  // Every message says the same thing, because it is the thing a reader would otherwise not learn:
+  // the run would have been GREEN.
+  test("both refusals say that the run would have exited 0", () => {
+    expect(missingDbConfig({})).toContain("would still exit 0");
+    expect(
+      unreachableDb(
+        "postgresql://u@localhost/x_test",
+        new Error("ECONNREFUSED"),
+      ),
+    ).toContain("would still exit 0");
+  });
+
+  test("an unreachable database is named, with the driver's first line", () => {
+    const msg = unreachableDb(
+      "postgresql://u@localhost/secretaria_v4_test",
+      new Error('database "secretaria_v4_test" does not exist\n  at pg'),
+    );
+    expect(msg).toContain("secretaria_v4_test");
+    expect(msg).toContain("does not exist");
+    expect(msg).not.toContain("  at pg");
+  });
+
+  test("every refusal says how to fix it", () => {
+    for (const msg of [
+      missingDbConfig({}) ?? "",
+      unreachableDb("postgresql://u@localhost/x_test", new Error("boom")),
+    ]) {
+      expect(msg).toContain("db:test:setup");
+      expect(msg).toContain(DB_GATE_OPT_OUT);
+    }
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,13 @@
 import "@testing-library/jest-dom";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
-import { DB_GATE_OPT_OUT, missingDbConfig, unreachableDb } from "./db-gate";
+import {
+  DB_GATE_OPT_OUT,
+  missingDbConfig,
+  PROBE_DEADLINE_MS,
+  unreachableDb,
+  withDeadline,
+} from "./db-gate";
 
 // NOTE: happy-dom registration and the Bun-native global capture live in
 // ./dom-setup.ts, which bunfig.toml preloads BEFORE this file. The DOM must
@@ -52,19 +58,34 @@ if (testSuUrl) {
 const missing = missingDbConfig(process.env);
 if (missing) throw new Error(`tests: ${missing}`);
 if (process.env[DB_GATE_OPT_OUT] !== "1") {
-  const probeUrl = process.env.MIGRATION_DATABASE_URL as string;
-  const probe = new PrismaClient({
-    adapter: new PrismaPg({ connectionString: probeUrl }),
-  });
-  try {
-    // The same question every guarded file asks, asked once and early. Asked of the MIGRATION role:
-    // it is the one that creates and drops the fixtures, so a database that answers it answers for
-    // the app role too (they share a host and differ only in privilege).
-    await probe.$queryRaw`SELECT 1`;
-  } catch (err) {
-    throw new Error(`tests: ${unreachableDb(probeUrl, err)}`);
-  } finally {
-    await probe.$disconnect();
+  // BOTH connections, because both are what a guarded file asks for. Every `describe.skipIf(!dbUp)`
+  // block sits behind a `SELECT 1` on the migration role AND one on the app role, and the two
+  // authenticate as different roles with different credentials. Probing only the first passes a run
+  // whose app role cannot log in, which skips the same blocks just as silently: measured with a
+  // valid migration URL and a nonexistent app role, one file reported `6 pass, 14 skip, 0 fail`,
+  // exit 0. The URLs read here are the ones forced above, so this asks the question in exactly the
+  // shape the guarded files will ask it.
+  for (const variable of [
+    "MIGRATION_DATABASE_URL",
+    "TEST_APP_DATABASE_URL",
+  ] as const) {
+    const url = process.env[variable] as string;
+    const probe = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: url }),
+    });
+    try {
+      await withDeadline(
+        probe.$queryRaw`SELECT 1`,
+        PROBE_DEADLINE_MS,
+        variable,
+      );
+      await probe.$disconnect();
+    } catch (err) {
+      // Not awaited: the connection this is trying to close is the one that just failed to answer,
+      // and waiting on it is the stall the deadline above exists to end.
+      void probe.$disconnect().catch(() => {});
+      throw new Error(`tests: ${unreachableDb(variable, url, err)}`);
+    }
   }
 }
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,6 +5,7 @@ import {
   DB_GATE_OPT_OUT,
   missingDbConfig,
   PROBE_DEADLINE_MS,
+  probeTargets,
   unreachableDb,
   withDeadline,
 } from "./db-gate";
@@ -65,11 +66,7 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
   // valid migration URL and a nonexistent app role, one file reported `6 pass, 14 skip, 0 fail`,
   // exit 0. The URLs read here are the ones forced above, so this asks the question in exactly the
   // shape the guarded files will ask it.
-  for (const variable of [
-    "MIGRATION_DATABASE_URL",
-    "TEST_APP_DATABASE_URL",
-  ] as const) {
-    const url = process.env[variable] as string;
+  for (const { variable, url } of probeTargets(process.env)) {
     const probe = new PrismaClient({
       adapter: new PrismaPg({ connectionString: url }),
     });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,7 @@
 import "@testing-library/jest-dom";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { DB_GATE_OPT_OUT, missingDbConfig, unreachableDb } from "./db-gate";
 
 // NOTE: happy-dom registration and the Bun-native global capture live in
 // ./dom-setup.ts, which bunfig.toml preloads BEFORE this file. The DOM must
@@ -43,6 +46,28 @@ if (testSuUrl) {
     process.env.LANGGRAPH_DATABASE_URL = appUrl.toString();
   }
 }
+// THE GATE. Everything above points the suite at the test database; this refuses to start when
+// there is nothing at the other end, because a suite that skips its database-backed half exits 0 and
+// reads as green. The reasoning, the measurements and the opt-out live in ./db-gate.ts.
+const missing = missingDbConfig(process.env);
+if (missing) throw new Error(`tests: ${missing}`);
+if (process.env[DB_GATE_OPT_OUT] !== "1") {
+  const probeUrl = process.env.MIGRATION_DATABASE_URL as string;
+  const probe = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: probeUrl }),
+  });
+  try {
+    // The same question every guarded file asks, asked once and early. Asked of the MIGRATION role:
+    // it is the one that creates and drops the fixtures, so a database that answers it answers for
+    // the app role too (they share a host and differ only in privilege).
+    await probe.$queryRaw`SELECT 1`;
+  } catch (err) {
+    throw new Error(`tests: ${unreachableDb(probeUrl, err)}`);
+  } finally {
+    await probe.$disconnect();
+  }
+}
+
 process.env.JWT_SECRET = "test-secret-key-for-testing-only";
 // NOTE: Force a deterministic Google client id so the auth controller registers
 // `/auth/google` regardless of the developer's local `.env` and so tests can

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,10 +1,9 @@
 import "@testing-library/jest-dom";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { PrismaClient } from "@/../generated/prisma/client";
 import {
   DB_GATE_OPT_OUT,
   missingDbConfig,
-  PROBE_DEADLINE_MS,
+  PROBE_BACKSTOP_MS,
+  probePoolConfig,
   probeTargets,
   unreachableDb,
   withDeadline,
@@ -66,14 +65,21 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
   // valid migration URL and a nonexistent app role, one file reported `6 pass, 14 skip, 0 fail`,
   // exit 0. The URLs read here are the ones forced above, so this asks the question in exactly the
   // shape the guarded files will ask it.
+  // Imported HERE, not at the top of the file. `generated/prisma` is gitignored and `bun install`
+  // does not produce it, so a static import fails on any checkout that has not run
+  // `bun run prisma:generate` yet, and it fails BEFORE the opt-out is read: measured, a run of a
+  // database-free test file with ALLOW_NO_DB=1 died on `Cannot find module`, where the same file on
+  // the base commit ran. The gate must not be the reason a run without a database cannot start.
+  const { PrismaPg } = await import("@prisma/adapter-pg");
+  const { PrismaClient } = await import("@/../generated/prisma/client");
   for (const { variable, url } of probeTargets(process.env)) {
     const probe = new PrismaClient({
-      adapter: new PrismaPg({ connectionString: url }),
+      adapter: new PrismaPg(probePoolConfig(url)),
     });
     try {
       await withDeadline(
         probe.$queryRaw`SELECT 1`,
-        PROBE_DEADLINE_MS,
+        PROBE_BACKSTOP_MS,
         variable,
       );
       await probe.$disconnect();

--- a/tests/utils/db-gate-noop.ts
+++ b/tests/utils/db-gate-noop.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+
+// A test file with nothing in it, on purpose. It is the target of the subprocess runs in
+// tests/lib/db-gate.test.ts, which are about what the PRELOAD does before any test file is
+// loaded: when the gate refuses, this never executes and the run exits non-zero; when the
+// opt-out disarms the gate, this is what proves the run got as far as executing a test.
+test("the suite reached a test file", () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
Fixes #351

A suite that never ran its database-backed half prints the same last line as one that did: `0 fail`, exit 0.

More than 150 `describe` blocks are guarded by `describe.skipIf(!dbUp)`, where `dbUp` is a connection attempt each file makes on its own. When `TEST_MIGRATION_DATABASE_URL` / `TEST_APP_DATABASE_URL` are unset, or the database does not answer, every one of those blocks is skipped and nothing says so above the summary. The guard is right (a contributor without a database has to be able to run the rest); what was missing is the distinction between *no database, on purpose* and *no database, and nobody noticed*.

## What this does

The preload refuses to start, naming what is missing and how to fix it, before the first test runs. `ALLOW_NO_DB=1` is the deliberate opt-out.

```
error: tests: TEST_MIGRATION_DATABASE_URL and TEST_APP_DATABASE_URL are not set, so every
database-backed test in this suite would be SKIPPED and the run would still exit 0.
  - in a worktree: cp ../main/.env .env
  - first time on this machine: bun run db:test:setup
  - deliberately without a database: ALLOW_NO_DB=1 bun test
```

Two halves, because they are provable in different ways. `missingDbConfig` is a pure function over the environment, so it can be tested with fixtures. The reachability probe asks **both** connections, once at preload instead of 150-odd times: a guarded file authenticates as the migration role AND as the app role, so probing only the first passes a run whose app role cannot log in. It is bounded by a 10s deadline, because an endpoint that accepts the connection and never answers turns a gate into a second way to stall.

**Preventive, not a tally.** Counting skips after the run reports the same fact one run too late, and against a number nobody reads. Refusing to start names what is missing while the reader is still looking at the command they typed.

## Validation scope

**Proved by fixture** (the decision, 12 tests): each missing variable is named, both when both are gone; an empty string counts as missing; the opt-out is exact-match (`ALLOW_NO_DB=true` does not disarm it); every message states that the run would still exit 0; the refusal names *which* of the two connections failed, since both point at the same database; the driver's reason survives on one line and a runaway error is truncated; the deadline rejects and its timer does not outlive a probe that answered.

**Proved as a run** (the gate itself, 2 tests): the preload is not reachable from a test, so these spawn a real `bun test` against a no-op file with a real broken environment. An app role that cannot log in stops the run even with a healthy migration role; `ALLOW_NO_DB=1` gets past the probe and executes a test.

**Measured end to end**, five situations:

| situation | before | after |
| --- | --- | --- |
| configured | runs | runs (`6059 pass, 0 fail`) |
| database not answering | `0 pass, 10 skip, 0 fail`, exit 0 | error, exit 1 |
| variable set to empty | silent skip | error naming the variable, exit 1 |
| no `.env` (fresh clone) | `3839 pass, 2008 skip, 0 fail`, exit 0 | error naming both, exit 1 |
| app role cannot log in, migration role healthy | `6 pass, 14 skip, 0 fail`, exit 0 | error naming `TEST_APP_DATABASE_URL`, exit 1 |
| endpoint accepts and never answers | hung, still alive at 45s with no output | refusal at 10s |
| `ALLOW_NO_DB=1`, no database | n/a | `4291 pass, 2085 skip, 0 fail`, exit 0 |
| `ALLOW_NO_DB=1` on a checkout with no `generated/prisma` | n/a | runs (the gate is read before the client is imported) |
| fresh clone, following the printed line as one paste | n/a | cold container to a running suite in 12s |

**Mutation**, one at a time, each killing exactly its owning test and no other: treat an empty variable as set; accept any truthy opt-out value; drop the "would still exit 0" sentence; keep the whole driver error; drop the `clearTimeout`; probe only the migration role; let the opt-out skip the variable check but not the probe; label the probe with the derived variable; give the backstop no headroom over the driver's own timeout.

Two controls worth writing down. `env -u TEST_MIGRATION_DATABASE_URL bun test` does **not** reproduce a fresh clone: Bun re-reads `.env` and puts the variable back, so that run is green while testing nothing; the real case needed `.env` moved out of the way. And asserting on `process.getActiveResourcesInfo()` proves nothing about a leaked timer under Bun, which returns an empty list; that check had to be measured from a subprocess instead.

No credential travels in the refusal: measured on the four driver errors a reader actually hits (bad password, closed port, unknown host, missing database), none echoes the connection string, and the URL is printed as its database name only.

`bun run check` green on this branch (6135 pass, 0 fail), and CI green on the same head.

Not validated: CI, which provisions its own Postgres and therefore never had this hole. The change only makes a missing database louder, so a CI run either behaves exactly as before or fails loudly at preload.
