### PR TITLE
Pair a redirect episode by the fact, not by five predicates

### DIFF
--- a/prisma/migrations/20260826140000_conversation_redirect_origin/migration.sql
+++ b/prisma/migrations/20260826140000_conversation_redirect_origin/migration.sql
@@ -1,4 +1,8 @@
--- The WhatsApp entry conversation a widget thread was redirected from, as Chatwoot's per-account
--- display_id. Mirrored from the webhook payload; the fork writes it at token-resolve time, which is
--- the one moment the two halves of a redirect episode are known together (issue #222).
+-- The WhatsApp entry conversation a widget thread was redirected FROM (Chatwoot's display_id),
+-- mirrored from the webhook payload. NULL on every conversation outside a redirect episode.
 ALTER TABLE "conversations" ADD COLUMN "redirect_origin_display_id" INTEGER;
+
+-- Ordering mark for the column above: the conversation `updated_at` of the payload that last wrote
+-- it. Its own mark because the fork records the pairing with a write of its own, and it cannot be
+-- ordered by `last_event_at`, which a column write does not move.
+ALTER TABLE "conversations" ADD COLUMN "chatwoot_redirect_origin_at" DOUBLE PRECISION;

--- a/prisma/migrations/20260826140000_conversation_redirect_origin/migration.sql
+++ b/prisma/migrations/20260826140000_conversation_redirect_origin/migration.sql
@@ -1,0 +1,4 @@
+-- The WhatsApp entry conversation a widget thread was redirected from, as Chatwoot's per-account
+-- display_id. Mirrored from the webhook payload; the fork writes it at token-resolve time, which is
+-- the one moment the two halves of a redirect episode are known together (issue #222).
+ALTER TABLE "conversations" ADD COLUMN "redirect_origin_display_id" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -453,23 +453,23 @@ model Contact {
 }
 
 model Conversation {
-  id                     BigInt    @id @default(autoincrement())
-  tenantId               BigInt    @map("tenant_id")
-  chatwootInstanceId     BigInt    @map("chatwoot_instance_id")
-  inboxId                BigInt?   @map("inbox_id")
-  contactId              BigInt?   @map("contact_id")
-  chatwootConversationId Int       @map("chatwoot_conversation_id")
+  id                      BigInt    @id @default(autoincrement())
+  tenantId                BigInt    @map("tenant_id")
+  chatwootInstanceId      BigInt    @map("chatwoot_instance_id")
+  inboxId                 BigInt?   @map("inbox_id")
+  contactId               BigInt?   @map("contact_id")
+  chatwootConversationId  Int       @map("chatwoot_conversation_id")
   // The Chatwoot ContactInbox id (native: one contact on one inbox/channel). This is the discriminator
   // for the agent's graph memory thread — keying by contact-inbox keeps a contact's parallel channels
   // (WhatsApp vs Instagram, …) in SEPARATE memories instead of mixing them. Mirrored from the webhook
   // payload (conversation.contact_inbox.id), always present for real traffic. NULL only on legacy rows.
-  contactInboxId         Int?      @map("contact_inbox_id")
-  status                 String // mirror: open|pending|resolved|snoozed
-  assigneeId             Int?      @map("assignee_id")
-  assigneeType           String?   @map("assignee_type") // User|AgentBot
+  contactInboxId          Int?      @map("contact_inbox_id")
+  status                  String // mirror: open|pending|resolved|snoozed
+  assigneeId              Int?      @map("assignee_id")
+  assigneeType            String?   @map("assignee_type") // User|AgentBot
   // Display name of the current human assignee (meta.assignee.name), mirrored so the console shows a
   // real name instead of "Human #id". NULL when unassigned or assigned to a bot.
-  assigneeName           String?   @map("assignee_name")
+  assigneeName            String?   @map("assignee_name")
   // Who closed this conversation, recorded at the moment WE close it: "agent" (the
   // resolve_conversation tool), "followup_abandonment", "redirect_closing", "console", or
   // "legacy_unknown" for a row the migration found already resolved. NULL = not resolved, or
@@ -477,7 +477,7 @@ model Conversation {
   // `auto_resolve_after`) — none of which reach us, which is why the dashboard reads a recorded
   // origin instead of inferring one from status + assignee. Cleared whenever the mirror applies a
   // status that is not "resolved". See src/modules/conversations/resolution-origin.ts.
-  resolvedBy             String?   @map("resolved_by")
+  resolvedBy              String?   @map("resolved_by")
   // The conversation's status version as the CLOSING CALLER observed it — the floor that says which
   // close the stamp is about. The caller's reading and not the row's at write time: a reopen
   // mirrored between the toggle returning and the write would otherwise date the stamp to the wrong
@@ -487,15 +487,15 @@ model Conversation {
   // saying nothing about the current one. A claim at or below this floor predates the stamp and is
   // therefore a different close. NULL on a Chatwoot that sends no versions, where there is nothing
   // to compare and the rule falls back to its unprotected form.
-  resolvedByAt           Float?    @map("resolved_by_at")
-  threadId               String    @map("thread_id") // tenantId:instanceId:convId
+  resolvedByAt            Float?    @map("resolved_by_at")
+  threadId                String    @map("thread_id") // tenantId:instanceId:convId
   // Mirror of the conversation's Chatwoot custom attributes and of the LINKED KANBAN CARD's ones
   // (conversation.custom_attributes / conversation.kanban_task.custom_attributes on the webhook
   // payload). Same contract as Contact.customAttributes: refreshed on every event, read by the
   // attribute-context block. kanbanAttributes stays {} on upstream Chatwoot (no card in the payload).
-  customAttributes       Json      @default("{}") @map("custom_attributes")
-  kanbanAttributes       Json      @default("{}") @map("kanban_attributes")
-  lastEventAt            DateTime? @map("last_event_at")
+  customAttributes        Json      @default("{}") @map("custom_attributes")
+  kanbanAttributes        Json      @default("{}") @map("kanban_attributes")
+  lastEventAt             DateTime? @map("last_event_at")
   // Ordering watermark for conversation-level STATE (status + assignee), mirrored from the payload's
   // conversation `updated_at` — the source row's version stamp, which advances on every write to it,
   // including the status and assignee changes that `last_activity_at` ignores. lastEventAt cannot
@@ -512,12 +512,12 @@ model Conversation {
   // as a timestamp: two writes to the same conversation land microseconds apart, and a TIMESTAMP(3)
   // would round them to the same millisecond, making the version comparison lose the ordering these
   // columns exist to provide.
-  chatwootStatusAt       Float?    @map("chatwoot_status_at")
-  chatwootAssigneeAt     Float?    @map("chatwoot_assignee_at")
+  chatwootStatusAt        Float?    @map("chatwoot_status_at")
+  chatwootAssigneeAt      Float?    @map("chatwoot_assignee_at")
   // Debounce watermark: the Chatwoot message id of the last inbound message already handled
   // (responded to or deliberately skipped). The flush re-fetches and answers only ids beyond it,
   // so re-arm / retry / a concurrent claim cannot produce a duplicate reply. NULL = nothing handled.
-  lastHandledMessageId   Int?      @map("last_handled_message_id")
+  lastHandledMessageId    Int?      @map("last_handled_message_id")
   // Timestamp of the last INCOMING customer message — the WhatsApp 24h service-window anchor. A
   // proactive (follow-up/nudge) free-form send is only allowed within the window; outside it, an
   // approved template (HSM) is required. NULL = no inbound seen yet.
@@ -548,51 +548,57 @@ model Conversation {
   // Watermark for follow-up single-shot semantics: set after each follow-up (sent or silenced).
   // Another follow-up can only fire once the client speaks again (lastInboundAt > lastFollowUpAt).
   // NULL = no follow-up has ever been attempted for this conversation.
-  lastFollowUpAt         DateTime? @map("last_follow_up_at")
+  lastFollowUpAt          DateTime? @map("last_follow_up_at")
   // Last agent-turn failure for this conversation, surfaced to the operator with a manual
   // "re-engage" action. Sanitized (no PII/secret in the clear); cleared on a successful turn.
   // NULL = the last turn was fine (or none ran yet).
-  lastError              String?   @map("last_error")
-  lastErrorAt            DateTime? @map("last_error_at")
+  lastError               String?   @map("last_error")
+  lastErrorAt             DateTime? @map("last_error_at")
   // When the "the agent could not answer, a human has to take over" private note was last posted for
   // this conversation. Distinct from lastErrorAt, which is stamped on EVERY failed attempt including
   // the ones a retry will fix: this one is only stamped when the turn is definitively lost, and it is
   // the coalescing anchor + the concurrency claim (the conditional write that sets it is what elects
   // the single announcer). NULL = never announced.
-  failureNoticeSentAt    DateTime? @map("failure_notice_sent_at")
+  failureNoticeSentAt     DateTime? @map("failure_notice_sent_at")
   // When the customer activated test mode in this conversation by sending /teste (item 1). NULL =
   // not activated; a "test" agent stays silent until this is set. /reset deliberately does NOT clear
   // it (the conversation keeps answering after a reset).
-  testActivatedAt        DateTime? @map("test_activated_at")
+  testActivatedAt         DateTime? @map("test_activated_at")
   // When the one-shot "this agent is in test mode, send /teste to activate" private note was posted
   // to a silenced conversation. Anti-spam: posted at most once per conversation (NULL = not yet).
   // /reset clears it so a fresh note can be posted on the next silenced message.
-  testNoticeSentAt       DateTime? @map("test_notice_sent_at")
+  testNoticeSentAt        DateTime? @map("test_notice_sent_at")
   // When the one-shot "message received outside business hours" private note was posted. Same anti-spam
   // one-shot as testNoticeSentAt: the agent stays silent outside its configured business hours and the
   // operator is notified once per conversation (NULL = not yet). /reset clears it.
-  outOfHoursNoticeSentAt DateTime? @map("out_of_hours_notice_sent_at")
+  outOfHoursNoticeSentAt  DateTime? @map("out_of_hours_notice_sent_at")
   // When the customer-facing out-of-hours message was last SENT (issue #153). Separate from the note
   // above because the two answer different questions on different clocks: the note tells the operator
   // why the bot is quiet, once per conversation; the message tells the CUSTOMER, once per local day,
   // and a conversation that already carried a note today must still get the message the first time the
   // operator writes one. NULL = never sent. /reset clears it.
-  awayMessageSentAt      DateTime? @map("away_message_sent_at")
+  awayMessageSentAt       DateTime? @map("away_message_sent_at")
   // WhatsApp→chat redirect gate watermarks (only on the entry WhatsApp conversation). redirectSentAt =
   // when the redirect link was last sent (one-shot + cooldown anchor); redirectCount = how many times it
   // has been sent (bounded by maxResends). NULL/0 = never redirected.
-  redirectSentAt         DateTime? @map("redirect_sent_at")
-  redirectCount          Int       @default(0) @map("redirect_count")
+  redirectSentAt          DateTime? @map("redirect_sent_at")
+  redirectCount           Int       @default(0) @map("redirect_count")
   // Cross-link watermark (only on the widget conversation). Set once, when the redirect merge is linked
   // to the WhatsApp sibling: test-mode activation propagated + the cross-link private notes posted. NULL
   // = not yet linked; a non-null value stops the one-shot from re-running / re-spamming.
-  redirectLinkedAt       DateTime? @map("redirect_linked_at")
+  redirectLinkedAt        DateTime? @map("redirect_linked_at")
   // Closing watermark (only on the widget conversation). Set once, via a CAS, by whichever fires first:
   // the follow-up ladder's terminal "closing" stage OR the widget conversation being resolved. Guarantees
   // the closing message + resolve is delivered at most once per redirect episode. NULL = not yet closed.
-  redirectClosedAt       DateTime? @map("redirect_closed_at")
-  createdAt              DateTime  @default(now()) @map("created_at")
-  updatedAt              DateTime  @updatedAt @map("updated_at")
+  redirectClosedAt        DateTime? @map("redirect_closed_at")
+  // The WhatsApp entry conversation this widget thread was redirected FROM, as its chatwootConversationId
+  // (Chatwoot's per-account display_id, the same number this table's chatwootConversationId holds — never
+  // Chatwoot's primary key). Written by the fork's token resolve at the one moment the pairing is a fact
+  // and mirrored from the webhook payload; NULL on the entry half, on every conversation outside a
+  // redirect episode, and on episodes that began before the fork carried it (issue #222).
+  redirectOriginDisplayId Int?      @map("redirect_origin_display_id")
+  createdAt               DateTime  @default(now()) @map("created_at")
+  updatedAt               DateTime  @updatedAt @map("updated_at")
 
   tenant   Tenant           @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   instance ChatwootInstance @relation(fields: [chatwootInstanceId], references: [id], onDelete: Cascade)
@@ -625,18 +631,18 @@ model Conversation {
 //     exactly for what it holds; below the OLDEST id it holds, the answer is "older than anything we
 //     remember", which is the ancient re-delivery the mark was guarding against in the first place.
 model AgentThread {
-  id                  BigInt   @id @default(autoincrement())
-  tenantId            BigInt   @map("tenant_id")
-  chatwootInstanceId  BigInt   @map("chatwoot_instance_id")
-  contactInboxId      Int      @map("contact_inbox_id")
-  threadId            String   @map("thread_id")
-  lastConversationId  Int?     @map("last_conversation_id")
-  lastSyncedMessageId Int?     @map("last_synced_message_id")
-  lastAgentMessageId  Int?     @map("last_agent_message_id")
-  recentSyncedMessageIds Int[] @default([]) @map("recent_synced_message_ids")
-  recentAgentMessageIds  Int[] @default([]) @map("recent_agent_message_ids")
-  createdAt           DateTime @default(now()) @map("created_at")
-  updatedAt           DateTime @updatedAt @map("updated_at")
+  id                     BigInt   @id @default(autoincrement())
+  tenantId               BigInt   @map("tenant_id")
+  chatwootInstanceId     BigInt   @map("chatwoot_instance_id")
+  contactInboxId         Int      @map("contact_inbox_id")
+  threadId               String   @map("thread_id")
+  lastConversationId     Int?     @map("last_conversation_id")
+  lastSyncedMessageId    Int?     @map("last_synced_message_id")
+  lastAgentMessageId     Int?     @map("last_agent_message_id")
+  recentSyncedMessageIds Int[]    @default([]) @map("recent_synced_message_ids")
+  recentAgentMessageIds  Int[]    @default([]) @map("recent_agent_message_ids")
+  createdAt              DateTime @default(now()) @map("created_at")
+  updatedAt              DateTime @updatedAt @map("updated_at")
 
   tenant   Tenant           @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   instance ChatwootInstance @relation(fields: [chatwootInstanceId], references: [id], onDelete: Cascade)
@@ -852,30 +858,30 @@ model PlaygroundSession {
 // is per turn, so a reload with no clean mark cannot tell an approved reply from one nothing ever
 // screened. A turn it never ran on has no row and still comes from the checkpointer alone.
 model PlaygroundTurnNote {
-  id       BigInt @id @default(autoincrement())
-  tenantId BigInt @map("tenant_id")
-  agentId  BigInt @map("agent_id")
-  threadId String @map("thread_id")
+  id              BigInt   @id @default(autoincrement())
+  tenantId        BigInt   @map("tenant_id")
+  agentId         BigInt   @map("agent_id")
+  threadId        String   @map("thread_id")
   // The AIMessage this OVERRIDES, when the rebuilt transcript still shows it. Null for a turn the
   // thread has no record of (the input block); set but no longer shown when the agent's reply was
   // empty, since the rebuild drops an AI message with no text. Both of those are placed instead,
   // by the two ids below.
-  messageId String? @map("message_id")
+  messageId       String?  @map("message_id")
   // Where a blocked turn goes: the last message the rebuilt transcript SHOWED when it happened, so
   // it lands after that turn. Deliberately not the raw tail of the thread, which can be a message
   // the rebuild drops. Null means the thread was empty, i.e. it goes first.
-  anchorMessageId String? @map("anchor_message_id")
+  anchorMessageId String?  @map("anchor_message_id")
   // The human message of this turn, minted by the service for EVERY turn. Two readers: the media
   // saved for a blocked turn joins back on it, and an annotation whose own reply was dropped is
   // placed after it.
-  userMessageId String? @map("user_message_id")
+  userMessageId   String?  @map("user_message_id")
   // The customer's own text, carried only for a blocked turn (the thread never received it).
-  userText String? @map("user_text")
+  userText        String?  @map("user_text")
   // What the operator saw in place of the model's reply. Empty for a suppressed one.
-  reply String
+  reply           String
   // The TraceGuardrail entries for this turn, as the live turn returned them.
-  guardrails Json
-  createdAt  DateTime @default(now()) @map("created_at")
+  guardrails      Json
+  createdAt       DateTime @default(now()) @map("created_at")
 
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
@@ -1204,28 +1210,28 @@ model OutboundWebhookDelivery {
 // ──────────────────────────────────────────────────── scheduler ──
 
 model SchedulerJob {
-  id        BigInt             @id @default(autoincrement())
-  tenantId  BigInt             @map("tenant_id")
-  kind      SchedulerJobKind
-  dedupeKey String             @map("dedupe_key")
-  payload   Json               @default("{}")
+  id            BigInt             @id @default(autoincrement())
+  tenantId      BigInt             @map("tenant_id")
+  kind          SchedulerJobKind
+  dedupeKey     String             @map("dedupe_key")
+  payload       Json               @default("{}")
   /// The encrypted half of a payload, for the kinds that carry one (today: INGEST_MESSAGE, whose
   /// rendered message body is a contact's own words). A plain String because `encryptJson` returns a
   /// base64 blob and secrets do not go in a `Json` column, where accidental logging or serialization
   /// of the whole payload would carry them along — the same rule VaultEntry.secret and
   /// ChatwootInstance.adminToken follow. Null for every kind that carries nothing sensitive.
-  payloadSecret String?        @map("payload_secret")
-  status    SchedulerJobStatus @default(PENDING)
-  runAt     DateTime           @map("run_at")
-  attempts  Int                @default(0)
-  claimedAt DateTime?          @map("claimed_at")
+  payloadSecret String?            @map("payload_secret")
+  status        SchedulerJobStatus @default(PENDING)
+  runAt         DateTime           @map("run_at")
+  attempts      Int                @default(0)
+  claimedAt     DateTime?          @map("claimed_at")
   // Which claim on this row is the current one. The claim BUMPS it and hands the value to the
   // handler; the three writes that finish a job CAS on it, so a run whose claim was superseded
   // writes nothing instead of landing on work it does not own (issue #164).
-  claimSeq  Int                @default(0) @map("claim_seq")
-  lastError String?            @map("last_error")
-  createdAt DateTime           @default(now()) @map("created_at")
-  updatedAt DateTime           @updatedAt @map("updated_at")
+  claimSeq      Int                @default(0) @map("claim_seq")
+  lastError     String?            @map("last_error")
+  createdAt     DateTime           @default(now()) @map("created_at")
+  updatedAt     DateTime           @updatedAt @map("updated_at")
 
   tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
@@ -1242,28 +1248,28 @@ model SchedulerJob {
 // are validated by modules/documents/blocks.ts, not by Prisma — the shapes are unions, and a JSON
 // column is what lets the vocabulary grow without a migration per block type.
 model DocumentTemplate {
-  id          BigInt   @id @default(autoincrement())
-  tenantId    BigInt   @map("tenant_id")
+  id           BigInt   @id @default(autoincrement())
+  tenantId     BigInt   @map("tenant_id")
   // UNIQUE per tenant, and not for tidiness: the name is what the MODEL reads to choose between the
   // document tools an agent was granted. Two templates called "Orçamento" publish two tools with the
   // same description and nothing to pick between them, so the agent sends whichever it happens to
   // choose. Enforced separately from the slug because a caller can supply its own slug, which would
   // otherwise let the same name through twice.
-  name        String
+  name         String
   // Tool-name-safe identifier. UNIQUE per tenant because it becomes the agent's tool name
   // (send_<slug>) and two tools with one name is a grant the operator cannot tell apart.
-  slug        String
-  description String?
-  blocks      Json     @default("[]")
-  fields      Json     @default("[]")
-  style       Json     @default("{}")
+  slug         String
+  description  String?
+  blocks       Json     @default("[]")
+  fields       Json     @default("[]")
+  style        Json     @default("{}")
   // Per-template document counter, bumped once per issued row. Monotonic, not gapless: a crash
   // between the insert and the bump leaves the row unnumbered and the heal takes the next value.
-  lastNumber  Int      @default(0) @map("last_number")
-  numberPrefix String? @map("number_prefix")
-  enabled     Boolean  @default(true)
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  lastNumber   Int      @default(0) @map("last_number")
+  numberPrefix String?  @map("number_prefix")
+  enabled      Boolean  @default(true)
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
 
   tenant          Tenant               @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   issuedDocuments IssuedDocument[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -603,6 +603,10 @@ model Conversation {
   // Chatwoot's primary key). Written by the fork's token resolve at the one moment the pairing is a fact
   // and mirrored from the webhook payload; NULL on the entry half, on every conversation outside a
   // redirect episode, and on episodes that began before the fork carried it (issue #222).
+  //
+  // It also goes BACK to NULL: the fork clears the pairing when a re-entry's token names no origin,
+  // and states that as an explicit null on the payload rather than by omitting the key — which is
+  // why the mirror distinguishes a stated null from an absent key (`normalize.ts`).
   redirectOriginDisplayId  Int?      @map("redirect_origin_display_id")
   createdAt                DateTime  @default(now()) @map("created_at")
   updatedAt                DateTime  @updatedAt @map("updated_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -528,7 +528,7 @@ model Conversation {
   // Timestamp of the last INCOMING customer message — the WhatsApp 24h service-window anchor. A
   // proactive (follow-up/nudge) free-form send is only allowed within the window; outside it, an
   // approved template (HSM) is required. NULL = no inbound seen yet.
-  lastInboundAt          DateTime? @map("last_inbound_at")
+  lastInboundAt            DateTime? @map("last_inbound_at")
   // Chatwoot's own first-response SLA, mirrored rather than derived. Chatwoot computes both from
   // the messages table and ships them on every conversation payload, so the pair answers "how long
   // did the team take to answer" on an inbox the agent never touched — the one question the
@@ -550,8 +550,8 @@ model Conversation {
   // NULL = the payload never carried it: a conversation with no qualifying reply yet, or one no
   // event has been seen for since these columns existed. The KPI needs both, and reports the size
   // of its sample beside the median so a partial backfill can be seen instead of assumed away.
-  chatwootCreatedAt      DateTime? @map("chatwoot_created_at")
-  chatwootFirstReplyAt   DateTime? @map("chatwoot_first_reply_at")
+  chatwootCreatedAt        DateTime? @map("chatwoot_created_at")
+  chatwootFirstReplyAt     DateTime? @map("chatwoot_first_reply_at")
   // Watermark for follow-up single-shot semantics: set after each follow-up (sent or silenced).
   // Another follow-up can only fire once the client speaks again (lastInboundAt > lastFollowUpAt).
   // NULL = no follow-up has ever been attempted for this conversation.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -453,23 +453,23 @@ model Contact {
 }
 
 model Conversation {
-  id                      BigInt    @id @default(autoincrement())
-  tenantId                BigInt    @map("tenant_id")
-  chatwootInstanceId      BigInt    @map("chatwoot_instance_id")
-  inboxId                 BigInt?   @map("inbox_id")
-  contactId               BigInt?   @map("contact_id")
-  chatwootConversationId  Int       @map("chatwoot_conversation_id")
+  id                       BigInt    @id @default(autoincrement())
+  tenantId                 BigInt    @map("tenant_id")
+  chatwootInstanceId       BigInt    @map("chatwoot_instance_id")
+  inboxId                  BigInt?   @map("inbox_id")
+  contactId                BigInt?   @map("contact_id")
+  chatwootConversationId   Int       @map("chatwoot_conversation_id")
   // The Chatwoot ContactInbox id (native: one contact on one inbox/channel). This is the discriminator
   // for the agent's graph memory thread — keying by contact-inbox keeps a contact's parallel channels
   // (WhatsApp vs Instagram, …) in SEPARATE memories instead of mixing them. Mirrored from the webhook
   // payload (conversation.contact_inbox.id), always present for real traffic. NULL only on legacy rows.
-  contactInboxId          Int?      @map("contact_inbox_id")
-  status                  String // mirror: open|pending|resolved|snoozed
-  assigneeId              Int?      @map("assignee_id")
-  assigneeType            String?   @map("assignee_type") // User|AgentBot
+  contactInboxId           Int?      @map("contact_inbox_id")
+  status                   String // mirror: open|pending|resolved|snoozed
+  assigneeId               Int?      @map("assignee_id")
+  assigneeType             String?   @map("assignee_type") // User|AgentBot
   // Display name of the current human assignee (meta.assignee.name), mirrored so the console shows a
   // real name instead of "Human #id". NULL when unassigned or assigned to a bot.
-  assigneeName            String?   @map("assignee_name")
+  assigneeName             String?   @map("assignee_name")
   // Who closed this conversation, recorded at the moment WE close it: "agent" (the
   // resolve_conversation tool), "followup_abandonment", "redirect_closing", "console", or
   // "legacy_unknown" for a row the migration found already resolved. NULL = not resolved, or
@@ -477,7 +477,7 @@ model Conversation {
   // `auto_resolve_after`) — none of which reach us, which is why the dashboard reads a recorded
   // origin instead of inferring one from status + assignee. Cleared whenever the mirror applies a
   // status that is not "resolved". See src/modules/conversations/resolution-origin.ts.
-  resolvedBy              String?   @map("resolved_by")
+  resolvedBy               String?   @map("resolved_by")
   // The conversation's status version as the CLOSING CALLER observed it — the floor that says which
   // close the stamp is about. The caller's reading and not the row's at write time: a reopen
   // mirrored between the toggle returning and the write would otherwise date the stamp to the wrong
@@ -487,15 +487,15 @@ model Conversation {
   // saying nothing about the current one. A claim at or below this floor predates the stamp and is
   // therefore a different close. NULL on a Chatwoot that sends no versions, where there is nothing
   // to compare and the rule falls back to its unprotected form.
-  resolvedByAt            Float?    @map("resolved_by_at")
-  threadId                String    @map("thread_id") // tenantId:instanceId:convId
+  resolvedByAt             Float?    @map("resolved_by_at")
+  threadId                 String    @map("thread_id") // tenantId:instanceId:convId
   // Mirror of the conversation's Chatwoot custom attributes and of the LINKED KANBAN CARD's ones
   // (conversation.custom_attributes / conversation.kanban_task.custom_attributes on the webhook
   // payload). Same contract as Contact.customAttributes: refreshed on every event, read by the
   // attribute-context block. kanbanAttributes stays {} on upstream Chatwoot (no card in the payload).
-  customAttributes        Json      @default("{}") @map("custom_attributes")
-  kanbanAttributes        Json      @default("{}") @map("kanban_attributes")
-  lastEventAt             DateTime? @map("last_event_at")
+  customAttributes         Json      @default("{}") @map("custom_attributes")
+  kanbanAttributes         Json      @default("{}") @map("kanban_attributes")
+  lastEventAt              DateTime? @map("last_event_at")
   // Ordering watermark for conversation-level STATE (status + assignee), mirrored from the payload's
   // conversation `updated_at` — the source row's version stamp, which advances on every write to it,
   // including the status and assignee changes that `last_activity_at` ignores. lastEventAt cannot
@@ -512,12 +512,19 @@ model Conversation {
   // as a timestamp: two writes to the same conversation land microseconds apart, and a TIMESTAMP(3)
   // would round them to the same millisecond, making the version comparison lose the ordering these
   // columns exist to provide.
-  chatwootStatusAt        Float?    @map("chatwoot_status_at")
-  chatwootAssigneeAt      Float?    @map("chatwoot_assignee_at")
+  chatwootStatusAt         Float?    @map("chatwoot_status_at")
+  chatwootAssigneeAt       Float?    @map("chatwoot_assignee_at")
+  // Third mark, same axis, for `redirectOriginDisplayId`. It needs one of its own because the fork
+  // records the pairing with an update of its own, so from that write on the field describes a
+  // version the other two marks do not. And it cannot fall back to `lastEventAt` the way the
+  // attribute bags do: a column write leaves Chatwoot's `last_activity_at` untouched, so the
+  // conversation_updated that announces a new pairing arrives with a FROZEN activity timestamp and a
+  // recency fence would discard exactly the payload that carries the answer.
+  chatwootRedirectOriginAt Float?    @map("chatwoot_redirect_origin_at")
   // Debounce watermark: the Chatwoot message id of the last inbound message already handled
   // (responded to or deliberately skipped). The flush re-fetches and answers only ids beyond it,
   // so re-arm / retry / a concurrent claim cannot produce a duplicate reply. NULL = nothing handled.
-  lastHandledMessageId    Int?      @map("last_handled_message_id")
+  lastHandledMessageId     Int?      @map("last_handled_message_id")
   // Timestamp of the last INCOMING customer message — the WhatsApp 24h service-window anchor. A
   // proactive (follow-up/nudge) free-form send is only allowed within the window; outside it, an
   // approved template (HSM) is required. NULL = no inbound seen yet.
@@ -548,57 +555,57 @@ model Conversation {
   // Watermark for follow-up single-shot semantics: set after each follow-up (sent or silenced).
   // Another follow-up can only fire once the client speaks again (lastInboundAt > lastFollowUpAt).
   // NULL = no follow-up has ever been attempted for this conversation.
-  lastFollowUpAt          DateTime? @map("last_follow_up_at")
+  lastFollowUpAt           DateTime? @map("last_follow_up_at")
   // Last agent-turn failure for this conversation, surfaced to the operator with a manual
   // "re-engage" action. Sanitized (no PII/secret in the clear); cleared on a successful turn.
   // NULL = the last turn was fine (or none ran yet).
-  lastError               String?   @map("last_error")
-  lastErrorAt             DateTime? @map("last_error_at")
+  lastError                String?   @map("last_error")
+  lastErrorAt              DateTime? @map("last_error_at")
   // When the "the agent could not answer, a human has to take over" private note was last posted for
   // this conversation. Distinct from lastErrorAt, which is stamped on EVERY failed attempt including
   // the ones a retry will fix: this one is only stamped when the turn is definitively lost, and it is
   // the coalescing anchor + the concurrency claim (the conditional write that sets it is what elects
   // the single announcer). NULL = never announced.
-  failureNoticeSentAt     DateTime? @map("failure_notice_sent_at")
+  failureNoticeSentAt      DateTime? @map("failure_notice_sent_at")
   // When the customer activated test mode in this conversation by sending /teste (item 1). NULL =
   // not activated; a "test" agent stays silent until this is set. /reset deliberately does NOT clear
   // it (the conversation keeps answering after a reset).
-  testActivatedAt         DateTime? @map("test_activated_at")
+  testActivatedAt          DateTime? @map("test_activated_at")
   // When the one-shot "this agent is in test mode, send /teste to activate" private note was posted
   // to a silenced conversation. Anti-spam: posted at most once per conversation (NULL = not yet).
   // /reset clears it so a fresh note can be posted on the next silenced message.
-  testNoticeSentAt        DateTime? @map("test_notice_sent_at")
+  testNoticeSentAt         DateTime? @map("test_notice_sent_at")
   // When the one-shot "message received outside business hours" private note was posted. Same anti-spam
   // one-shot as testNoticeSentAt: the agent stays silent outside its configured business hours and the
   // operator is notified once per conversation (NULL = not yet). /reset clears it.
-  outOfHoursNoticeSentAt  DateTime? @map("out_of_hours_notice_sent_at")
+  outOfHoursNoticeSentAt   DateTime? @map("out_of_hours_notice_sent_at")
   // When the customer-facing out-of-hours message was last SENT (issue #153). Separate from the note
   // above because the two answer different questions on different clocks: the note tells the operator
   // why the bot is quiet, once per conversation; the message tells the CUSTOMER, once per local day,
   // and a conversation that already carried a note today must still get the message the first time the
   // operator writes one. NULL = never sent. /reset clears it.
-  awayMessageSentAt       DateTime? @map("away_message_sent_at")
+  awayMessageSentAt        DateTime? @map("away_message_sent_at")
   // WhatsApp→chat redirect gate watermarks (only on the entry WhatsApp conversation). redirectSentAt =
   // when the redirect link was last sent (one-shot + cooldown anchor); redirectCount = how many times it
   // has been sent (bounded by maxResends). NULL/0 = never redirected.
-  redirectSentAt          DateTime? @map("redirect_sent_at")
-  redirectCount           Int       @default(0) @map("redirect_count")
+  redirectSentAt           DateTime? @map("redirect_sent_at")
+  redirectCount            Int       @default(0) @map("redirect_count")
   // Cross-link watermark (only on the widget conversation). Set once, when the redirect merge is linked
   // to the WhatsApp sibling: test-mode activation propagated + the cross-link private notes posted. NULL
   // = not yet linked; a non-null value stops the one-shot from re-running / re-spamming.
-  redirectLinkedAt        DateTime? @map("redirect_linked_at")
+  redirectLinkedAt         DateTime? @map("redirect_linked_at")
   // Closing watermark (only on the widget conversation). Set once, via a CAS, by whichever fires first:
   // the follow-up ladder's terminal "closing" stage OR the widget conversation being resolved. Guarantees
   // the closing message + resolve is delivered at most once per redirect episode. NULL = not yet closed.
-  redirectClosedAt        DateTime? @map("redirect_closed_at")
+  redirectClosedAt         DateTime? @map("redirect_closed_at")
   // The WhatsApp entry conversation this widget thread was redirected FROM, as its chatwootConversationId
   // (Chatwoot's per-account display_id, the same number this table's chatwootConversationId holds — never
   // Chatwoot's primary key). Written by the fork's token resolve at the one moment the pairing is a fact
   // and mirrored from the webhook payload; NULL on the entry half, on every conversation outside a
   // redirect episode, and on episodes that began before the fork carried it (issue #222).
-  redirectOriginDisplayId Int?      @map("redirect_origin_display_id")
-  createdAt               DateTime  @default(now()) @map("created_at")
-  updatedAt               DateTime  @updatedAt @map("updated_at")
+  redirectOriginDisplayId  Int?      @map("redirect_origin_display_id")
+  createdAt                DateTime  @default(now()) @map("created_at")
+  updatedAt                DateTime  @updatedAt @map("updated_at")
 
   tenant   Tenant           @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   instance ChatwootInstance @relation(fields: [chatwootInstanceId], references: [id], onDelete: Cascade)

--- a/src/modules/channel-redirect/cross-link.ts
+++ b/src/modules/channel-redirect/cross-link.ts
@@ -64,8 +64,10 @@ export interface LinkRedirectParams {
     testActivatedAt: Date | null;
     contactId: bigint | null;
     // The episode's stored origin, when the fork wrote one (#222). Null falls back to the old
-    // most-recently-active predicate, which is all a pre-#222 episode has.
+    // most-recently-active predicate, which is all a pre-#222 episode has — unless the mark below
+    // says the fork spoke and the answer was "none", in which case there is no sibling at all.
     redirectOriginDisplayId: number | null;
+    chatwootRedirectOriginAt: number | null;
   };
   base?: PrismaClient;
   now?: Date;
@@ -99,6 +101,7 @@ export async function linkRedirectConversations(
           entryInboxId,
           widget: {
             redirectOriginDisplayId: p.widgetConv.redirectOriginDisplayId,
+            chatwootRedirectOriginAt: p.widgetConv.chatwootRedirectOriginAt,
             contactId: p.widgetConv.contactId,
           },
         });

--- a/src/modules/channel-redirect/cross-link.ts
+++ b/src/modules/channel-redirect/cross-link.ts
@@ -78,8 +78,9 @@ export interface LinkRedirectResult {
 }
 
 // Link the widget conversation to its WhatsApp sibling exactly once. The redirectLinkedAt watermark is
-// set unconditionally (even with no sibling / on a note failure) so this never re-runs or re-spams; the
-// notes themselves are best-effort, mirroring the webhook's other private-note posts.
+// CLAIMED for the episode this call read (even with no sibling / on a note failure) so this never
+// re-runs or re-spams; the notes themselves are best-effort, mirroring the webhook's other
+// private-note posts.
 export async function linkRedirectConversations(
   p: LinkRedirectParams,
 ): Promise<LinkRedirectResult> {
@@ -117,16 +118,43 @@ export async function linkRedirectConversations(
     p.widgetConv.testActivatedAt,
   );
 
-  // Watermark the widget conversation (+ propagate) — ALWAYS, so this one-shot never re-runs.
-  await runScopedOn(base, sysCtx(p.tenantId), (db) =>
-    db.conversation.update({
-      where: { id: p.widgetConv.id },
+  // CLAIM the cross-link for the episode this call read, rather than stamp it. Two conditions, one
+  // question — is this still the episode whose sibling I just looked up?
+  //
+  // `redirectOriginDisplayId` is the half that #222 made askable. The origin above comes from the
+  // delivery's own snapshot, and the stamp below lands after two database round trips and a Chatwoot
+  // POST; a pairing accepted in that window moves the episode, and stamping anyway spends the NEXT
+  // episode's only shot on the previous one's notes — the inbound that belongs to the new origin
+  // finds the watermark set and links nothing, ever. Losing the claim is not a failure: it means
+  // another episode owns this conversation now, and its own first inbound will link it.
+  //
+  // `redirectLinkedAt: null` is the caller's fence, moved into the same statement. It was read a
+  // dozen awaits ago, so two inbounds arriving together both passed it and both posted a pair of
+  // private notes. Asked here it costs nothing and the one-shot is one for real.
+  //
+  // The propagation rides along deliberately: a `/teste` copied from a sibling this conversation is
+  // no longer paired with would silence the wrong agent on the wrong episode.
+  const claimed = await runScopedOn(base, sysCtx(p.tenantId), async (db) => {
+    const res = await db.conversation.updateMany({
+      where: {
+        id: p.widgetConv.id,
+        redirectLinkedAt: null,
+        redirectOriginDisplayId: p.widgetConv.redirectOriginDisplayId,
+      },
       data: {
         redirectLinkedAt: now,
         ...(propagate ? { testActivatedAt: now } : {}),
       },
-    }),
-  );
+    });
+    return res.count === 1;
+  });
+  if (!claimed) {
+    logger.info(
+      "channel-redirect: cross-link stood down — the episode moved while it read (widget conv=%d)",
+      p.widgetConv.displayId,
+    );
+    return { testActivatedAt: p.widgetConv.testActivatedAt };
+  }
 
   // Cross-link private notes (best-effort). Needs the deployment baseUrl + accountId + the bot client.
   if (sibling) {

--- a/src/modules/channel-redirect/cross-link.ts
+++ b/src/modules/channel-redirect/cross-link.ts
@@ -131,6 +131,13 @@ export async function linkRedirectConversations(
   // finds the watermark set and links nothing, ever. Losing the claim is not a failure: it means
   // another episode owns this conversation now, and its own first inbound will link it.
   //
+  // `chatwootRedirectOriginAt` is the third, and it is what makes the origin condition mean the same
+  // thing the lookup meant. Since the stated clear became an answer of its own, `(origin=null,
+  // mark=null)` and `(origin=null, mark=set)` are different states — never told, versus told there is
+  // none — and a claim comparing only the origin reads them as one. A call that resolved its sibling
+  // through the recency fallback did so on the licence of the first state; a clear landing under it
+  // revokes that licence, and the notes would go to a conversation the source just disowned.
+  //
   // `redirectLinkedAt: null` is the caller's fence, moved into the same statement. It was read a
   // dozen awaits ago, so two inbounds arriving together both passed it and both posted a pair of
   // private notes. Asked here it costs nothing and the one-shot is one for real.
@@ -143,6 +150,7 @@ export async function linkRedirectConversations(
         id: p.widgetConv.id,
         redirectLinkedAt: null,
         redirectOriginDisplayId: p.widgetConv.redirectOriginDisplayId,
+        chatwootRedirectOriginAt: p.widgetConv.chatwootRedirectOriginAt,
       },
       data: {
         redirectLinkedAt: now,

--- a/src/modules/channel-redirect/cross-link.ts
+++ b/src/modules/channel-redirect/cross-link.ts
@@ -131,12 +131,17 @@ export async function linkRedirectConversations(
   // finds the watermark set and links nothing, ever. Losing the claim is not a failure: it means
   // another episode owns this conversation now, and its own first inbound will link it.
   //
-  // `chatwootRedirectOriginAt` is the third, and it is what makes the origin condition mean the same
-  // thing the lookup meant. Since the stated clear became an answer of its own, `(origin=null,
-  // mark=null)` and `(origin=null, mark=set)` are different states — never told, versus told there is
-  // none — and a claim comparing only the origin reads them as one. A call that resolved its sibling
-  // through the recency fallback did so on the licence of the first state; a clear landing under it
-  // revokes that licence, and the notes would go to a conversation the source just disowned.
+  // `chatwootRedirectOriginAt` is the third, and it applies ONLY where the origin cannot answer,
+  // which is when the origin is null. Since the stated clear became an answer of its own,
+  // `(origin=null, mark=null)` and `(origin=null, mark=set)` are different states — never told,
+  // versus told there is none — and a claim comparing only the origin reads them as one. A call that
+  // resolved its sibling through the recency fallback did so on the licence of the first state; a
+  // clear landing under it revokes that licence, and the notes would go to a conversation the source
+  // just disowned.
+  //
+  // Its NULLNESS, never its value: the mark is a version and advances on every payload that states
+  // the pairing, the same pairing included, so comparing it for equality would read an ordinary
+  // webhook as an episode change and spend this inbound's only attempt on nothing.
   //
   // `redirectLinkedAt: null` is the caller's fence, moved into the same statement. It was read a
   // dozen awaits ago, so two inbounds arriving together both passed it and both posted a pair of
@@ -150,7 +155,14 @@ export async function linkRedirectConversations(
         id: p.widgetConv.id,
         redirectLinkedAt: null,
         redirectOriginDisplayId: p.widgetConv.redirectOriginDisplayId,
-        chatwootRedirectOriginAt: p.widgetConv.chatwootRedirectOriginAt,
+        ...(p.widgetConv.redirectOriginDisplayId === null
+          ? {
+              chatwootRedirectOriginAt:
+                p.widgetConv.chatwootRedirectOriginAt === null
+                  ? null
+                  : { not: null },
+            }
+          : {}),
       },
       data: {
         redirectLinkedAt: now,

--- a/src/modules/channel-redirect/cross-link.ts
+++ b/src/modules/channel-redirect/cross-link.ts
@@ -3,6 +3,7 @@ import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { loadAgentBot, loadChatwootClient } from "@/modules/chatwoot/instance";
+import { episodeOriginQuery } from "./episode";
 import type { ChannelRedirectConfig } from "./service";
 
 // After the WhatsApp→chat redirect merges a lead onto the widget conversation, this links the two
@@ -62,6 +63,9 @@ export interface LinkRedirectParams {
     displayId: number;
     testActivatedAt: Date | null;
     contactId: bigint | null;
+    // The episode's stored origin, when the fork wrote one (#222). Null falls back to the old
+    // most-recently-active predicate, which is all a pre-#222 episode has.
+    redirectOriginDisplayId: number | null;
   };
   base?: PrismaClient;
   now?: Date;
@@ -83,21 +87,29 @@ export async function linkRedirectConversations(
   const now = p.now ?? new Date();
   const entryInboxId = p.cfg.entryInboxId;
 
-  // The WhatsApp sibling: the same contact's most-recently-active conversation on the entry inbox.
-  const sibling =
-    p.widgetConv.contactId === null || entryInboxId === null
+  // The WhatsApp entry half of this episode: the stored pairing when there is one, the old
+  // most-recently-active predicate when there is not (episodeOriginQuery's header says why).
+  const originQuery =
+    entryInboxId === null
       ? null
-      : await runScopedOn(base, sysCtx(p.tenantId), (db) =>
-          db.conversation.findFirst({
-            where: {
-              contactId: p.widgetConv.contactId,
-              chatwootInstanceId: p.instanceId,
-              inbox: { chatwootInboxId: entryInboxId },
-            },
-            select: { chatwootConversationId: true, testActivatedAt: true },
-            orderBy: { lastEventAt: "desc" },
-          }),
-        );
+      : episodeOriginQuery({
+          tenantId: p.tenantId,
+          instanceId: p.instanceId,
+          entryInboxId,
+          widget: {
+            redirectOriginDisplayId: p.widgetConv.redirectOriginDisplayId,
+            contactId: p.widgetConv.contactId,
+          },
+        });
+  const sibling = originQuery
+    ? await runScopedOn(base, sysCtx(p.tenantId), (db) =>
+        db.conversation.findFirst({
+          where: originQuery.where,
+          select: { chatwootConversationId: true, testActivatedAt: true },
+          ...(originQuery.orderBy ? { orderBy: originQuery.orderBy } : {}),
+        }),
+      )
+    : null;
 
   const propagate = shouldPropagateTestMode(
     p.mode,

--- a/src/modules/channel-redirect/episode.ts
+++ b/src/modules/channel-redirect/episode.ts
@@ -136,3 +136,82 @@ export async function episodeTestActivatedAt(
   });
   return sibling?.testActivatedAt ?? null;
 }
+
+// ── the episode's other half ──────────────────────────────────────────────────────────────────────
+
+// WHICH conversation is the WhatsApp entry half of a widget conversation's episode. Two callers ask
+// it — the cross-link (to post the pair of notes) and the follow-up ladder (to re-send the link and,
+// at the closing stage, to RESOLVE that conversation) — and until #222 each answered it on its own by
+// taking the contact's most-recently-active conversation on the entry inbox.
+//
+// That predicate is wrong, and so were the four others written before it: activity is not the funnel
+// (writing into an old entry conversation makes it the latest); the most recent `redirectSentAt` can
+// name a link that was never clicked while an older unconsumed one still is; `/reset` clears that
+// anchor without revoking the link it already sent; and uniqueness on the inbox proves uniqueness,
+// not origin. Each is an inference about an event this side never observes, and the consumers act on
+// it destructively.
+//
+// So the answer is read, not inferred: the fork's token resolve writes the origin onto the widget
+// conversation at the one moment both halves are known together, and it reaches us on the webhook
+// payload. `redirectOriginDisplayId` IS the answer whenever it is there.
+//
+// The old predicate stays as the fallback, for the two populations that have no stored answer and
+// never will: episodes that began before the fork carried the field, and instances running a Chatwoot
+// that does not send it. It is not a second opinion — it is only consulted when there is no fact.
+export interface EpisodeOriginParams {
+  tenantId: bigint;
+  instanceId: bigint;
+  entryInboxId: number;
+  widget: {
+    // The widget conversation's stored pairing, straight off the mirror. Non-null ⇒ this is the answer.
+    redirectOriginDisplayId: number | null;
+    contactId: bigint | null;
+  };
+}
+
+// Whether the pairing is a stored fact. Pure, and the reason a caller can tell the two apart when it
+// reports what it acted on.
+export function hasStoredOrigin(
+  redirectOriginDisplayId: number | null,
+): boolean {
+  return redirectOriginDisplayId !== null;
+}
+
+// What to look the origin up BY, rather than the row itself: the two callers need different columns
+// off it (the cross-link wants the activation stamp, the ladder wants the 24h-window inputs), so each
+// keeps its own `select` and shares the only part that was ever wrong — which row to select.
+//
+// `null` ⇒ there is nothing to look up at all, and the caller has no sibling.
+export function episodeOriginQuery(p: EpisodeOriginParams): {
+  where: {
+    chatwootInstanceId: bigint;
+    chatwootConversationId?: number;
+    contactId?: bigint;
+    inbox?: { chatwootInboxId: number };
+  };
+  orderBy?: { lastEventAt: "desc" };
+  // How the row was chosen, for the caller's log line: an episode acted on by inference is one whose
+  // answer can be wrong, and that is worth being able to see from the outside.
+  by: "stored" | "recency";
+} | null {
+  const stored = p.widget.redirectOriginDisplayId;
+  if (stored !== null) {
+    return {
+      where: {
+        chatwootInstanceId: p.instanceId,
+        chatwootConversationId: stored,
+      },
+      by: "stored",
+    };
+  }
+  if (p.widget.contactId === null) return null;
+  return {
+    where: {
+      chatwootInstanceId: p.instanceId,
+      contactId: p.widget.contactId,
+      inbox: { chatwootInboxId: p.entryInboxId },
+    },
+    orderBy: { lastEventAt: "desc" },
+    by: "recency",
+  };
+}

--- a/src/modules/channel-redirect/episode.ts
+++ b/src/modules/channel-redirect/episode.ts
@@ -165,6 +165,12 @@ export interface EpisodeOriginParams {
   widget: {
     // The widget conversation's stored pairing, straight off the mirror. Non-null ⇒ this is the answer.
     redirectOriginDisplayId: number | null;
+    // The pairing's version mark, and here it is read for one bit only: whether the fork has EVER
+    // spoken about this conversation. Stored null is two different facts — "nobody ever told us" and
+    // "the fork said this episode has no WhatsApp half" — and they want opposite answers. Required
+    // rather than optional so a caller that has not thought about it does not get the old behaviour
+    // by omission.
+    chatwootRedirectOriginAt: number | null;
     contactId: bigint | null;
   };
 }
@@ -204,6 +210,17 @@ export function episodeOriginQuery(p: EpisodeOriginParams): {
       by: "stored",
     };
   }
+  // A STATED clear is an answer, not a gap. The fork writes it when a token resumes this conversation
+  // naming no origin, and falling back to recency there would hand the ladder the contact's most
+  // recent WhatsApp thread — one this episode was explicitly said not to have — on a consumer that
+  // messages it and RESOLVES it. The fallback exists for the populations that have no stored answer
+  // and never will, and a conversation the fork has spoken about is not one of them.
+  //
+  // The one case this cannot separate is a Chatwoot too old to send `updated_at`: it states the clear
+  // and stamps no mark, so the clear reads as silence and takes the fallback. That is the same
+  // degradation the pairing's ordering already has on those instances, and it fails to the behaviour
+  // they had before the field existed.
+  if (p.widget.chatwootRedirectOriginAt !== null) return null;
   if (p.widget.contactId === null) return null;
   return {
     where: {

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -916,6 +916,7 @@ export async function deliverRedirectClosing(
         chatwootStatusAt: true,
         lastInboundAt: true,
         redirectOriginDisplayId: true,
+        chatwootRedirectOriginAt: true,
         inbox: { select: { agentId: true, channelType: true, provider: true } },
       },
     });
@@ -998,6 +999,12 @@ export async function deliverRedirectClosing(
   // them, until fazer-ai/chatwoot#418 is deployed) matches only while it still has none, so the
   // arrival of a first pairing stands this run down rather than letting it act on the recency
   // fallback it read.
+  //
+  // And the mark goes with it, because the origin alone cannot say which null this is. `(null, null)`
+  // is nobody ever told us and licenses the recency fallback this run may have used; `(null, set)` is
+  // the fork saying this episode has no WhatsApp half. A clear landing between the read and this
+  // write turns the first into the second without changing the origin, and a claim comparing only the
+  // origin would carry the goodbye through to a thread the source just disowned.
   const won = await runScopedOn(base, sysCtx(p.tenantId), async (db) => {
     const res = await db.conversation.updateMany({
       where: {
@@ -1007,6 +1014,7 @@ export async function deliverRedirectClosing(
         redirectClosedAt: null,
         lastInboundAt: cx.widget.lastInboundAt,
         redirectOriginDisplayId: cx.widget.redirectOriginDisplayId,
+        chatwootRedirectOriginAt: cx.widget.chatwootRedirectOriginAt,
       },
       data: { redirectClosedAt: now },
     });

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -129,6 +129,13 @@ export interface RedirectFollowUpPayload {
   // Agent.id, serialized as a string — scheduler job payloads are plain JSON.
   agentId: string;
   entryInboxId: number | null;
+  // The redirect episode this ladder was armed for, as the pairing stood in the EVENT that armed it
+  // — not as the row read, which can still be holding the previous pairing back (see the savepoint
+  // in chatwoot/mirror.ts). The dedupe key names the conversation and every episode it ever has
+  // shares it, so this is the only thing that tells the retirement which ladder is the one it means.
+  // Absent ⇒ armed before this field existed, or by a Chatwoot that does not speak about pairings;
+  // `null` ⇒ the event stated there is no pairing.
+  originDisplayId?: number | null;
 }
 
 // Parse (and validate) a claimed job's raw payload. Pure — no I/O — so "is this payload usable" is
@@ -150,7 +157,20 @@ export function parseRedirectFollowUpPayload(
   const entryInboxId =
     typeof payload.entryInboxId === "number" ? payload.entryInboxId : null;
   if (!stage || !widgetThreadId || !agentId) return null;
-  return { stage, widgetThreadId, agentId, entryInboxId };
+  // Read as three states, and put back the same way: a stage advance rebuilds the payload field by
+  // field, so anything this drops is gone from the job for good.
+  const origin = payload.originDisplayId;
+  return {
+    stage,
+    widgetThreadId,
+    agentId,
+    entryInboxId,
+    ...(typeof origin === "number"
+      ? { originDisplayId: origin }
+      : origin === null
+        ? { originDisplayId: null }
+        : {}),
+  };
 }
 
 // Pure: the nudge content for each stage, kept separate from I/O so "what do we say" is trivially
@@ -176,6 +196,9 @@ export interface ArmRedirectChatFollowUpParams {
   widgetThreadId: string;
   agentId: bigint;
   entryInboxId: number | null;
+  // The episode this message belongs to, taken from the EVENT. Omitted when the payload said
+  // nothing about a pairing, which is every Chatwoot without fazer-ai/chatwoot#418.
+  originDisplayId?: number | null;
   cfg: {
     chatFollowupEnabled: boolean;
     chatFollowupDelayValue: number;
@@ -237,6 +260,9 @@ export async function armRedirectChatFollowUp(
       widgetThreadId: p.widgetThreadId,
       agentId: p.agentId.toString(),
       entryInboxId: p.entryInboxId,
+      ...(p.originDisplayId !== undefined
+        ? { originDisplayId: p.originDisplayId }
+        : {}),
     },
     base: p.base,
   });
@@ -679,6 +705,9 @@ export async function redirectFollowUpHandler(
             widgetThreadId: payload.widgetThreadId,
             agentId: payload.agentId,
             entryInboxId,
+            ...(payload.originDisplayId !== undefined
+              ? { originDisplayId: payload.originDisplayId }
+              : {}),
           },
         };
 
@@ -732,6 +761,9 @@ export async function redirectFollowUpHandler(
                   agentId: payload.agentId,
                   entryInboxId,
                   nudgeRetries: retry.attempt,
+                  ...(payload.originDisplayId !== undefined
+                    ? { originDisplayId: payload.originDisplayId }
+                    : {}),
                 },
               };
         }

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -282,7 +282,11 @@ async function resolveWhatsAppSibling(
           chatwootConversationId: widgetConversationId,
         },
       },
-      select: { contactId: true, redirectOriginDisplayId: true },
+      select: {
+        contactId: true,
+        redirectOriginDisplayId: true,
+        chatwootRedirectOriginAt: true,
+      },
     });
     if (!widgetConv) return null;
     const originQuery = episodeOriginQuery({
@@ -291,6 +295,7 @@ async function resolveWhatsAppSibling(
       entryInboxId,
       widget: {
         redirectOriginDisplayId: widgetConv.redirectOriginDisplayId,
+        chatwootRedirectOriginAt: widgetConv.chatwootRedirectOriginAt,
         contactId: widgetConv.contactId,
       },
     });

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -272,22 +272,35 @@ async function resolveWhatsAppSibling(
   widgetConversationId: number,
   entryInboxId: number,
   base: PrismaClient,
+  // The episode to resolve FOR, when the caller is holding one. A closing that has already posted on
+  // the chat is committed to an episode: re-reading the pairing at that point lets a re-entry landing
+  // during those round trips redirect the WhatsApp half — a clear leaves the original thread open, a
+  // move sends the goodbye to (and RESOLVES) the conversation the new episode just paired with. The
+  // ladder's own stage-2 send has no such commitment and keeps reading fresh, which is what lets a
+  // /reset stand it down.
+  pinned?: {
+    contactId: bigint | null;
+    redirectOriginDisplayId: number | null;
+    chatwootRedirectOriginAt: number | null;
+  },
 ): Promise<WhatsAppSibling | null> {
   return runScopedOn(base, sysCtx(tenantId), async (db) => {
-    const widgetConv = await db.conversation.findUnique({
-      where: {
-        tenantId_chatwootInstanceId_chatwootConversationId: {
-          tenantId,
-          chatwootInstanceId: instanceId,
-          chatwootConversationId: widgetConversationId,
+    const widgetConv =
+      pinned ??
+      (await db.conversation.findUnique({
+        where: {
+          tenantId_chatwootInstanceId_chatwootConversationId: {
+            tenantId,
+            chatwootInstanceId: instanceId,
+            chatwootConversationId: widgetConversationId,
+          },
         },
-      },
-      select: {
-        contactId: true,
-        redirectOriginDisplayId: true,
-        chatwootRedirectOriginAt: true,
-      },
-    });
+        select: {
+          contactId: true,
+          redirectOriginDisplayId: true,
+          chatwootRedirectOriginAt: true,
+        },
+      }));
     if (!widgetConv) return null;
     const originQuery = episodeOriginQuery({
       tenantId,
@@ -915,6 +928,7 @@ export async function deliverRedirectClosing(
         status: true,
         chatwootStatusAt: true,
         lastInboundAt: true,
+        contactId: true,
         redirectOriginDisplayId: true,
         chatwootRedirectOriginAt: true,
         inbox: { select: { agentId: true, channelType: true, provider: true } },
@@ -1160,6 +1174,14 @@ export async function deliverRedirectClosing(
     p.widgetConversationId,
     p.entryInboxId,
     base,
+    // The episode this run CLAIMED, not whatever the row says now. By here the chat half may already
+    // have had its goodbye and its resolve, so this run is committed to an episode; a re-entry
+    // landing during those round trips must not move the conversation the WhatsApp half closes.
+    {
+      contactId: cx.widget.contactId,
+      redirectOriginDisplayId: cx.widget.redirectOriginDisplayId,
+      chatwootRedirectOriginAt: cx.widget.chatwootRedirectOriginAt,
+    },
   );
   // NOTE: ONE watermark read and ONE fence, in that order, and nothing between the fence and the
   // send. Asking the watermark again after the fence — which is what a second `stillDelivering()`

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -910,6 +910,7 @@ export async function deliverRedirectClosing(
         status: true,
         chatwootStatusAt: true,
         lastInboundAt: true,
+        redirectOriginDisplayId: true,
         inbox: { select: { agentId: true, channelType: true, provider: true } },
       },
     });
@@ -979,6 +980,19 @@ export async function deliverRedirectClosing(
   }
 
   // Claim the closing: set the watermark only if still unset AND the episode is the one this run read.
+  //
+  // `redirectOriginDisplayId` is the third condition, and the one this path has nothing else to put
+  // in its place. The closing RESOLVES the WhatsApp conversation the pairing names; the resolve
+  // trigger reaches here straight from a webhook, with no job to ask about, so every fence the ladder
+  // gets from `stillWanted` is one this caller skips. Between the read at the top and this write sit
+  // an agent read, a bot load and a client build — a re-entry accepted in that window re-points the
+  // episode, and a goodbye sent afterwards resolves a thread this conversation is no longer paired
+  // with. Losing the claim leaves the anchor free, so the episode that IS current still gets its own.
+  //
+  // Null is a value here, not a wildcard: a widget conversation with no stored pairing (every one of
+  // them, until fazer-ai/chatwoot#418 is deployed) matches only while it still has none, so the
+  // arrival of a first pairing stands this run down rather than letting it act on the recency
+  // fallback it read.
   const won = await runScopedOn(base, sysCtx(p.tenantId), async (db) => {
     const res = await db.conversation.updateMany({
       where: {
@@ -987,6 +1001,7 @@ export async function deliverRedirectClosing(
         chatwootConversationId: p.widgetConversationId,
         redirectClosedAt: null,
         lastInboundAt: cx.widget.lastInboundAt,
+        redirectOriginDisplayId: cx.widget.redirectOriginDisplayId,
       },
       data: { redirectClosedAt: now },
     });

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -25,7 +25,7 @@ import {
   proactiveSendMode,
   readServiceWindowConfig,
 } from "@/modules/service-window/service";
-import { episodeTestActivatedAt } from "./episode";
+import { episodeOriginQuery, episodeTestActivatedAt } from "./episode";
 import { interpolateLink, resolveRedirectLink } from "./gate";
 import {
   type ChannelRedirectConfig,
@@ -255,12 +255,17 @@ interface WhatsAppSibling {
   provider: string | null;
 }
 
-// Resolve the WhatsApp sibling conversation of a widget conversation's contact: the OTHER conversation
-// on the SAME contact whose inbox is the agent's configured entry (official WhatsApp) inbox, most-
-// recently-active. Returns everything the proactive WhatsApp touches need — the sibling's conversation id
-// (to post on), the contact's Chatwoot id (the token identity), plus the 24h-window inputs (lastInboundAt
-// + inbox channel/provider). Powers stage 2 (re-send the link) AND the closing. null when the contact has
-// no such conversation (never messaged that inbox, or the merge never linked it).
+// Resolve the WhatsApp entry half of a widget conversation's redirect episode. Returns everything the
+// proactive WhatsApp touches need — the sibling's conversation id (to post on), the contact's Chatwoot
+// id (the token identity), plus the 24h-window inputs (lastInboundAt + inbox channel/provider). Powers
+// stage 2 (re-send the link) AND the closing, which RESOLVES the conversation it names.
+//
+// WHICH row that is comes from episodeOriginQuery: the pairing the fork stored at resolve time, or —
+// only when there is none — the most-recently-active predicate this function used to apply on its own.
+// #222 is why: the closing acts destructively on the answer, and the old predicate is an inference
+// about an event this side never observes.
+//
+// null when there is no such conversation (never messaged that inbox, or the merge never linked it).
 async function resolveWhatsAppSibling(
   tenantId: bigint,
   instanceId: bigint,
@@ -277,15 +282,22 @@ async function resolveWhatsAppSibling(
           chatwootConversationId: widgetConversationId,
         },
       },
-      select: { contactId: true },
+      select: { contactId: true, redirectOriginDisplayId: true },
     });
-    if (!widgetConv?.contactId) return null;
-    const sibling = await db.conversation.findFirst({
-      where: {
+    if (!widgetConv) return null;
+    const originQuery = episodeOriginQuery({
+      tenantId,
+      instanceId,
+      entryInboxId,
+      widget: {
+        redirectOriginDisplayId: widgetConv.redirectOriginDisplayId,
         contactId: widgetConv.contactId,
-        chatwootInstanceId: instanceId,
-        inbox: { chatwootInboxId: entryInboxId },
       },
+    });
+    if (!originQuery) return null;
+    const sibling = await db.conversation.findFirst({
+      where: originQuery.where,
+      ...(originQuery.orderBy ? { orderBy: originQuery.orderBy } : {}),
       select: {
         chatwootConversationId: true,
         status: true,
@@ -294,7 +306,6 @@ async function resolveWhatsAppSibling(
         contact: { select: { chatwootContactId: true } },
         inbox: { select: { channelType: true, provider: true } },
       },
-      orderBy: { lastEventAt: "desc" },
     });
     if (!sibling?.contact?.chatwootContactId) return null;
     return {
@@ -367,6 +378,8 @@ export async function sendWhatsAppFollowUp(
     instanceId: p.instanceId,
     chatwootContactId: sibling.chatwootContactId,
     widgetInboxId: p.cfg.widgetInboxId,
+    // The link is re-sent ON the sibling, so the sibling IS this redirect's origin.
+    originDisplayId: sibling.chatwootConversationId,
     openWidget: p.cfg.openWidget,
     ttlSeconds: REDIRECT_LINK_TTL_SECONDS,
     base: p.base,

--- a/src/modules/channel-redirect/followup.ts
+++ b/src/modules/channel-redirect/followup.ts
@@ -1000,11 +1000,16 @@ export async function deliverRedirectClosing(
   // arrival of a first pairing stands this run down rather than letting it act on the recency
   // fallback it read.
   //
-  // And the mark goes with it, because the origin alone cannot say which null this is. `(null, null)`
-  // is nobody ever told us and licenses the recency fallback this run may have used; `(null, set)` is
-  // the fork saying this episode has no WhatsApp half. A clear landing between the read and this
-  // write turns the first into the second without changing the origin, and a claim comparing only the
-  // origin would carry the goodbye through to a thread the source just disowned.
+  // And the mark comes in ONLY where the origin cannot answer, which is when the origin is null.
+  // `(null, null)` is nobody ever told us and licenses the recency fallback this run may have used;
+  // `(null, set)` is the fork saying this episode has no WhatsApp half. A clear landing between the
+  // read and this write turns the first into the second without changing the origin.
+  //
+  // Its NULLNESS, never its value. The mark is a version: it advances on every payload that states
+  // the pairing, the ones that state the SAME pairing included. Compared for equality it turns any
+  // ordinary webhook arriving mid-run into "the episode moved", and on this path that is permanent —
+  // the ladder is cancelled by the time the resolve trigger runs, so this is the only closing the
+  // episode will ever get. The identity is the origin; the mark only tells two nulls apart.
   const won = await runScopedOn(base, sysCtx(p.tenantId), async (db) => {
     const res = await db.conversation.updateMany({
       where: {
@@ -1014,7 +1019,14 @@ export async function deliverRedirectClosing(
         redirectClosedAt: null,
         lastInboundAt: cx.widget.lastInboundAt,
         redirectOriginDisplayId: cx.widget.redirectOriginDisplayId,
-        chatwootRedirectOriginAt: cx.widget.chatwootRedirectOriginAt,
+        ...(cx.widget.redirectOriginDisplayId === null
+          ? {
+              chatwootRedirectOriginAt:
+                cx.widget.chatwootRedirectOriginAt === null
+                  ? null
+                  : { not: null },
+            }
+          : {}),
       },
       data: { redirectClosedAt: now },
     });

--- a/src/modules/channel-redirect/gate.ts
+++ b/src/modules/channel-redirect/gate.ts
@@ -42,6 +42,10 @@ export interface ResolveRedirectLinkParams {
   // Stored in the token, injected into the widget on land (the cloned WhatsApp message). Omitted by the
   // proactive WhatsApp follow-up (nothing new to clone — the lead already saw their first message).
   clonedMessage?: string;
+  // The WhatsApp entry conversation the link is being sent on (its chatwootConversationId). Rides in
+  // the token so the fork can stamp it on the widget conversation, which is what turns the episode's
+  // pairing from an inference into a fact (issue #222).
+  originDisplayId: number;
   openWidget: boolean;
   ttlSeconds: number;
   base: PrismaClient;
@@ -156,6 +160,7 @@ export async function resolveRedirectLink(
       identifier,
       message: p.clonedMessage,
       ttlSeconds: p.ttlSeconds,
+      originDisplayId: p.originDisplayId,
     });
     if (!websiteUrl) {
       logger.warn(
@@ -209,7 +214,9 @@ export function interpolateLink(template: string, url: string): string {
 export interface RunRedirectGateParams {
   tenantId: bigint;
   instanceId: bigint;
-  conversationId: number; // Chatwoot display id, for logging
+  // Chatwoot display id of the conversation the gate is running on — the WhatsApp ENTRY half of the
+  // episode. Load-bearing since #222: it is what the token carries as the redirect's origin.
+  conversationId: number;
   conv: {
     id: bigint;
     contactId: bigint | null;
@@ -262,6 +269,7 @@ export async function runRedirectGate(
     instanceId,
     chatwootContactId: contact.chatwootContactId,
     widgetInboxId,
+    originDisplayId: p.conversationId,
     clonedMessage:
       cfg.cloneWaMessage && p.clonedMessage
         ? clipText(p.clonedMessage, MAX_CLONE_CHARS)

--- a/src/modules/chatwoot/client.ts
+++ b/src/modules/chatwoot/client.ts
@@ -1057,11 +1057,19 @@ export class ChatwootClient {
     );
   }
 
+  // NOTE: `originDisplayId` is the conversation the link is being SENT ON (the WhatsApp entry
+  // thread), and the mint is the only moment the two halves of a redirect episode are known
+  // together — the resolve endpoint identifies the CONTACT, and a contact does not say which of its
+  // conversations minted the link (issue #222). The fork carries it in the token and stamps it on
+  // the widget conversation, where it reaches us on the webhook payload. It authorizes the value
+  // against the caller: an origin this token cannot see is REFUSED (404/401), not dropped, so a
+  // link whose episode could not be paired is never handed back.
   async mintRedirectToken(p: {
     inboxId: number;
     identifier: string;
     message?: string;
     ttlSeconds?: number;
+    originDisplayId?: number;
   }): Promise<{ token: string; websiteUrl: string | null }> {
     const res = (await this.request(
       this.config.adminToken,
@@ -1072,6 +1080,7 @@ export class ChatwootClient {
         identifier: p.identifier,
         message: p.message,
         ttl_seconds: p.ttlSeconds,
+        origin_display_id: p.originDisplayId,
       },
     )) as { token?: string; website_url?: string | null } | null;
     if (!res?.token) {

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -61,6 +61,12 @@ export interface MirrorResult {
   assigneeId: number | null;
   assigneeType: string | null;
   lastEventAt: Date | null;
+  // This event moved the conversation into a DIFFERENT redirect episode, and the write above already
+  // released the episode's watermarks on the row. What the mirror cannot release is the work already
+  // armed for the old episode: the REDIRECT_FOLLOWUP ladder, whose stages message the paired WhatsApp
+  // thread and resolve it. Reported rather than retired here so the retirement sits with the other
+  // episode-lifecycle handling (and with /reset, which retires the same key for the same reason).
+  redirectEpisodeReleased: boolean;
 }
 
 export async function mirrorChatwootEvent(
@@ -85,6 +91,7 @@ export async function mirrorChatwootEvent(
       assigneeId: null,
       assigneeType: null,
       lastEventAt: null,
+      redirectEpisodeReleased: false,
     };
   }
   const convId = n.conversationId;
@@ -159,6 +166,7 @@ export async function mirrorChatwootEvent(
           status: true,
           resolvedBy: true,
           resolvedByAt: true,
+          redirectOriginDisplayId: true,
           // Read so the stale branch can tell a reading it already has from one it does not, and
           // skip the UPDATE in the common case rather than rewriting the same two values.
           chatwootCreatedAt: true,
@@ -201,6 +209,34 @@ export async function mirrorChatwootEvent(
           stampedAfterVersion: existing.resolvedByAt,
         });
 
+      // The pairing is the redirect episode's IDENTITY, so a genuinely different one means this
+      // widget conversation is in a NEW episode and the per-episode one-shots belong to the old one.
+      // `redirectLinkedAt` gates the cross-link and `redirectClosedAt` is the at-most-once claim for
+      // the goodbye: left standing, the second episode gets neither — the cross-link reads a
+      // watermark the first episode set, and the closing CAS asks for a null the first episode spent.
+      // Both symptoms predate #222 and neither could be fixed before it, because until the fork
+      // recorded the pairing nothing on this side could tell one episode from the next.
+      //
+      // Asked of a PREVIOUSLY STATED origin, not of the stored value, and that is the whole
+      // distinction: stored null is both "the fork never spoke about this conversation" (every
+      // conversation, before fazer-ai/chatwoot#418 is deployed) and "the fork said there is none".
+      // `chatwootRedirectOriginAt` separates them — it is set the first time we are TOLD. Leaning the
+      // other way would release the episode of every live conversation on the day the fork ships,
+      // re-running each cross-link and posting its private notes a second time; leaning this way
+      // leaves exactly the behaviour of today for a pairing we are only now learning.
+      const releasesEpisode =
+        existing != null &&
+        decision.redirectOrigin &&
+        existing.chatwootRedirectOriginAt != null &&
+        (n.redirectOriginDisplayId ?? null) !==
+          existing.redirectOriginDisplayId;
+      // Written with the pairing wherever the pairing is written, the stale branch included: that
+      // branch is where the pairing's own conversation_updated ORDINARILY lands, since
+      // `last_activity_at` does not move on a column write.
+      const episodeRelease = releasesEpisode
+        ? { redirectLinkedAt: null, redirectClosedAt: null }
+        : {};
+
       if (existing && decision.stale) {
         // NOTE: A stale event says nothing about the conversation's STATE, with three exceptions, all
         // written here because this branch returns before the update.
@@ -240,6 +276,7 @@ export async function mirrorChatwootEvent(
           ...(decision.redirectOriginAt != null
             ? { chatwootRedirectOriginAt: decision.redirectOriginAt }
             : {}),
+          ...episodeRelease,
           ...staleSla,
         };
         if (Object.keys(staleWrites).length > 0) {
@@ -259,6 +296,7 @@ export async function mirrorChatwootEvent(
           assigneeId: existing.assigneeId,
           assigneeType: existing.assigneeType,
           lastEventAt: existing.lastEventAt,
+          redirectEpisodeReleased: releasesEpisode,
         };
       }
 
@@ -320,6 +358,8 @@ export async function mirrorChatwootEvent(
           assigneeId: n.assigneeId ?? null,
           assigneeType: n.assigneeType ?? null,
           lastEventAt: createdLastEventAt,
+          // A row born now has no previous episode to release.
+          redirectEpisodeReleased: false,
         };
       }
 
@@ -387,6 +427,7 @@ export async function mirrorChatwootEvent(
           ...(decision.redirectOriginAt != null
             ? { chatwootRedirectOriginAt: decision.redirectOriginAt }
             : {}),
+          ...episodeRelease,
         },
       });
       const inboxIdStr = inboxRowId != null ? String(inboxRowId) : null;
@@ -425,6 +466,7 @@ export async function mirrorChatwootEvent(
         assigneeId: nextAssigneeId,
         assigneeType: nextAssigneeType,
         lastEventAt: effectiveLastEventAt,
+        redirectEpisodeReleased: releasesEpisode,
       };
     });
   });

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -263,20 +263,41 @@ export async function mirrorChatwootEvent(
       // Best-effort for the DOMAIN, like the outbound emit above: a scheduler write must not be able
       // to fail the mirror. A ladder left standing re-reads the pairing before it acts and its
       // closing claim carries the origin it read, so the fences downstream are the floor.
+      //
+      // A SAVEPOINT, because catching the rejection is not enough to make it best-effort. A statement
+      // that Postgres rejects — a deadlock, a statement timeout — aborts the whole transaction at the
+      // server, and every statement after it fails with `current transaction is aborted` no matter
+      // what JavaScript did with the error. Without the savepoint the catch reads as a degradation
+      // and delivers a rollback: the pairing itself would be lost.
+      //
+      // Losing the mirror write is the worse end of the trade, and not by a little. This path is
+      // detached and Chatwoot already has its 200, so a rejection escaping here leaves the delivery
+      // row on PROCESSING with nothing running and that event never comes back — a transient
+      // deadlock in the scheduler would drop the pairing permanently. Rolling back to the savepoint
+      // keeps the pairing and leaves the ladder standing, which is the degradation the paragraph
+      // above already describes and the downstream fences already handle.
       if (releasesEpisode && opts.redirectLadderDedupeKey) {
-        await retireJobsByDedupeKeyOn(
-          db,
-          tenantId,
-          "REDIRECT_FOLLOWUP",
-          opts.redirectLadderDedupeKey,
-        ).catch((err) => {
+        await db.$executeRawUnsafe("SAVEPOINT retire_redirect_ladder");
+        try {
+          await retireJobsByDedupeKeyOn(
+            db,
+            tenantId,
+            "REDIRECT_FOLLOWUP",
+            opts.redirectLadderDedupeKey,
+          );
+          await db.$executeRawUnsafe(
+            "RELEASE SAVEPOINT retire_redirect_ladder",
+          );
+        } catch (err) {
+          await db.$executeRawUnsafe(
+            "ROLLBACK TO SAVEPOINT retire_redirect_ladder",
+          );
           logger.warn(
             "chatwoot: could not retire the previous redirect episode's ladder (conv=%s): %s",
             String(convId),
             err instanceof Error ? err.message : String(err),
           );
-          return 0;
-        });
+        }
       }
 
       if (existing && decision.stale) {

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -4,6 +4,7 @@ import basePrisma from "@/api/lib/prisma";
 import { withEntityLock } from "@/lib/locks";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import { clearsResolutionOrigin } from "@/modules/conversations/resolution-origin";
+import { retireJobsByDedupeKeyOn } from "@/modules/scheduler/service";
 import { emitOutbound } from "@/modules/webhooks/outbound/service";
 import { isNewIncomingMessage } from "./normalize";
 import { decideConversationWrites, type StatePayload } from "./state-order";
@@ -61,12 +62,6 @@ export interface MirrorResult {
   assigneeId: number | null;
   assigneeType: string | null;
   lastEventAt: Date | null;
-  // This event moved the conversation into a DIFFERENT redirect episode, and the write above already
-  // released the episode's watermarks on the row. What the mirror cannot release is the work already
-  // armed for the old episode: the REDIRECT_FOLLOWUP ladder, whose stages message the paired WhatsApp
-  // thread and resolve it. Reported rather than retired here so the retirement sits with the other
-  // episode-lifecycle handling (and with /reset, which retires the same key for the same reason).
-  redirectEpisodeReleased: boolean;
 }
 
 export async function mirrorChatwootEvent(
@@ -78,7 +73,14 @@ export async function mirrorChatwootEvent(
   // command like /teste|/reset on a test-mode agent), so don't advance lastInboundAt — otherwise it
   // would look like a fresh reply and arm a follow-up / extend the 24h window. Mode is resolved by the
   // caller (the mirror is generic and runs before the gate).
-  opts: { suppressInboundWatermark?: boolean } = {},
+  opts: {
+    suppressInboundWatermark?: boolean;
+    // The dedupe key of the redirect ladder armed for this conversation, when the caller has one.
+    // Handed IN rather than derived here: the key belongs to the channel-redirect module and the
+    // mirror has no business knowing how it is spelled — what it owns is the instant it is retired at,
+    // which has to be the same transaction that moves the pairing. See `releasesEpisode` below.
+    redirectLadderDedupeKey?: string;
+  } = {},
 ): Promise<MirrorResult> {
   if (n.conversationId === null) {
     return {
@@ -91,7 +93,6 @@ export async function mirrorChatwootEvent(
       assigneeId: null,
       assigneeType: null,
       lastEventAt: null,
-      redirectEpisodeReleased: false,
     };
   }
   const convId = n.conversationId;
@@ -236,6 +237,38 @@ export async function mirrorChatwootEvent(
       const episodeRelease = releasesEpisode
         ? { redirectLinkedAt: null, redirectClosedAt: null }
         : {};
+      // The other half of the release, and it has to be ATOMIC with the pairing write, not merely
+      // after it. The ladder messages the paired WhatsApp thread and RESOLVES it, and retiring is the
+      // one signal that reaches a worker which has already claimed — a cancel touches PENDING rows
+      // only.
+      //
+      // Outside this transaction the ordering goes wrong in a way that has nothing to do with
+      // failure: the pairing's `conversation_updated` and the cloned `message_created` that follows
+      // it are two deliveries, and processed concurrently the message can arm the NEW episode's
+      // ladder between the pairing committing and a retirement running afterwards — which would then
+      // mark the new episode's own job DONE, on a dedupe key that carries no generation to tell them
+      // apart. Inside, the UPDATE takes the row lock on that key and holds it to commit, so an arm
+      // racing it blocks and lands after. Work armed for the next episode survives; work armed for
+      // the previous one does not.
+      //
+      // Best-effort for the DOMAIN, like the outbound emit above: a scheduler write must not be able
+      // to fail the mirror. A ladder left standing re-reads the pairing before it acts and its
+      // closing claim carries the origin it read, so the fences downstream are the floor.
+      if (releasesEpisode && opts.redirectLadderDedupeKey) {
+        await retireJobsByDedupeKeyOn(
+          db,
+          tenantId,
+          "REDIRECT_FOLLOWUP",
+          opts.redirectLadderDedupeKey,
+        ).catch((err) => {
+          logger.warn(
+            "chatwoot: could not retire the previous redirect episode's ladder (conv=%s): %s",
+            String(convId),
+            err instanceof Error ? err.message : String(err),
+          );
+          return 0;
+        });
+      }
 
       if (existing && decision.stale) {
         // NOTE: A stale event says nothing about the conversation's STATE, with three exceptions, all
@@ -296,7 +329,6 @@ export async function mirrorChatwootEvent(
           assigneeId: existing.assigneeId,
           assigneeType: existing.assigneeType,
           lastEventAt: existing.lastEventAt,
-          redirectEpisodeReleased: releasesEpisode,
         };
       }
 
@@ -359,7 +391,6 @@ export async function mirrorChatwootEvent(
           assigneeType: n.assigneeType ?? null,
           lastEventAt: createdLastEventAt,
           // A row born now has no previous episode to release.
-          redirectEpisodeReleased: false,
         };
       }
 
@@ -466,7 +497,6 @@ export async function mirrorChatwootEvent(
         assigneeId: nextAssigneeId,
         assigneeType: nextAssigneeType,
         lastEventAt: effectiveLastEventAt,
-        redirectEpisodeReleased: releasesEpisode,
       };
     });
   });

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -202,17 +202,21 @@ export async function mirrorChatwootEvent(
         });
 
       if (existing && decision.stale) {
-        // NOTE: A stale event says nothing about the conversation, with ONE exception: a close of ours
-        // that this ordering refused. Written here because this branch returns before the update.
-        // `resolvedBy != null` is a write-avoidance guard, not part of the rule: this branch is
-        // taken by every out-of-order delivery, and clearing a column that is already null would
-        // add an UPDATE to each one.
-        // NOTE: And a second exception, for the same reason stated the other way round: the ORDER
-        // this event lost is about the conversation's STATE. The SLA pair it carries is not state
-        // this side maintains — it is two immutable readings Chatwoot computed from its own
-        // messages table — so losing the ordering says nothing about them, and a row that has never
-        // seen them yet is exactly the row a late delivery can still teach. Compared rather than
-        // written blind so the common stale delivery, which repeats what is stored, adds no UPDATE.
+        // NOTE: A stale event says nothing about the conversation's STATE, with three exceptions, all
+        // written here because this branch returns before the update.
+        //
+        // One is a close of ours that this ordering refused. Another is the redirect pairing, which
+        // is ordered by a mark of its own and is routinely carried by a payload that is behind on
+        // everything else — see the stale branch of `decideConversationWrites`. `decision` decides
+        // both; this only spends the UPDATE when there is something to write, since every
+        // out-of-order delivery lands here.
+        //
+        // The third is the SLA pair, for the same reason stated the other way round: the ORDER this
+        // event lost is about the conversation's STATE. The SLA pair is not state this side
+        // maintains — it is two immutable readings Chatwoot computed from its own messages table —
+        // so losing the ordering says nothing about them, and a row that has never seen them yet is
+        // exactly the row a late delivery can still teach. Compared rather than written blind so the
+        // common stale delivery, which repeats what is stored, adds no UPDATE.
         const staleSla: typeof slaWrites = {};
         if (
           slaWrites.chatwootCreatedAt != null &&
@@ -226,15 +230,22 @@ export async function mirrorChatwootEvent(
             existing.chatwootFirstReplyAt?.getTime()
         )
           staleSla.chatwootFirstReplyAt = slaWrites.chatwootFirstReplyAt;
-        const clearsOrigin =
-          dropsResolutionOrigin && existing.resolvedBy != null;
-        if (clearsOrigin || Object.keys(staleSla).length > 0) {
+        const staleWrites = {
+          ...(dropsResolutionOrigin && existing.resolvedBy != null
+            ? { resolvedBy: null, resolvedByAt: null }
+            : {}),
+          ...(decision.redirectOrigin && n.redirectOriginDisplayId != null
+            ? { redirectOriginDisplayId: n.redirectOriginDisplayId }
+            : {}),
+          ...(decision.redirectOriginAt != null
+            ? { chatwootRedirectOriginAt: decision.redirectOriginAt }
+            : {}),
+          ...staleSla,
+        };
+        if (Object.keys(staleWrites).length > 0) {
           await db.conversation.update({
             where: { id: existing.id },
-            data: {
-              ...(clearsOrigin ? { resolvedBy: null, resolvedByAt: null } : {}),
-              ...staleSla,
-            },
+            data: staleWrites,
           });
         }
         return {

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -243,9 +243,6 @@ export async function mirrorChatwootEvent(
       // Written with the pairing wherever the pairing is written, the stale branch included: that
       // branch is where the pairing's own conversation_updated ORDINARILY lands, since
       // `last_activity_at` does not move on a column write.
-      const episodeRelease = releasesEpisode
-        ? { redirectLinkedAt: null, redirectClosedAt: null }
-        : {};
       // The other half of the release, and it has to be ATOMIC with the pairing write, not merely
       // after it. The ladder messages the paired WhatsApp thread and RESOLVES it, and retiring is the
       // one signal that reaches a worker which has already claimed — a cancel touches PENDING rows
@@ -260,22 +257,23 @@ export async function mirrorChatwootEvent(
       // racing it blocks and lands after. Work armed for the next episode survives; work armed for
       // the previous one does not.
       //
-      // Best-effort for the DOMAIN, like the outbound emit above: a scheduler write must not be able
-      // to fail the mirror. A ladder left standing re-reads the pairing before it acts and its
-      // closing claim carries the origin it read, so the fences downstream are the floor.
-      //
-      // A SAVEPOINT, because catching the rejection is not enough to make it best-effort. A statement
-      // that Postgres rejects — a deadlock, a statement timeout — aborts the whole transaction at the
+      // A SAVEPOINT, because catching the rejection would not contain the failure. A statement that
+      // Postgres rejects — a deadlock, a statement timeout — aborts the whole transaction at the
       // server, and every statement after it fails with `current transaction is aborted` no matter
-      // what JavaScript did with the error. Without the savepoint the catch reads as a degradation
-      // and delivers a rollback: the pairing itself would be lost.
+      // what JavaScript did with the error. Without the savepoint this catch reads as a degradation
+      // and delivers a rollback of the whole mirror write.
       //
-      // Losing the mirror write is the worse end of the trade, and not by a little. This path is
-      // detached and Chatwoot already has its 200, so a rejection escaping here leaves the delivery
-      // row on PROCESSING with nothing running and that event never comes back — a transient
-      // deadlock in the scheduler would drop the pairing permanently. Rolling back to the savepoint
-      // keeps the pairing and leaves the ladder standing, which is the degradation the paragraph
-      // above already describes and the downstream fences already handle.
+      // And letting it escape is worse still: this path is detached with Chatwoot's 200 already sent,
+      // so a rejection leaves the delivery row on PROCESSING with nothing running and that event
+      // never comes back — a transient deadlock in the scheduler would drop the pairing permanently.
+      //
+      // What must NOT survive the rollback is the pairing. The ladder carries no episode of its own,
+      // so committing the new pairing over a ladder that could not be retired hands the PREVIOUS
+      // episode's schedule to the NEW one: its next stage re-reads the pairing and nudges, then
+      // resolves, a conversation that has just started. So the pairing stands still with it, and
+      // nothing is lost by that — every later payload for this conversation restates the pairing and
+      // the mark it is ordered by has not moved either, so the next delivery applies both together.
+      let retiredLadder = true;
       if (releasesEpisode && opts.redirectLadderDedupeKey) {
         await db.$executeRawUnsafe("SAVEPOINT retire_redirect_ladder");
         try {
@@ -292,13 +290,22 @@ export async function mirrorChatwootEvent(
           await db.$executeRawUnsafe(
             "ROLLBACK TO SAVEPOINT retire_redirect_ladder",
           );
+          retiredLadder = false;
           logger.warn(
-            "chatwoot: could not retire the previous redirect episode's ladder (conv=%s): %s",
+            "chatwoot: could not retire the previous redirect episode's ladder, holding the pairing back (conv=%s): %s",
             String(convId),
             err instanceof Error ? err.message : String(err),
           );
         }
       }
+      // The pairing moves only with a ladder that stood down. Everything else this event carries is
+      // unaffected: the mirror writes each field on its own terms.
+      const writesRedirectOrigin = decision.redirectOrigin && retiredLadder;
+      const redirectOriginAt = retiredLadder ? decision.redirectOriginAt : null;
+      const episodeRelease =
+        releasesEpisode && retiredLadder
+          ? { redirectLinkedAt: null, redirectClosedAt: null }
+          : {};
 
       if (existing && decision.stale) {
         // NOTE: A stale event says nothing about the conversation's STATE, with three exceptions, all
@@ -333,11 +340,11 @@ export async function mirrorChatwootEvent(
           ...(dropsResolutionOrigin && existing.resolvedBy != null
             ? { resolvedBy: null, resolvedByAt: null }
             : {}),
-          ...(decision.redirectOrigin
+          ...(writesRedirectOrigin
             ? { redirectOriginDisplayId: n.redirectOriginDisplayId ?? null }
             : {}),
-          ...(decision.redirectOriginAt != null
-            ? { chatwootRedirectOriginAt: decision.redirectOriginAt }
+          ...(redirectOriginAt != null
+            ? { chatwootRedirectOriginAt: redirectOriginAt }
             : {}),
           ...episodeRelease,
           ...staleSla,
@@ -482,11 +489,11 @@ export async function mirrorChatwootEvent(
           // fork records the pairing, so ordering this field by recency would both miss the race and
           // discard the conversation_updated that announces the change. The consumer messages AND
           // resolves the conversation this names, so a regression acts on the wrong thread.
-          ...(decision.redirectOrigin
+          ...(writesRedirectOrigin
             ? { redirectOriginDisplayId: n.redirectOriginDisplayId ?? null }
             : {}),
-          ...(decision.redirectOriginAt != null
-            ? { chatwootRedirectOriginAt: decision.redirectOriginAt }
+          ...(redirectOriginAt != null
+            ? { chatwootRedirectOriginAt: redirectOriginAt }
             : {}),
           ...episodeRelease,
         },

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -101,7 +101,7 @@ export async function mirrorChatwootEvent(
     status: n.status ?? null,
     assigneeStated: n.assigneeType !== undefined,
     assigneeType: n.assigneeType ?? null,
-    redirectOriginStated: n.redirectOriginDisplayId != null,
+    redirectOriginStated: n.redirectOriginDisplayId !== undefined,
   };
   // The inbound watermark (`lastInboundAt`) advances only on a brand-new incoming customer message
   // (message_created), never on a message_updated — our own STT/vision write-back re-dispatches one
@@ -234,8 +234,8 @@ export async function mirrorChatwootEvent(
           ...(dropsResolutionOrigin && existing.resolvedBy != null
             ? { resolvedBy: null, resolvedByAt: null }
             : {}),
-          ...(decision.redirectOrigin && n.redirectOriginDisplayId != null
-            ? { redirectOriginDisplayId: n.redirectOriginDisplayId }
+          ...(decision.redirectOrigin
+            ? { redirectOriginDisplayId: n.redirectOriginDisplayId ?? null }
             : {}),
           ...(decision.redirectOriginAt != null
             ? { chatwootRedirectOriginAt: decision.redirectOriginAt }
@@ -297,8 +297,8 @@ export async function mirrorChatwootEvent(
                   kanbanAttributes: n.kanbanAttributes as Prisma.InputJsonValue,
                 }
               : {}),
-            ...(n.redirectOriginDisplayId != null
-              ? { redirectOriginDisplayId: n.redirectOriginDisplayId }
+            ...(decision.redirectOrigin
+              ? { redirectOriginDisplayId: n.redirectOriginDisplayId ?? null }
               : {}),
           },
           select: { id: true },
@@ -381,8 +381,8 @@ export async function mirrorChatwootEvent(
           // fork records the pairing, so ordering this field by recency would both miss the race and
           // discard the conversation_updated that announces the change. The consumer messages AND
           // resolves the conversation this names, so a regression acts on the wrong thread.
-          ...(decision.redirectOrigin && n.redirectOriginDisplayId != null
-            ? { redirectOriginDisplayId: n.redirectOriginDisplayId }
+          ...(decision.redirectOrigin
+            ? { redirectOriginDisplayId: n.redirectOriginDisplayId ?? null }
             : {}),
           ...(decision.redirectOriginAt != null
             ? { chatwootRedirectOriginAt: decision.redirectOriginAt }

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -282,6 +282,9 @@ export async function mirrorChatwootEvent(
             tenantId,
             "REDIRECT_FOLLOWUP",
             opts.redirectLadderDedupeKey,
+            // The episode this write is moving TO. Work already armed for it is the new episode's,
+            // and the retirement is only about the one being left behind.
+            { originDisplayId: n.redirectOriginDisplayId ?? null },
           );
           await db.$executeRawUnsafe(
             "RELEASE SAVEPOINT retire_redirect_ladder",

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -101,6 +101,7 @@ export async function mirrorChatwootEvent(
     status: n.status ?? null,
     assigneeStated: n.assigneeType !== undefined,
     assigneeType: n.assigneeType ?? null,
+    redirectOriginStated: n.redirectOriginDisplayId != null,
   };
   // The inbound watermark (`lastInboundAt`) advances only on a brand-new incoming customer message
   // (message_created), never on a message_updated — our own STT/vision write-back re-dispatches one
@@ -162,6 +163,7 @@ export async function mirrorChatwootEvent(
           // skip the UPDATE in the common case rather than rewriting the same two values.
           chatwootCreatedAt: true,
           chatwootFirstReplyAt: true,
+          chatwootRedirectOriginAt: true,
         },
       });
       const prevAssigneeId = existing?.assigneeId ?? null;
@@ -173,6 +175,7 @@ export async function mirrorChatwootEvent(
               statusAt: existing.chatwootStatusAt,
               assigneeAt: existing.chatwootAssigneeAt,
               assigneeType: existing.assigneeType,
+              redirectOriginAt: existing.chatwootRedirectOriginAt,
             }
           : null,
         now,
@@ -267,6 +270,7 @@ export async function mirrorChatwootEvent(
             lastEventAt: createdLastEventAt,
             chatwootStatusAt: decision.statusAt,
             chatwootAssigneeAt: decision.assigneeAt,
+            chatwootRedirectOriginAt: decision.redirectOriginAt,
             lastInboundAt: inboundAt,
             // A row created mid-dialogue needs no special case here: what it stores is what
             // Chatwoot measured over the whole conversation, not what we happened to witness.
@@ -358,14 +362,19 @@ export async function mirrorChatwootEvent(
           ...(decision.unversioned && n.kanbanAttributes
             ? { kanbanAttributes: n.kanbanAttributes as Prisma.InputJsonValue }
             : {}),
-          // NOTE: Written whenever the payload names one, WITHOUT the version fence the bags carry.
-          // The pairing is not conversation state that a stale event could regress — the fork writes
-          // it once, before any event that carries the conversation exists, and re-entry only ever
-          // moves it forward to the origin of the redirect that just happened. What a fence would buy
-          // is nothing; what it would cost is the episode staying unpaired because the payload that
-          // named it happened to lose the ordering race.
-          ...(n.redirectOriginDisplayId != null
+          // NOTE: Fenced by its OWN version mark, not by the recency the bags use. A widget
+          // conversation can be re-entered from a second WhatsApp thread, and every payload carries
+          // the pairing as of when it was SERIALIZED — a retried delivery (3 attempts, 3s apart)
+          // therefore carries the older answer and would otherwise regress the row. `last_activity_at`
+          // cannot separate two re-entries inside one second, and it does not move at all when the
+          // fork records the pairing, so ordering this field by recency would both miss the race and
+          // discard the conversation_updated that announces the change. The consumer messages AND
+          // resolves the conversation this names, so a regression acts on the wrong thread.
+          ...(decision.redirectOrigin && n.redirectOriginDisplayId != null
             ? { redirectOriginDisplayId: n.redirectOriginDisplayId }
+            : {}),
+          ...(decision.redirectOriginAt != null
+            ? { chatwootRedirectOriginAt: decision.redirectOriginAt }
             : {}),
         },
       });

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -110,6 +110,7 @@ export async function mirrorChatwootEvent(
     assigneeStated: n.assigneeType !== undefined,
     assigneeType: n.assigneeType ?? null,
     redirectOriginStated: n.redirectOriginDisplayId !== undefined,
+    redirectOriginCleared: n.redirectOriginDisplayId === null,
   };
   // The inbound watermark (`lastInboundAt`) advances only on a brand-new incoming customer message
   // (message_created), never on a message_updated — our own STT/vision write-back re-dispatches one
@@ -185,6 +186,12 @@ export async function mirrorChatwootEvent(
               assigneeAt: existing.chatwootAssigneeAt,
               assigneeType: existing.assigneeType,
               redirectOriginAt: existing.chatwootRedirectOriginAt,
+              // The mark OR a stored origin: a Chatwoot too old to send `updated_at` writes the
+              // pairing and stamps nothing, so the mark alone would read those conversations as
+              // never having been told, and a clear there would pass as silence.
+              redirectOriginKnown:
+                existing.chatwootRedirectOriginAt != null ||
+                existing.redirectOriginDisplayId != null,
             }
           : null,
         now,
@@ -221,14 +228,16 @@ export async function mirrorChatwootEvent(
       // Asked of a PREVIOUSLY STATED origin, not of the stored value, and that is the whole
       // distinction: stored null is both "the fork never spoke about this conversation" (every
       // conversation, before fazer-ai/chatwoot#418 is deployed) and "the fork said there is none".
-      // `chatwootRedirectOriginAt` separates them — it is set the first time we are TOLD. Leaning the
+      // Being told is what separates them, and it leaves two possible traces — the mark, or a stored
+      // origin from an instance too old to send a version to stamp one with. Leaning the
       // other way would release the episode of every live conversation on the day the fork ships,
       // re-running each cross-link and posting its private notes a second time; leaning this way
       // leaves exactly the behaviour of today for a pairing we are only now learning.
       const releasesEpisode =
         existing != null &&
         decision.redirectOrigin &&
-        existing.chatwootRedirectOriginAt != null &&
+        (existing.chatwootRedirectOriginAt != null ||
+          existing.redirectOriginDisplayId != null) &&
         (n.redirectOriginDisplayId ?? null) !==
           existing.redirectOriginDisplayId;
       // Written with the pairing wherever the pairing is written, the stale branch included: that

--- a/src/modules/chatwoot/mirror.ts
+++ b/src/modules/chatwoot/mirror.ts
@@ -282,6 +282,9 @@ export async function mirrorChatwootEvent(
                   kanbanAttributes: n.kanbanAttributes as Prisma.InputJsonValue,
                 }
               : {}),
+            ...(n.redirectOriginDisplayId != null
+              ? { redirectOriginDisplayId: n.redirectOriginDisplayId }
+              : {}),
           },
           select: { id: true },
         });
@@ -354,6 +357,15 @@ export async function mirrorChatwootEvent(
             : {}),
           ...(decision.unversioned && n.kanbanAttributes
             ? { kanbanAttributes: n.kanbanAttributes as Prisma.InputJsonValue }
+            : {}),
+          // NOTE: Written whenever the payload names one, WITHOUT the version fence the bags carry.
+          // The pairing is not conversation state that a stale event could regress — the fork writes
+          // it once, before any event that carries the conversation exists, and re-entry only ever
+          // moves it forward to the origin of the redirect that just happened. What a fence would buy
+          // is nothing; what it would cost is the episode staying unpaired because the payload that
+          // named it happened to lose the ordering race.
+          ...(n.redirectOriginDisplayId != null
+            ? { redirectOriginDisplayId: n.redirectOriginDisplayId }
             : {}),
         },
       });

--- a/src/modules/chatwoot/normalize.ts
+++ b/src/modules/chatwoot/normalize.ts
@@ -219,6 +219,13 @@ export function normalizeChatwootEvent(
     ? attrs(kanbanTask.custom_attributes)
     : undefined;
   if (taskAttrs) normalized.kanbanAttributes = taskAttrs;
+  // The redirect episode's other half, when the fork wrote one. Absent rather than null on everything
+  // that is not the widget side of an episode, so a payload that says nothing never clears a pairing
+  // an earlier one established (issue #222).
+  const redirectOrigin = conv ? num(conv.redirect_origin_display_id) : null;
+  if (redirectOrigin !== null && redirectOrigin > 0) {
+    normalized.redirectOriginDisplayId = redirectOrigin;
+  }
   normalized.inboxName = inboxObj ? str(inboxObj.name) : null;
   // `channel` (channel_type) is exposed by EventDataPresenter on conversation events.
   normalized.channel = conv ? str(conv.channel) : null;

--- a/src/modules/chatwoot/normalize.ts
+++ b/src/modules/chatwoot/normalize.ts
@@ -222,9 +222,14 @@ export function normalizeChatwootEvent(
   // The redirect episode's other half, when the fork wrote one. Absent rather than null on everything
   // that is not the widget side of an episode, so a payload that says nothing never clears a pairing
   // an earlier one established (issue #222).
-  const redirectOrigin = conv ? num(conv.redirect_origin_display_id) : null;
-  if (redirectOrigin !== null && redirectOrigin > 0) {
-    normalized.redirectOriginDisplayId = redirectOrigin;
+  // PRESENCE of the key is the statement, not the value: the fork always ships it (nil included) and
+  // a Chatwoot without it never does, so `in` is what separates "there is no pairing" from "this
+  // instance does not speak about pairings". A present-but-unusable value (0, a string, a negative)
+  // reads as none rather than as silence — the sender did speak, it just said nothing usable.
+  if (conv && "redirect_origin_display_id" in conv) {
+    const redirectOrigin = num(conv.redirect_origin_display_id);
+    normalized.redirectOriginDisplayId =
+      redirectOrigin !== null && redirectOrigin > 0 ? redirectOrigin : null;
   }
   normalized.inboxName = inboxObj ? str(inboxObj.name) : null;
   // `channel` (channel_type) is exposed by EventDataPresenter on conversation events.

--- a/src/modules/chatwoot/state-order.ts
+++ b/src/modules/chatwoot/state-order.ts
@@ -39,7 +39,7 @@
  * the delayed event and it applies when it lands. The witness argument was an artifact of the
  * guard it was written against.
  *
- * ## Why two marks and not one
+ * ## Why three marks and not one
  *
  * Each field is ordered by the version of the payload that last WROTE it. After a degraded payload
  * lands, the status and the assignee legitimately reflect different versions of the source row, so
@@ -49,6 +49,13 @@
  *
  * Splitting them is also what makes the reopen exception safe. It moves the STATUS mark only, so a
  * handoff event still in flight is still ordered by an assignee mark the snapshot never touched.
+ *
+ * The third mark, the redirect pairing, is the same argument reached from the other end. It is
+ * written by an update of its own on the source row (fazer-ai/chatwoot#418), so from that write on it
+ * describes a version neither of the other two does. It also cannot borrow their fallback: recording
+ * the pairing writes a column, and by point 3 above a column write leaves `last_activity_at` exactly
+ * where it was, so the event that carries the answer arrives with a frozen activity timestamp and a
+ * recency fence would throw away precisely the payload it exists to keep.
  *
  * ## Versions are compared as raw unix-seconds doubles
  *
@@ -71,6 +78,8 @@ export interface StatePayload {
   assigneeStated: boolean;
   /** The assignee type stated, null meaning unassigned. Only meaningful when `assigneeStated`. */
   assigneeType: string | null;
+  /** True when the payload names a redirect origin. The fork omits the key outside an episode. */
+  redirectOriginStated: boolean;
 }
 
 /** The ordering state already stored for this conversation. Null when there is no row yet. */
@@ -79,6 +88,7 @@ export interface StateRow {
   statusAt: number | null;
   assigneeAt: number | null;
   assigneeType: string | null;
+  redirectOriginAt: number | null;
 }
 
 export interface StateDecision {
@@ -105,6 +115,20 @@ export interface StateDecision {
   statusAt: number | null;
   /** Version to stamp on the assignee mark, or null to leave it where it is. */
   assigneeAt: number | null;
+  /**
+   * Whether the payload's redirect origin may overwrite the stored pairing. A THIRD mark, for the
+   * same reason there are already two: the pairing is written by its own update on the source row
+   * (fazer-ai/chatwoot#418), so after that write the field legitimately reflects a different version
+   * than the status and the assignee do.
+   *
+   * Ordered by version and NEVER by `last_activity_at`, which is the one axis that cannot see this
+   * field move: recording the pairing writes a column, and a column write does not advance
+   * `last_activity_at` at all. Its own conversation_updated therefore arrives carrying a FROZEN
+   * activity timestamp, and a recency fence would discard exactly the event that carries the answer.
+   */
+  redirectOrigin: boolean;
+  /** Version to stamp on the redirect-origin mark, or null to leave it where it is. */
+  redirectOriginAt: number | null;
   /**
    * `lastEventAt`, clamped so it never rewinds. This is both what gets WRITTEN and what gets
    * RETURNED: the webhook broadcasts it and the console sorts the conversation list on it, so
@@ -136,6 +160,8 @@ export function decideConversationWrites(
       unversioned: true,
       statusAt: payload.status != null ? payload.version : null,
       assigneeAt: payload.assigneeStated ? payload.version : null,
+      redirectOrigin: payload.redirectOriginStated,
+      redirectOriginAt: payload.redirectOriginStated ? payload.version : null,
       activityAt: eventAt,
     };
   }
@@ -148,6 +174,10 @@ export function decideConversationWrites(
     row.assigneeAt != null &&
     payload.version != null &&
     payload.version < row.assigneeAt;
+  const olderThanRedirectOrigin =
+    row.redirectOriginAt != null &&
+    payload.version != null &&
+    payload.version < row.redirectOriginAt;
 
   // Out-of-order guard, on the axis the event itself offers.
   //
@@ -175,6 +205,8 @@ export function decideConversationWrites(
       unversioned: false,
       statusAt: null,
       assigneeAt: null,
+      redirectOrigin: false,
+      redirectOriginAt: null,
       activityAt: row.activityAt ?? eventAt,
     };
   }
@@ -219,6 +251,16 @@ export function decideConversationWrites(
       ? payload.version
       : null;
 
+  // NOTE: `>=` again, and here it is not only idempotence. The fork records the pairing and then the
+  // conversation_updated it causes is dispatched, so the companions of that one write — and every
+  // message snapshot serialized from the same row version — agree by construction. Rejecting an
+  // equal version would let delivery order decide which of two identical readings stands.
+  //
+  // A payload carrying NO version (Chatwoot < 4.0.2) writes and stamps nothing, which is the
+  // pre-fence behaviour: there is no key to order by, so last write wins, as it did before.
+  const redirectOrigin =
+    payload.redirectOriginStated && !olderThanRedirectOrigin;
+
   return {
     stale: false,
     status,
@@ -226,6 +268,8 @@ export function decideConversationWrites(
     unversioned: row.activityAt == null || eventAt >= row.activityAt,
     statusAt: status != null ? advances(row.statusAt) : null,
     assigneeAt: assignee ? advances(row.assigneeAt) : null,
+    redirectOrigin,
+    redirectOriginAt: redirectOrigin ? advances(row.redirectOriginAt) : null,
     activityAt:
       row.activityAt != null && row.activityAt > eventAt
         ? row.activityAt

--- a/src/modules/chatwoot/state-order.ts
+++ b/src/modules/chatwoot/state-order.ts
@@ -89,6 +89,12 @@ export interface StatePayload {
    * payload from a Chatwoot without that change.
    */
   redirectOriginStated: boolean;
+  /**
+   * True when what the payload states is that there is NO pairing. Meaningful only with
+   * `redirectOriginStated`, and separate from it because a stated nil is not always an answer: see
+   * `redirectOriginAnswers` below.
+   */
+  redirectOriginCleared: boolean;
 }
 
 /** The ordering state already stored for this conversation. Null when there is no row yet. */
@@ -98,6 +104,12 @@ export interface StateRow {
   assigneeAt: number | null;
   assigneeType: string | null;
   redirectOriginAt: number | null;
+  /**
+   * Whether this conversation has EVER had a pairing stated about it — the mark, or a stored origin
+   * for the versionless instances that write the value and stamp nothing. Both are evidence; only
+   * having neither is silence.
+   */
+  redirectOriginKnown: boolean;
 }
 
 export interface StateDecision {
@@ -176,6 +188,23 @@ export function decideConversationWrites(
   // reading of the source. Claiming a version for it would protect it: a complete event delivered
   // afterwards but serialized before, carrying the real `pending` or `resolved`, would lose on
   // `olderThanStatus` and the invented `open` would stand until something newer arrived.
+  // WHETHER THE PAYLOAD ANSWERS THE PAIRING QUESTION, which is not the same as speaking about it.
+  //
+  // A stated pairing always answers. A stated NIL only answers when there was something to clear:
+  // the fork ships the key on every conversation once it is deployed, and the column is NULL for
+  // every episode that began before it existed. Read as an answer, the first payload after the
+  // upgrade converts "nobody ever told us" into "there is none" on EVERY live conversation at once —
+  // which stamps the mark, and a stamped mark is what tells `episodeOriginQuery` to refuse the
+  // recency fallback those episodes have always run on. They would lose their cross-link and every
+  // later WhatsApp touch, with nothing in the data to say why.
+  //
+  // A clear is a TRANSITION, and Chatwoot's own column cannot say which null it is holding either:
+  // a token that names no origin writes NULL over a NULL. So the only thing that separates the two
+  // is on this side — whether a pairing was ever stated about this conversation before.
+  const redirectOriginAnswers =
+    payload.redirectOriginStated &&
+    (!payload.redirectOriginCleared || (row?.redirectOriginKnown ?? false));
+
   if (row === null) {
     return {
       stale: false,
@@ -184,8 +213,8 @@ export function decideConversationWrites(
       unversioned: true,
       statusAt: payload.status != null ? payload.version : null,
       assigneeAt: payload.assigneeStated ? payload.version : null,
-      redirectOrigin: payload.redirectOriginStated,
-      redirectOriginAt: payload.redirectOriginStated ? payload.version : null,
+      redirectOrigin: redirectOriginAnswers,
+      redirectOriginAt: redirectOriginAnswers ? payload.version : null,
       activityAt: eventAt,
     };
   }
@@ -240,9 +269,9 @@ export function decideConversationWrites(
       unversioned: false,
       statusAt: null,
       assigneeAt: null,
-      redirectOrigin: payload.redirectOriginStated && !olderThanRedirectOrigin,
+      redirectOrigin: redirectOriginAnswers && !olderThanRedirectOrigin,
       redirectOriginAt:
-        payload.redirectOriginStated && !olderThanRedirectOrigin
+        redirectOriginAnswers && !olderThanRedirectOrigin
           ? advancesFrom(row.redirectOriginAt, payload.version)
           : null,
       activityAt: row.activityAt ?? eventAt,
@@ -294,8 +323,7 @@ export function decideConversationWrites(
   //
   // A payload carrying NO version (Chatwoot < 4.0.2) writes and stamps nothing, which is the
   // pre-fence behaviour: there is no key to order by, so last write wins, as it did before.
-  const redirectOrigin =
-    payload.redirectOriginStated && !olderThanRedirectOrigin;
+  const redirectOrigin = redirectOriginAnswers && !olderThanRedirectOrigin;
 
   return {
     stale: false,

--- a/src/modules/chatwoot/state-order.ts
+++ b/src/modules/chatwoot/state-order.ts
@@ -27,6 +27,10 @@
  * A message snapshot moves no state and claims no version. That single sentence closes issue #61:
  * the frozen tail has nothing to say, whatever second it landed in.
  *
+ * "Nothing to say" is about STATE. A payload also carries the redirect pairing, which is ordered by
+ * its own mark and is not conversation state at all — so a payload discarded for state can still be
+ * the only witness of a pairing, and is.
+ *
  * One exception, and it is the source's own doing: a brand-new incoming customer message reopens
  * the conversation BEFORE the event is dispatched (`Message#execute_after_create_commit_callbacks`
  * runs `reopen_conversation`, then `dispatch_create_events`). That is a status change, never an
@@ -92,7 +96,13 @@ export interface StateRow {
 }
 
 export interface StateDecision {
-  /** The payload is behind the row on every axis it offers: apply nothing, keep the row as is. */
+  /**
+   * The payload is behind the row on every STATE axis it offers, so none of the conversation state
+   * below is applied. Not "apply nothing": the redirect pairing has a mark of its own and is decided
+   * separately, precisely because the payload that first carries one is routinely behind on the rest
+   * (see the stale branch below). `mirrorChatwootEvent` returns early on this flag, and writes what
+   * the two exceptions — the pairing, and a refused close's `resolvedBy` — tell it to.
+   */
   stale: boolean;
   /** The status to write, or null to keep the stored one. */
   status: string | null;
@@ -135,6 +145,15 @@ export interface StateDecision {
    * reporting a delayed payload's older timestamp would rewind every client's idea of recency.
    */
   activityAt: Date;
+}
+
+// A mark moves only forward, and only when the payload carries a version to move it to. Shared by
+// both exits below because the stale branch writes the pairing too.
+function advancesFrom(
+  mark: number | null,
+  version: number | null,
+): number | null {
+  return version != null && (mark == null || version > mark) ? version : null;
 }
 
 export function decideConversationWrites(
@@ -197,6 +216,17 @@ export function decideConversationWrites(
       : payload.activityAt != null &&
         row.activityAt != null &&
         row.activityAt > payload.activityAt;
+  // NOTE: A stale payload still delivers a PAIRING it is ordered to deliver, and that is the one
+  // exception this branch has. `stale` means "behind the row on every axis this payload offers", and
+  // until the third mark existed those axes were the whole payload. They are not any more: the
+  // pairing is ordered by its own mark, and the first payload to carry one is routinely behind on the
+  // others — a retried snapshot, or any event at all on a conversation the mirror has been following
+  // since before the fork had the field, where the other two marks are set and this one is null.
+  // Discarding it wholesale leaves the episode unpaired and sends the caller to the recency fallback
+  // this column exists to remove, on a consumer that messages AND resolves what it picks.
+  //
+  // Nothing else leaks through: the flags below say so field by field, so a delayed message cannot
+  // reopen a conversation or rewind the activity watermark on the pairing's ticket.
   if (stale) {
     return {
       stale: true,
@@ -205,8 +235,11 @@ export function decideConversationWrites(
       unversioned: false,
       statusAt: null,
       assigneeAt: null,
-      redirectOrigin: false,
-      redirectOriginAt: null,
+      redirectOrigin: payload.redirectOriginStated && !olderThanRedirectOrigin,
+      redirectOriginAt:
+        payload.redirectOriginStated && !olderThanRedirectOrigin
+          ? advancesFrom(row.redirectOriginAt, payload.version)
+          : null,
       activityAt: row.activityAt ?? eventAt,
     };
   }
@@ -247,9 +280,7 @@ export function decideConversationWrites(
   // read from the row at dispatch (`set_conversation_activity` runs first), so a newer message
   // always saw the newer state.
   const advances = (mark: number | null): number | null =>
-    payload.version != null && (mark == null || payload.version > mark)
-      ? payload.version
-      : null;
+    advancesFrom(mark, payload.version);
 
   // NOTE: `>=` again, and here it is not only idempotence. The fork records the pairing and then the
   // conversation_updated it causes is dispatched, so the companions of that one write — and every

--- a/src/modules/chatwoot/state-order.ts
+++ b/src/modules/chatwoot/state-order.ts
@@ -82,7 +82,12 @@ export interface StatePayload {
   assigneeStated: boolean;
   /** The assignee type stated, null meaning unassigned. Only meaningful when `assigneeStated`. */
   assigneeType: string | null;
-  /** True when the payload names a redirect origin. The fork omits the key outside an episode. */
+  /**
+   * True when the payload SPEAKS about the redirect pairing, which includes stating that there is
+   * none: the fork ships the key on every conversation, nil included, and clears the pairing when a
+   * re-entry's token names no origin. False only when the key is absent altogether, which is every
+   * payload from a Chatwoot without that change.
+   */
   redirectOriginStated: boolean;
 }
 

--- a/src/modules/chatwoot/types.ts
+++ b/src/modules/chatwoot/types.ts
@@ -168,4 +168,9 @@ export interface NormalizedChatwootEvent {
   // Kanban::Task#common_event_data carries `custom_attributes`). `undefined` ⇒ absent (upstream
   // Chatwoot, or a conversation with no card).
   kanbanAttributes?: Record<string, unknown>;
+  // The WhatsApp entry conversation this widget thread was redirected FROM, as its display_id
+  // (conversation.redirect_origin_display_id, which the fork's token resolve writes at the one moment
+  // the pairing is a fact). `undefined` ⇒ absent from this payload: the entry half, a conversation
+  // outside a redirect episode, or a Chatwoot too old to send it (issue #222).
+  redirectOriginDisplayId?: number;
 }

--- a/src/modules/chatwoot/types.ts
+++ b/src/modules/chatwoot/types.ts
@@ -170,7 +170,15 @@ export interface NormalizedChatwootEvent {
   kanbanAttributes?: Record<string, unknown>;
   // The WhatsApp entry conversation this widget thread was redirected FROM, as its display_id
   // (conversation.redirect_origin_display_id, which the fork's token resolve writes at the one moment
-  // the pairing is a fact). `undefined` ⇒ absent from this payload: the entry half, a conversation
-  // outside a redirect episode, or a Chatwoot too old to send it (issue #222).
-  redirectOriginDisplayId?: number;
+  // the pairing is a fact).
+  //
+  // THREE states, and the difference between the last two is load-bearing:
+  //   number    — this is the pairing.
+  //   null      — the payload STATES there is none. The fork clears the pairing when a re-entry's
+  //               token names no origin, and that clear has to reach the row: the consumer holding
+  //               the previous pairing is the one that must stop acting on it.
+  //   undefined — the payload said nothing, which is every event from a Chatwoot without
+  //               fazer-ai/chatwoot#418. Reading it as a clear would wipe every episode's pairing on
+  //               the first ordinary message (issue #222).
+  redirectOriginDisplayId?: number | null;
 }

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -1162,6 +1162,7 @@ async function maybeConsumeCommandOrGate(params: {
         redirectSentAt: true,
         redirectCount: true,
         redirectLinkedAt: true,
+        redirectOriginDisplayId: true,
         inboxId: true,
       },
     });
@@ -1574,6 +1575,7 @@ async function maybeConsumeCommandOrGate(params: {
           displayId: conversationId,
           testActivatedAt: ctx.conv.testActivatedAt,
           contactId: ctx.conv.contactId,
+          redirectOriginDisplayId: ctx.conv.redirectOriginDisplayId,
         },
         base,
       });

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -1765,11 +1765,17 @@ async function maybeConsumeCommandOrGate(params: {
     // other side's anchors and ladder standing, and the funnel can be re-run but not re-closed. The
     // operator resets the other side to finish the job.
     //
-    // Reaching across needs to know WHICH widget chat opened from this entry, and that is not
-    // derivable here: the merge happens inside Chatwoot's token resolve and what comes back names
-    // the CONTACT, not the conversation the token was minted on. Every predicate over the mirrored
-    // rows is a guess, and this command cancels appointment reminders — issue #222 carries the fork
-    // change that would make the pair a fact.
+    // Reaching across needs to know WHICH widget chat opened from this entry, and that used to be
+    // underivable: the merge happens inside Chatwoot's token resolve and what comes back names the
+    // CONTACT, not the conversation the token was minted on, so every predicate over the mirrored
+    // rows was a guess — on a command that cancels appointment reminders. Issue #222 removed that:
+    // the widget row now records the entry conversation it opened from, so this direction is a
+    // lookup rather than an inference.
+    //
+    // The scoping stands anyway, and deliberately. Widening what a /reset erases is a change to what
+    // the operator asked for, on the command whose whole ordering above exists to bound what it
+    // touches; it is the operator's call, not a side effect of the pairing becoming available. What
+    // changed is that the reach is now implementable, not that it is wanted here.
 
     // FIRST among the mutations, and the ordering is the whole fence. Two races pull in opposite
     // directions and only this position settles both.

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -1163,6 +1163,7 @@ async function maybeConsumeCommandOrGate(params: {
         redirectCount: true,
         redirectLinkedAt: true,
         redirectOriginDisplayId: true,
+        chatwootRedirectOriginAt: true,
         inboxId: true,
       },
     });
@@ -1576,6 +1577,7 @@ async function maybeConsumeCommandOrGate(params: {
           testActivatedAt: ctx.conv.testActivatedAt,
           contactId: ctx.conv.contactId,
           redirectOriginDisplayId: ctx.conv.redirectOriginDisplayId,
+          chatwootRedirectOriginAt: ctx.conv.chatwootRedirectOriginAt,
         },
         base,
       });
@@ -2772,37 +2774,24 @@ export async function processChatwootDelivery(
     params.instanceId,
     n,
     base,
-    { suppressInboundWatermark: commandActive },
+    {
+      suppressInboundWatermark: commandActive,
+      // Which ladder goes with the episode, if this event turns out to move the pairing. Computed
+      // here because the key is this module's to spell, retired in there because it has to be
+      // atomic with the write that moves it.
+      ...(n.conversationId !== null
+        ? {
+            redirectLadderDedupeKey: followUpDedupeKey(
+              chatwootThreadId(
+                params.tenantId,
+                params.instanceId,
+                n.conversationId,
+              ),
+            ),
+          }
+        : {}),
+    },
   );
-
-  // The other half of the episode release the mirror just wrote. Clearing `redirectLinkedAt` and
-  // `redirectClosedAt` frees the NEXT episode's one-shots; it does nothing about the ladder already
-  // armed for the previous one, whose stages message the paired WhatsApp thread and RESOLVE it. That
-  // thread is no longer this conversation's pairing, so the ladder has to stand down — the same
-  // retirement, by the same key, that /reset makes for the same reason.
-  //
-  // Retiring is what reaches a worker that has ALREADY claimed, which cancelling does not: the
-  // ladder's own fence asks whether its job is still wanted before every send and before the closing
-  // claim, so a run in flight for the old episode stops at its next ask instead of finishing on a
-  // thread that moved. A run that never armed makes this a no-op — the key simply matches nothing.
-  //
-  // Best-effort, and deliberately not fatal: the mirror has committed by now, and a failure to
-  // retire must not drop the message that reported the change. The stages it leaves standing all
-  // re-read the pairing before they act.
-  if (mirror.redirectEpisodeReleased && n.conversationId !== null) {
-    await retireRedirectFollowUp(
-      params.tenantId,
-      chatwootThreadId(params.tenantId, params.instanceId, n.conversationId),
-      base,
-    ).catch((err) => {
-      logger.warn(
-        "chatwoot: could not retire the previous redirect episode's ladder (conv=%s): %s",
-        String(n.conversationId),
-        errMsg(err),
-      );
-      return 0;
-    });
-  }
 
   // NOTE: A command that will not run is otherwise indistinguishable from ordinary customer text, in the
   // logs and in the conversation alike — which is what left issue #270 undiagnosable from the

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2769,6 +2769,35 @@ export async function processChatwootDelivery(
     { suppressInboundWatermark: commandActive },
   );
 
+  // The other half of the episode release the mirror just wrote. Clearing `redirectLinkedAt` and
+  // `redirectClosedAt` frees the NEXT episode's one-shots; it does nothing about the ladder already
+  // armed for the previous one, whose stages message the paired WhatsApp thread and RESOLVE it. That
+  // thread is no longer this conversation's pairing, so the ladder has to stand down — the same
+  // retirement, by the same key, that /reset makes for the same reason.
+  //
+  // Retiring is what reaches a worker that has ALREADY claimed, which cancelling does not: the
+  // ladder's own fence asks whether its job is still wanted before every send and before the closing
+  // claim, so a run in flight for the old episode stops at its next ask instead of finishing on a
+  // thread that moved. A run that never armed makes this a no-op — the key simply matches nothing.
+  //
+  // Best-effort, and deliberately not fatal: the mirror has committed by now, and a failure to
+  // retire must not drop the message that reported the change. The stages it leaves standing all
+  // re-read the pairing before they act.
+  if (mirror.redirectEpisodeReleased && n.conversationId !== null) {
+    await retireRedirectFollowUp(
+      params.tenantId,
+      chatwootThreadId(params.tenantId, params.instanceId, n.conversationId),
+      base,
+    ).catch((err) => {
+      logger.warn(
+        "chatwoot: could not retire the previous redirect episode's ladder (conv=%s): %s",
+        String(n.conversationId),
+        errMsg(err),
+      );
+      return 0;
+    });
+  }
+
   // NOTE: A command that will not run is otherwise indistinguishable from ordinary customer text, in the
   // logs and in the conversation alike — which is what left issue #270 undiagnosable from the
   // outside. This is the only place that knows all three values the diagnosis needs, and past it

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -3510,6 +3510,11 @@ export async function processChatwootDelivery(
               ),
               agentId: rt.agentId,
               entryInboxId: redirectCfg.entryInboxId,
+              // From the EVENT, not from the mirrored row: a mirror write whose ladder retirement
+              // was rejected holds the pairing back, and this same delivery still arms. Reading the
+              // row there would stamp the episode being left behind, and the payload that finally
+              // applies the pairing would retire the ladder it had just armed.
+              originDisplayId: n.redirectOriginDisplayId,
               cfg: redirectCfg,
               base,
             });

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -262,9 +262,27 @@ export async function retireJobsByDedupeKey(
   dedupeKey: string,
   base: PrismaClient = basePrisma,
 ): Promise<number> {
-  return runScopedOn(base, sysCtx(tenantId), async (db) => {
-    const stamp = JSON.stringify({ cancelledAt: new Date().toISOString() });
-    return db.$executeRaw`
+  return runScopedOn(base, sysCtx(tenantId), (db) =>
+    retireJobsByDedupeKeyOn(db, tenantId, kind, dedupeKey),
+  );
+}
+
+// The same retirement on the CALLER'S connection, for a caller whose atomicity matters — the same
+// shape and the same reason as `revokeJobsByKeyPrefixOn` above.
+//
+// It is not only about sharing a pool slot here. Run inside the caller's transaction this UPDATE
+// takes the row lock on the dedupe key and holds it to commit, so a concurrent arm on that key
+// blocks and lands AFTER the retirement rather than before it. That ordering is the whole point for
+// the mirror's episode release: work armed for the NEW episode must survive the retirement of the
+// old one, and outside the transaction there is a window where it does not.
+export async function retireJobsByDedupeKeyOn(
+  db: ScopedDb,
+  tenantId: bigint,
+  kind: SchedulerJobKind,
+  dedupeKey: string,
+): Promise<number> {
+  const stamp = JSON.stringify({ cancelledAt: new Date().toISOString() });
+  return db.$executeRaw`
       UPDATE scheduler_jobs
          SET status = 'DONE',
              payload = payload || ${stamp}::jsonb,
@@ -274,7 +292,6 @@ export async function retireJobsByDedupeKey(
          AND kind = ${kind}::"SchedulerJobKind"
          AND dedupe_key = ${dedupeKey}
          AND status IN ('PENDING', 'CLAIMED')`;
-  });
 }
 
 function readJobRetirement(

--- a/src/modules/scheduler/service.ts
+++ b/src/modules/scheduler/service.ts
@@ -275,13 +275,31 @@ export async function retireJobsByDedupeKey(
 // blocks and lands AFTER the retirement rather than before it. That ordering is the whole point for
 // the mirror's episode release: work armed for the NEW episode must survive the retirement of the
 // old one, and outside the transaction there is a window where it does not.
+//
+// `keepEpisode` is for a caller whose dedupe key outlives the thing being retired. The key names the
+// CONVERSATION, so every episode that conversation ever has shares it, and a retirement that runs
+// after the NEXT episode's work was armed would take that with it — which is reachable, not
+// theoretical: a mirror write whose retirement was rejected holds the pairing back and the same
+// delivery goes on to arm anyway, so the payload that finally applies the pairing is the one that
+// would kill it. Given, the retirement leaves the named episode's own work standing. A payload that
+// does not state an episode is the previous one's by construction: it predates the field, or it came
+// from a Chatwoot that does not speak about pairings at all.
 export async function retireJobsByDedupeKeyOn(
   db: ScopedDb,
   tenantId: bigint,
   kind: SchedulerJobKind,
   dedupeKey: string,
+  keepEpisode?: { originDisplayId: number | null },
 ): Promise<number> {
   const stamp = JSON.stringify({ cancelledAt: new Date().toISOString() });
+  // Two questions, not one: whether an episode was named at all, and which. A cleared pairing names
+  // the episode `null`, and that is a real episode with work of its own — distinct from "no episode
+  // given", which retires everything the way this always did.
+  const keeps = keepEpisode !== undefined;
+  const keepOrigin =
+    keepEpisode?.originDisplayId != null
+      ? String(keepEpisode.originDisplayId)
+      : null;
   return db.$executeRaw`
       UPDATE scheduler_jobs
          SET status = 'DONE',
@@ -291,7 +309,12 @@ export async function retireJobsByDedupeKeyOn(
        WHERE tenant_id = ${tenantId}
          AND kind = ${kind}::"SchedulerJobKind"
          AND dedupe_key = ${dedupeKey}
-         AND status IN ('PENDING', 'CLAIMED')`;
+         AND status IN ('PENDING', 'CLAIMED')
+         AND NOT (
+               ${keeps}::boolean
+           AND jsonb_exists(payload, 'originDisplayId')
+           AND payload->>'originDisplayId' IS NOT DISTINCT FROM ${keepOrigin}::text
+         )`;
 }
 
 function readJobRetirement(

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -386,6 +386,54 @@ describe.skipIf(!dbUp)(
       });
     };
 
+    // Review round 5 of #355. The closing RESOLVES the WhatsApp conversation it names, and on this
+    // path there is no job to ask about — the resolve webhook enters it directly — so the claim CAS is
+    // the only thing standing between a run that read one episode and a conversation that is now in
+    // another. The pairing is read at the top and the claim is written after the agent read, the bot
+    // load and the client build; a re-entry accepted in that window re-points the episode, and a
+    // goodbye sent afterwards resolves a thread this conversation is no longer paired with.
+    test("the pairing moving under the closing stops the claim", async () => {
+      await rearm();
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: WIDGET },
+        data: { redirectOriginDisplayId: SIBLING },
+      });
+      // The rendezvous is the closing's OWN read of the widget conversation — identified by the
+      // select only it makes — so the flip lands strictly between that read and the claim.
+      const flipping = appDb.$extends({
+        query: {
+          conversation: {
+            async findUnique({ args, query }) {
+              const res = await query(args);
+              const sel = args.select as Record<string, unknown> | undefined;
+              if (sel?.chatwootStatusAt && sel?.lastInboundAt && sel?.inbox) {
+                await suDb.conversation.updateMany({
+                  where: { tenantId: tid, chatwootConversationId: WIDGET },
+                  data: { redirectOriginDisplayId: SIBLING + 100 },
+                });
+              }
+              return res;
+            },
+          },
+        },
+      }) as unknown as PrismaClient;
+      try {
+        await resolveWidget(flipping);
+        expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+        const widget = await suDb.conversation.findFirstOrThrow({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          select: { redirectClosedAt: true },
+        });
+        // Not burned either: the episode that is current now still gets its own goodbye.
+        expect(widget.redirectClosedAt).toBeNull();
+      } finally {
+        await suDb.conversation.updateMany({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          data: { redirectOriginDisplayId: null },
+        });
+      }
+    });
+
     test("a switched-off agent posts no goodbye on the sibling", async () => {
       await suDb.agent.update({
         where: { id: agent },

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -386,6 +386,45 @@ describe.skipIf(!dbUp)(
       });
     };
 
+    // Review round 7 of #355, and the same question one state deeper. A closing that starts from
+    // `(origin=null, mark=null)` resolved its sibling through the recency fallback; a stated clear
+    // landing under it makes that answer wrong, and the claim compares only the origin, so both
+    // nulls match and the goodbye goes out on a thread the source just disowned.
+    test("a stated clear landing under the closing stops the claim", async () => {
+      await rearm();
+      const flipping = appDb.$extends({
+        query: {
+          conversation: {
+            async findUnique({ args, query }) {
+              const res = await query(args);
+              const sel = args.select as Record<string, unknown> | undefined;
+              if (sel?.chatwootStatusAt && sel?.lastInboundAt && sel?.inbox) {
+                await suDb.conversation.updateMany({
+                  where: { tenantId: tid, chatwootConversationId: WIDGET },
+                  data: { chatwootRedirectOriginAt: 1_786_000_000.5 },
+                });
+              }
+              return res;
+            },
+          },
+        },
+      }) as unknown as PrismaClient;
+      try {
+        await resolveWidget(flipping);
+        expect(wire.filter((u) => u.includes("/messages"))).toEqual([]);
+        const widget = await suDb.conversation.findFirstOrThrow({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          select: { redirectClosedAt: true },
+        });
+        expect(widget.redirectClosedAt).toBeNull();
+      } finally {
+        await suDb.conversation.updateMany({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          data: { chatwootRedirectOriginAt: null },
+        });
+      }
+    });
+
     // Review round 6 of #355, and the effect rather than the decision table. A STATED clear reaches
     // this consumer as a stored null, which is also what "the fork never spoke about this
     // conversation" looks like — and the old predicate answers the second one. Read as a gap it

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -386,6 +386,60 @@ describe.skipIf(!dbUp)(
       });
     };
 
+    // Review round 9 of #355, and it is round 7's fix read back. The mark is a VERSION: it advances
+    // on every payload that states the pairing, the ones that state the SAME pairing included. Used
+    // as an equality token it turns any ordinary webhook arriving mid-run into "the episode moved",
+    // and on this path that is permanent — the ladder is already cancelled, so the resolve trigger is
+    // the only closing this episode will ever get.
+    test("an ordinary same-origin update does not cost the closing its claim", async () => {
+      await rearm();
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: WIDGET },
+        data: {
+          redirectOriginDisplayId: SIBLING,
+          chatwootRedirectOriginAt: 1_786_000_000.5,
+        },
+      });
+      const bumping = appDb.$extends({
+        query: {
+          conversation: {
+            async findUnique({ args, query }) {
+              const res = await query(args);
+              const sel = args.select as Record<string, unknown> | undefined;
+              if (sel?.chatwootStatusAt && sel?.lastInboundAt && sel?.inbox) {
+                // Same origin, newer version: the shape of every retried or ordinary delivery.
+                await suDb.conversation.updateMany({
+                  where: { tenantId: tid, chatwootConversationId: WIDGET },
+                  data: { chatwootRedirectOriginAt: 1_786_000_090.5 },
+                });
+              }
+              return res;
+            },
+          },
+        },
+      }) as unknown as PrismaClient;
+      try {
+        await resolveWidget(bumping);
+        // The episode never changed, so the goodbye goes out and the anchor is spent.
+        const widget = await suDb.conversation.findFirstOrThrow({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          select: { redirectClosedAt: true },
+        });
+        expect(widget.redirectClosedAt).not.toBeNull();
+        expect(
+          wire.filter((u) => u.includes(`/conversations/${SIBLING}/messages`)),
+        ).not.toEqual([]);
+      } finally {
+        await suDb.conversation.updateMany({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          data: {
+            redirectOriginDisplayId: null,
+            chatwootRedirectOriginAt: null,
+          },
+        });
+      }
+    });
+
     // Review round 7 of #355, and the same question one state deeper. A closing that starts from
     // `(origin=null, mark=null)` resolved its sibling through the recency fallback; a stated clear
     // landing under it makes that answer wrong, and the claim compares only the origin, so both

--- a/tests/modules/channel-redirect-closing-origin.test.ts
+++ b/tests/modules/channel-redirect-closing-origin.test.ts
@@ -386,6 +386,35 @@ describe.skipIf(!dbUp)(
       });
     };
 
+    // Review round 6 of #355, and the effect rather than the decision table. A STATED clear reaches
+    // this consumer as a stored null, which is also what "the fork never spoke about this
+    // conversation" looks like — and the old predicate answers the second one. Read as a gap it
+    // hands the closing the contact's most recent WhatsApp thread and that thread gets a goodbye and
+    // a resolve, on an episode the source said has no WhatsApp half at all.
+    test("a stated clear leaves the closing with no sibling to post on", async () => {
+      await rearm();
+      await suDb.conversation.updateMany({
+        where: { tenantId: tid, chatwootConversationId: WIDGET },
+        data: {
+          redirectOriginDisplayId: null,
+          // The mark is the whole difference: we have been told, and the answer was "none".
+          chatwootRedirectOriginAt: 1_786_000_000.5,
+        },
+      });
+      try {
+        await resolveWidget();
+        // The sibling exists and recency would have found it. Nothing is posted on it.
+        expect(
+          wire.filter((u) => u.includes(`/conversations/${SIBLING}/`)),
+        ).toEqual([]);
+      } finally {
+        await suDb.conversation.updateMany({
+          where: { tenantId: tid, chatwootConversationId: WIDGET },
+          data: { chatwootRedirectOriginAt: null },
+        });
+      }
+    });
+
     // Review round 5 of #355. The closing RESOLVES the WhatsApp conversation it names, and on this
     // path there is no job to ask about — the resolve webhook enters it directly — so the claim CAS is
     // the only thing standing between a run that read one episode and a conversation that is now in

--- a/tests/modules/channel-redirect-cross-link.test.ts
+++ b/tests/modules/channel-redirect-cross-link.test.ts
@@ -1,10 +1,19 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
 import {
   chatSideNote,
   conversationUrl,
+  linkRedirectConversations,
   shouldPropagateTestMode,
   whatsappSideNote,
 } from "@/modules/channel-redirect/cross-link";
+import {
+  CHANNEL_REDIRECT_DEFAULTS,
+  type ChannelRedirectConfig,
+} from "@/modules/channel-redirect/service";
+import { seedChatwootInstance } from "../utils/chatwoot";
 
 describe("conversationUrl", () => {
   test("builds the operator dashboard deep link", () => {
@@ -53,3 +62,173 @@ describe("cross-link notes", () => {
     expect(note).toContain("http://x/app/accounts/1/conversations/14");
   });
 });
+
+// ── which conversation the cross-link actually reads (issue #222) ──
+
+// The notes are best-effort HTTP, so they are not what this asserts. The test-mode propagation is:
+// it reads the SIBLING's activation stamp and writes it onto the widget row, so a durable effect in
+// the database says which row was read — no Chatwoot double, no mock.module.
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const ENTRY_INBOX = 310;
+const WIDGET_INBOX = 311;
+const ORIGIN_CONV = 9301;
+const DECOY_CONV = 9302;
+const WIDGET_CONV = 9303;
+
+describe.skipIf(!dbUp)(
+  "linkRedirectConversations picks the episode's origin",
+  () => {
+    let tenantId = 0n;
+    let instanceId = 0n;
+    let widgetRowId = 0n;
+    let contactId = 0n;
+
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "XLINK", slug: `xlink-${process.pid}` },
+      });
+      tenantId = t.id;
+      // TEST-NET-3 on the discard port: the note posts are best-effort and must die without DNS.
+      const inst = await seedChatwootInstance(suDb, {
+        tenantId,
+        accountId: 12,
+        baseUrl: "https://203.0.113.12:9",
+        adminToken: encryptJson("ADMIN"),
+      });
+      instanceId = inst.id;
+      const entryInbox = await suDb.inbox.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootInboxId: ENTRY_INBOX,
+          name: "WhatsApp",
+        },
+        select: { id: true },
+      });
+      const widgetInbox = await suDb.inbox.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootInboxId: WIDGET_INBOX,
+          name: "Site",
+        },
+        select: { id: true },
+      });
+      const contact = await suDb.contact.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootContactId: 991,
+        },
+        select: { id: true },
+      });
+      contactId = contact.id;
+      const activated = new Date("2026-07-06T12:00:00Z");
+      // The origin: activated, and deliberately the OLDER of the two entry conversations.
+      await suDb.conversation.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          inboxId: entryInbox.id,
+          contactId: contact.id,
+          chatwootConversationId: ORIGIN_CONV,
+          status: "pending",
+          threadId: `${tenantId}:${instanceId}:${ORIGIN_CONV}`,
+          lastEventAt: new Date(Date.now() - 60_000),
+          testActivatedAt: activated,
+        },
+      });
+      // The decoy: newer, never activated. The old predicate takes this one.
+      await suDb.conversation.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          inboxId: entryInbox.id,
+          contactId: contact.id,
+          chatwootConversationId: DECOY_CONV,
+          status: "pending",
+          threadId: `${tenantId}:${instanceId}:${DECOY_CONV}`,
+          lastEventAt: new Date(Date.now() + 60_000),
+          testActivatedAt: null,
+        },
+      });
+      const widget = await suDb.conversation.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          inboxId: widgetInbox.id,
+          contactId: contact.id,
+          chatwootConversationId: WIDGET_CONV,
+          status: "pending",
+          threadId: `${tenantId}:${instanceId}:${WIDGET_CONV}`,
+          lastEventAt: new Date(),
+          redirectOriginDisplayId: ORIGIN_CONV,
+        },
+        select: { id: true },
+      });
+      widgetRowId = widget.id;
+    });
+
+    afterAll(async () => {
+      if (!dbUp) return;
+      await suDb.tenant.delete({ where: { id: tenantId } }).catch(() => {});
+      await su?.$disconnect();
+      await app?.$disconnect();
+    });
+
+    test("propagates the STORED origin's activation, not the newest entry conversation's", async () => {
+      const cfg: ChannelRedirectConfig = {
+        ...CHANNEL_REDIRECT_DEFAULTS,
+        enabled: true,
+        entryInboxId: ENTRY_INBOX,
+        widgetInboxId: WIDGET_INBOX,
+      };
+      const out = await linkRedirectConversations({
+        tenantId,
+        instanceId,
+        agentId: 1n,
+        mode: "test",
+        cfg,
+        widgetConv: {
+          id: widgetRowId,
+          displayId: WIDGET_CONV,
+          testActivatedAt: null,
+          contactId,
+          redirectOriginDisplayId: ORIGIN_CONV,
+        },
+        base: appDb,
+      });
+
+      // Only the origin is activated, so a propagation at all means the origin was the row read.
+      expect(out.testActivatedAt).not.toBeNull();
+      const row = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: { testActivatedAt: true, redirectLinkedAt: true },
+      });
+      expect(row.testActivatedAt).not.toBeNull();
+      expect(row.redirectLinkedAt).not.toBeNull();
+    });
+  },
+);

--- a/tests/modules/channel-redirect-cross-link.test.ts
+++ b/tests/modules/channel-redirect-cross-link.test.ts
@@ -217,6 +217,7 @@ describe.skipIf(!dbUp)(
           testActivatedAt: null,
           contactId,
           redirectOriginDisplayId: ORIGIN_CONV,
+          chatwootRedirectOriginAt: null,
         },
         base: appDb,
       });
@@ -267,6 +268,7 @@ describe.skipIf(!dbUp)(
           contactId,
           // The snapshot this delivery started from: the origin as it stood before the move.
           redirectOriginDisplayId: ORIGIN_CONV,
+          chatwootRedirectOriginAt: null,
         },
         base: appDb,
       });
@@ -314,6 +316,7 @@ describe.skipIf(!dbUp)(
             testActivatedAt: null,
             contactId,
             redirectOriginDisplayId: ORIGIN_CONV,
+            chatwootRedirectOriginAt: null,
           },
           base: appDb,
         });

--- a/tests/modules/channel-redirect-cross-link.test.ts
+++ b/tests/modules/channel-redirect-cross-link.test.ts
@@ -230,5 +230,106 @@ describe.skipIf(!dbUp)(
       expect(row.testActivatedAt).not.toBeNull();
       expect(row.redirectLinkedAt).not.toBeNull();
     });
+
+    // Review round 5 of #355. The origin this call resolves its sibling with is read at the top of
+    // the delivery, and the watermark it stamps is written after two round trips and a Chatwoot POST.
+    // A pairing accepted in that window moves the episode, and stamping anyway spends the NEXT
+    // episode's only shot on the previous episode's notes: the inbound for the new origin finds the
+    // watermark set and links nothing, ever.
+    test("does not stamp the watermark when the pairing moved under it", async () => {
+      const cfg: ChannelRedirectConfig = {
+        ...CHANNEL_REDIRECT_DEFAULTS,
+        enabled: true,
+        entryInboxId: ENTRY_INBOX,
+        widgetInboxId: WIDGET_INBOX,
+      };
+      // The episode released and re-paired to the decoy while this delivery was reading, which is
+      // exactly what the mirror writes when it accepts a different origin.
+      await suDb.conversation.update({
+        where: { id: widgetRowId },
+        data: {
+          redirectLinkedAt: null,
+          testActivatedAt: null,
+          redirectOriginDisplayId: DECOY_CONV,
+        },
+      });
+
+      const out = await linkRedirectConversations({
+        tenantId,
+        instanceId,
+        agentId: 1n,
+        mode: "test",
+        cfg,
+        widgetConv: {
+          id: widgetRowId,
+          displayId: WIDGET_CONV,
+          testActivatedAt: null,
+          contactId,
+          // The snapshot this delivery started from: the origin as it stood before the move.
+          redirectOriginDisplayId: ORIGIN_CONV,
+        },
+        base: appDb,
+      });
+
+      const row = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: { testActivatedAt: true, redirectLinkedAt: true },
+      });
+      // Nothing claimed, so the next inbound — the one that belongs to the decoy episode — still
+      // gets its cross-link. And nothing propagated either: the activation it would have carried
+      // over belongs to the origin this episode no longer has.
+      expect(row.redirectLinkedAt).toBeNull();
+      expect(row.testActivatedAt).toBeNull();
+      expect(out.testActivatedAt).toBeNull();
+    });
+
+    // The claim is the one-shot, not the caller's fence. That fence reads `redirectLinkedAt` at the
+    // top of the delivery and this write lands a dozen awaits later, so two inbounds arriving
+    // together both passed it — and an unconditional stamp let both post their pair of private notes.
+    test("a second call finds the watermark taken and does not re-stamp it", async () => {
+      const cfg: ChannelRedirectConfig = {
+        ...CHANNEL_REDIRECT_DEFAULTS,
+        enabled: true,
+        entryInboxId: ENTRY_INBOX,
+        widgetInboxId: WIDGET_INBOX,
+      };
+      await suDb.conversation.update({
+        where: { id: widgetRowId },
+        data: {
+          redirectLinkedAt: null,
+          testActivatedAt: null,
+          redirectOriginDisplayId: ORIGIN_CONV,
+        },
+      });
+      const call = () =>
+        linkRedirectConversations({
+          tenantId,
+          instanceId,
+          agentId: 1n,
+          mode: "test",
+          cfg,
+          widgetConv: {
+            id: widgetRowId,
+            displayId: WIDGET_CONV,
+            testActivatedAt: null,
+            contactId,
+            redirectOriginDisplayId: ORIGIN_CONV,
+          },
+          base: appDb,
+        });
+
+      await call();
+      const first = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: { redirectLinkedAt: true },
+      });
+      await call();
+      const second = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: { redirectLinkedAt: true },
+      });
+      expect(first.redirectLinkedAt).not.toBeNull();
+      expect(second.redirectLinkedAt).toEqual(first.redirectLinkedAt);
+    });
   },
 );

--- a/tests/modules/channel-redirect-cross-link.test.ts
+++ b/tests/modules/channel-redirect-cross-link.test.ts
@@ -340,6 +340,56 @@ describe.skipIf(!dbUp)(
       });
     });
 
+    // Review round 9 of #355. The mark is a VERSION and advances on every payload that states the
+    // pairing, the ones stating the SAME pairing included. Compared for equality it reads an ordinary
+    // webhook arriving mid-call as an episode change and spends this inbound's attempt on nothing:
+    // no notes, no propagation, on an episode that never moved.
+    test("an ordinary same-origin update does not cost the cross-link its claim", async () => {
+      const cfg: ChannelRedirectConfig = {
+        ...CHANNEL_REDIRECT_DEFAULTS,
+        enabled: true,
+        entryInboxId: ENTRY_INBOX,
+        widgetInboxId: WIDGET_INBOX,
+      };
+      await suDb.conversation.update({
+        where: { id: widgetRowId },
+        data: {
+          redirectLinkedAt: null,
+          testActivatedAt: null,
+          redirectOriginDisplayId: ORIGIN_CONV,
+          // Newer than what the call carries, same origin.
+          chatwootRedirectOriginAt: 1_786_000_090.5,
+        },
+      });
+
+      await linkRedirectConversations({
+        tenantId,
+        instanceId,
+        agentId: 1n,
+        mode: "test",
+        cfg,
+        widgetConv: {
+          id: widgetRowId,
+          displayId: WIDGET_CONV,
+          testActivatedAt: null,
+          contactId,
+          redirectOriginDisplayId: ORIGIN_CONV,
+          chatwootRedirectOriginAt: 1_786_000_000.5,
+        },
+        base: appDb,
+      });
+
+      const row = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: { redirectLinkedAt: true },
+      });
+      expect(row.redirectLinkedAt).not.toBeNull();
+      await suDb.conversation.update({
+        where: { id: widgetRowId },
+        data: { chatwootRedirectOriginAt: null },
+      });
+    });
+
     // The claim is the one-shot, not the caller's fence. That fence reads `redirectLinkedAt` at the
     // top of the delivery and this write lands a dozen awaits later, so two inbounds arriving
     // together both passed it — and an unconditional stamp let both post their pair of private notes.

--- a/tests/modules/channel-redirect-cross-link.test.ts
+++ b/tests/modules/channel-redirect-cross-link.test.ts
@@ -285,6 +285,61 @@ describe.skipIf(!dbUp)(
       expect(out.testActivatedAt).toBeNull();
     });
 
+    // Review round 7 of #355. Since round 6, `(origin=null, mark=null)` and `(origin=null, mark=set)`
+    // are DIFFERENT states — never told, versus told there is none — and a claim that compares only
+    // the origin reads them as one. This call resolved its sibling through the recency fallback,
+    // which is what "never told" licenses; a stated clear landing under it revokes that licence, and
+    // the notes would go to a WhatsApp conversation the source just said is not this episode's.
+    test("does not stamp when a stated clear lands on the legacy state", async () => {
+      const cfg: ChannelRedirectConfig = {
+        ...CHANNEL_REDIRECT_DEFAULTS,
+        enabled: true,
+        entryInboxId: ENTRY_INBOX,
+        widgetInboxId: WIDGET_INBOX,
+      };
+      await suDb.conversation.update({
+        where: { id: widgetRowId },
+        data: {
+          redirectLinkedAt: null,
+          testActivatedAt: null,
+          // What the mirror wrote while this call was reading: same null, and a mark that turns it
+          // from silence into an answer.
+          redirectOriginDisplayId: null,
+          chatwootRedirectOriginAt: 1_786_000_000.5,
+        },
+      });
+
+      const out = await linkRedirectConversations({
+        tenantId,
+        instanceId,
+        agentId: 1n,
+        mode: "test",
+        cfg,
+        widgetConv: {
+          id: widgetRowId,
+          displayId: WIDGET_CONV,
+          testActivatedAt: null,
+          contactId,
+          // The snapshot this delivery started from: nobody had said anything yet.
+          redirectOriginDisplayId: null,
+          chatwootRedirectOriginAt: null,
+        },
+        base: appDb,
+      });
+
+      const row = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: { testActivatedAt: true, redirectLinkedAt: true },
+      });
+      expect(row.redirectLinkedAt).toBeNull();
+      expect(row.testActivatedAt).toBeNull();
+      expect(out.testActivatedAt).toBeNull();
+      await suDb.conversation.update({
+        where: { id: widgetRowId },
+        data: { chatwootRedirectOriginAt: null },
+      });
+    });
+
     // The claim is the one-shot, not the caller's fence. That fence reads `redirectLinkedAt` at the
     // top of the delivery and this write lands a dozen awaits later, so two inbounds arriving
     // together both passed it — and an unconditional stamp let both post their pair of private notes.

--- a/tests/modules/channel-redirect-episode.test.ts
+++ b/tests/modules/channel-redirect-episode.test.ts
@@ -64,10 +64,57 @@ describe("episodeOriginQuery", () => {
     entryInboxId: ENTRY_INBOX,
   };
 
+  // Review round 6 of #355. Two different facts arrive as the same stored null, and only one of them
+  // means "ask the old predicate". `chatwootRedirectOriginAt` is what separates them: it is set the
+  // first time the fork speaks about this conversation, whatever it says.
+  test("a STATED clear has no sibling: it is an answer, not a gap", () => {
+    const q = episodeOriginQuery({
+      ...base,
+      widget: {
+        chatwootRedirectOriginAt: 1_786_000_000.5,
+        redirectOriginDisplayId: null,
+        contactId: 9n,
+      },
+    });
+    // Not a recency fallback. The source said this episode has no WhatsApp half, and the consumers
+    // of this answer MESSAGE and RESOLVE what it names.
+    expect(q).toBeNull();
+  });
+
+  test("never having been told still falls back to recency", () => {
+    const q = episodeOriginQuery({
+      ...base,
+      widget: {
+        chatwootRedirectOriginAt: null,
+        redirectOriginDisplayId: null,
+        contactId: 9n,
+      },
+    });
+    expect(q?.by).toBe("recency");
+  });
+
+  // A stated pairing is the answer whether or not we hold a mark for it — a Chatwoot too old to send
+  // `updated_at` writes the value and stamps nothing.
+  test("a stored pairing with no mark is still the answer", () => {
+    const q = episodeOriginQuery({
+      ...base,
+      widget: {
+        chatwootRedirectOriginAt: null,
+        redirectOriginDisplayId: 41,
+        contactId: 9n,
+      },
+    });
+    expect(q?.by).toBe("stored");
+  });
+
   test("a stored pairing IS the answer: looked up by id, with no ordering to lose it", () => {
     const q = episodeOriginQuery({
       ...base,
-      widget: { redirectOriginDisplayId: 41, contactId: 9n },
+      widget: {
+        chatwootRedirectOriginAt: null,
+        redirectOriginDisplayId: 41,
+        contactId: 9n,
+      },
     });
     expect(q?.by).toBe("stored");
     expect(q?.where).toEqual({
@@ -84,11 +131,19 @@ describe("episodeOriginQuery", () => {
     // Same inputs as the fallback case below, plus the fact. The fact is what changes the answer.
     const stored = episodeOriginQuery({
       ...base,
-      widget: { redirectOriginDisplayId: 41, contactId: 9n },
+      widget: {
+        chatwootRedirectOriginAt: null,
+        redirectOriginDisplayId: 41,
+        contactId: 9n,
+      },
     });
     const inferred = episodeOriginQuery({
       ...base,
-      widget: { redirectOriginDisplayId: null, contactId: 9n },
+      widget: {
+        chatwootRedirectOriginAt: null,
+        redirectOriginDisplayId: null,
+        contactId: 9n,
+      },
     });
     expect(stored?.by).toBe("stored");
     expect(inferred?.by).toBe("recency");
@@ -98,7 +153,11 @@ describe("episodeOriginQuery", () => {
   test("no stored pairing falls back to the old most-recently-active predicate", () => {
     const q = episodeOriginQuery({
       ...base,
-      widget: { redirectOriginDisplayId: null, contactId: 9n },
+      widget: {
+        chatwootRedirectOriginAt: null,
+        redirectOriginDisplayId: null,
+        contactId: 9n,
+      },
     });
     expect(q?.by).toBe("recency");
     expect(q?.where).toEqual({
@@ -113,7 +172,11 @@ describe("episodeOriginQuery", () => {
     expect(
       episodeOriginQuery({
         ...base,
-        widget: { redirectOriginDisplayId: null, contactId: null },
+        widget: {
+          chatwootRedirectOriginAt: null,
+          redirectOriginDisplayId: null,
+          contactId: null,
+        },
       }),
     ).toBeNull();
   });
@@ -123,7 +186,11 @@ describe("episodeOriginQuery", () => {
   test("a stored pairing answers even with no contact on the row", () => {
     const q = episodeOriginQuery({
       ...base,
-      widget: { redirectOriginDisplayId: 41, contactId: null },
+      widget: {
+        chatwootRedirectOriginAt: null,
+        redirectOriginDisplayId: 41,
+        contactId: null,
+      },
     });
     expect(q?.by).toBe("stored");
   });

--- a/tests/modules/channel-redirect-episode.test.ts
+++ b/tests/modules/channel-redirect-episode.test.ts
@@ -4,7 +4,9 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import { runScopedOn } from "@/lib/tenancy";
 import {
+  episodeOriginQuery,
   episodeTestActivatedAt,
+  hasStoredOrigin,
   needsEpisodeLookup,
   redirectSide,
 } from "@/modules/channel-redirect/episode";
@@ -53,6 +55,87 @@ describe("redirectSide", () => {
 
 // Each row is a reason NOT to touch the database, and the reactive gate runs on every inbound
 // message, so this is the predicate that keeps that path free.
+// Issue #222. WHICH conversation is the entry half is the one question the cross-link and the ladder
+// share, and the ladder's closing RESOLVES the row it names — so a decision table, not a fixture.
+describe("episodeOriginQuery", () => {
+  const base = {
+    tenantId: 1n,
+    instanceId: 7n,
+    entryInboxId: ENTRY_INBOX,
+  };
+
+  test("a stored pairing IS the answer: looked up by id, with no ordering to lose it", () => {
+    const q = episodeOriginQuery({
+      ...base,
+      widget: { redirectOriginDisplayId: 41, contactId: 9n },
+    });
+    expect(q?.by).toBe("stored");
+    expect(q?.where).toEqual({
+      chatwootInstanceId: 7n,
+      chatwootConversationId: 41,
+    });
+    // No orderBy: one row answers, so there is nothing to rank — which is the whole point.
+    expect(q?.orderBy).toBeUndefined();
+    // And the contact is not part of the question, so a merge that moved it cannot change the answer.
+    expect(Object.keys(q?.where ?? {})).not.toContain("contactId");
+  });
+
+  test("the stored pairing wins even when a newer entry conversation exists", () => {
+    // Same inputs as the fallback case below, plus the fact. The fact is what changes the answer.
+    const stored = episodeOriginQuery({
+      ...base,
+      widget: { redirectOriginDisplayId: 41, contactId: 9n },
+    });
+    const inferred = episodeOriginQuery({
+      ...base,
+      widget: { redirectOriginDisplayId: null, contactId: 9n },
+    });
+    expect(stored?.by).toBe("stored");
+    expect(inferred?.by).toBe("recency");
+    expect(stored?.where).not.toEqual(inferred?.where);
+  });
+
+  test("no stored pairing falls back to the old most-recently-active predicate", () => {
+    const q = episodeOriginQuery({
+      ...base,
+      widget: { redirectOriginDisplayId: null, contactId: 9n },
+    });
+    expect(q?.by).toBe("recency");
+    expect(q?.where).toEqual({
+      chatwootInstanceId: 7n,
+      contactId: 9n,
+      inbox: { chatwootInboxId: ENTRY_INBOX },
+    });
+    expect(q?.orderBy).toEqual({ lastEventAt: "desc" });
+  });
+
+  test("no pairing and no contact ⇒ nothing to look up at all", () => {
+    expect(
+      episodeOriginQuery({
+        ...base,
+        widget: { redirectOriginDisplayId: null, contactId: null },
+      }),
+    ).toBeNull();
+  });
+
+  // A contactless widget row still answers when the pairing is stored: the fact does not need the
+  // contact, and refusing there would strand exactly the episodes this change exists to pair.
+  test("a stored pairing answers even with no contact on the row", () => {
+    const q = episodeOriginQuery({
+      ...base,
+      widget: { redirectOriginDisplayId: 41, contactId: null },
+    });
+    expect(q?.by).toBe("stored");
+  });
+});
+
+describe("hasStoredOrigin", () => {
+  test("separates a fact from an inference", () => {
+    expect(hasStoredOrigin(41)).toBe(true);
+    expect(hasStoredOrigin(null)).toBe(false);
+  });
+});
+
 describe("needsEpisodeLookup", () => {
   const base = {
     agentMode: "test",

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -467,6 +467,103 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
     });
   };
 
+  // Review round 10 of #355. A timed close (`closeChat: true`) posts the goodbye on the chat and
+  // resolves it BEFORE it looks the WhatsApp sibling up, and every fence past that first send is
+  // deliberately skipped — half a goodbye is worse than a duplicate. So the sibling lookup is the one
+  // read that happens after this run is already committed to an episode, and re-reading the pairing
+  // there lets a re-entry landing inside those round trips redirect the WhatsApp half: a move sends
+  // the goodbye to, and RESOLVES, the conversation the NEW episode just paired with.
+  test("a re-entry during the chat close cannot move which sibling is closed", async () => {
+    await restoreAnchor();
+    const DECOY_CONV = 7173;
+    const entry = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: ENTRY_CONV },
+      select: { inboxId: true, contactId: true },
+    });
+    await suDb.conversation.upsert({
+      where: {
+        tenantId_chatwootInstanceId_chatwootConversationId: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootConversationId: DECOY_CONV,
+        },
+      },
+      create: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        inboxId: entry.inboxId,
+        contactId: entry.contactId,
+        chatwootConversationId: DECOY_CONV,
+        status: "pending",
+        threadId: `${tenantId}:${instanceId}:${DECOY_CONV}`,
+        lastEventAt: new Date(Date.now() + 120_000),
+        lastInboundAt: new Date(),
+      },
+      update: {},
+    });
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: WIDGET_CONV },
+      data: {
+        redirectOriginDisplayId: ENTRY_CONV,
+        chatwootRedirectOriginAt: 1_786_000_000.5,
+      },
+    });
+
+    const s = stubClient();
+    const moving = {
+      ...s,
+      makeClient: async () => {
+        const inner = await s.makeClient();
+        return {
+          ...inner,
+          sendMessage: async (c: number, t: string) => {
+            // The chat half has left. From here the run cannot stop, and this is where a second
+            // redirect lands.
+            if (c === WIDGET_CONV) {
+              await suDb.conversation.updateMany({
+                where: { tenantId, chatwootConversationId: WIDGET_CONV },
+                data: {
+                  redirectOriginDisplayId: DECOY_CONV,
+                  chatwootRedirectOriginAt: 1_786_000_090.5,
+                },
+              });
+            }
+            return inner.sendMessage(c, t);
+          },
+        } as unknown as Awaited<ReturnType<typeof s.makeClient>>;
+      },
+    };
+
+    try {
+      await deliverRedirectClosing({
+        tenantId,
+        instanceId,
+        widgetConversationId: WIDGET_CONV,
+        entryInboxId: 110,
+        closingMessage: "Vamos encerrar por aqui.",
+        closeChat: true,
+        base: appDb,
+        deps: { makeClient: moving.makeClient },
+      });
+
+      // The episode this run claimed is the one it closes, on both halves.
+      expect(s.sent.map(([c]) => c)).toEqual([WIDGET_CONV, ENTRY_CONV]);
+      expect(s.resolved).toEqual([WIDGET_CONV, ENTRY_CONV]);
+    } finally {
+      await suDb.conversation.updateMany({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        data: {
+          redirectOriginDisplayId: null,
+          chatwootRedirectOriginAt: null,
+        },
+      });
+      await suDb.conversation
+        .deleteMany({ where: { tenantId, chatwootConversationId: DECOY_CONV } })
+        .catch(() => {});
+      await restoreAnchor();
+    }
+  });
+
   test("a closing whose anchor was cleared mid-run sends nothing", async () => {
     await restoreAnchor();
     const s = stubClient();

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -40,6 +40,34 @@ describe("parseRedirectFollowUpPayload", () => {
     });
   });
 
+  // The stage advance rebuilds this payload field by field, so a state parse drops is gone from the
+  // job for good — and the one it would drop is the episode the retirement reads.
+  test("the episode survives the round trip in all three states", () => {
+    expect(
+      parseRedirectFollowUpPayload({
+        stage: "chat",
+        widgetThreadId: "1:2:3",
+        agentId: "9",
+        originDisplayId: 6203,
+      }),
+    ).toMatchObject({ originDisplayId: 6203 });
+    expect(
+      parseRedirectFollowUpPayload({
+        stage: "chat",
+        widgetThreadId: "1:2:3",
+        agentId: "9",
+        originDisplayId: null,
+      }),
+    ).toMatchObject({ originDisplayId: null });
+    expect(
+      parseRedirectFollowUpPayload({
+        stage: "chat",
+        widgetThreadId: "1:2:3",
+        agentId: "9",
+      }),
+    ).not.toHaveProperty("originDisplayId");
+  });
+
   test("valid whatsapp-stage payload with a null entryInboxId", () => {
     expect(
       parseRedirectFollowUpPayload({
@@ -166,6 +194,67 @@ describe("armRedirectChatFollowUp", () => {
       agentId: "9",
       entryInboxId: 7,
     });
+  });
+
+  // Review round 12 of #355. The stamp is what lets the mirror's retirement tell the ladder it is
+  // ending from the one it is starting, and both directions matter: an event that states an episode
+  // must put it on the job, and an event that states none must leave the key OFF rather than write
+  // a null that reads as "the cleared episode".
+  test("stamps the episode the arming event stated", async () => {
+    const { fn, calls } = fakeEnqueue();
+    await armRedirectChatFollowUp(
+      {
+        tenantId: 1n,
+        instanceId: 2n,
+        widgetThreadId: "1:2:30",
+        agentId: 9n,
+        entryInboxId: 7,
+        originDisplayId: 6203,
+        cfg,
+        now,
+      },
+      fn,
+    );
+    expect(calls[0]?.payload).toEqual({
+      stage: "chat",
+      widgetThreadId: "1:2:30",
+      agentId: "9",
+      entryInboxId: 7,
+      originDisplayId: 6203,
+    });
+  });
+
+  test("a stated clear is stamped as the episode it is; silence is stamped not at all", async () => {
+    const cleared = fakeEnqueue();
+    await armRedirectChatFollowUp(
+      {
+        tenantId: 1n,
+        instanceId: 2n,
+        widgetThreadId: "1:2:30",
+        agentId: 9n,
+        entryInboxId: 7,
+        originDisplayId: null,
+        cfg,
+        now,
+      },
+      cleared.fn,
+    );
+    expect(cleared.calls[0]?.payload).toMatchObject({ originDisplayId: null });
+
+    const silent = fakeEnqueue();
+    await armRedirectChatFollowUp(
+      {
+        tenantId: 1n,
+        instanceId: 2n,
+        widgetThreadId: "1:2:30",
+        agentId: 9n,
+        entryInboxId: 7,
+        cfg,
+        now,
+      },
+      silent.fn,
+    );
+    expect(silent.calls[0]?.payload).not.toHaveProperty("originDisplayId");
   });
 
   test("no-ops only when EVERY follow-up step is disabled", async () => {
@@ -1057,12 +1146,14 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
 
   const claimed = async (
     stage: "chat" | "whatsapp" | "closing" = "chat",
+    originDisplayId?: number | null,
   ): Promise<ClaimedJob> => {
     const payload = {
       stage,
       widgetThreadId: widgetThread,
       agentId: agentId.toString(),
       entryInboxId: 110,
+      ...(originDisplayId !== undefined ? { originDisplayId } : {}),
     };
     const row = await suDb.schedulerJob.upsert({
       where: {
@@ -1130,6 +1221,69 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
       });
     }
   }
+
+  // Review round 12 of #355. Every reschedule here rebuilds the payload field by field, so the
+  // episode stamp the retirement reads has to be listed on each one or the ladder loses it at the
+  // first stage advance — and a ladder with no stamp reads as the PREVIOUS episode's, which is
+  // exactly the job the next pairing change retires.
+  test("a stage advance carries the episode stamp forward", async () => {
+    const job = await claimed("chat", 6203);
+    const s = stubClient();
+
+    const result = await withUnresolvableCredential(() =>
+      redirectFollowUpHandler(job, appDb, {
+        ...deps(),
+        makeClient: s.makeClient,
+      }),
+    );
+
+    expect(result.outcome).toBe("reschedule");
+    if (result.outcome === "reschedule") {
+      expect(result.payload).toMatchObject({ originDisplayId: 6203 });
+    }
+
+    // And the ordinary escalation, which is a different reschedule with a payload of its own. Driven
+    // by switching stage 1 OFF rather than by letting it run: the advance is what is under test, and
+    // a real model turn behind it would only add a way for this to fail for another reason.
+    const before = await suDb.agent.findUniqueOrThrow({
+      where: { id: agentId },
+      select: { settings: true },
+    });
+    const settings = before.settings as {
+      channelRedirect: Record<string, unknown>;
+    };
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        settings: {
+          ...settings,
+          channelRedirect: {
+            ...settings.channelRedirect,
+            chatFollowupEnabled: false,
+          },
+        },
+      },
+    });
+    try {
+      const escalated = await redirectFollowUpHandler(
+        await claimed("chat", 6203),
+        appDb,
+        deps(),
+      );
+      expect(escalated.outcome).toBe("reschedule");
+      if (escalated.outcome === "reschedule") {
+        expect(escalated.payload).toMatchObject({
+          stage: "whatsapp",
+          originDisplayId: 6203,
+        });
+      }
+    } finally {
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: { settings: before.settings ?? {} },
+      });
+    }
+  });
 
   test("a chat stage whose agent cannot author retries the stage instead of escalating", async () => {
     const job = await claimed("chat");

--- a/tests/modules/channel-redirect-followup.test.ts
+++ b/tests/modules/channel-redirect-followup.test.ts
@@ -623,6 +623,72 @@ describe.skipIf(!dbUp)("a ladder retired while claimed", () => {
   // The other ordering, and the one the anchor alone cannot see. Above, the reset lands AFTER the
   // claim and the post-claim re-read catches it. Here it lands BEFORE: the resolve trigger reaches
   // this function straight from a webhook, so it carries no `stillWanted`, and while it is loading
+  // Issue #222. The closing MESSAGES and RESOLVES the conversation it picks, and it used to pick the
+  // contact's most-recently-active conversation on the entry inbox. Writing into an older entry
+  // conversation is enough to make it the latest, so the goodbye and the resolve land on a thread that
+  // was never this episode's origin. Here the decoy is deliberately newer, and the stored pairing
+  // still wins.
+  test("the closing acts on the STORED origin, not the most recently active entry conversation", async () => {
+    await restoreAnchor();
+    const DECOY_CONV = 7173;
+    const entryInboxRow = await suDb.inbox.findFirstOrThrow({
+      where: { tenantId, chatwootInboxId: 110 },
+      select: { id: true },
+    });
+    const contactRow = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: ENTRY_CONV },
+      select: { contactId: true },
+    });
+    await suDb.conversation.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        inboxId: entryInboxRow.id,
+        contactId: contactRow.contactId,
+        chatwootConversationId: DECOY_CONV,
+        status: "pending",
+        threadId: `${tenantId}:${instanceId}:${DECOY_CONV}`,
+        // NEWER than the origin: the old predicate would take this one.
+        lastEventAt: new Date(Date.now() + 60_000),
+        lastInboundAt: new Date(),
+      },
+    });
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: WIDGET_CONV },
+      data: { redirectOriginDisplayId: ENTRY_CONV },
+    });
+
+    const s = stubClient();
+    try {
+      const outcome = await deliverRedirectClosing({
+        tenantId,
+        instanceId,
+        widgetConversationId: WIDGET_CONV,
+        entryInboxId: 110,
+        closingMessage: "Vamos encerrar por aqui.",
+        closeChat: true,
+        base: suDb as unknown as PrismaClient,
+        deps: { makeClient: s.makeClient },
+      });
+
+      expect(outcome).toBe("delivered");
+      expect(s.sent.map(([c]) => c)).toEqual([WIDGET_CONV, ENTRY_CONV]);
+      expect(s.resolved).toContain(ENTRY_CONV);
+      // The decoy is untouched: not messaged, and above all not resolved.
+      expect(s.sent.map(([c]) => c)).not.toContain(DECOY_CONV);
+      expect(s.resolved).not.toContain(DECOY_CONV);
+    } finally {
+      await suDb.conversation.updateMany({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        data: { redirectOriginDisplayId: null },
+      });
+      await suDb.conversation.deleteMany({
+        where: { tenantId, chatwootConversationId: DECOY_CONV },
+      });
+      await restoreAnchor();
+    }
+  });
+
   // the conversation, the agent, the bot and the client, /reset clears the anchor. The claim then
   // SUCCEEDS -- `redirectClosedAt: null` reads the same whether nobody ever closed it or the command
   // just wiped it -- and every check downstream is happy with the timestamp this run itself wrote.

--- a/tests/modules/channel-redirect-gate.test.ts
+++ b/tests/modules/channel-redirect-gate.test.ts
@@ -73,6 +73,10 @@ const calls: {
   searches: number;
   unlinks: number;
   mintedFor: string[];
+  // The conversation each token names as the redirect's ORIGIN (#222). The mint is the only moment
+  // the two halves of an episode are known together, so a token minted without it produces a link
+  // whose episode can never be paired.
+  mintedOrigin: Array<number | undefined>;
   selfReads: number;
 } = {
   merges: [],
@@ -80,6 +84,7 @@ const calls: {
   searches: 0,
   unlinks: 0,
   mintedFor: [],
+  mintedOrigin: [],
   selfReads: 0,
 };
 // The race the recovery has to survive: the holder released the identifier between the 422 and the
@@ -120,6 +125,11 @@ function installChatwootDouble(): void {
       // What the token was minted FOR. The widget identifies with this value, so a token carrying the
       // old identifier would hand the lead to whoever holds it.
       calls.mintedFor.push(String(body.identifier));
+      calls.mintedOrigin.push(
+        body.origin_display_id === undefined
+          ? undefined
+          : Number(body.origin_display_id),
+      );
       return json({
         token: "tok-123",
         website_url: "https://chat.example.com",
@@ -294,6 +304,7 @@ describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
     calls.searches = 0;
     calls.unlinks = 0;
     calls.mintedFor = [];
+    calls.mintedOrigin = [];
     calls.selfReads = 0;
     releaseHolderAfterCollision = false;
     failStampWith = null;
@@ -406,6 +417,8 @@ describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
     expect(outcome).toBe("sent");
     expect(calls.stamps).toBe(0);
     expect(calls.mintedFor).toEqual([`fzwa:${conv.chatwootContactId}`]);
+    // The token names the conversation the gate is running on, which IS the episode's entry half.
+    expect(calls.mintedOrigin).toEqual([7305]);
   });
   test("a WhatsApp contact that already carries another identifier still ends up holding ours", async () => {
     const conv = await seedConversation(7306);

--- a/tests/modules/channel-redirect-update-event.test.ts
+++ b/tests/modules/channel-redirect-update-event.test.ts
@@ -287,15 +287,23 @@ describe.skipIf(!dbUp)(
       });
     });
 
-    // Review round 9 of #355. The retirement runs inside the mirror's transaction, and a statement
-    // Postgres REJECTS there aborts the whole transaction at the server: every statement after it
-    // fails with `current transaction is aborted`, whatever JavaScript did with the rejection. A
-    // plain catch would therefore read as a degradation and deliver a rollback of the pairing —
-    // and this path is detached with Chatwoot's 200 already sent, so that event never comes back.
+    // Rounds 9 and 10 of #355, and they settle two halves of one question.
     //
-    // Reproduced with a genuinely failing statement rather than a thrown Error, because a thrown
-    // Error does not abort a Postgres transaction and would prove nothing.
-    test("a scheduler statement Postgres rejects does not cost the pairing", async () => {
+    // The savepoint is round 9: the retirement runs inside the mirror's transaction, and a statement
+    // Postgres REJECTS there aborts the whole transaction at the server. Every statement after it
+    // fails with `current transaction is aborted`, whatever JavaScript did with the rejection, so a
+    // plain catch read as a degradation and delivered a rollback. Reproduced with a genuinely failing
+    // statement rather than a thrown Error, because a thrown Error does not abort a Postgres
+    // transaction and would prove nothing.
+    //
+    // What round 10 adds is WHAT survives that rollback. Committing the new pairing over a ladder
+    // that could not be retired is the one combination that must not happen: the ladder carries no
+    // episode of its own, so it would re-read the pairing and run the PREVIOUS episode's schedule
+    // against the NEW one — a nudge and a resolve on a conversation that just started. So the pairing
+    // stands still with it. Nothing is lost by that: every later payload for this conversation
+    // restates the pairing, and the mark it is ordered by has not moved either, so the next delivery
+    // applies both together.
+    test("a scheduler statement Postgres rejects holds the pairing back", async () => {
       const FOURTH = 6204;
       const breaking = appDb.$extends({
         query: {
@@ -314,15 +322,69 @@ describe.skipIf(!dbUp)(
         },
       }) as unknown as PrismaClient;
 
-      await armLadder();
+      const key = await armLadder();
+      const stamped = new Date();
+      await suDb.conversation.updateMany({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        data: { redirectLinkedAt: stamped, redirectClosedAt: stamped },
+      });
+      const before = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: {
+          redirectOriginDisplayId: true,
+          chatwootRedirectOriginAt: true,
+        },
+      });
       await deliver(
         widgetConversation(FOURTH),
         "conversation_updated",
         breaking,
       );
 
-      // The pairing survived the aborted statement, rolled back to the savepoint.
-      expect((await widgetRow()).redirectOriginDisplayId).toBe(FOURTH);
+      // Nothing about the episode moved: not the pairing, not the mark it is ordered by, not the
+      // one-shots. The mark matters as much as the value — advanced on its own it would describe a
+      // pairing the row never took, and refuse the payload that comes to deliver it. And releasing
+      // the watermarks here would re-run the cross-link on an episode that is still the current one.
+      const after = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: {
+          redirectOriginDisplayId: true,
+          chatwootRedirectOriginAt: true,
+          redirectLinkedAt: true,
+          redirectClosedAt: true,
+        },
+      });
+      expect(after.redirectOriginDisplayId).toBe(
+        before.redirectOriginDisplayId,
+      );
+      expect(after.chatwootRedirectOriginAt).toBe(
+        before.chatwootRedirectOriginAt,
+      );
+      expect(after.redirectLinkedAt).not.toBeNull();
+      expect(after.redirectClosedAt).not.toBeNull();
+      expect(await ladderState(key)).toEqual({
+        status: "PENDING",
+        cancelled: false,
+      });
+
+      // And the next ordinary delivery applies both. The event never had to come back from
+      // Chatwoot for this: every payload for the conversation restates the pairing.
+      await deliver(widgetConversation(FOURTH), "conversation_updated");
+      const applied = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: WIDGET_CONV },
+        select: {
+          redirectOriginDisplayId: true,
+          redirectLinkedAt: true,
+          redirectClosedAt: true,
+        },
+      });
+      expect(applied.redirectOriginDisplayId).toBe(FOURTH);
+      expect(applied.redirectLinkedAt).toBeNull();
+      expect(applied.redirectClosedAt).toBeNull();
+      expect(await ladderState(key)).toEqual({
+        status: "DONE",
+        cancelled: true,
+      });
     });
 
     test("the cloned message that follows is what links the episode", async () => {

--- a/tests/modules/channel-redirect-update-event.test.ts
+++ b/tests/modules/channel-redirect-update-event.test.ts
@@ -233,7 +233,9 @@ describe.skipIf(!dbUp)(
     // messages the paired WhatsApp thread and RESOLVES it, and a worker that already read its sibling
     // passes every fence it has left — so the episode change has to retire it, which is the one
     // signal that reaches a run already claimed.
-    async function armLadder() {
+    // `origin` omitted ⇒ a payload with no episode on it, which is every ladder armed before this
+    // field existed and every one armed from a Chatwoot that does not speak about pairings.
+    async function armLadder(origin?: number | null) {
       const key = followUpDedupeKey(
         chatwootThreadId(tenantId, instanceId, WIDGET_CONV),
       );
@@ -245,7 +247,10 @@ describe.skipIf(!dbUp)(
           tenantId,
           kind: "REDIRECT_FOLLOWUP",
           dedupeKey: key,
-          payload: { stage: "whatsapp" },
+          payload: {
+            stage: "whatsapp",
+            ...(origin !== undefined ? { originDisplayId: origin } : {}),
+          },
           status: "PENDING",
           runAt: new Date(Date.now() + 600_000),
         },
@@ -384,6 +389,69 @@ describe.skipIf(!dbUp)(
       expect(await ladderState(key)).toEqual({
         status: "DONE",
         cancelled: true,
+      });
+    });
+
+    // Review round 12 of #355. The dedupe key names the CONVERSATION, and until now the retirement
+    // took every job under it — so a retirement running AFTER the new episode's ladder was armed
+    // killed the ladder it exists to protect. That ordering is reachable, and by the failure path
+    // right above: a delivery whose retirement was rejected holds the pairing back and then goes on
+    // to arm anyway, because the arm keys off the widget INBOX and never reads the pairing. The next
+    // payload restates the pairing, retires successfully, and takes the new episode's ladder with
+    // it. Nothing re-arms it either: `redirectLinkedAt` is cleared by the release, but the cross-link
+    // that reads it only runs on an INBOUND event, and the lead that was just redirected has stopped
+    // talking — which is the silence the ladder was armed to chase.
+    //
+    // So the job carries the episode it was armed for, and a retirement keeps its own. A payload
+    // with no episode on it is the previous episode's by construction: it predates the field.
+    test("a ladder armed for the episode being written survives the retirement", async () => {
+      const FIFTH = 6205;
+      const key = await armLadder(FIFTH);
+      await deliver(widgetConversation(FIFTH), "conversation_updated");
+      expect((await widgetRow()).redirectOriginDisplayId).toBe(FIFTH);
+      expect(await ladderState(key)).toEqual({
+        status: "PENDING",
+        cancelled: false,
+      });
+    });
+
+    // And the whole chain, in the order it actually happens: the retirement is rejected, the delivery
+    // arms the new episode's ladder anyway, and the payload that finally applies the pairing must
+    // leave that ladder standing.
+    test("a retirement that was rejected does not cost the new episode its ladder", async () => {
+      const SIXTH = 6206;
+      const breaking = appDb.$extends({
+        query: {
+          async $executeRaw({ args, query }) {
+            const sql = Array.isArray(args)
+              ? String((args as unknown[])[0])
+              : String(
+                  (args as { strings?: string[] }).strings?.join("") ?? "",
+                );
+            if (sql.includes("scheduler_jobs")) {
+              return query(["SELECT 1 / 0"] as never);
+            }
+            return query(args);
+          },
+        },
+      }) as unknown as PrismaClient;
+
+      await armLadder(null);
+      await deliver(
+        widgetConversation(SIXTH),
+        "conversation_updated",
+        breaking,
+      );
+      // Held back, so the row still names the previous episode.
+      expect((await widgetRow()).redirectOriginDisplayId).not.toBe(SIXTH);
+      // What the same delivery arms next, from the cloned message: the NEW episode's ladder.
+      const key = await armLadder(SIXTH);
+
+      await deliver(widgetConversation(SIXTH), "conversation_updated");
+      expect((await widgetRow()).redirectOriginDisplayId).toBe(SIXTH);
+      expect(await ladderState(key)).toEqual({
+        status: "PENDING",
+        cancelled: false,
       });
     });
 

--- a/tests/modules/channel-redirect-update-event.test.ts
+++ b/tests/modules/channel-redirect-update-event.test.ts
@@ -1,0 +1,241 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
+import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// Round 3 of fazer-ai/chatwoot#418's review asked whether the standalone `conversation_updated` the
+// fork now emits for a new pairing can make a consumer act EARLY: on the message-bearing path it is
+// dispatched before `message_created`, measured on a live instance.
+//
+//   origin changes, cloned message  ->  1. conversation_updated (new origin)
+//                                       2. message_created      (new origin)
+//
+// It cannot, and this is where that is pinned. Everything the episode does — the cross-link, the
+// ladder's re-arm, the turn itself — is gated on a brand-new INCOMING customer message, and the
+// update is not one. What the update does is state a value, which is the whole reason it exists:
+// on the message-LESS path it is the only witness there is.
+//
+// Asserted on the EFFECT rather than on one gate, because there are two and both are older than this
+// change: the call site of `maybeConsumeCommandOrGate` is itself `(act || commandActive) &&
+// isNewIncoming`, so deleting the `isNewIncomingMessage(n)` inside the cross-link block leaves these
+// tests green. Two fences on something that messages and resolves a customer's conversation is a
+// choice, not an accident, and the effect is what has to hold whichever one is load-bearing.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const WIDGET_INBOX = 61;
+const ENTRY_INBOX = 62;
+const WIDGET_CONV = 6100;
+const OLD_ORIGIN = 6201;
+const NEW_ORIGIN = 6202;
+
+let tenantId = 0n;
+let instanceId = 0n;
+let deliverySeq = 0;
+let stamp = Math.floor(Date.now() / 1000);
+const realFetch = globalThis.fetch;
+
+function widgetConversation(origin: number) {
+  stamp += 1;
+  return {
+    id: WIDGET_CONV,
+    inbox_id: WIDGET_INBOX,
+    status: "pending",
+    contact_inbox: { id: 61_000 + WIDGET_CONV },
+    meta: {
+      assignee_type: "AgentBot",
+      assignee: { id: 9, name: "Atendente" },
+      sender: { id: 61, name: "Lead" },
+    },
+    channel: "Channel::WebWidget",
+    // Frozen, exactly as the fork sends it: recording the pairing is a column write and Chatwoot's
+    // `last_activity_at` does not move on one.
+    last_activity_at: Math.floor(Date.now() / 1000) - 4366,
+    updated_at: stamp,
+    redirect_origin_display_id: origin,
+  };
+}
+
+async function deliver(payload: Record<string, unknown>, event: string) {
+  deliverySeq += 1;
+  const n = normalizeChatwootEvent({ event, ...payload });
+  if (!n) throw new Error("payload did not normalize");
+  const delivery = await suDb.chatwootWebhookDelivery.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      deliveryId: `ru-${process.pid}-${deliverySeq}`,
+      event,
+      status: "PENDING",
+    },
+    select: { id: true },
+  });
+  await processChatwootDelivery({
+    tenantId,
+    instanceId,
+    deliveryRowId: delivery.id,
+    agentBotId: 9,
+    normalized: n,
+    base: appDb,
+  });
+}
+
+async function widgetRow() {
+  return suDb.conversation.findFirstOrThrow({
+    where: { tenantId, chatwootConversationId: WIDGET_CONV },
+    select: { redirectOriginDisplayId: true, redirectLinkedAt: true },
+  });
+}
+
+describe.skipIf(!dbUp)(
+  "the pairing's own event states a value, it does not trigger the episode",
+  () => {
+    beforeAll(async () => {
+      globalThis.fetch = (async (
+        _input: RequestInfo | URL,
+        _init?: RequestInit,
+      ) =>
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as typeof globalThis.fetch;
+      const t = await suDb.tenant.create({
+        data: { name: "RU", slug: `redirect-update-${process.pid}` },
+      });
+      tenantId = t.id;
+      const inst = await seedChatwootInstance(suDb, {
+        tenantId,
+        accountId: 31,
+        baseUrl: "https://chat.ru.example",
+        adminToken: encryptJson("ADMIN"),
+      });
+      instanceId = inst.id;
+      const agent = await suDb.agent.create({
+        data: {
+          tenantId,
+          name: "Atendente",
+          systemPrompt: "Você é prestativa.",
+          modelConfig: { provider: "openai", model: "gpt-5.4-mini" },
+          settings: {
+            // Debounce ON so the inbound message ARMS a turn instead of running one: the cross-link
+            // runs before the debounce gate, and a live turn here would reach a model provider.
+            debounce: { enabled: true },
+            channelRedirect: {
+              enabled: true,
+              entryInboxId: ENTRY_INBOX,
+              widgetInboxId: WIDGET_INBOX,
+            },
+          },
+        },
+      });
+      await suDb.chatwootAgentBot.create({
+        data: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          agentId: agent.id,
+          chatwootAgentBotId: 9,
+          accessToken: encryptJson("BOT"),
+          webhookSecret: encryptJson("S"),
+          webhookRouteTokenHash: `ru-route-${process.pid}`,
+          name: "Atendente",
+        },
+      });
+      for (const chatwootInboxId of [WIDGET_INBOX, ENTRY_INBOX]) {
+        await suDb.inbox.create({
+          data: {
+            tenantId,
+            chatwootInstanceId: instanceId,
+            chatwootInboxId,
+            name: `inbox-${chatwootInboxId}`,
+            agentId: agent.id,
+          },
+        });
+      }
+    });
+
+    afterAll(async () => {
+      globalThis.fetch = realFetch;
+      if (!dbUp) return;
+      for (const table of [
+        "execution_logs",
+        "scheduler_jobs",
+        "chatwoot_webhook_deliveries",
+        "conversations",
+        "contacts",
+        "inboxes",
+        "chatwoot_agent_bots",
+        "agents",
+        "chatwoot_instances",
+        "chatwoot_deployments",
+      ]) {
+        await suDb
+          .$executeRawUnsafe(
+            `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+          )
+          .catch(() => {});
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+      await su?.$disconnect();
+      await app?.$disconnect();
+    });
+
+    test("a conversation_updated mirrors the new pairing and links nothing", async () => {
+      await deliver(widgetConversation(OLD_ORIGIN), "conversation_updated");
+      expect(await widgetRow()).toEqual({
+        redirectOriginDisplayId: OLD_ORIGIN,
+        redirectLinkedAt: null,
+      });
+
+      // The event the review was about: it carries the NEW origin and precedes the cloned message.
+      await deliver(widgetConversation(NEW_ORIGIN), "conversation_updated");
+      const afterUpdate = await widgetRow();
+      // The value is stated...
+      expect(afterUpdate.redirectOriginDisplayId).toBe(NEW_ORIGIN);
+      // ...and the episode is untouched: no cross-link ran, so nothing acted on either origin.
+      expect(afterUpdate.redirectLinkedAt).toBeNull();
+    });
+
+    test("the cloned message that follows is what links the episode", async () => {
+      await deliver(
+        {
+          id: 77_001,
+          private: false,
+          content: "oi, vim do WhatsApp",
+          message_type: "incoming",
+          sender: { id: 61, name: "Lead", type: null },
+          conversation: widgetConversation(NEW_ORIGIN),
+        },
+        "message_created",
+      );
+      const row = await widgetRow();
+      expect(row.redirectOriginDisplayId).toBe(NEW_ORIGIN);
+      expect(row.redirectLinkedAt).not.toBeNull();
+    });
+  },
+);

--- a/tests/modules/channel-redirect-update-event.test.ts
+++ b/tests/modules/channel-redirect-update-event.test.ts
@@ -83,7 +83,11 @@ function widgetConversation(origin: number) {
   };
 }
 
-async function deliver(payload: Record<string, unknown>, event: string) {
+async function deliver(
+  payload: Record<string, unknown>,
+  event: string,
+  db?: PrismaClient,
+) {
   deliverySeq += 1;
   const n = normalizeChatwootEvent({ event, ...payload });
   if (!n) throw new Error("payload did not normalize");
@@ -103,7 +107,7 @@ async function deliver(payload: Record<string, unknown>, event: string) {
     deliveryRowId: delivery.id,
     agentBotId: 9,
     normalized: n,
-    base: appDb,
+    base: db ?? appDb,
   });
 }
 
@@ -281,6 +285,44 @@ describe.skipIf(!dbUp)(
         status: "PENDING",
         cancelled: false,
       });
+    });
+
+    // Review round 9 of #355. The retirement runs inside the mirror's transaction, and a statement
+    // Postgres REJECTS there aborts the whole transaction at the server: every statement after it
+    // fails with `current transaction is aborted`, whatever JavaScript did with the rejection. A
+    // plain catch would therefore read as a degradation and deliver a rollback of the pairing —
+    // and this path is detached with Chatwoot's 200 already sent, so that event never comes back.
+    //
+    // Reproduced with a genuinely failing statement rather than a thrown Error, because a thrown
+    // Error does not abort a Postgres transaction and would prove nothing.
+    test("a scheduler statement Postgres rejects does not cost the pairing", async () => {
+      const FOURTH = 6204;
+      const breaking = appDb.$extends({
+        query: {
+          async $executeRaw({ args, query }) {
+            const sql = Array.isArray(args)
+              ? String((args as unknown[])[0])
+              : String(
+                  (args as { strings?: string[] }).strings?.join("") ?? "",
+                );
+            if (sql.includes("scheduler_jobs")) {
+              // A real error on this connection, which is what aborts the transaction.
+              return query(["SELECT 1 / 0"] as never);
+            }
+            return query(args);
+          },
+        },
+      }) as unknown as PrismaClient;
+
+      await armLadder();
+      await deliver(
+        widgetConversation(FOURTH),
+        "conversation_updated",
+        breaking,
+      );
+
+      // The pairing survived the aborted statement, rolled back to the savepoint.
+      expect((await widgetRow()).redirectOriginDisplayId).toBe(FOURTH);
     });
 
     test("the cloned message that follows is what links the episode", async () => {

--- a/tests/modules/channel-redirect-update-event.test.ts
+++ b/tests/modules/channel-redirect-update-event.test.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
+import { chatwootThreadId } from "@/graph/checkpointer";
+import { followUpDedupeKey } from "@/modules/channel-redirect/followup";
 import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { seedChatwootInstance } from "../utils/chatwoot";
@@ -52,6 +54,7 @@ const ENTRY_INBOX = 62;
 const WIDGET_CONV = 6100;
 const OLD_ORIGIN = 6201;
 const NEW_ORIGIN = 6202;
+const THIRD_ORIGIN = 6203;
 
 let tenantId = 0n;
 let instanceId = 0n;
@@ -219,6 +222,65 @@ describe.skipIf(!dbUp)(
       expect(afterUpdate.redirectOriginDisplayId).toBe(NEW_ORIGIN);
       // ...and the episode is untouched: no cross-link ran, so nothing acted on either origin.
       expect(afterUpdate.redirectLinkedAt).toBeNull();
+    });
+
+    // Review round 5 of #355. Clearing the row's watermarks frees the NEXT episode's one-shots and
+    // does nothing about the work already armed for the previous one. The REDIRECT_FOLLOWUP ladder
+    // messages the paired WhatsApp thread and RESOLVES it, and a worker that already read its sibling
+    // passes every fence it has left — so the episode change has to retire it, which is the one
+    // signal that reaches a run already claimed.
+    async function armLadder() {
+      const key = followUpDedupeKey(
+        chatwootThreadId(tenantId, instanceId, WIDGET_CONV),
+      );
+      await suDb.schedulerJob.deleteMany({
+        where: { tenantId, kind: "REDIRECT_FOLLOWUP", dedupeKey: key },
+      });
+      await suDb.schedulerJob.create({
+        data: {
+          tenantId,
+          kind: "REDIRECT_FOLLOWUP",
+          dedupeKey: key,
+          payload: { stage: "whatsapp" },
+          status: "PENDING",
+          runAt: new Date(Date.now() + 600_000),
+        },
+      });
+      return key;
+    }
+
+    async function ladderState(key: string) {
+      const row = await suDb.schedulerJob.findFirstOrThrow({
+        where: { tenantId, kind: "REDIRECT_FOLLOWUP", dedupeKey: key },
+        select: { status: true, payload: true },
+      });
+      return {
+        status: row.status,
+        cancelled:
+          (row.payload as { cancelledAt?: unknown } | null)?.cancelledAt !=
+          null,
+      };
+    }
+
+    test("a pairing that moves retires the previous episode's ladder", async () => {
+      const key = await armLadder();
+      await deliver(widgetConversation(THIRD_ORIGIN), "conversation_updated");
+      expect((await widgetRow()).redirectOriginDisplayId).toBe(THIRD_ORIGIN);
+      expect(await ladderState(key)).toEqual({
+        status: "DONE",
+        cancelled: true,
+      });
+    });
+
+    // And the other side of it: a retried delivery of the SAME pairing describes the episode that is
+    // running, so the ladder it armed is the one that should still run.
+    test("a repeat of the same pairing leaves the ladder armed", async () => {
+      const key = await armLadder();
+      await deliver(widgetConversation(THIRD_ORIGIN), "conversation_updated");
+      expect(await ladderState(key)).toEqual({
+        status: "PENDING",
+        cancelled: false,
+      });
     });
 
     test("the cloned message that follows is what links the episode", async () => {

--- a/tests/modules/chatwoot-mirror-redirect-origin.test.ts
+++ b/tests/modules/chatwoot-mirror-redirect-origin.test.ts
@@ -624,4 +624,109 @@ describe.skipIf(!dbUp)("mirror: the redirect pairing never regresses", () => {
     expect(await storedOrigin(56)).toBe(91);
     expect(await watermarks(56)).toEqual({ linked: true, closed: true });
   });
+
+  // ── Review round 8 of #355: the upgrade day. ──
+
+  async function marks(convId: number) {
+    const row = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: convId },
+      select: {
+        redirectOriginDisplayId: true,
+        chatwootRedirectOriginAt: true,
+        redirectLinkedAt: true,
+        redirectClosedAt: true,
+      },
+    });
+    return row;
+  }
+
+  // The regression this guards, and it fires on EVERY conversation at once. A redirect episode that
+  // began before the fork carried the field has a NULL column in Chatwoot, and once the fork ships,
+  // every payload for it carries the key with nil. Read as a stated clear, that stamps the mark, and
+  // a stamped mark is what tells `episodeOriginQuery` to refuse the recency fallback — so the first
+  // inbound after the upgrade loses its cross-link and every later WhatsApp touch loses its sibling.
+  //
+  // A clear is a TRANSITION, and there is nothing to transition from here. Silence and the column's
+  // default arrive as the same bytes, so the only thing that separates them is whether we were ever
+  // told about a pairing on this conversation.
+  test("a null on a conversation we were never told about is not a clear", async () => {
+    const T = 1_786_700_000;
+    await mirror(
+      clonedMessage(57, {
+        messageId: 9200,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+      }),
+    );
+    await setWatermarks(57, new Date());
+
+    // The fork is deployed: the key is present on every payload from now on, and nil.
+    await mirror(
+      clonedMessage(57, {
+        messageId: 9201,
+        lastActivityAt: T + 60,
+        updatedAt: T + 60.1,
+        origin: null,
+      }),
+    );
+
+    const row = await marks(57);
+    expect(row.redirectOriginDisplayId).toBeNull();
+    // Not stamped: nothing was stated, so the fallback this episode has always used stays open.
+    expect(row.chatwootRedirectOriginAt).toBeNull();
+    expect(row.redirectLinkedAt).not.toBeNull();
+  });
+
+  // And the clear that IS a transition still counts, mark and all.
+  test("a null after a pairing we were told about is a clear", async () => {
+    const T = 1_786_710_000;
+    await mirror(
+      clonedMessage(58, {
+        messageId: 9300,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    await mirror(
+      clonedMessage(58, {
+        messageId: 9301,
+        lastActivityAt: T + 60,
+        updatedAt: T + 60.1,
+        origin: null,
+      }),
+    );
+    const row = await marks(58);
+    expect(row.redirectOriginDisplayId).toBeNull();
+    expect(row.chatwootRedirectOriginAt).toBe(T + 60.1);
+  });
+
+  // The other half of round 8: a stored pairing with no mark. A Chatwoot too old to send
+  // `updated_at` writes the value and stamps nothing, so the mark cannot be the only evidence that
+  // we were told — the stored origin is evidence of its own, and a change away from it is a new
+  // episode exactly as it would be with a mark.
+  test("a versionless pairing that changes still releases the episode", async () => {
+    const T = 1_786_720_000;
+    await mirror(
+      clonedMessage(59, { messageId: 9400, lastActivityAt: T, origin: 77 }),
+    );
+    let row = await marks(59);
+    expect(row.redirectOriginDisplayId).toBe(77);
+    // No `updated_at` on that payload, so nothing to stamp: this is the state the finding is about.
+    expect(row.chatwootRedirectOriginAt).toBeNull();
+
+    await setWatermarks(59, new Date());
+    await mirror(
+      clonedMessage(59, {
+        messageId: 9401,
+        lastActivityAt: T + 60,
+        origin: 91,
+      }),
+    );
+
+    row = await marks(59);
+    expect(row.redirectOriginDisplayId).toBe(91);
+    expect(row.redirectLinkedAt).toBeNull();
+    expect(row.redirectClosedAt).toBeNull();
+  });
 });

--- a/tests/modules/chatwoot-mirror-redirect-origin.test.ts
+++ b/tests/modules/chatwoot-mirror-redirect-origin.test.ts
@@ -47,7 +47,9 @@ const INBOX = 91;
 interface ConvOver {
   lastActivityAt: number;
   updatedAt?: number;
-  origin?: number;
+  // Omitted ⇒ the key is absent from the payload (a Chatwoot that does not speak about pairings);
+  // `null` ⇒ the key is present and states "no pairing", which is how the fork announces a clear.
+  origin?: number | null;
 }
 
 function convPayload(convId: number, over: ConvOver) {
@@ -317,9 +319,69 @@ describe.skipIf(!dbUp)("mirror: the redirect pairing never regresses", () => {
     expect(await storedOrigin(43)).toBe(91);
   });
 
-  // A payload that names no origin leaves the stored one alone: most events on a widget conversation
-  // are ordinary traffic, and the fork omits the key outside a redirect episode.
-  test("a payload with no origin leaves the pairing standing", async () => {
+  // The fork CLEARS the pairing when a re-entry's token names no origin (fazer-ai/chatwoot#418), and
+  // states that clear as an explicit null rather than by omitting the key. Mirroring it is the whole
+  // point: the consumer holding the previous pairing is the one that has to stop acting on it.
+  test("an explicit null clears the stored pairing", async () => {
+    const T = 1_786_570_000;
+    await mirror(
+      clonedMessage(48, {
+        messageId: 8700,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    expect(await storedOrigin(48)).toBe(77);
+
+    await mirror({
+      event: "conversation_updated",
+      ...convPayload(48, {
+        lastActivityAt: T,
+        updatedAt: T + 5.4,
+        origin: null,
+      }),
+    });
+    expect(await storedOrigin(48)).toBeNull();
+  });
+
+  // ...and the clear is ordered like any other statement about the pairing: a retried delivery of the
+  // payload that set it cannot bring it back.
+  test("a stale payload cannot undo a clear", async () => {
+    const T = 1_786_580_000;
+    await mirror(
+      clonedMessage(49, {
+        messageId: 8800,
+        lastActivityAt: T,
+        updatedAt: T + 0.11,
+        origin: 77,
+      }),
+    );
+    await mirror({
+      event: "conversation_updated",
+      ...convPayload(49, {
+        lastActivityAt: T,
+        updatedAt: T + 0.62,
+        origin: null,
+      }),
+    });
+    expect(await storedOrigin(49)).toBeNull();
+
+    await mirror(
+      clonedMessage(49, {
+        messageId: 8800,
+        lastActivityAt: T,
+        updatedAt: T + 0.11,
+        origin: 77,
+      }),
+    );
+    expect(await storedOrigin(49)).toBeNull();
+  });
+
+  // A payload that OMITS the key leaves the stored one alone. Absent is not null: it is what a
+  // Chatwoot without fazer-ai/chatwoot#418 sends on every event, and reading it as a clear would wipe
+  // the pairing of every episode on the first ordinary message.
+  test("a payload with no origin key leaves the pairing standing", async () => {
     const T = 1_786_540_000;
     await mirror(
       clonedMessage(44, {

--- a/tests/modules/chatwoot-mirror-redirect-origin.test.ts
+++ b/tests/modules/chatwoot-mirror-redirect-origin.test.ts
@@ -237,6 +237,72 @@ describe.skipIf(!dbUp)("mirror: the redirect pairing never regresses", () => {
     expect(await storedOrigin(45)).toBe(91);
   });
 
+  // The pairing rides on payloads whose STATE is old news, and the two questions are independent. A
+  // conversation the mirror has been following for a while has newer status/assignee/activity marks
+  // and no redirect mark at all — the shape of every conversation live when the fork gains the field,
+  // and of a rolling deploy. The first payload to carry the pairing can easily be behind on those
+  // other axes (a retry, a frozen message snapshot), and discarding it wholesale would leave the
+  // episode unpaired and send the caller to the recency fallback this whole change exists to remove.
+  test("a payload behind on state still delivers a pairing it is the first to carry", async () => {
+    const T = 1_786_550_000;
+    // A conversation already being mirrored, with no pairing yet.
+    await mirror(
+      clonedMessage(46, {
+        messageId: 8500,
+        lastActivityAt: T + 600,
+        updatedAt: T + 600.5,
+      }),
+    );
+    expect(await storedOrigin(46)).toBeNull();
+
+    // The delayed delivery: older on every axis the row already holds, and the only witness of the
+    // pairing.
+    await mirror(
+      clonedMessage(46, {
+        messageId: 8499,
+        lastActivityAt: T,
+        updatedAt: T + 0.5,
+        origin: 77,
+      }),
+    );
+    expect(await storedOrigin(46)).toBe(77);
+  });
+
+  // ...and being let through for the pairing does not let the rest of that payload in. A brand-new
+  // incoming message normally reopens a conversation, which is the one status a message snapshot
+  // carries faithfully; a DELAYED one must not, and the pairing must not become the loophole.
+  test("...without letting the stale payload move any other state", async () => {
+    const T = 1_786_560_000;
+    await mirror({
+      event: "conversation_resolved",
+      ...convPayload(47, {
+        lastActivityAt: T + 600,
+        updatedAt: T + 600.5,
+      }),
+      status: "resolved",
+    });
+    await mirror(
+      clonedMessage(47, {
+        messageId: 8599,
+        lastActivityAt: T,
+        updatedAt: T + 0.5,
+        origin: 77,
+      }),
+    );
+    const row = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: 47 },
+      select: {
+        redirectOriginDisplayId: true,
+        status: true,
+        lastEventAt: true,
+      },
+    });
+    expect(row.redirectOriginDisplayId).toBe(77);
+    expect(row.status).toBe("resolved");
+    // And the activity watermark does not rewind to the delayed payload's.
+    expect(row.lastEventAt).toEqual(new Date((T + 600) * 1000));
+  });
+
   // A Chatwoot too old to send `updated_at` has nothing to order by. It keeps the pre-fence
   // behaviour — last write wins — rather than losing the pairing outright.
   test("without a version the payload still writes the pairing", async () => {

--- a/tests/modules/chatwoot-mirror-redirect-origin.test.ts
+++ b/tests/modules/chatwoot-mirror-redirect-origin.test.ts
@@ -1,0 +1,275 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { mirrorChatwootEvent } from "@/modules/chatwoot/mirror";
+import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// Issue #222, review round 1 of #355. The pairing is written by the fork's token resolve and read
+// by the closing stage, which MESSAGES and RESOLVES the conversation it names — so a pairing that
+// regresses to a previous episode's origin acts destructively on the wrong WhatsApp thread.
+//
+// A widget conversation can be re-entered from a second WhatsApp thread, and every payload that
+// carries the conversation carries whatever the pairing was when it was SERIALIZED. Delivery is not
+// serialization order: `AgentBots::WebhookJob` retries 3 times, 3s apart. `last_activity_at` cannot
+// separate two re-entries inside one second (whole-second resolution), so the only key that can is
+// the conversation's own `updated_at`, which moves on every write to the row — the update that
+// records the pairing included.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let instanceId = 0n;
+const INBOX = 91;
+
+interface ConvOver {
+  lastActivityAt: number;
+  updatedAt?: number;
+  origin?: number;
+}
+
+function convPayload(convId: number, over: ConvOver) {
+  return {
+    id: convId,
+    inbox_id: INBOX,
+    status: "open",
+    contact_inbox: { id: 77_000 + convId },
+    meta: {
+      assignee_type: null,
+      assignee: null,
+      sender: {
+        id: 600 + convId,
+        name: "Lead",
+        phone_number: "+5511988887777",
+      },
+    },
+    channel: "Channel::WebWidget",
+    last_activity_at: over.lastActivityAt,
+    ...(over.updatedAt !== undefined ? { updated_at: over.updatedAt } : {}),
+    ...(over.origin !== undefined
+      ? { redirect_origin_display_id: over.origin }
+      : {}),
+  };
+}
+
+async function mirror(payload: unknown) {
+  const n = normalizeChatwootEvent(payload);
+  expect(n).not.toBeNull();
+  if (!n) throw new Error("unreachable");
+  return mirrorChatwootEvent(tenantId, instanceId, n, appDb);
+}
+
+// A cloned message arriving for a widget conversation: the snapshot embeds the pairing as it stood
+// when the message fired.
+function clonedMessage(convId: number, over: ConvOver & { messageId: number }) {
+  return {
+    event: "message_created",
+    id: over.messageId,
+    content: "Oi, vim do WhatsApp",
+    message_type: "incoming",
+    private: false,
+    conversation: convPayload(convId, over),
+  };
+}
+
+async function storedOrigin(convId: number) {
+  const row = await suDb.conversation.findFirstOrThrow({
+    where: { tenantId, chatwootConversationId: convId },
+    select: { redirectOriginDisplayId: true },
+  });
+  return row.redirectOriginDisplayId;
+}
+
+describe.skipIf(!dbUp)("mirror: the redirect pairing never regresses", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: {
+        name: "MIRROR-REDIRECT-ORIGIN",
+        slug: `mirror-redirect-origin-${process.pid}`,
+      },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 11,
+      baseUrl: "https://chat.example.com",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+  });
+
+  afterAll(async () => {
+    if (!dbUp) return;
+    await suDb.tenant.delete({ where: { id: tenantId } }).catch(() => {});
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  // The race the fence exists for. Both re-entries land in ONE second, so `last_activity_at` cannot
+  // separate them; the retried delivery of the FIRST arrives after the second and carries origin 77.
+  test("a retried snapshot cannot overwrite a newer origin inside one second", async () => {
+    const T = 1_786_500_000;
+    await mirror(
+      clonedMessage(40, {
+        messageId: 8001,
+        lastActivityAt: T,
+        updatedAt: T + 0.11,
+        origin: 77,
+      }),
+    );
+    await mirror(
+      clonedMessage(40, {
+        messageId: 8002,
+        lastActivityAt: T,
+        updatedAt: T + 0.62,
+        origin: 91,
+      }),
+    );
+    expect(await storedOrigin(40)).toBe(91);
+
+    // The retry of the first delivery, unchanged, ~9s late.
+    await mirror(
+      clonedMessage(40, {
+        messageId: 8001,
+        lastActivityAt: T,
+        updatedAt: T + 0.11,
+        origin: 77,
+      }),
+    );
+    expect(await storedOrigin(40)).toBe(91);
+  });
+
+  // The fork emits a conversation_updated of its own when the pairing changes on an existing
+  // conversation (fazer-ai/chatwoot#418). It carries a FRESH `updated_at` and the FROZEN
+  // `last_activity_at` — the column write does not move that one — so recency cannot order it and
+  // the version must.
+  test("the pairing's own conversation_updated applies despite a frozen last_activity_at", async () => {
+    const T = 1_786_510_000;
+    await mirror(
+      clonedMessage(41, {
+        messageId: 8100,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    expect(await storedOrigin(41)).toBe(77);
+
+    await mirror({
+      event: "conversation_updated",
+      ...convPayload(41, {
+        lastActivityAt: T,
+        updatedAt: T + 5.4,
+        origin: 91,
+      }),
+    });
+    expect(await storedOrigin(41)).toBe(91);
+  });
+
+  // Ordinary forward motion still works: a later episode's snapshot, serialized after the write,
+  // carries the newer origin and takes it.
+  test("a newer origin still takes over", async () => {
+    const T = 1_786_520_000;
+    await mirror(
+      clonedMessage(42, {
+        messageId: 8200,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    await mirror(
+      clonedMessage(42, {
+        messageId: 8201,
+        lastActivityAt: T + 600,
+        updatedAt: T + 600.1,
+        origin: 91,
+      }),
+    );
+    expect(await storedOrigin(42)).toBe(91);
+  });
+
+  // The mirror creates the row from whatever event it sees FIRST, which is not necessarily the
+  // oldest one: a retry can put the newer re-entry ahead of the older. The mark has to be stamped at
+  // creation too, or the row is born unprotected and the delayed payload regresses it.
+  test("a row born from the newer payload is already protected from the older one", async () => {
+    const T = 1_786_525_000;
+    await mirror(
+      clonedMessage(45, {
+        messageId: 8250,
+        lastActivityAt: T,
+        updatedAt: T + 0.62,
+        origin: 91,
+      }),
+    );
+    expect(await storedOrigin(45)).toBe(91);
+
+    await mirror(
+      clonedMessage(45, {
+        messageId: 8249,
+        lastActivityAt: T,
+        updatedAt: T + 0.11,
+        origin: 77,
+      }),
+    );
+    expect(await storedOrigin(45)).toBe(91);
+  });
+
+  // A Chatwoot too old to send `updated_at` has nothing to order by. It keeps the pre-fence
+  // behaviour — last write wins — rather than losing the pairing outright.
+  test("without a version the payload still writes the pairing", async () => {
+    const T = 1_786_530_000;
+    await mirror(
+      clonedMessage(43, { messageId: 8300, lastActivityAt: T, origin: 77 }),
+    );
+    expect(await storedOrigin(43)).toBe(77);
+    await mirror(
+      clonedMessage(43, { messageId: 8301, lastActivityAt: T, origin: 91 }),
+    );
+    expect(await storedOrigin(43)).toBe(91);
+  });
+
+  // A payload that names no origin leaves the stored one alone: most events on a widget conversation
+  // are ordinary traffic, and the fork omits the key outside a redirect episode.
+  test("a payload with no origin leaves the pairing standing", async () => {
+    const T = 1_786_540_000;
+    await mirror(
+      clonedMessage(44, {
+        messageId: 8400,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    await mirror(
+      clonedMessage(44, {
+        messageId: 8401,
+        lastActivityAt: T + 60,
+        updatedAt: T + 60.1,
+      }),
+    );
+    expect(await storedOrigin(44)).toBe(77);
+  });
+});

--- a/tests/modules/chatwoot-mirror-redirect-origin.test.ts
+++ b/tests/modules/chatwoot-mirror-redirect-origin.test.ts
@@ -400,4 +400,228 @@ describe.skipIf(!dbUp)("mirror: the redirect pairing never regresses", () => {
     );
     expect(await storedOrigin(44)).toBe(77);
   });
+
+  // ── Review round 5 of #355: the pairing is the EPISODE'S IDENTITY, so the row's per-episode
+  //    watermarks have to move with it. `redirectLinkedAt` and `redirectClosedAt` are one-shots
+  //    scoped to "this redirect episode": the first gates the cross-link, the second is the
+  //    at-most-once claim for the goodbye. Neither knew which origin it was stamped for, because
+  //    until #222 nothing on this side did. ──
+
+  async function setWatermarks(convId: number, at: Date | null) {
+    await suDb.conversation.updateMany({
+      where: { tenantId, chatwootConversationId: convId },
+      data: { redirectLinkedAt: at, redirectClosedAt: at },
+    });
+  }
+
+  async function watermarks(convId: number) {
+    const row = await suDb.conversation.findFirstOrThrow({
+      where: { tenantId, chatwootConversationId: convId },
+      select: { redirectLinkedAt: true, redirectClosedAt: true },
+    });
+    return {
+      linked: row.redirectLinkedAt !== null,
+      closed: row.redirectClosedAt !== null,
+    };
+  }
+
+  // The defect this releases. Without it the second episode never gets its cross-link (the one-shot
+  // reads a watermark the FIRST episode set) and never gets its goodbye (the closing CAS asks for
+  // `redirectClosedAt: null` and the first episode already spent it).
+  test("a different origin releases the previous episode's watermarks", async () => {
+    const T = 1_786_600_000;
+    await mirror(
+      clonedMessage(50, {
+        messageId: 8500,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    await setWatermarks(50, new Date());
+
+    await mirror({
+      event: "conversation_updated",
+      ...convPayload(50, { lastActivityAt: T, updatedAt: T + 5, origin: 91 }),
+    });
+
+    expect(await storedOrigin(50)).toBe(91);
+    expect(await watermarks(50)).toEqual({ linked: false, closed: false });
+  });
+
+  // The other half, and the one that keeps this from being a wipe on every delivery: the retried
+  // snapshot of the SAME episode says nothing new, so the episode it describes is still running.
+  test("a retry of the same origin leaves the episode standing", async () => {
+    const T = 1_786_610_000;
+    await mirror(
+      clonedMessage(51, {
+        messageId: 8600,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    await setWatermarks(51, new Date());
+
+    await mirror(
+      clonedMessage(51, {
+        messageId: 8601,
+        lastActivityAt: T + 30,
+        updatedAt: T + 30.1,
+        origin: 77,
+      }),
+    );
+
+    expect(await storedOrigin(51)).toBe(77);
+    expect(await watermarks(51)).toEqual({ linked: true, closed: true });
+  });
+
+  // LEARNING a pairing is not a new episode, and the column alone cannot tell the two apart: stored
+  // null is both "the fork never spoke about this conversation" and "the fork said there is none".
+  // `chatwootRedirectOriginAt` is what separates them — it is set the first time we are TOLD — and
+  // the direction of the mistake decides which way to lean. Releasing here would re-run the
+  // cross-link on a live episode and post its private notes a second time, on every conversation, the
+  // day fazer-ai/chatwoot#418 is deployed; not releasing leaves exactly the behaviour of today.
+  test("the first pairing ever stated leaves the episode standing", async () => {
+    const T = 1_786_620_000;
+    await mirror(
+      clonedMessage(52, {
+        messageId: 8700,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+      }),
+    );
+    await setWatermarks(52, new Date());
+
+    await mirror(
+      clonedMessage(52, {
+        messageId: 8701,
+        lastActivityAt: T + 30,
+        updatedAt: T + 30.1,
+        origin: 77,
+      }),
+    );
+
+    expect(await storedOrigin(52)).toBe(77);
+    expect(await watermarks(52)).toEqual({ linked: true, closed: true });
+  });
+
+  // A stated clear IS an episode change: the fork writes it when a token resumes this conversation
+  // naming no origin, which is a resume with no WhatsApp half. What must not follow is the previous
+  // episode's ladder closing a thread this conversation is no longer paired with.
+  test("a stated clear releases the episode too", async () => {
+    const T = 1_786_630_000;
+    await mirror(
+      clonedMessage(53, {
+        messageId: 8800,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    await setWatermarks(53, new Date());
+
+    await mirror({
+      event: "conversation_updated",
+      ...convPayload(53, { lastActivityAt: T, updatedAt: T + 5, origin: null }),
+    });
+
+    expect(await storedOrigin(53)).toBeNull();
+    expect(await watermarks(53)).toEqual({ linked: false, closed: false });
+  });
+
+  // The release rides with the WRITE, so it has to reach the stale branch as well: that branch is
+  // where the pairing's own `conversation_updated` lands whenever the payload is behind on activity,
+  // which is the ordinary case for it (`last_activity_at` does not move on a column write).
+  test("the stale branch releases the episode with the pairing it writes", async () => {
+    const T = 1_786_640_000;
+    await mirror(
+      clonedMessage(54, {
+        messageId: 8900,
+        lastActivityAt: T + 600,
+        updatedAt: T + 600.1,
+        origin: 77,
+      }),
+    );
+    await setWatermarks(54, new Date());
+
+    // Older on activity than what is stored — this is the stale branch — but newer on the pairing's
+    // own mark, so the pairing applies and the episode goes with it.
+    await mirror({
+      event: "conversation_updated",
+      ...convPayload(54, {
+        lastActivityAt: T,
+        updatedAt: T + 700,
+        origin: 91,
+      }),
+    });
+
+    expect(await storedOrigin(54)).toBe(91);
+    expect(await watermarks(54)).toEqual({ linked: false, closed: false });
+  });
+
+  // The release rides on the pairing being APPLIED, and both halves of that matter. A payload that
+  // says nothing about the pairing is not an episode change — it is every ordinary message from a
+  // Chatwoot without fazer-ai/chatwoot#418, and reading its silence as "no origin, therefore
+  // different" would release the episode of every conversation on every delivery.
+  test("a payload that omits the key leaves the episode standing", async () => {
+    const T = 1_786_650_000;
+    await mirror(
+      clonedMessage(55, {
+        messageId: 9000,
+        lastActivityAt: T,
+        updatedAt: T + 0.1,
+        origin: 77,
+      }),
+    );
+    await setWatermarks(55, new Date());
+
+    await mirror(
+      clonedMessage(55, {
+        messageId: 9001,
+        lastActivityAt: T + 60,
+        updatedAt: T + 60.1,
+      }),
+    );
+
+    expect(await storedOrigin(55)).toBe(77);
+    expect(await watermarks(55)).toEqual({ linked: true, closed: true });
+  });
+
+  // And the other half: a pairing the version fence REFUSES describes an episode that already ended,
+  // so it cannot end the one running now. Releasing on a value that is not written would let the
+  // retried delivery of a previous episode wipe the current episode's one-shots.
+  test("a refused older pairing leaves the episode standing", async () => {
+    const T = 1_786_660_000;
+    await mirror(
+      clonedMessage(56, {
+        messageId: 9100,
+        lastActivityAt: T,
+        updatedAt: T + 0.11,
+        origin: 77,
+      }),
+    );
+    await mirror(
+      clonedMessage(56, {
+        messageId: 9101,
+        lastActivityAt: T,
+        updatedAt: T + 0.62,
+        origin: 91,
+      }),
+    );
+    await setWatermarks(56, new Date());
+
+    // The retry of the first delivery: a DIFFERENT origin, and one this row already moved past.
+    await mirror(
+      clonedMessage(56, {
+        messageId: 9100,
+        lastActivityAt: T,
+        updatedAt: T + 0.11,
+        origin: 77,
+      }),
+    );
+
+    expect(await storedOrigin(56)).toBe(91);
+    expect(await watermarks(56)).toEqual({ linked: true, closed: true });
+  });
 });

--- a/tests/modules/chatwoot-payload-shape.test.ts
+++ b/tests/modules/chatwoot-payload-shape.test.ts
@@ -220,6 +220,36 @@ describe.skipIf(!dbUp)(
       expect(rows.map((r) => r.chatwootConversationId)).toEqual([DISPLAY_ID]);
     });
 
+    // Issue #222, and the same display-id-not-table-id rule this file exists for. The fork stamps the
+    // redirect episode's origin on the widget conversation and ships it on push_data; it is the ENTRY
+    // conversation's display id, so it lands in a column the mirror compares against
+    // chatwootConversationId.
+    test("the redirect origin rides in on the payload and lands in the column", async () => {
+      const ORIGIN_DISPLAY = 4242;
+      await mirror({
+        event: "message_created",
+        ...messageBody(),
+        conversation: {
+          ...conversationBody(),
+          redirect_origin_display_id: ORIGIN_DISPLAY,
+        },
+      });
+      const row = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: DISPLAY_ID },
+        select: { redirectOriginDisplayId: true },
+      });
+      expect(row.redirectOriginDisplayId).toBe(ORIGIN_DISPLAY);
+
+      // A later payload that says nothing about the pairing must not wipe it: absent is "this event
+      // did not mention it", the same convention the attribute bags follow.
+      await mirror({ event: "conversation_updated", ...conversationBody() });
+      const after = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: DISPLAY_ID },
+        select: { redirectOriginDisplayId: true },
+      });
+      expect(after.redirectOriginDisplayId).toBe(ORIGIN_DISPLAY);
+    });
+
     // Same rule from the other end: a body about a different SUBJECT writes nothing at all, rather
     // than a row keyed by that subject's id.
     test("a contact body opens no conversation row", async () => {

--- a/tests/modules/chatwoot-reset.test.ts
+++ b/tests/modules/chatwoot-reset.test.ts
@@ -1351,6 +1351,47 @@ describe.skipIf(!dbUp)(
       });
     });
 
+    // The pairing is NOT one of them, and the difference is what each column is. The four above are
+    // one-shot / cooldown watermarks: /reset clears them so the funnel can be run again. The pairing
+    // is an observed FACT — which WhatsApp conversation this chat was opened from — and /reset does
+    // not undo that; it does not un-click the link the lead clicked.
+    //
+    // Clearing it would be strictly worse, not neutral. `episodeOriginQuery` falls back to the
+    // contact's most recently active entry conversation when there is no stored answer, which is the
+    // inference #222 exists to remove: the reset would trade a right answer for a guess, on a
+    // consumer that MESSAGES and RESOLVES the conversation it picks. And nothing goes stale by
+    // keeping it: the value only ever changes when a new redirect is actually consumed, and then the
+    // fork writes the new origin over it.
+    test("the pairing survives, because a reset does not un-click the link", async () => {
+      await suDb.conversation.updateMany({
+        where: { tenantId, chatwootConversationId: CONV_ID },
+        data: {
+          redirectOriginDisplayId: 4242,
+          redirectLinkedAt: new Date(),
+          redirectClosedAt: new Date(),
+        },
+      });
+      const cw = fakeChatwoot();
+      globalThis.fetch = cw.impl;
+      await sendReset();
+
+      const conv = await suDb.conversation.findFirstOrThrow({
+        where: { tenantId, chatwootConversationId: CONV_ID },
+        select: {
+          redirectOriginDisplayId: true,
+          redirectLinkedAt: true,
+          redirectClosedAt: true,
+        },
+      });
+      expect(conv).toEqual({
+        // The episode can be run again...
+        redirectLinkedAt: null,
+        redirectClosedAt: null,
+        // ...against the origin it actually came from.
+        redirectOriginDisplayId: 4242,
+      });
+    });
+
     // Jobs the episode armed. /reset already cancels FOLLOWUP and MEMORY_COMPACT; these two carry
     // exactly the same argument and were left running.
     test("the jobs the episode armed are cancelled with it", async () => {

--- a/tests/modules/chatwoot-state-order.test.ts
+++ b/tests/modules/chatwoot-state-order.test.ts
@@ -288,10 +288,36 @@ const CASES: Case[] = [
     row: storedRow({ activityAt: LATER, redirectOriginAt: V_OLD }),
     want: { redirectOrigin: true, redirectOriginAt: V_NEW, unversioned: false },
   },
+  // The stale branch's one exception: `stale` means "behind on every axis this payload OFFERS", and
+  // the pairing is an axis of its own. The first payload to carry one is routinely behind on the
+  // others — a retry, or any event on a conversation the mirror followed since before the fork had
+  // the field, where the other two marks are set and this one is null.
   {
-    name: "a stale event writes no pairing at all",
+    name: "a stale event still delivers a pairing its own mark does not refuse",
     payload: conversationEvent({ version: V_OLD, redirectOriginStated: true }),
-    row: storedRow({ redirectOriginAt: V_OLD }),
+    row: storedRow({ redirectOriginAt: null }),
+    want: { stale: true, redirectOrigin: true, redirectOriginAt: V_OLD },
+  },
+  {
+    name: "...and nothing else leaks through with it",
+    payload: conversationEvent({
+      version: V_OLD,
+      reopensConversation: true,
+      redirectOriginStated: true,
+    }),
+    row: storedRow({ redirectOriginAt: null }),
+    want: { status: null, assignee: false, unversioned: false },
+  },
+  {
+    name: "a stale event behind the redirect mark too writes no pairing",
+    payload: conversationEvent({ version: V_OLD, redirectOriginStated: true }),
+    row: storedRow({ redirectOriginAt: V_NOW }),
+    want: { stale: true, redirectOrigin: false, redirectOriginAt: null },
+  },
+  {
+    name: "a stale event that names no pairing writes none",
+    payload: conversationEvent({ version: V_OLD }),
+    row: storedRow({ redirectOriginAt: null }),
     want: { stale: true, redirectOrigin: false, redirectOriginAt: null },
   },
   // No version to order by (Chatwoot < 4.0.2): the pre-fence behaviour, stated rather than implied.

--- a/tests/modules/chatwoot-state-order.test.ts
+++ b/tests/modules/chatwoot-state-order.test.ts
@@ -28,6 +28,7 @@ function conversationEvent(over: Partial<StatePayload> = {}): StatePayload {
     status: "resolved",
     assigneeStated: true,
     assigneeType: "User",
+    redirectOriginCleared: false,
     redirectOriginStated: false,
     ...over,
   };
@@ -48,6 +49,7 @@ function storedRow(over: Partial<StateRow> = {}): StateRow {
     assigneeAt: V_NOW,
     assigneeType: "AgentBot",
     redirectOriginAt: null,
+    redirectOriginKnown: false,
     ...over,
   };
 }

--- a/tests/modules/chatwoot-state-order.test.ts
+++ b/tests/modules/chatwoot-state-order.test.ts
@@ -28,6 +28,7 @@ function conversationEvent(over: Partial<StatePayload> = {}): StatePayload {
     status: "resolved",
     assigneeStated: true,
     assigneeType: "User",
+    redirectOriginStated: false,
     ...over,
   };
 }
@@ -46,6 +47,7 @@ function storedRow(over: Partial<StateRow> = {}): StateRow {
     statusAt: V_NOW,
     assigneeAt: V_NOW,
     assigneeType: "AgentBot",
+    redirectOriginAt: null,
     ...over,
   };
 }
@@ -241,6 +243,69 @@ const CASES: Case[] = [
     payload: conversationEvent({ status: null }),
     row: null,
     want: { status: null, statusAt: null, assigneeAt: V_NEW },
+  },
+
+  // The redirect pairing (#222), on its own mark. The consumer of this field messages AND resolves
+  // the conversation it names, so a value that regresses to a previous episode's origin acts
+  // destructively on the wrong WhatsApp thread.
+  {
+    name: "a payload that names no origin writes none and stamps nothing",
+    payload: messageEvent({ activityAt: NOW }),
+    row: storedRow({ redirectOriginAt: V_NOW }),
+    want: { redirectOrigin: false, redirectOriginAt: null },
+  },
+  {
+    name: "a message snapshot DOES carry the pairing, unlike status and assignee",
+    payload: messageEvent({ activityAt: NOW, redirectOriginStated: true }),
+    row: storedRow(),
+    want: { redirectOrigin: true, redirectOriginAt: V_NEW },
+  },
+  {
+    name: "a retried snapshot behind the mark cannot regress the pairing",
+    payload: messageEvent({
+      version: V_OLD,
+      activityAt: LATER,
+      redirectOriginStated: true,
+    }),
+    row: storedRow({ redirectOriginAt: V_NOW }),
+    want: { stale: false, redirectOrigin: false, redirectOriginAt: null },
+  },
+  {
+    name: "an equal version writes the same reading rather than letting delivery order decide",
+    payload: messageEvent({ version: V_NOW, redirectOriginStated: true }),
+    row: storedRow({ redirectOriginAt: V_NOW }),
+    want: { redirectOrigin: true, redirectOriginAt: null },
+  },
+  // The event the fork emits when the pairing changes on an existing conversation: a fresh version
+  // and a last_activity_at that a column write never moved. Recency would discard it; version does not.
+  {
+    name: "the pairing's own event applies on version, with a frozen last_activity_at",
+    payload: conversationEvent({
+      version: V_NEW,
+      activityAt: EARLIER,
+      redirectOriginStated: true,
+    }),
+    row: storedRow({ activityAt: LATER, redirectOriginAt: V_OLD }),
+    want: { redirectOrigin: true, redirectOriginAt: V_NEW, unversioned: false },
+  },
+  {
+    name: "a stale event writes no pairing at all",
+    payload: conversationEvent({ version: V_OLD, redirectOriginStated: true }),
+    row: storedRow({ redirectOriginAt: V_OLD }),
+    want: { stale: true, redirectOrigin: false, redirectOriginAt: null },
+  },
+  // No version to order by (Chatwoot < 4.0.2): the pre-fence behaviour, stated rather than implied.
+  {
+    name: "a versionless payload writes the pairing and stamps no mark",
+    payload: messageEvent({ version: null, redirectOriginStated: true }),
+    row: storedRow({ redirectOriginAt: null }),
+    want: { redirectOrigin: true, redirectOriginAt: null },
+  },
+  {
+    name: "the first pairing seen on a conversation with no row claims the mark",
+    payload: messageEvent({ redirectOriginStated: true }),
+    row: null,
+    want: { redirectOrigin: true, redirectOriginAt: V_NEW },
   },
 ];
 


### PR DESCRIPTION
## What was missing

A redirect episode spans two conversations — the WhatsApp **entry** thread (which carries `redirectSentAt` / `redirectCount`) and the **widget** thread the lead lands on (which carries `redirectLinkedAt` / `redirectClosedAt`) — and nothing on this side could say which widget chat opened from which entry conversation. The merge happens inside Chatwoot's token resolve, and what comes back identifies the **contact**.

The five predicates over the mirrored rows are enumerated in #222, each wrong for its own reason. All five are inferences about an event this side never observes, and the consumers act on them destructively: the closing stage messages **and resolves** the conversation it names.

## The change

The answer is now recorded where it is known. fazer-ai/chatwoot#418 carries the origin in the redirect token and stamps it on the widget conversation at resolve time — before any event carrying that conversation exists — and ships it on `push_data`. This side sends it at mint, mirrors it off the webhook, and reads it instead of guessing.

- **`mintRedirectToken` takes `originDisplayId`.** The gate passes the conversation it is running on; the WhatsApp follow-up passes the sibling it re-sends on. Both already had it in hand.
- **`normalize` + `mirror` carry it into `Conversation.redirectOriginDisplayId`.** It is the **display id** — the same number `chatwootConversationId` holds — never Chatwoot's primary key, which is the confusion #257 is about. A payload that does not mention the pairing does not clear it.
- **`episodeOriginQuery` answers *which* row is the entry half**, and the two callers that used to answer it on their own (`cross-link`, the ladder's `resolveWhatsAppSibling`) now share it. It reports `by: "stored" | "recency"` so an episode acted on by inference is visible from the outside.
- **The pairing gets an ordering mark of its own**, `chatwootRedirectOriginAt`, alongside `chatwootStatusAt` and `chatwootAssigneeAt`. Round 1 of the review is why; see below.

### Why the pairing needs a third version mark

A widget conversation can be re-entered from a **second** WhatsApp thread, and every payload carries the pairing as of when it was **serialized**, not when it was delivered. `AgentBots::WebhookJob` retries 3 times, 3s apart, so a retried snapshot of the older re-entry can land after the newer one. `last_activity_at` cannot separate two re-entries inside one second, and — the part that decides the design — it does not move **at all** when the fork records the pairing, because that is a column write.

So the fork's own `conversation_updated` for a new pairing arrives with a **frozen** `last_activity_at`. Measured on the live instance: `updated_at=1787752427.514484` against `last_activity_at=1787748061`, 4366 seconds behind. A recency fence would discard exactly the payload that carries the answer. The version fence takes it.

Fed that real payload through the mirror both ways, against a row holding an older origin:

```
recency fence (decision.unversioned)  →  redirectOriginDisplayId stays 99   ✗
version fence (this PR)               →  redirectOriginDisplayId becomes 2  ✓
```

A Chatwoot too old to send `updated_at` writes the pairing and stamps no mark, which is the pre-fence behaviour: there is no key to order by, so last write wins, as it did before.

The mark also carved out the one exception the stale branch has. `stale` means "behind the row on every axis this payload offers", and until the pairing had a mark of its own those axes were the whole payload — so the branch was discarding a pairing along with the state. The payload that FIRST carries one is routinely behind on the others: a retried snapshot, or **any** event on a conversation the mirror has been following since before the fork had the field, where the other two marks are set and this one is null. That is every live conversation at the upgrade. The branch now decides the pairing on its own mark and writes only that — a delayed message still cannot reopen a conversation or rewind the activity watermark on the pairing's ticket.

### What `/reset` does with it: nothing

`/reset` clears four redirect columns and deliberately leaves this one. Those four are one-shot / cooldown **watermarks**, cleared so the funnel can be run again; the pairing is an observed fact, and a reset does not un-click the link the lead clicked. Clearing it would send `episodeOriginQuery` to the recency fallback — the inference this PR removes — on a consumer that messages **and resolves** what it picks. It cannot go stale either: the value changes only when a new redirect is consumed, and the fork writes over it then (or clears it, when that redirect names no origin).

The old predicate stays as the fallback, and only that: it is consulted when there is no stored answer, which is every episode that began before the fork carried the field and every instance running a Chatwoot that does not send it.

### When the pairing moves, the episode moves with it

Round 5 of the review, three findings, one question: nothing on this side was keyed to the origin that was current when it acted. The pairing is the episode's **identity**, and the consumers were all written under the limit this PR removes.

- **The mirror releases the episode** when it accepts a genuinely different pairing: `redirectLinkedAt` and `redirectClosedAt` cleared alongside the write, in the stale branch too, since the pairing's own `conversation_updated` ordinarily lands stale. Left standing, a second episode on the same widget conversation gets neither its cross-link (the one-shot reads a watermark the first episode set) nor its goodbye (the closing CAS asks for a null the first episode spent).
- **The webhook retires the previous episode's ladder.** `REDIRECT_FOLLOWUP` messages the paired WhatsApp thread and resolves it, and retirement is the one signal that reaches a worker already claimed — `cancelPendingJob` touches PENDING rows only. Same key, same call `/reset` makes.
- **The cross-link claims its watermark** for the origin it read instead of stamping it, and **the closing CAS carries the origin the run read**. The resolve trigger enters the closing straight from a webhook with no job to ask about, so on that path the claim is the only fence.

"Genuinely different" is asked of a **previously STATED** origin, not of the stored value. Stored null is both "the fork never spoke about this conversation" and "the fork said there is none"; `chatwootRedirectOriginAt` is what separates them, and it is set the first time we are told. Leaning the other way releases the episode of every live conversation on the day fazer-ai/chatwoot#418 deploys, re-running each cross-link and posting its private notes a second time. Leaning this way leaves exactly today's behaviour for a pairing we are only now learning.

It is also fenced on the pairing being **applied**, not merely stated — a payload that omits the key would otherwise read as "no origin, therefore different" and release the episode on every ordinary delivery.

Both symptoms predate this PR: `redirectLinkedAt === null` and the `redirectClosedAt: null` CAS are untouched by this branch. What changed is that the row can now tell one episode from the next.

### The clear is an answer, and the ladder retires with the pairing

Round 6, and the first of its two findings is the pair of the clear itself: making a clear observable created a **second null**, and the consumer read the two as one.

`episodeOriginQuery` now takes `chatwootRedirectOriginAt` and returns **no sibling** for a stated clear. Told-and-empty means this episode has no WhatsApp half; never-told still falls back to recency, which is what the fallback was written for. Read as a gap instead, a stated clear handed the closing the contact's most recent WhatsApp thread — to message and to **resolve** — on an episode the source said had none. The parameter is required rather than optional so a caller that has not thought about the question cannot get the old behaviour by omission; the type error is what located both call sites and the webhook's `ctx.conv` select.

The one case it cannot separate is a Chatwoot too old to send `updated_at`: it states the clear and stamps no mark, so the clear reads as silence and takes the fallback. Same degradation the pairing's ordering already has on those instances, failing to the behaviour they had before the field existed.

The second finding moved the ladder retirement **into the mirror's transaction**. Outside it, the pairing's `conversation_updated` and the cloned `message_created` that follows are two deliveries: processed concurrently, the message can arm the NEW episode's ladder between the pairing committing and the retirement running, and the retirement then marks the new episode's own job `DONE` — the dedupe key carries no generation to tell them apart. Inside, the `UPDATE` holds the row lock on that key to commit, so a racing arm lands after it and survives. Same rule `/reset` states in its own ordering comment, reached by one transaction instead of by ordering two.

`retireJobsByDedupeKeyOn` takes the caller's already-scoped connection, the same shape as `revokeJobsByKeyPrefixOn` beside it. The dedupe key is passed **in** to the mirror rather than derived there: the key belongs to channel-redirect and the mirror has no business spelling it, which also keeps `followup.ts`'s import graph out of the mirror.

### The two nulls reach the claims too

Round 7, and the tail of the same thread: since the stated clear became an answer of its own, `(origin=null, mark=null)` and `(origin=null, mark=set)` are different states, and both episode claims were comparing the origin alone.

A run that resolved its sibling through the recency fallback did so on the licence of the first state. A clear landing between that read and the claim revokes the licence **without changing the origin**, so the CAS still matched — the cross-link stamped its watermark and posted its notes on a conversation the source had just disowned, and the closing carried its goodbye and its resolve to the same thread. Both claims now compare `chatwootRedirectOriginAt` beside the origin, in the same statement as the rest of the question.

### Upgrade day: a nil is only a clear when there was something to clear

Round 8, and the first finding fires on **every conversation at once**. An episode that began before the fork carried the field has a NULL column in Chatwoot, and from the moment fazer-ai/chatwoot#418 ships, every payload for it carries the key with nil. Presence alone read that as a stated clear, stamped the mark, and a stamped mark is what tells `episodeOriginQuery` to refuse the recency fallback those episodes have always run on. They would lose their cross-link and every later WhatsApp touch, with nothing in the data to say why.

The payload contract cannot carry the distinction, because **Chatwoot's own column cannot say which null it holds either**: a token naming no origin writes NULL over a NULL, and the fork has no more history than the column. What separates them is that a clear is a **transition**. `decideConversationWrites` now asks whether a pairing was ever stated about this conversation before, and a nil with no history is silence rather than an answer — not written, not stamped, fallback untouched. A nil that follows a pairing we were told about is still a clear, mark and all.

The second finding is the same question one instance older: "was ever stated" cannot be the mark alone, because a Chatwoot too old to send `updated_at` writes the pairing and stamps nothing. A stored non-null origin is evidence of its own; without it, a change away from a versionless pairing left the previous episode's watermarks and ladder standing.

### What the mark is, and what it is not

Round 9 is round 7 read back, and the two pull in opposite directions on the same line — which is the signal that the model was wrong rather than the code.

`chatwootRedirectOriginAt` is a **version**. It advances on every payload that states the pairing, the ones stating the SAME pairing included, so as an equality token in a claim it turned any ordinary webhook arriving between a run's read and its CAS into "the episode moved". On the resolve-triggered closing that is permanent: the ladder is cancelled by then, so it is the only closing the episode will ever get.

The identity is the **origin**; the mark exists here only to tell two nulls apart. Both claims now compare its nullness, and only when the origin they read was null:

```
origin non-null  ->  compare the origin. The mark is irrelevant.
origin null      ->  compare the origin AND whether the mark is set:
                     null = never told (recency licensed) | set = told there is none
```

Every transition that matters still breaks a claim, and a pairing merely restated no longer does.

The retirement inside the mirror's transaction also gets a **savepoint**. Catching the rejection never made it best-effort: a statement Postgres rejects aborts the transaction at the server, so the conversation update after it fails with `current transaction is aborted` and the pairing rolls back. Letting it throw is worse — this path is detached with Chatwoot's 200 already sent, so a rejection leaves the delivery on PROCESSING and that event never comes back. The savepoint keeps the pairing and leaves the ladder standing, which is the degradation the comment already described and the downstream fences already handle.

### What survives a failed retirement, and what a started close keeps

Round 10 finished what round 9 started. The savepoint was the right mechanism; the wrong thing was surviving the rollback. The ladder carries no episode of its own, so committing the new pairing over a ladder that could not be retired hands the **previous** episode's schedule to the **new** one: its next stage re-reads the pairing and nudges, then resolves, a conversation that has just started.

So the pairing stands still with it — the origin, the version mark (advanced alone it would describe a pairing the row never took, and refuse the payload coming to deliver it) and the episode's one-shots (released alone they re-run the cross-link on an episode that is still current). Nothing is lost: every later payload restates the pairing and the mark has not moved either, so the next ordinary delivery applies the whole transition.

The second half is the closing's last read. A timed close posts the goodbye on the chat and resolves it **before** looking the WhatsApp sibling up, and every fence past that first send is skipped on purpose — half a goodbye is worse than a duplicate. So a re-entry landing inside those round trips moved the WhatsApp half: a clear left the original thread open, a move sent the goodbye to, and RESOLVED, the conversation the new episode had just paired with. `resolveWhatsAppSibling` now resolves for the episode the claim validated when the closing calls it; stage 2 keeps reading fresh, which is what lets a `/reset` stand it down.

### The ladder carries the episode it was armed for

Round 12, and it is the failure path above that reaches it. The retirement took every job under the dedupe key, and that key names the **conversation** — every episode it ever has shares it. A delivery whose retirement was rejected holds the pairing back and then goes on to arm anyway, because the arm keys off the widget inbox and never reads the pairing; the next payload restates the pairing, retires successfully, and takes the **new** episode's ladder with it. Nothing re-arms it: the release clears `redirectLinkedAt`, but the cross-link that reads it only runs on an inbound event, and the lead who was just redirected has gone quiet — which is the silence the ladder was armed to chase.

So the job states the episode it was armed for, read from the **event** and not from the row (the row can still be holding the previous pairing back), and a retirement keeps its own. A payload that states no episode is the previous one's by construction: it predates the field, or it came from a Chatwoot that does not speak about pairings. Three states again — absent, `null` (a stated clear is an episode with work of its own), a number — and both reschedules list it, because the payload is rebuilt field by field there and anything unlisted is gone at the first stage advance. That last one is not hypothetical: the mutation that drops it from the ordinary escalation survived the first battery, and the test that kills it was written for that.

### Scope

`/reset` keeps today's scope, and `episode.ts`'s activation lookup stays contact-wide. #222 is the pairing; test-mode activation is a property of the person, not of the pair, and what the pairing now makes fixable is separate.

One comment in `/reset` did have to change rather than stay: it said reaching across to the other half of the pair was **underivable**, and named #222 as the change that would make it a fact. It is derivable now. Widening what the command erases is still the operator's call and not a side effect of the pairing becoming available, so the comment now says the reach is implementable rather than wanted here.

## Validation scope

**Proven live**, against a real Chatwoot fork instance (4.17.0, its own database, port 13222) running fazer-ai/chatwoot#418 — the agents code doing the minting, the browser flow doing the resolve, and the payload Chatwoot actually built for the agent bot:

```
mint (this repo's client) →  origin_display_id=7
resolve (widget flow)     →  widget conversation = 8
agent-bot payload         →  conversation.redirect_origin_display_id=7
normalizeChatwootEvent    →  redirectOriginDisplayId=7
mirrorChatwootEvent       →  conversation 8 → redirectOriginDisplayId=7
```

The defect half reproduces on the unchanged code: after a real mint + resolve, both conversations carry `additional_attributes={}` and `custom_attributes={}` and neither names the other.

The episode release was proven the same way, against the two payloads the fork's own token resolve produced for conversation 1 — one naming a new origin, one stating a clear — replayed through the mirror against a row holding the previous episode:

```
stored before        origin=99  linked=set  closed=set
fork's own event     redirect_origin_display_id=2   updated_at=1787752427.51  last_activity_at=1787748061
after the mirror     origin=2   linked=null closed=null

fork's stated clear  redirect_origin_display_id=null (key present)  updated_at=1787755100.93
after the mirror     origin=null  linked=null closed=null

the same bytes again (the retry the fork's job makes, 3s apart)
after the mirror     origin=null  linked=set  closed=set
```

The third block is the one that matters as much as the first: a retried delivery of the pairing already accepted describes the episode that is running, and must not wipe it.

**Proven by test**, every one red against the inference:

| test | observable effect |
| --- | --- |
| `episodeOriginQuery` decision table | the fact wins, with no `orderBy` to lose it; the contact leaves the question |
| the ladder's closing | messages and **resolves** the stored origin, with a deliberately newer decoy left untouched |
| `linkRedirectConversations` | propagates the stored origin's activation, not the decoy's |
| payload → column | the field arrives on a real payload shape and lands; a later payload that says nothing does not wipe it |
| the gate's mint | the token names the conversation the gate is running on |
| the pairing never regresses (DB-backed) | a retried snapshot inside one second, a frozen `last_activity_at`, a row born from the newer payload, no-version and no-origin payloads |
| a stale payload still delivers a first pairing | and moves no status, no assignee and no activity watermark with it |
| `/reset` keeps the pairing | the four watermarks go, the fact stays |
| the pairing's own event is not a trigger | `conversation_updated` mirrors the value and links nothing; the cloned message that follows links the episode |
| `decideConversationWrites` table | eleven rows for the third mark, stale branch included |
| the episode moves with the pairing (DB-backed) | a different origin and a stated clear release the watermarks; a retry of the same origin, a first pairing ever stated, an omitted key and a refused older pairing all leave them standing; the stale branch releases too |
| the ladder is retired when the pairing moves | the `REDIRECT_FOLLOWUP` row goes `DONE` with its tombstone; a repeat of the same pairing leaves it `PENDING` |
| the cross-link claims rather than stamps | a pairing that moved under it stops the stamp, the propagation and the notes; a second call finds the watermark taken |
| the closing claim carries the origin it read | a pairing moving between the closing's read and its claim leaves the anchor free for the episode that is current |
| a stated clear has no sibling | the decision table, and the effect: the closing posts nothing on a sibling recency would have found |
| the retirement is atomic with the pairing | the ladder goes `DONE` from inside the mirror's transaction |
| a stated clear landing under a claim | the cross-link stands down and the closing leaves its anchor free, with only the mark moving |
| upgrade day | a nil on a conversation nobody ever spoke about is not a clear: not stamped, watermarks untouched; a nil after a stated pairing still is |
| a versionless pairing that changes | releases the episode with no mark to prove it was stated, on the strength of the stored origin |
| an ordinary same-origin update | costs neither the closing nor the cross-link its claim |
| a scheduler statement Postgres rejects | pairing, mark and one-shots all stand still, and the next delivery applies the whole transition (reproduced with `SELECT 1 / 0` on that connection, not a thrown Error) |
| a re-entry during a timed close | both halves close the episode the claim validated, with a decoy on the entry inbox that the unpinned lookup messaged and resolved instead |

Mutation battery on the fence: nine mutations, all killed. The one that first survived — dropping the mark at row **creation** — was a real hole (a row born from the newer payload was left unprotected) and now has its own test.

Second battery, on the episode release: six mutations, two survived and both were genuine coverage holes, now closed. Dropping `decision.redirectOrigin` from the release condition was the serious one — it would have released the episode on every payload that omits the key, which is every event from a Chatwoot without the fork. Dropping `redirectLinkedAt: null` from the cross-link claim survived because the at-most-once it buys had no test; it has one now.

Third battery, on round 6: dropping the stated-clear guard kills two (the decision table and the closing's effect), and disabling the in-transaction retirement kills one. One of those readings was a false zero first — zsh does not word-split an unquoted parameter, so a two-file `bun test` argument became one bogus path and the harness reported "no test failed" for a probe that never ran. Every mutation count here was re-taken with the paths passed separately.

One documented survivor, in code that predates this PR: deleting `isNewIncomingMessage(n)` from the cross-link block changes nothing, because the call site of `maybeConsumeCommandOrGate` is already `(act || commandActive) && isNewIncoming`. Two fences on something destructive is a choice, so the test asserts the effect rather than either gate.

`bun check`: **6392 pass, 0 fail, 0 skip**, across 452 files, re-run on the rebase onto #285, #364, #282 and #360.

That number is worth a note. The earlier rounds of this PR reported ~5900 from a clone that had no `.env` and no generated Prisma client, so every database-backed block was skipping in silence — the exact failure #354 landed to stop, and its gate is what caught it here on the first run after the rebase. The DB-backed half of this PR's own tests had been exercised in the other checkout, but the suite total quoted above did not cover it. Everything reported in this section was re-run with the database connected.

**Not validated**: a second redirect clicked end to end in the browser (the release below was proven with the fork's own captured payloads, not by re-clicking), the fallback path against a real pre-#418 Chatwoot, and the two-re-entries-in-one-second race against a live instance — that one is exercised against the mirror with the real payload shape, not by clicking two links in the same second. The fallback is the code that was already there, unchanged, and it is covered by the tests that exercise `by: "recency"`, but no live instance without the field was exercised.

## Depends on

fazer-ai/chatwoot#418. Until that is deployed, `origin_display_id` is ignored by the mint endpoint and every episode takes the fallback — which is exactly today's behaviour.

Fixes #222











