### PR TITLE
Let one follow-up step keep firing while an appointment stands, instead of only the whole agent

### DIFF
--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -896,6 +896,8 @@
     "followUpHoursDefault": "Follow agent's main schedule",
     "followUpHoursInherited": "Inherited:",
     "followUpHoursUnit": "Hours",
+    "followUpIgnorePause": "Send this step even during an appointment",
+    "followUpIgnorePauseHint": "Exempts THIS step from the pause below. Use it for a step that only means anything while the appointment stands, such as a payment deadline; the other steps keep waiting.",
     "followUpInstructions": "Follow-up instructions",
     "followUpInstructionsPlaceholder": "E.g.: Greet the customer warmly, remind them of the open question, and offer to help.",
     "followUpLabelMultiAccount": "This agent serves more than one Chatwoot account, so labels can't be listed. Type each label exactly as it appears.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -899,6 +899,8 @@
     "followUpHoursDefault": "Seguir o horário principal do agente",
     "followUpHoursInherited": "Herdado:",
     "followUpHoursUnit": "Horas",
+    "followUpIgnorePause": "Enviar esta etapa mesmo durante um agendamento",
+    "followUpIgnorePauseHint": "Isenta ESTA etapa da pausa abaixo. Use em uma etapa que só faz sentido enquanto o agendamento está de pé, como um prazo de pagamento; as demais etapas continuam esperando.",
     "followUpInstructions": "Instruções de follow-up",
     "followUpInstructionsPlaceholder": "Ex.: Cumprimente o cliente, relembre a pergunta em aberto e ofereça ajuda.",
     "followUpLabelMultiAccount": "Este agente atende mais de uma conta do Chatwoot, então as etiquetas não podem ser listadas. Digite cada etiqueta exatamente como aparece.",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -70,7 +70,6 @@ import {
   type ChannelRedirectConfig,
   readChannelRedirectConfig,
 } from "@/modules/channel-redirect/service";
-import { FOLLOW_UP_MAX_STEPS } from "@/modules/followups/settings";
 import {
   GUARDRAILS_DEFAULTS,
   type GuardrailsConfig,
@@ -90,6 +89,7 @@ import {
 } from "./ChannelRedirectTab";
 import { ChannelsTab } from "./ChannelsTab";
 import { ExportAgentModal } from "./ExportAgentModal";
+import { followUpToForm, followUpToStored } from "./followUpFormState";
 import { GeneralTab } from "./GeneralTab";
 import { GuardrailsTab } from "./GuardrailsTab";
 import { readGuardrailsFormState } from "./guardrailsFormState";
@@ -242,17 +242,6 @@ function str(v: unknown): string {
 function num(v: unknown): string {
   return typeof v === "number" ? String(v) : "";
 }
-// Read the follow-up step's labels: the new `assignLabels` array, falling back to the legacy single
-// `assignLabel` string so an agent saved before multi-label keeps its label in the editor.
-function stepLabels(st: Record<string, unknown>): string[] {
-  if (Array.isArray(st.assignLabels)) {
-    return st.assignLabels.filter((l): l is string => typeof l === "string");
-  }
-  return typeof st.assignLabel === "string" && st.assignLabel
-    ? [st.assignLabel]
-    : [];
-}
-
 // Split the editor's "agent:<id>" | "team:<id>" | "" target back into the stored handoff shape. Only
 // "pinned" carries a concrete target; the other modes null both out. Mirrors readBehaviorState's
 // inverse (which packs targetAgentId/targetTeamId into `target`).
@@ -291,23 +280,6 @@ function readModelState(a: Agent) {
   };
 }
 
-// Map the raw followUp bag into the editor's step list from the multi-step `steps` array. No
-// back-compat: a bag without a steps array yields one default step (the old flat config is not read).
-// Always returns at least one step.
-function readFollowUpSteps(fu: Record<string, unknown>) {
-  const rawSteps =
-    Array.isArray(fu.steps) && fu.steps.length > 0
-      ? (fu.steps as Record<string, unknown>[])
-      : [{}];
-  return rawSteps.slice(0, FOLLOW_UP_MAX_STEPS).map((st) => ({
-    delayValue: num(st.delayValue) || "30",
-    delayUnit: str(st.delayUnit) || "minutes",
-    instructions: str(st.instructions),
-    assignLabels: stepLabels(st),
-    resolve: st.resolve === true,
-  }));
-}
-
 function readBehaviorState(a: Agent) {
   const s = (a.settings ?? {}) as Record<string, unknown>;
   const d = (s.debounce ?? {}) as Record<string, unknown>;
@@ -315,7 +287,6 @@ function readBehaviorState(a: Agent) {
   const tt = (s.tts ?? {}) as Record<string, unknown>;
   const sp = (s.split ?? {}) as Record<string, unknown>;
   const sw = (s.serviceWindow ?? {}) as Record<string, unknown>;
-  const fu = (s.followUp ?? {}) as Record<string, unknown>;
   const vi = (s.vision ?? {}) as Record<string, unknown>;
   const ho = (s.handoff ?? {}) as Record<string, unknown>;
   const ka = (s.kanban ?? {}) as Record<string, unknown>;
@@ -388,11 +359,7 @@ function readBehaviorState(a: Agent) {
         : "",
       templateContent: str(sw.templateContent),
     },
-    followUp: {
-      enabled: typeof fu.enabled === "boolean" ? fu.enabled : false,
-      steps: readFollowUpSteps(fu),
-      pauseWhileAppointment: fu.pauseWhileAppointment !== false,
-    },
+    followUp: followUpToForm(s),
     handoff: {
       mode: str(ho.mode) || "route",
       target: num(ho.targetAgentId)
@@ -681,6 +648,7 @@ function AgentEditor() {
         instructions: "",
         assignLabels: [] as string[],
         resolve: false,
+        ignoreAppointmentPause: false,
       },
     ],
     pauseWhileAppointment: true,
@@ -1216,26 +1184,7 @@ function AgentEditor() {
           .filter(Boolean),
         templateContent: serviceWindow.templateContent.trim() || null,
       },
-      followUp: {
-        enabled: followUp.enabled,
-        pauseWhileAppointment: followUp.pauseWhileAppointment,
-        // `resolve` is sent only for the LAST step (the server also enforces this); `assignLabels` is
-        // omitted when empty so the persisted shape stays minimal and round-trips cleanly.
-        steps: followUp.steps.map((s, i) => {
-          const labels = s.assignLabels
-            .map((l) => l.trim())
-            .filter((l) => l.length > 0);
-          return {
-            delayValue: Math.max(1, Number(s.delayValue) || 1),
-            delayUnit: s.delayUnit,
-            instructions: s.instructions.trim(),
-            ...(labels.length > 0 ? { assignLabels: labels } : {}),
-            ...(i === followUp.steps.length - 1 && s.resolve
-              ? { resolve: true }
-              : {}),
-          };
-        }),
-      },
+      followUp: followUpToStored(followUp),
       vision: {
         enabled: vision.enabled,
         provider: vision.provider,

--- a/src/client/pages/agents/BehaviorTab.tsx
+++ b/src/client/pages/agents/BehaviorTab.tsx
@@ -228,15 +228,16 @@ interface ServiceWindowState {
   templateContent: string;
 }
 
-interface FollowUpStepState {
+export interface FollowUpStepState {
   delayValue: string;
   delayUnit: string;
   instructions: string;
   assignLabels: string[]; // labels added to the conversation when this step fires
   resolve: boolean; // honored only on the last step
+  ignoreAppointmentPause: boolean; // fire this step even while an appointment stands
 }
 
-interface FollowUpState {
+export interface FollowUpState {
   enabled: boolean;
   steps: FollowUpStepState[];
   pauseWhileAppointment: boolean;
@@ -822,6 +823,7 @@ function FollowUpStepsEditor({
           instructions: "",
           assignLabels: [],
           resolve: false,
+          ignoreAppointmentPause: false,
         },
       ],
     }));
@@ -924,6 +926,28 @@ function FollowUpStepsEditor({
                 ariaLabel={t("editor.followUpAssignLabel", "Assign label")}
               />
             </FormField>
+            {/* Only while the agent-wide pause is ON: with it off nothing pauses, so this switch
+                would decide nothing. Hidden is not off — the value is kept and saved either way. */}
+            {followUp.pauseWhileAppointment && (
+              <div className="flex flex-col gap-1.5">
+                <SwitchField
+                  checked={step.ignoreAppointmentPause}
+                  onCheckedChange={(v) =>
+                    updateStep(index, { ignoreAppointmentPause: v })
+                  }
+                  label={t(
+                    "editor.followUpIgnorePause",
+                    "Send this step even during an appointment",
+                  )}
+                />
+                <p className="text-text-muted text-xs">
+                  {t(
+                    "editor.followUpIgnorePauseHint",
+                    "Exempts THIS step from the pause below. Use it for a step that only means anything while the appointment stands, such as a payment deadline; the other steps keep waiting.",
+                  )}
+                </p>
+              </div>
+            )}
             {isLast && (
               <SwitchField
                 checked={step.resolve}

--- a/src/client/pages/agents/followUpFormState.ts
+++ b/src/client/pages/agents/followUpFormState.ts
@@ -54,14 +54,14 @@ export function followUpToStored(form: FollowUpState): {
         delayValue: Math.max(1, Number(s.delayValue) || 1),
         delayUnit: s.delayUnit,
         instructions: s.instructions.trim(),
-        // The optional actions are omitted when off, so the persisted shape stays minimal and an
-        // agent saved through this form is byte-comparable with one that was never opened.
+        // NOTE: the optional actions are omitted when off, so the persisted shape stays minimal
+        // and an agent saved through this form is byte-comparable with one that was never opened.
         ...(labels.length > 0 ? { assignLabels: labels } : {}),
-        // `resolve` is sent only for the LAST step (the server also enforces this).
+        // NOTE: `resolve` is sent only for the LAST step (the server also enforces this).
         ...(i === form.steps.length - 1 && s.resolve ? { resolve: true } : {}),
-        // Sent whatever `pauseWhileAppointment` says. The editor HIDES this switch while the
-        // agent-wide pause is off, because there the opt-out decides nothing; hiding it must not
-        // delete it, or turning the pause off and on again would silently clear every step's
+        // NOTE: sent whatever `pauseWhileAppointment` says. The editor HIDES this switch while
+        // the agent-wide pause is off, because there the opt-out decides nothing; hiding it must
+        // not delete it, or turning the pause off and on again would silently clear every step's
         // exemption.
         ...(s.ignoreAppointmentPause ? { ignoreAppointmentPause: true } : {}),
       };

--- a/src/client/pages/agents/followUpFormState.ts
+++ b/src/client/pages/agents/followUpFormState.ts
@@ -1,0 +1,89 @@
+import { FOLLOW_UP_MAX_STEPS } from "@/modules/followups/settings";
+import type { FollowUpState, FollowUpStepState } from "./BehaviorTab";
+
+// The agent editor's Follow-up block, as a pair of pure functions: stored settings → form state →
+// stored settings. It lives outside the page for the reason the Memory and TTS pairs do — the
+// Behavior save REPLACES the whole `followUp` block with what the form holds, so a field the form
+// does not carry is not merely un-editable, it is DELETED on the next save — and for one this block
+// has alone: a step is a BAG of optional fields, and `followUpToStored` rebuilds each one field by
+// field. A rebuild lists what to keep, so the field added next is dropped by omission, silently, on
+// the first save by an operator who never opened that switch. The round-trip test over this pair
+// reads the field list off `FollowUpStep` itself, so that omission fails a test instead.
+
+export function followUpToForm(settings: unknown): FollowUpState {
+  const s = (settings ?? {}) as Record<string, unknown>;
+  const fu = (s.followUp ?? {}) as Record<string, unknown>;
+  return {
+    enabled: typeof fu.enabled === "boolean" ? fu.enabled : false,
+    steps: readSteps(fu),
+    pauseWhileAppointment: fu.pauseWhileAppointment !== false,
+  };
+}
+
+// Map the raw followUp bag into the editor's step list from the multi-step `steps` array. No
+// back-compat: a bag without a steps array yields one default step (the old flat config is not read).
+// Always returns at least one step.
+function readSteps(fu: Record<string, unknown>): FollowUpStepState[] {
+  const rawSteps =
+    Array.isArray(fu.steps) && fu.steps.length > 0
+      ? (fu.steps as Record<string, unknown>[])
+      : [{}];
+  return rawSteps.slice(0, FOLLOW_UP_MAX_STEPS).map((st) => ({
+    delayValue: num(st.delayValue) || "30",
+    delayUnit: str(st.delayUnit) || "minutes",
+    instructions: str(st.instructions),
+    assignLabels: stepLabels(st),
+    resolve: st.resolve === true,
+    ignoreAppointmentPause: st.ignoreAppointmentPause === true,
+  }));
+}
+
+export function followUpToStored(form: FollowUpState): {
+  enabled: boolean;
+  pauseWhileAppointment: boolean;
+  steps: Record<string, unknown>[];
+} {
+  return {
+    enabled: form.enabled,
+    pauseWhileAppointment: form.pauseWhileAppointment,
+    steps: form.steps.map((s, i) => {
+      const labels = s.assignLabels
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+      return {
+        delayValue: Math.max(1, Number(s.delayValue) || 1),
+        delayUnit: s.delayUnit,
+        instructions: s.instructions.trim(),
+        // The optional actions are omitted when off, so the persisted shape stays minimal and an
+        // agent saved through this form is byte-comparable with one that was never opened.
+        ...(labels.length > 0 ? { assignLabels: labels } : {}),
+        // `resolve` is sent only for the LAST step (the server also enforces this).
+        ...(i === form.steps.length - 1 && s.resolve ? { resolve: true } : {}),
+        // Sent whatever `pauseWhileAppointment` says. The editor HIDES this switch while the
+        // agent-wide pause is off, because there the opt-out decides nothing; hiding it must not
+        // delete it, or turning the pause off and on again would silently clear every step's
+        // exemption.
+        ...(s.ignoreAppointmentPause ? { ignoreAppointmentPause: true } : {}),
+      };
+    }),
+  };
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function num(v: unknown): string {
+  return typeof v === "number" ? String(v) : "";
+}
+
+// Read the follow-up step's labels: the new `assignLabels` array, falling back to the legacy single
+// `assignLabel` string so an agent saved before multi-label keeps its label in the editor.
+function stepLabels(st: Record<string, unknown>): string[] {
+  if (Array.isArray(st.assignLabels)) {
+    return st.assignLabels.filter((l): l is string => typeof l === "string");
+  }
+  return typeof st.assignLabel === "string" && st.assignLabel
+    ? [st.assignLabel]
+    : [];
+}

--- a/src/modules/agents/settings-schema.ts
+++ b/src/modules/agents/settings-schema.ts
@@ -225,7 +225,7 @@ const followUpStep = z.looseObject({
     .boolean()
     .optional()
     .describe(
-      "let THIS step fire while a booking stands, with followUp.pauseWhileAppointment left on for the others; decides nothing when that flag is off",
+      "let THIS step fire while a booking stands; no-op unless followUp.pauseWhileAppointment is on",
     ),
 });
 

--- a/src/modules/agents/settings-schema.ts
+++ b/src/modules/agents/settings-schema.ts
@@ -221,6 +221,12 @@ const followUpStep = z.looseObject({
     .optional()
     .describe("merged into the conversation's labels, never replacing"),
   resolve: z.boolean().optional().describe("honored on the LAST step only"),
+  ignoreAppointmentPause: z
+    .boolean()
+    .optional()
+    .describe(
+      "let THIS step fire while a booking stands, with followUp.pauseWhileAppointment left on for the others; decides nothing when that flag is off",
+    ),
 });
 
 const followUp = z.looseObject({

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -1042,7 +1042,7 @@ export async function getConversationDetail(
     // reason — and, because the completion marker yields to this flag, would hide a finished sequence
     // behind it. It also skips the query on every conversation with nothing to suppress.
     //
-    // Which step is about to fire decides it, not the agent (issue #103). `nextStep` is 1-based for
+    // NOTE: which step is about to fire decides it, not the agent (issue #103). `nextStep` is 1-based for
     // display, so the step the worker will actually run is `steps[nextStep - 1]` — the same index the
     // handler resolves from the job's payload, and the same one the sweep reads for step 0. The three
     // agreeing is not the same condition copied three times: it is the three reading the same step.

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -966,7 +966,19 @@ export async function getConversationDetail(
       (agent?.followUpArmedAt == null ||
         conv.lastInboundAt == null ||
         conv.lastInboundAt < agent.followUpArmedAt);
-    if (job && !fencedStep0Job && followUpLive) {
+    // NOTE: a job whose step no longer exists is a sequence that is OVER, and the handler says so
+    // by returning `done` on its very first look (issue #103 moved that check to the top). An
+    // operator who shortens a sequence with a later-step job still pending leaves exactly that
+    // state, so the console has to reach the same terminal answer — otherwise it counts down to a
+    // step that will never fire, prints "step 5 of 1", and (once the step decides the pause)
+    // reports the conversation as appointment-paused over a job that is about to end instead.
+    //
+    // Its own arm, ahead of both others, because falling through is not the same answer: the
+    // estimate arm below would offer step 1, which is a countdown for a sequence about to end.
+    const jobStepGone = job != null && cfg.steps[jobStepIndex] === undefined;
+    if (jobStepGone) {
+      nextStep = null;
+    } else if (job && !fencedStep0Job && followUpLive) {
       const stepIndex = jobStepIndex;
       nextStep = stepIndex + 1;
       // job.runAt is NOT the firing time yet — the sweep enqueues step 0 with runAt=now (and re-arms

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -1041,10 +1041,18 @@ export async function getConversationDetail(
     // its own, and announcing "paused by appointment" there would state a reason that is not the
     // reason — and, because the completion marker yields to this flag, would hide a finished sequence
     // behind it. It also skips the query on every conversation with nothing to suppress.
+    //
+    // Which step is about to fire decides it, not the agent (issue #103). `nextStep` is 1-based for
+    // display, so the step the worker will actually run is `steps[nextStep - 1]` — the same index the
+    // handler resolves from the job's payload, and the same one the sweep reads for step 0. The three
+    // agreeing is not the same condition copied three times: it is the three reading the same step.
+    const upcomingStep =
+      nextStep === null ? undefined : cfg.steps[nextStep - 1];
     const pausedByAppointment =
       nextStep !== null &&
       cfg.enabled &&
       cfg.pauseWhileAppointment &&
+      !upcomingStep?.ignoreAppointmentPause &&
       !managedByRedirect &&
       (await runScopedOn(
         base,

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -31,6 +31,7 @@ import {
 } from "@/modules/chatwoot/normalize";
 import { reconcileMirrorFromLive } from "@/modules/chatwoot/reconcile";
 import { recordResolutionOrigin } from "@/modules/conversations/record-resolution";
+import { appointmentPauseApplies } from "@/modules/followups/appointment-pause";
 import { isFollowUpLive } from "@/modules/followups/eligibility";
 import type { FollowUpDelayUnit } from "@/modules/followups/settings";
 import {
@@ -1054,17 +1055,16 @@ export async function getConversationDetail(
     // reason — and, because the completion marker yields to this flag, would hide a finished sequence
     // behind it. It also skips the query on every conversation with nothing to suppress.
     //
-    // NOTE: which step is about to fire decides it, not the agent (issue #103). `nextStep` is 1-based for
-    // display, so the step the worker will actually run is `steps[nextStep - 1]` — the same index the
-    // handler resolves from the job's payload, and the same one the sweep reads for step 0. The three
-    // agreeing is not the same condition copied three times: it is the three reading the same step.
+    // NOTE: which step is about to fire decides it, not the agent (issue #103). `nextStep` is
+    // 1-based for display, so the step the worker will actually run is `steps[nextStep - 1]` — the
+    // same index the handler resolves from the job's payload. The three sites agreeing is not the
+    // same condition written out three times: it is one function, asked here about this step.
     const upcomingStep =
       nextStep === null ? undefined : cfg.steps[nextStep - 1];
     const pausedByAppointment =
       nextStep !== null &&
       cfg.enabled &&
-      cfg.pauseWhileAppointment &&
-      !upcomingStep?.ignoreAppointmentPause &&
+      appointmentPauseApplies(cfg, upcomingStep) &&
       !managedByRedirect &&
       (await runScopedOn(
         base,

--- a/src/modules/followups/appointment-pause.ts
+++ b/src/modules/followups/appointment-pause.ts
@@ -1,0 +1,31 @@
+import type { FollowUpConfig, FollowUpStep } from "./settings";
+
+// Does the appointment pause apply to THIS step?
+//
+// One question, asked from three places that reach it by completely different routes, and the whole
+// point of it being one function is that they cannot answer it differently:
+//
+//   - the SWEEP, deciding whether to enqueue at all, asks about `cfg.steps[0]` — the only step it
+//     ever starts a sequence with;
+//   - the HANDLER, holding a claimed job, asks about the step its payload names;
+//   - the CONSOLE, rendering a conversation, asks about the step that is next to fire.
+//
+// `followUp.pauseWhileAppointment` is per AGENT, and it answers for a whole sequence a question two
+// kinds of step answer oppositely (issue #103). A re-engagement nudge wants to be held while a
+// booking stands; a payment-deadline step wants exactly the reverse — it only means anything WHILE
+// the booking is unconfirmed, and it is the step that later frees the slot. So the agent-wide flag
+// is the default and a single step may be exempted from it, which makes the deciding pair
+// (agent, step) rather than (agent).
+//
+// Deliberately NOT a notion of "paid" or "confirmed": the platform does not know what those mean
+// for any given operator, and the step that does is the one they wrote.
+//
+// An absent step means the pause applies. That is the fail-safe direction — a caller that cannot
+// name a step has not shown an exemption — and it is what `cfg.steps[0]` yields for a config whose
+// steps the reader could not parse at all.
+export function appointmentPauseApplies(
+  cfg: FollowUpConfig,
+  step: FollowUpStep | undefined,
+): boolean {
+  return cfg.pauseWhileAppointment && step?.ignoreAppointmentPause !== true;
+}

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -104,8 +104,18 @@ async function sweepHandler(
   // NOTE: read one tick before the query, so a settings change lands on the NEXT pass at worst
   // (60s). Nothing is sent on this read: the handler re-checks against fresh settings before the
   // nudge, which is where correctness lives.
+  //
+  // NOTE: `cfg.enabled` first, and it is not redundant. An agent whose follow-up is OFF can still
+  // carry a step-0 exemption from when it was on, and `appointmentPauseApplies` would answer about
+  // it — correctly, since it decides the pause and nothing else. Exempting it would lift the fence
+  // for an agent that sends nothing: the sweep's SQL never tests `followUp.enabled` (it tests
+  // `follow_up_armed_at`, which is stamped on the OFF→ON transition and never cleared going back),
+  // so those conversations would be enqueued every minute for the handler to discard on its first
+  // look, each one holding a slot of the LIMIT 500 away from an agent that would actually send.
   const unfencedAgentIds = configs
-    .filter(({ cfg }) => !appointmentPauseApplies(cfg, cfg.steps[0]))
+    .filter(
+      ({ cfg }) => cfg.enabled && !appointmentPauseApplies(cfg, cfg.steps[0]),
+    )
     .map(({ id }) => id);
   // NOTE: -1 stands in for the empty set. Prisma.join refuses an empty list, and an agent id is a
   // positive bigint, so the sentinel can never match a row — `<> ALL` then holds for everyone,

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -24,6 +24,7 @@ import {
 } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import {
+  FOLLOW_UP_MAX_STEPS,
   type FollowUpStep,
   isNewFollowUpEpisode,
   readFollowUpConfig,
@@ -134,32 +135,46 @@ async function sweepHandler(
         -- parseStartMs (all-day → UTC midnight; offset-less datetime → 'Z'), so the SQL and JS
         -- liveness decisions agree regardless of the session/host time zones.
         -- Invalid/absent start = not-future (fail-safe: only the queued arm suppresses then).
+        --
+        -- Both halves below are compared AS JSONB, never as text. ->> renders a JSON string and a
+        -- JSON boolean to the same characters, and the readers do not: bag.pauseWhileAppointment
+        -- !== false keeps the pause ON for a stored "false" while ->> read it as OFF, which is
+        -- the fence lifting itself on a spelling. = 'false'::jsonb is true for the boolean alone.
+        -- All seven spellings measured against the reader; that string was the only disagreement.
         AND NOT (
-          coalesce(a.settings->'followUp'->>'pauseWhileAppointment', 'true') <> 'false'
-          -- ...and NO step opted out of it (issue #103). Deliberately EXISTENTIAL, not positional:
-          -- the sweep asks "could any step want to fire through an appointment?" and the handler
-          -- asks "does THIS step want to?". Asking about step 0 here instead would put an INDEX in
-          -- the SQL, and the index the reader uses is not the raw one — readFollowUpConfig drops
-          -- every non-object entry before numbering, so a stored [7, {opted out}] (which REST
-          -- stores as written: the agent body types settings as an opaque record) leaves the sweep
-          -- suppressing the very step the handler would fire. There is no index to disagree about
-          -- if nobody reads one.
+          coalesce(
+            a.settings->'followUp'->'pauseWhileAppointment',
+            'true'::jsonb
+          ) <> 'false'::jsonb
+          -- ...and the step this sweep is about to enqueue did not opt out of it (issue #103).
           --
-          -- The cost is bounded and lands on the safe side: an agent whose LATER step opts out gets
-          -- step 0 enqueued during an appointment, and the handler's own gate reschedules it — which
-          -- is exactly what every conversation did before this predicate existed. Suppressing
-          -- wrongly is the expensive direction, because the follow-up then never happens at all.
-          AND NOT EXISTS (
-            SELECT 1
-            FROM jsonb_array_elements(
-              CASE
-                WHEN jsonb_typeof(a.settings->'followUp'->'steps') = 'array'
-                  THEN a.settings->'followUp'->'steps'
-                ELSE '[]'::jsonb
-              END
-            ) AS step
-            WHERE step->>'ignoreAppointmentPause' = 'true'
-          )
+          -- The subject is STEP 0, because step 0 is the only step the sweep ever enqueues, and it
+          -- is the reader's step 0, which is NOT raw index 0: readFollowUpConfig keeps the first
+          -- FOLLOW_UP_MAX_STEPS raw entries, drops every non-object among them, and numbers what is
+          -- left. Measured live — PATCH /api/v1/agents/:id types settings as an opaque record, not
+          -- as the MCP behaviour schema, so [7, {opted out}] stores with HTTP 200 — and read
+          -- positionally the sweep suppresses the very step the handler fires.
+          --
+          -- IN ('object','array') and not just 'object' because the reader's test is
+          -- typeof raw === "object" && raw !== null, which an array passes. No step at all leaves
+          -- the coalesce, matching the reader's fallback to a default step that carries no opt-out.
+          AND coalesce(
+            (
+              SELECT e.value->'ignoreAppointmentPause'
+              FROM jsonb_array_elements(
+                CASE
+                  WHEN jsonb_typeof(a.settings->'followUp'->'steps') = 'array'
+                    THEN a.settings->'followUp'->'steps'
+                  ELSE '[]'::jsonb
+                END
+              ) WITH ORDINALITY AS e(value, ord)
+              WHERE e.ord <= ${FOLLOW_UP_MAX_STEPS}
+                AND jsonb_typeof(e.value) IN ('object', 'array')
+              ORDER BY e.ord
+              LIMIT 1
+            ),
+            'false'::jsonb
+          ) <> 'true'::jsonb
           AND EXISTS (
             SELECT 1
             FROM scheduler_jobs sj

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -136,15 +136,30 @@ async function sweepHandler(
         -- Invalid/absent start = not-future (fail-safe: only the queued arm suppresses then).
         AND NOT (
           coalesce(a.settings->'followUp'->>'pauseWhileAppointment', 'true') <> 'false'
-          -- ...and STEP 0 did not opt out of it (issue #103). The sweep only ever enqueues step 0,
-          -- so step 0 is the only step whose flag it can read — the later ones are the handler's,
-          -- which knows its own stepIndex. Read beside pauseWhileAppointment for the same
-          -- reason it lives there: this predicate is the SQL mirror of the handler's gate, and the
-          -- two drifting apart is what issues #39 and #60 already cost once each.
-          AND coalesce(
-            a.settings->'followUp'->'steps'->0->>'ignoreAppointmentPause',
-            'false'
-          ) <> 'true'
+          -- ...and NO step opted out of it (issue #103). Deliberately EXISTENTIAL, not positional:
+          -- the sweep asks "could any step want to fire through an appointment?" and the handler
+          -- asks "does THIS step want to?". Asking about step 0 here instead would put an INDEX in
+          -- the SQL, and the index the reader uses is not the raw one — readFollowUpConfig drops
+          -- every non-object entry before numbering, so a stored [7, {opted out}] (which REST
+          -- stores as written: the agent body types settings as an opaque record) leaves the sweep
+          -- suppressing the very step the handler would fire. There is no index to disagree about
+          -- if nobody reads one.
+          --
+          -- The cost is bounded and lands on the safe side: an agent whose LATER step opts out gets
+          -- step 0 enqueued during an appointment, and the handler's own gate reschedules it — which
+          -- is exactly what every conversation did before this predicate existed. Suppressing
+          -- wrongly is the expensive direction, because the follow-up then never happens at all.
+          AND NOT EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(
+              CASE
+                WHEN jsonb_typeof(a.settings->'followUp'->'steps') = 'array'
+                  THEN a.settings->'followUp'->'steps'
+                ELSE '[]'::jsonb
+              END
+            ) AS step
+            WHERE step->>'ignoreAppointmentPause' = 'true'
+          )
           AND EXISTS (
             SELECT 1
             FROM scheduler_jobs sj

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -14,6 +14,7 @@ import {
   parseSchedule,
 } from "@/modules/business-hours/hours";
 import { readChannelRedirectConfig } from "@/modules/channel-redirect/service";
+import { appointmentPauseApplies } from "@/modules/followups/appointment-pause";
 import { isFollowUpLive } from "@/modules/followups/eligibility";
 import {
   type ClaimedJob,
@@ -24,7 +25,6 @@ import {
 } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import {
-  FOLLOW_UP_MAX_STEPS,
   type FollowUpStep,
   isNewFollowUpEpisode,
   readFollowUpConfig,
@@ -65,15 +65,18 @@ async function sweepHandler(
   const agents = await runScopedOn(base, sysCtx(tenantId), (db) =>
     db.agent.findMany({
       where: { enabled: true },
-      select: { settings: true },
+      select: { id: true, settings: true },
     }),
   );
+  const configs = agents.map((a) => ({
+    id: a.id,
+    cfg: readFollowUpConfig(a.settings),
+  }));
   // The sweep only ever STARTS a sequence (step 0), so its cutoff is the minimum FIRST-step delay
   // across enabled agents. Later steps are scheduled precisely by the handler, not the sweep.
-  const enabledDelays = agents
-    .map((a) => readFollowUpConfig(a.settings))
-    .filter((cfg) => cfg.enabled)
-    .map((cfg) => cfg.steps[0])
+  const enabledDelays = configs
+    .filter(({ cfg }) => cfg.enabled)
+    .map(({ cfg }) => cfg.steps[0])
     .filter((s): s is FollowUpStep => s !== undefined)
     .map((s) => stepDelayMinutes(s));
   if (enabledDelays.length === 0) {
@@ -84,6 +87,32 @@ async function sweepHandler(
   }
   const cutoffMin = Math.min(...enabledDelays);
   const cutoff = new Date(Date.now() - cutoffMin * 60_000);
+
+  // Agents the appointment fence does not apply to, asked of `appointmentPauseApplies` — the same
+  // function the handler and the console ask — about `cfg.steps[0]`, the only step this sweep ever
+  // starts a sequence with.
+  //
+  // Asked HERE, in TypeScript, and not mirrored in the query. Two JSON predicates used to live in
+  // the SQL, and three review rounds in a row found a way for them to disagree with the reader: raw
+  // index 0 is not the reader's step 0 (non-object entries are dropped BEFORE numbering), `->>`
+  // renders a JSON string and a JSON boolean identically while the reader does not, and an
+  // unbounded `jsonb_array_elements` expands whatever the opaque REST settings write happened to
+  // store, per conversation, every minute. All three are one defect: a second implementation of a
+  // reader that already exists and had already RUN, right above, to compute the cutoff. What is
+  // left in SQL is the liveness of the appointment, which is rows rather than settings.
+  //
+  // NOTE: read one tick before the query, so a settings change lands on the NEXT pass at worst
+  // (60s). Nothing is sent on this read: the handler re-checks against fresh settings before the
+  // nudge, which is where correctness lives.
+  const unfencedAgentIds = configs
+    .filter(({ cfg }) => !appointmentPauseApplies(cfg, cfg.steps[0]))
+    .map(({ id }) => id);
+  // NOTE: -1 stands in for the empty set. Prisma.join refuses an empty list, and an agent id is a
+  // positive bigint, so the sentinel can never match a row — `<> ALL` then holds for everyone,
+  // which is what "nobody is exempt" has to mean.
+  const unfencedIdsSql = Prisma.sql`ARRAY[${Prisma.join(
+    unfencedAgentIds.length > 0 ? unfencedAgentIds : [-1n],
+  )}]::bigint[]`;
 
   // NOTE: column-to-column comparison (lastInboundAt > lastFollowUpAt) requires raw SQL;
   // Prisma's query builder cannot express it. The filter mirrors the handler's watermark gate
@@ -124,57 +153,20 @@ async function sweepHandler(
         -- NULL = never armed → fail-safe skip.
         AND a.follow_up_armed_at IS NOT NULL
         AND c.last_inbound_at >= a.follow_up_armed_at
-        -- NOTE: Pause re-engagement while the conversation has a LIVE future appointment, unless the
-        -- agent opted out (followUp.pauseWhileAppointment = false). SQL mirror of
-        -- projectAppointmentEvents (appointments/context.ts): a non-tombstoned reminder row counts
-        -- while it is still queued (PENDING/CLAIMED) OR its startISO is still ahead — firing marks
-        -- rows DONE, so after the LAST reminder only the future-start arm keeps suppression on
-        -- (issue #39). The cast is guarded (CASE + pg_input_is_valid; deploy mandates pg17):
-        -- startISO can be all-day (YYYY-MM-DD) or model-supplied garbage, and an unguarded cast
-        -- would abort the WHOLE tenant sweep. Offset-less values are pinned to UTC exactly like
-        -- parseStartMs (all-day → UTC midnight; offset-less datetime → 'Z'), so the SQL and JS
-        -- liveness decisions agree regardless of the session/host time zones.
-        -- Invalid/absent start = not-future (fail-safe: only the queued arm suppresses then).
+        -- NOTE: Pause re-engagement while the conversation has a LIVE future appointment, unless
+        -- this agent is exempt (unfencedAgentIds above, issue #103).
         --
-        -- Both halves below are compared AS JSONB, never as text. ->> renders a JSON string and a
-        -- JSON boolean to the same characters, and the readers do not: bag.pauseWhileAppointment
-        -- !== false keeps the pause ON for a stored "false" while ->> read it as OFF, which is
-        -- the fence lifting itself on a spelling. = 'false'::jsonb is true for the boolean alone.
-        -- All seven spellings measured against the reader; that string was the only disagreement.
+        -- SQL mirror of projectAppointmentEvents (appointments/context.ts): a non-tombstoned
+        -- reminder row counts while it is still queued (PENDING/CLAIMED) OR its startISO is still
+        -- ahead — firing marks rows DONE, so after the LAST reminder only the future-start arm
+        -- keeps suppression on (issue #39). The cast is guarded (CASE + pg_input_is_valid; deploy
+        -- mandates pg17): startISO can be all-day (YYYY-MM-DD) or model-supplied garbage, and an
+        -- unguarded cast would abort the WHOLE tenant sweep. Offset-less values are pinned to UTC
+        -- exactly like parseStartMs (all-day → UTC midnight; offset-less datetime → 'Z'), so the
+        -- SQL and JS liveness decisions agree regardless of the session/host time zones.
+        -- Invalid/absent start = not-future (fail-safe: only the queued arm suppresses then).
         AND NOT (
-          coalesce(
-            a.settings->'followUp'->'pauseWhileAppointment',
-            'true'::jsonb
-          ) <> 'false'::jsonb
-          -- ...and the step this sweep is about to enqueue did not opt out of it (issue #103).
-          --
-          -- The subject is STEP 0, because step 0 is the only step the sweep ever enqueues, and it
-          -- is the reader's step 0, which is NOT raw index 0: readFollowUpConfig keeps the first
-          -- FOLLOW_UP_MAX_STEPS raw entries, drops every non-object among them, and numbers what is
-          -- left. Measured live — PATCH /api/v1/agents/:id types settings as an opaque record, not
-          -- as the MCP behaviour schema, so [7, {opted out}] stores with HTTP 200 — and read
-          -- positionally the sweep suppresses the very step the handler fires.
-          --
-          -- IN ('object','array') and not just 'object' because the reader's test is
-          -- typeof raw === "object" && raw !== null, which an array passes. No step at all leaves
-          -- the coalesce, matching the reader's fallback to a default step that carries no opt-out.
-          AND coalesce(
-            (
-              SELECT e.value->'ignoreAppointmentPause'
-              FROM jsonb_array_elements(
-                CASE
-                  WHEN jsonb_typeof(a.settings->'followUp'->'steps') = 'array'
-                    THEN a.settings->'followUp'->'steps'
-                  ELSE '[]'::jsonb
-                END
-              ) WITH ORDINALITY AS e(value, ord)
-              WHERE e.ord <= ${FOLLOW_UP_MAX_STEPS}
-                AND jsonb_typeof(e.value) IN ('object', 'array')
-              ORDER BY e.ord
-              LIMIT 1
-            ),
-            'false'::jsonb
-          ) <> 'true'::jsonb
+          a.id <> ALL(${unfencedIdsSql})
           AND EXISTS (
             SELECT 1
             FROM scheduler_jobs sj
@@ -361,12 +353,11 @@ export async function followUpHandler(
   // cancelled. Defense in depth — the inbound that booked the appointment already cancels any prior
   // FOLLOWUP, and the sweep won't enqueue a new one meanwhile.
   //
-  // NOTE: BELOW the step resolution, and that order is the feature: the question is not "does this agent
-  // pause?" but "does THIS STEP pause?" (issue #103), and the step is not known any earlier. Moving
-  // it down costs nothing the gate used to catch — the only thing between the two is the
-  // out-of-range check, which ends the sequence outright, and a sequence that is over has nothing
-  // left to suppress.
-  if (ctx.followUpCfg.pauseWhileAppointment && !step.ignoreAppointmentPause) {
+  // NOTE: BELOW the step resolution, and that order is the feature: the pair that decides is
+  // (agent, step), and the step is not known any earlier (issue #103). Moving it down costs nothing
+  // the gate used to catch — the only thing between the two positions is the out-of-range check,
+  // which ends the sequence outright, and a sequence that is over has nothing left to suppress.
+  if (appointmentPauseApplies(ctx.followUpCfg, step)) {
     const blockedByAppointment = await hasLiveAppointment(
       tenantId,
       threadId,

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -136,6 +136,15 @@ async function sweepHandler(
         -- Invalid/absent start = not-future (fail-safe: only the queued arm suppresses then).
         AND NOT (
           coalesce(a.settings->'followUp'->>'pauseWhileAppointment', 'true') <> 'false'
+          -- ...and STEP 0 did not opt out of it (issue #103). The sweep only ever enqueues step 0,
+          -- so step 0 is the only step whose flag it can read — the later ones are the handler's,
+          -- which knows its own stepIndex. Read beside pauseWhileAppointment for the same
+          -- reason it lives there: this predicate is the SQL mirror of the handler's gate, and the
+          -- two drifting apart is what issues #39 and #60 already cost once each.
+          AND coalesce(
+            a.settings->'followUp'->'steps'->0->>'ignoreAppointmentPause',
+            'false'
+          ) <> 'true'
           AND EXISTS (
             SELECT 1
             FROM scheduler_jobs sj
@@ -304,12 +313,30 @@ export async function followUpHandler(
   });
   if (!ctx) return { outcome: "done" };
 
+  // Which step of the sequence this job is. The sweep enqueues step 0 (no stepIndex); each fired step
+  // reschedules the SAME row with the next index. Out-of-range (config shrank) → end the sequence.
+  const steps = ctx.followUpCfg.steps;
+  const stepIndex =
+    typeof job.payload.stepIndex === "number" &&
+    Number.isInteger(job.payload.stepIndex)
+      ? job.payload.stepIndex
+      : 0;
+  const step = steps[stepIndex];
+  if (!step) return { outcome: "done" };
+  const isLast = stepIndex === steps.length - 1;
+
   // Appointment suppression: hold the follow-up while this conversation has a LIVE appointment —
   // queued reminder OR already-fired one with the start still ahead (issue #39). Re-check later
   // instead of nudging OR ending the sequence, so it resumes once the appointment passes / is
   // cancelled. Defense in depth — the inbound that booked the appointment already cancels any prior
   // FOLLOWUP, and the sweep won't enqueue a new one meanwhile.
-  if (ctx.followUpCfg.pauseWhileAppointment) {
+  //
+  // BELOW the step resolution, and that order is the feature: the question is not "does this agent
+  // pause?" but "does THIS STEP pause?" (issue #103), and the step is not known any earlier. Moving
+  // it down costs nothing the gate used to catch — the only thing between the two is the
+  // out-of-range check, which ends the sequence outright, and a sequence that is over has nothing
+  // left to suppress.
+  if (ctx.followUpCfg.pauseWhileAppointment && !step.ignoreAppointmentPause) {
     const blockedByAppointment = await hasLiveAppointment(
       tenantId,
       threadId,
@@ -322,18 +349,6 @@ export async function followUpHandler(
       };
     }
   }
-
-  // Which step of the sequence this job is. The sweep enqueues step 0 (no stepIndex); each fired step
-  // reschedules the SAME row with the next index. Out-of-range (config shrank) → end the sequence.
-  const steps = ctx.followUpCfg.steps;
-  const stepIndex =
-    typeof job.payload.stepIndex === "number" &&
-    Number.isInteger(job.payload.stepIndex)
-      ? job.payload.stepIndex
-      : 0;
-  const step = steps[stepIndex];
-  if (!step) return { outcome: "done" };
-  const isLast = stepIndex === steps.length - 1;
 
   const { lastFollowUpAt, lastInboundAt, lastEventAt } = ctx.conv;
 

--- a/src/modules/followups/handlers.ts
+++ b/src/modules/followups/handlers.ts
@@ -331,7 +331,7 @@ export async function followUpHandler(
   // cancelled. Defense in depth — the inbound that booked the appointment already cancels any prior
   // FOLLOWUP, and the sweep won't enqueue a new one meanwhile.
   //
-  // BELOW the step resolution, and that order is the feature: the question is not "does this agent
+  // NOTE: BELOW the step resolution, and that order is the feature: the question is not "does this agent
   // pause?" but "does THIS STEP pause?" (issue #103), and the step is not known any earlier. Moving
   // it down costs nothing the gate used to catch — the only thing between the two is the
   // out-of-range check, which ends the sequence outright, and a sequence that is over has nothing

--- a/src/modules/followups/settings.ts
+++ b/src/modules/followups/settings.ts
@@ -21,6 +21,18 @@ export interface FollowUpStep {
   // Deterministic, system-applied actions when this step fires (even if the agent stays silent):
   assignLabels?: string[]; // Chatwoot labels to add (merged, never replacing the set)
   resolve?: boolean; // resolve the conversation — honored ONLY on the last step
+  // Let THIS step fire even while the conversation has a live appointment, with
+  // `pauseWhileAppointment` left on for every other step (issue #103).
+  //
+  // The agent-wide flag conflates two opposite things. A re-engagement nudge wants to be suppressed
+  // while a booking stands; a payment-deadline step wants exactly the reverse — it only means
+  // anything WHILE the booking is unconfirmed, and it is the step that later frees the slot. Without
+  // this, an operator who needs both in one sequence has to turn the pause off for the whole agent,
+  // which drops it where it was right.
+  //
+  // Deliberately NOT a notion of "paid" or "confirmed": the platform does not know what those mean
+  // for any given operator, and the step that does is the one they wrote.
+  ignoreAppointmentPause?: boolean;
 }
 
 export interface FollowUpConfig {
@@ -126,6 +138,7 @@ function readStep(raw: unknown): FollowUpStep | null {
   }
   if (labels.length > 0) step.assignLabels = labels;
   if (bag.resolve === true) step.resolve = true;
+  if (bag.ignoreAppointmentPause === true) step.ignoreAppointmentPause = true;
   return step;
 }
 
@@ -152,13 +165,11 @@ export function readFollowUpConfig(settings: unknown): FollowUpConfig {
   const lastIdx = steps.length - 1;
   steps = steps.map((s, i) => {
     if (i === lastIdx || !s.resolve) return s;
-    const stripped: FollowUpStep = {
-      delayValue: s.delayValue,
-      delayUnit: s.delayUnit,
-      instructions: s.instructions,
-    };
-    if (s.assignLabels) stripped.assignLabels = s.assignLabels;
-    return stripped;
+    // Removed with a rest spread, never rebuilt field by field. A rebuild lists what to keep, so every field
+    // added to a step after it was written is dropped here — silently, and only for a mid-sequence
+    // step that happens to carry `resolve`. `ignoreAppointmentPause` would have been the first.
+    const { resolve: _dropped, ...kept } = s;
+    return kept;
   });
 
   return {

--- a/src/modules/followups/settings.ts
+++ b/src/modules/followups/settings.ts
@@ -165,9 +165,10 @@ export function readFollowUpConfig(settings: unknown): FollowUpConfig {
   const lastIdx = steps.length - 1;
   steps = steps.map((s, i) => {
     if (i === lastIdx || !s.resolve) return s;
-    // Removed with a rest spread, never rebuilt field by field. A rebuild lists what to keep, so every field
-    // added to a step after it was written is dropped here — silently, and only for a mid-sequence
-    // step that happens to carry `resolve`. `ignoreAppointmentPause` would have been the first.
+    // NOTE: removed with a rest spread, never rebuilt field by field. A rebuild lists what to
+    // keep, so every field added to a step after it was written is dropped here — silently, and
+    // only for a mid-sequence step that happens to carry `resolve`. `ignoreAppointmentPause` would
+    // have been the first.
     const { resolve: _dropped, ...kept } = s;
     return kept;
   });

--- a/tests/client/followup-form-state.test.ts
+++ b/tests/client/followup-form-state.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  followUpToForm,
+  followUpToStored,
+} from "@/client/pages/agents/followUpFormState";
+import { readFollowUpConfig } from "@/modules/followups/settings";
+import { followUpStepFields } from "../utils/followup-step-fields";
+
+// The Behavior save REPLACES the whole `followUp` block with what the form holds, and each step is
+// rebuilt field by field. So a field the form does not carry is not merely un-editable: it is
+// DELETED on the next save by an operator who never opened that switch. That already happened to
+// `tts.baseURL`, which REST and MCP accept and the form did not. A step is the worst shape for it —
+// a bag of optional fields, three of them today — so the guard here is not a hand-written list: it
+// is the field list of `FollowUpStep` itself, read off the source the runtime consumes.
+
+// Every interface field, each set to something a default read would NOT produce, so a field the
+// form drops comes back different rather than coincidentally equal.
+const FULL_STEP = {
+  delayValue: 3,
+  delayUnit: "days",
+  instructions: "ask about the pending payment",
+  assignLabels: ["awaiting-payment"],
+  resolve: true,
+  ignoreAppointmentPause: true,
+};
+
+describe("agent editor follow-up round-trip", () => {
+  // The helper throws on an empty parse, so this is the assertion that the list is the RIGHT one:
+  // it names the field this issue adds, which is what every check below iterates over.
+  test("the field list is read off the interface, and it names the new field", () => {
+    expect(followUpStepFields()).toContain("ignoreAppointmentPause");
+  });
+
+  // The guard that catches the NEXT field: `FollowUpStep` growing a key the form does not carry
+  // fails here, at the moment it is added.
+  test("the form carries every field the step interface declares", () => {
+    expect(Object.keys(FULL_STEP).sort()).toEqual(followUpStepFields());
+    const round = followUpToStored(
+      followUpToForm({ followUp: { enabled: true, steps: [FULL_STEP] } }),
+    );
+    expect(Object.keys(round.steps[0] ?? {}).sort()).toEqual(
+      followUpStepFields(),
+    );
+    expect(round.steps[0]).toEqual(FULL_STEP);
+  });
+
+  // #103: the switch is HIDDEN while the agent-wide pause is off, because there it decides nothing.
+  // Hidden is not off — an operator who turns the pause off, saves, and turns it back on would
+  // otherwise find every step's exemption silently cleared.
+  test("an exemption survives a save made while the agent-wide pause is off", () => {
+    const stored = {
+      followUp: {
+        enabled: true,
+        pauseWhileAppointment: false,
+        steps: [
+          { delayValue: 1, delayUnit: "hours", instructions: "" },
+          FULL_STEP,
+        ],
+      },
+    };
+    const round = followUpToStored(followUpToForm(stored));
+    expect(round.pauseWhileAppointment).toBe(false);
+    expect(round.steps[1]?.ignoreAppointmentPause).toBe(true);
+  });
+
+  // A step that did not opt out writes no key at all, so an agent saved through this form stays
+  // byte-comparable with one that was never opened.
+  test("a step without the exemption writes no key for it", () => {
+    const round = followUpToStored(followUpToForm({}));
+    expect(round.steps[0]).toEqual({
+      delayValue: 30,
+      delayUnit: "minutes",
+      instructions: "",
+    });
+  });
+
+  // And what the form writes is what the runtime reads back: the pair is only worth anything if
+  // the reader agrees, since the reader is what the sweep and the handler consult.
+  test("what the form stores is what the runtime reader sees", () => {
+    const stored = followUpToStored(
+      followUpToForm({ followUp: { enabled: true, steps: [FULL_STEP] } }),
+    );
+    const cfg = readFollowUpConfig({ followUp: stored });
+    expect(cfg.steps[0]?.ignoreAppointmentPause).toBe(true);
+    expect(cfg.steps[0]?.delayValue).toBe(3);
+    expect(cfg.pauseWhileAppointment).toBe(true);
+  });
+});

--- a/tests/lib/astral-cap-sweep.test.ts
+++ b/tests/lib/astral-cap-sweep.test.ts
@@ -350,10 +350,10 @@ const BARE_SLICES: Record<
   "src/client/contexts/ThemeContext.tsx": [1, "index"],
   "src/client/lib/breadcrumbs.ts": [1, "array"],
   "src/client/pages/LogsPage.tsx": [1, "array"],
-  "src/client/pages/agents/AgentEditorPage.tsx": [1, "array"],
   "src/client/pages/agents/CapabilityMap.tsx": [1, "array"],
   "src/client/pages/agents/PlaygroundChat.tsx": [1, "array"],
   "src/client/pages/agents/PromptPanel.tsx": [1, "index"],
+  "src/client/pages/agents/followUpFormState.ts": [1, "array"],
   "src/client/pages/resources/ToolEditModal.tsx": [1, "index"],
   // The idempotency key's tail is a hex digest.
   "src/graph/tools/documents.ts": [1, "ascii"],

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -60,6 +60,8 @@ let convOurBotArmed = 0n;
 let convForeignBotEstimate = 0n;
 let convOurBotEstimate = 0n;
 let convUnidentifiedBotArmed = 0n;
+let convStepOptOutEstimate = 0n;
+let convStepOptOutArmedStep1 = 0n;
 let convNoBotRowArmed = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
@@ -481,6 +483,65 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     });
     convAppointmentOptOut = await seedAppointmentConv(313, optOutInbox.id, {
       startISO: new Date(Date.now() + 2 * 3_600_000).toISOString(),
+    });
+
+    // A third persona whose opt-out is PER STEP (issue #103): step 0 fires through an appointment
+    // (a payment-deadline chase), step 1 does not (ordinary re-engagement). The agent-wide
+    // `pauseWhileAppointment` stays ON, which is the whole point.
+    const stepOptOutAgent = await suDb.agent.create({
+      data: {
+        tenantId: tenant,
+        name: "FU Step Opt-Out",
+        systemPrompt: "x",
+        followUpArmedAt: new Date("2026-01-01T00:00:00Z"),
+        mode: "production",
+        modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        settings: {
+          followUp: {
+            enabled: true,
+            pauseWhileAppointment: true,
+            steps: [
+              {
+                delayValue: 2,
+                delayUnit: "minutes",
+                instructions: "",
+                ignoreAppointmentPause: true,
+              },
+              { delayValue: 2, delayUnit: "days", instructions: "" },
+            ],
+          },
+        },
+      },
+    });
+    const stepOptOutInbox = await suDb.inbox.create({
+      data: {
+        tenantId: tenant,
+        chatwootInstanceId: inst,
+        chatwootInboxId: 94,
+        name: "Sup pausa por etapa",
+        agentId: stepOptOutAgent.id,
+      },
+    });
+    convStepOptOutEstimate = await seedAppointmentConv(
+      330,
+      stepOptOutInbox.id,
+      { startISO: new Date(Date.now() + 2 * 3_600_000).toISOString() },
+    );
+    convStepOptOutArmedStep1 = await seedAppointmentConv(
+      331,
+      stepOptOutInbox.id,
+      { startISO: new Date(Date.now() + 2 * 3_600_000).toISOString() },
+      { lastFollowUpAt: FOLLOW_UP_AT },
+    );
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId: tenant,
+        kind: "FOLLOWUP",
+        dedupeKey: `followup:${tenant}:${inst}:331`,
+        status: "PENDING",
+        runAt: ARMED_STEP1_RUN_AT,
+        payload: { threadId: `${tenant}:${inst}:331`, stepIndex: 1 },
+      },
     });
 
     // ── A PENDING job the handler will drop at claim time (issue #72). A multi-step sequence leaves
@@ -975,6 +1036,34 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     );
     expect(d.followUp?.pausedByAppointment).toBe(false);
     expect(d.followUp?.nextStep).toBe(1);
+  });
+
+  // ISSUE #103. The indicator changes no behaviour, only what the operator reads — which is exactly
+  // why it is the site that gets left behind: the suite stays green and the symptom shows up on the
+  // screen. Left out, the console says "paused by appointment" over a step that fires in two minutes.
+  //
+  // The pair is what proves it reads the RIGHT step rather than any step: same agent, same live
+  // appointment, and the answer flips with which step comes next.
+  test("(#103) the step about to fire opted out → the console does not claim it is paused", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convStepOptOutEstimate,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBe(1);
+    expect(d.followUp?.pausedByAppointment).toBe(false);
+    expect(d.followUp?.nextRunAt).not.toBeNull();
+  });
+
+  test("(#103) the NEXT step did not opt out → still paused, on the same agent", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convStepOptOutArmedStep1,
+      appDb,
+    );
+    expect(d.followUp?.pausedByAppointment).toBe(true);
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
   });
 
   // Issue #72: the pending-job branch reported whatever the row said, while the handler re-checks all

--- a/tests/modules/conversation-followup-estimate.test.ts
+++ b/tests/modules/conversation-followup-estimate.test.ts
@@ -62,6 +62,7 @@ let convOurBotEstimate = 0n;
 let convUnidentifiedBotArmed = 0n;
 let convStepOptOutEstimate = 0n;
 let convStepOptOutArmedStep1 = 0n;
+let convStepOptOutStepGone = 0n;
 let convNoBotRowArmed = 0n;
 
 // The redirect follow-up job's run time, asserted verbatim as the widget conversation's redirectNext.
@@ -541,6 +542,28 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
         status: "PENDING",
         runAt: ARMED_STEP1_RUN_AT,
         payload: { threadId: `${tenant}:${inst}:331`, stepIndex: 1 },
+      },
+    });
+
+    // Review round 2: an operator who SHORTENS a sequence leaves a pending job for a step that no
+    // longer exists. The handler answers `done` on its first look, so the console has to reach the
+    // same terminal answer — before this it counted down to a step that will never fire and, once
+    // the step decides the pause, reported the conversation as appointment-paused over a job that
+    // is about to end. stepIndex 4 on a two-step sequence.
+    convStepOptOutStepGone = await seedAppointmentConv(
+      332,
+      stepOptOutInbox.id,
+      { startISO: new Date(Date.now() + 2 * 3_600_000).toISOString() },
+      { lastFollowUpAt: FOLLOW_UP_AT },
+    );
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId: tenant,
+        kind: "FOLLOWUP",
+        dedupeKey: `followup:${tenant}:${inst}:332`,
+        status: "PENDING",
+        runAt: ARMED_STEP1_RUN_AT,
+        payload: { threadId: `${tenant}:${inst}:332`, stepIndex: 4 },
       },
     });
 
@@ -1064,6 +1087,23 @@ describe.skipIf(!dbUp)("getConversationDetail — follow-up estimate", () => {
     expect(d.followUp?.pausedByAppointment).toBe(true);
     expect(d.followUp?.nextStep).toBeNull();
     expect(d.followUp?.nextRunAt).toBeNull();
+  });
+
+  // Review round 2, and it is a regression THIS PR introduced. Before the per-step read, the pause
+  // did not consult a step at all and the console's "paused" was accurate here, because the handler
+  // used to meet the appointment BEFORE it noticed the step was gone and rescheduled. Moving the
+  // gate below the step resolution made the handler end the sequence instead, so the same word on
+  // the screen became false. The console has to model the handler's terminal case, not just its
+  // pause.
+  test("(#103) a job past the end of a shrunk sequence reports no next step, and no pause", async () => {
+    const d = await getConversationDetail(
+      ctx(tenant),
+      convStepOptOutStepGone,
+      appDb,
+    );
+    expect(d.followUp?.nextStep).toBeNull();
+    expect(d.followUp?.nextRunAt).toBeNull();
+    expect(d.followUp?.pausedByAppointment).toBe(false);
   });
 
   // Issue #72: the pending-job branch reported whatever the row said, while the handler re-checks all

--- a/tests/modules/followup-appointment-pause.test.ts
+++ b/tests/modules/followup-appointment-pause.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { appointmentPauseApplies } from "@/modules/followups/appointment-pause";
+import {
+  type FollowUpConfig,
+  type FollowUpStep,
+  readFollowUpConfig,
+} from "@/modules/followups/settings";
+
+// The decision table for the pair that decides whether a live appointment holds a follow-up back:
+// the agent-wide flag and the step about to fire (issue #103). Three sites consult this — the
+// sweep's enqueue decision, the handler's gate, and the console's indicator — and they reach it by
+// completely different routes, so what makes them agree is that there is one function rather than
+// three conditions. A table here is what makes the function's answer reviewable without a database.
+
+function cfg(pause: boolean, steps: FollowUpStep[] = []): FollowUpConfig {
+  return {
+    enabled: true,
+    pauseWhileAppointment: pause,
+    steps:
+      steps.length > 0
+        ? steps
+        : [{ delayValue: 1, delayUnit: "minutes", instructions: "" }],
+  };
+}
+
+const step = (over: Partial<FollowUpStep> = {}): FollowUpStep => ({
+  delayValue: 1,
+  delayUnit: "minutes",
+  instructions: "",
+  ...over,
+});
+
+describe("appointmentPauseApplies", () => {
+  const CASES: Array<[string, boolean, FollowUpStep | undefined, boolean]> = [
+    ["pause on, ordinary step", true, step(), true],
+    [
+      "pause on, step opted out",
+      true,
+      step({ ignoreAppointmentPause: true }),
+      false,
+    ],
+    ["pause OFF, ordinary step", false, step(), false],
+    // The agent-wide off wins on its own: an opt-out on a step is not a second switch that could
+    // somehow turn the pause back ON.
+    [
+      "pause OFF, step opted out",
+      false,
+      step({ ignoreAppointmentPause: true }),
+      false,
+    ],
+    // A caller that cannot name a step has not shown an exemption, so the pause stands. This is the
+    // console's state between sequences and the sweep's state for a config with no readable step.
+    ["pause on, no step at all", true, undefined, true],
+    ["pause OFF, no step at all", false, undefined, false],
+  ];
+
+  for (const [name, pause, s, expected] of CASES) {
+    test(`${name} → pause ${expected ? "applies" : "does not apply"}`, () => {
+      expect(appointmentPauseApplies(cfg(pause), s)).toBe(expected);
+    });
+  }
+
+  // `false` is the ONLY value that turns the agent-wide pause off, and it has to be the boolean.
+  // A stored string "false" reads as ON, because the reader's test is `!== false`. Pinned here
+  // because the sweep used to ask this in SQL, where `->>` renders the string and the boolean
+  // identically and the fence lifted itself on a spelling.
+  test.each([
+    [undefined, true],
+    [true, true],
+    [false, false],
+    [null, true],
+    ["false", true],
+    ["true", true],
+    [0, true],
+  ] as Array<[unknown, boolean]>)(
+    "pauseWhileAppointment stored as %p → pause applies: %p",
+    (stored, applies) => {
+      const bag: Record<string, unknown> = {
+        enabled: true,
+        steps: [{ delayValue: 1, delayUnit: "minutes", instructions: "" }],
+      };
+      if (stored !== undefined) bag.pauseWhileAppointment = stored;
+      const read = readFollowUpConfig({ followUp: bag });
+      expect(appointmentPauseApplies(read, read.steps[0])).toBe(applies);
+    },
+  );
+
+  // And the mirror on the step's side: only the boolean `true` exempts a step, so a truthy string
+  // does not silently disable the fence for that step.
+  test.each([
+    [undefined, true],
+    [true, false],
+    [false, true],
+    ["true", true],
+    [1, true],
+  ] as Array<[unknown, boolean]>)(
+    "ignoreAppointmentPause stored as %p → pause applies: %p",
+    (stored, applies) => {
+      const bag: Record<string, unknown> = {
+        delayValue: 1,
+        delayUnit: "minutes",
+        instructions: "",
+      };
+      if (stored !== undefined) bag.ignoreAppointmentPause = stored;
+      const read = readFollowUpConfig({
+        followUp: { enabled: true, steps: [bag] },
+      });
+      expect(appointmentPauseApplies(read, read.steps[0])).toBe(applies);
+    },
+  );
+});

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -1074,11 +1074,15 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     ).toBeNull();
   });
 
-  // The other half of the existential predicate: a LATER step opting out lifts the fence too, and
-  // the handler's own gate is what then holds step 0 back. Enqueue-then-reschedule is the safe
-  // direction and it is what every conversation did before this predicate existed; suppressing
-  // wrongly is the direction where the follow-up never happens at all.
-  test("(#103) a LATER step opting out lets the sweep enqueue, and the handler still holds step 0", async () => {
+  // Review round 3, and the boundary of the feature, pinned so it cannot drift into a surprise.
+  // The sweep gates the START of a sequence, and the only step it can start is step 0, so a LATER
+  // step's opt-out does NOT lift the fence. It could not usefully: round 2 let it, and the cost was
+  // that an appointment-blocked conversation was re-armed every minute for as long as the booking
+  // stood, eating a slot of the sweep's LIMIT 500 and delaying conversations that would actually
+  // send. Once the sequence IS running the handler carries it, and each step's own gate honours its
+  // own opt-out — which is the reported case, where the payment chase is what fires while the
+  // booking stands and is therefore step 0.
+  test("(#103) a LATER step opting out does NOT lift the sweep's fence for step 0", async () => {
     await setAgentSteps([
       { delayValue: 1, delayUnit: "minutes", instructions: "re-engajamento" },
       {
@@ -1114,16 +1118,152 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
           dedupeKey: `followup:${threadOf(1110)}`,
         },
       }),
-    ).not.toBeNull();
+    ).toBeNull();
+    // And the step that DID opt out still fires once the sequence reaches it, which is what makes
+    // the fence above a cost decision rather than the opt-out failing to work. Its own conversation
+    // because the two states are mutually exclusive by construction: the sweep only looks at a
+    // conversation whose last inbound is NEWER than its last follow-up, and a sequence that reached
+    // step 1 is exactly the opposite.
+    // Step 1's own cadence is 1 day, so the last follow-up has to be far enough back for it to be
+    // due at all — otherwise the reschedule under test would be the delay, not the fence.
+    await seedConversation(1111, {
+      assigneeType: "AgentBot",
+      lastEventAt: new Date(Date.now() - 3 * 86_400_000),
+      lastInboundAt: new Date(Date.now() - 3 * 86_400_000),
+      lastFollowUpAt: new Date(Date.now() - 2 * 86_400_000),
+    });
+    await withReminder(1111, "ev_103i");
     const s = stubClient();
-    const result = await followUpHandler(jobFor(1110, 0), appDb, {
+    const result = await followUpHandler(jobFor(1111, 1), appDb, {
       makeModel: fakeModel,
       makeClient: s.makeClient,
       checkpointer: new MemorySaver(),
       persistUsage: async () => {},
     });
-    expect(result.outcome).toBe("reschedule");
+    // `done` and not `reschedule` is the whole assertion: `reschedule` is what the appointment
+    // gate returns, and it is what the counter-test above gets on the step WITHOUT the opt-out.
+    // The nudge lands as a private note here rather than a message, because this conversation is
+    // days past its last inbound and the WhatsApp 24h window governs a proactive send. That is
+    // unrelated to the pause, and asserting on `sent` would have measured the window, not this gate.
+    expect(result).toEqual({ outcome: "done" });
+    expect(s.notes.length).toBeGreaterThan(0);
     expect(s.sent).toEqual([]);
+  });
+
+  // Review round 3, from a mutation that SURVIVED: narrowing the SQL to jsonb_typeof = 'object'
+  // broke nothing, which meant the array half of the rule was untested. It is not decoration —
+  // `readStep` rejects on `!raw || typeof raw !== "object"`, and `typeof [] === "object"`, so the
+  // reader turns a bare array into a DEFAULT step that carries no opt-out and occupies position 0.
+  // Measured, not assumed: readFollowUpConfig on `[[], {opted out}]` answers two steps, the first
+  // being the default. So the fence must stay UP here, and an SQL that skipped the array would pick
+  // the opted-out object as step 0 and lift it.
+  test("(#103) a bare ARRAY entry counts as step 0, exactly as the reader counts it", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        settings: {
+          followUp: {
+            enabled: true,
+            steps: [
+              [],
+              {
+                delayValue: 1,
+                delayUnit: "minutes",
+                instructions: "cobrança",
+                ignoreAppointmentPause: true,
+              },
+            ],
+          },
+        },
+      },
+    });
+    // NOTE: 90 minutes, not the usual 5. The sweep's cutoff is the minimum FIRST-step delay across
+    // enabled agents, and here the reader's step 0 is the DEFAULT step the bare array becomes,
+    // whose delay is 60 minutes. Seeded any fresher, the conversation is filtered out before the
+    // predicate under test is ever reached, and the assertion below would pass on nothing.
+    await seedConversation(1113, {
+      assigneeType: "AgentBot",
+      lastEventAt: new Date(Date.now() - 90 * 60_000),
+      lastInboundAt: new Date(Date.now() - 90 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1113, "ev_103k");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 992n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1113)}`,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  // Review round 3. The SIBLING half of the same predicate, found by asking where else the sweep
+  // states something the reader also states. `->>` renders a JSON string and a JSON boolean to the
+  // same characters, and the reader does not: `bag.pauseWhileAppointment !== false` keeps the pause
+  // ON for a stored "false", while the text comparison read it as OFF and lifted the fence. All
+  // seven spellings were measured against the reader; the string was the only disagreement, and it
+  // is reachable through the same REST hole as the malformed step above. Predates #103 — the
+  // comparison is jsonb on both halves now.
+  test("(#103) a pauseWhileAppointment stored as the STRING false still pauses, like the reader", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        settings: {
+          followUp: {
+            enabled: true,
+            pauseWhileAppointment: "false",
+            steps: [
+              {
+                delayValue: 1,
+                delayUnit: "minutes",
+                instructions: "re-engajamento",
+              },
+            ],
+          },
+        },
+      },
+    });
+    await seedConversation(1112, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1112, "ev_103j");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 993n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1112)}`,
+        },
+      }),
+    ).toBeNull();
   });
 
   // NOTE: Firing a reminder marks its row DONE. Suppression anchored on PENDING rows alone goes

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -1211,6 +1211,58 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     ).toBeNull();
   });
 
+  // Review round 4, from a mutation that SURVIVED: dropping `!cfg.pauseWhileAppointment` from the
+  // exempt set broke no test. The agent-wide opt-out is the OLDER half of this predicate and it had
+  // no sweep coverage at all — every existing test exercised the fence staying up. Its positive
+  // case is what the boolean is for, and it is now the pair of the string test below.
+  test("(#103) pauseWhileAppointment false lets the sweep enqueue despite a live appointment", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        settings: {
+          followUp: {
+            enabled: true,
+            pauseWhileAppointment: false,
+            steps: [
+              {
+                delayValue: 1,
+                delayUnit: "minutes",
+                instructions: "re-engajamento",
+              },
+            ],
+          },
+        },
+      },
+    });
+    await seedConversation(1114, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1114, "ev_103l");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 991n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1114)}`,
+        },
+      }),
+    ).not.toBeNull();
+  });
+
   // Review round 3. The SIBLING half of the same predicate, found by asking where else the sweep
   // states something the reader also states. `->>` renders a JSON string and a JSON boolean to the
   // same characters, and the reader does not: `bag.pauseWhileAppointment !== false` keeps the pause

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -1263,6 +1263,88 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     ).not.toBeNull();
   });
 
+  // Review round 5. `unfencedAgentIds` answered for an agent whose follow-up is OFF, because
+  // `appointmentPauseApplies` is only asked about the pause and a retained step-0 exemption is
+  // still an exemption. Nothing downstream caught it: the sweep's SQL tests `follow_up_armed_at`,
+  // which is stamped on the OFF→ON transition and never cleared on the way back, so a disabled
+  // agent keeps passing that gate.
+  //
+  // The cost is the one the LIMIT 500 imposes. The handler discards these jobs on its first look,
+  // but the sweep re-enqueues them every minute, and each one occupies a slot that belongs to an
+  // agent that would actually send. Asking about a config whose follow-up is off is a question with
+  // no answer, so the filter is at the call site — NOT inside `appointmentPauseApplies`, which
+  // decides one thing and must keep deciding only that.
+  //
+  // The second agent is what makes this reachable: the sweep returns early when NO enabled agent
+  // has follow-up on, so a tenant with only the disabled one never runs the query at all.
+  test("(#103) an agent with follow-up OFF is not exempted from the fence by a retained opt-out", async () => {
+    const other = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Outra",
+        systemPrompt: "x",
+        followUpArmedAt: new Date(Date.now() - 30 * 86_400_000),
+        modelConfig: { provider: "openai", model: "gpt-4o-mini" },
+        settings: {
+          followUp: {
+            enabled: true,
+            steps: [{ delayValue: 1, delayUnit: "minutes", instructions: "" }],
+          },
+        },
+      },
+    });
+    try {
+      await suDb.agent.update({
+        where: { id: agentId },
+        data: {
+          settings: {
+            followUp: {
+              enabled: false,
+              pauseWhileAppointment: true,
+              steps: [
+                {
+                  delayValue: 1,
+                  delayUnit: "minutes",
+                  instructions: "cobranca",
+                  ignoreAppointmentPause: true,
+                },
+              ],
+            },
+          },
+        },
+      });
+      await seedConversation(1115, {
+        assigneeType: "AgentBot",
+        lastInboundAt: new Date(Date.now() - 5 * 60_000),
+        lastFollowUpAt: null,
+      });
+      await withReminder(1115, "ev_103m");
+      registerFollowUpHandlers();
+      await getJobHandler("FOLLOWUP_SWEEP")?.(
+        {
+          id: 992n,
+          tenantId,
+          kind: "FOLLOWUP_SWEEP",
+          payload: {},
+          attempts: 0,
+          claimSeq: 0,
+        },
+        appDb,
+      );
+      expect(
+        await suDb.schedulerJob.findFirst({
+          where: {
+            tenantId,
+            kind: "FOLLOWUP",
+            dedupeKey: `followup:${threadOf(1115)}`,
+          },
+        }),
+      ).toBeNull();
+    } finally {
+      await suDb.agent.delete({ where: { id: other.id } });
+    }
+  });
+
   // Review round 3. The SIBLING half of the same predicate, found by asking where else the sweep
   // states something the reader also states. `->>` renders a JSON string and a JSON boolean to the
   // same characters, and the reader does not: `bag.pauseWhileAppointment !== false` keeps the pause

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -112,6 +112,7 @@ type StepFixture = {
   instructions: string;
   assignLabel?: string;
   resolve?: boolean;
+  ignoreAppointmentPause?: boolean;
 };
 
 // A two-step sequence: step 0 (1 min) then a last step (1 day) that assigns a label and resolves.
@@ -687,6 +688,81 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     expect(s.sent.length).toBeGreaterThan(0);
   });
 
+  // ISSUE #103. `pauseWhileAppointment` is one boolean for the whole agent, and it conflates two
+  // opposite things: a re-engagement nudge wants to be suppressed while a booking stands, and a
+  // payment-deadline step wants exactly the reverse — it only means anything WHILE the booking is
+  // unconfirmed, and it is the step that later frees the slot. An operator who needs both in one
+  // sequence has no way to say so today.
+  //
+  // A live reminder in every one of these, so the only thing under test is which step is next.
+  async function withReminder(convId: number, tag: string) {
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "APPOINTMENT_REMINDER",
+        dedupeKey: `reminder:${tag}:1`,
+        status: "PENDING",
+        runAt: new Date(Date.now() + 60 * 60_000),
+        payload: { threadId: threadOf(convId), eventId: tag },
+      },
+    });
+  }
+
+  test("(#103) a step that opts out of the pause fires despite a live appointment", async () => {
+    await setAgentSteps([
+      {
+        delayValue: 1,
+        delayUnit: "minutes",
+        instructions: "cobrança de prazo",
+        ignoreAppointmentPause: true,
+      },
+    ]);
+    await seedConversation(1103, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1103, "ev_103a");
+    const s = stubClient();
+    const result = await followUpHandler(jobFor(1103), appDb, {
+      makeModel: fakeModel,
+      makeClient: s.makeClient,
+      checkpointer: new MemorySaver(),
+      persistUsage: async () => {},
+    });
+    expect(result).toEqual({ outcome: "done" });
+    expect(s.sent.length).toBeGreaterThan(0);
+  });
+
+  // The counter-assertion that makes the one above mean something: the opt-out is PER STEP, not a
+  // second way to spell `pauseWhileAppointment: false`. Step 0 opts out and step 1 does not, so the
+  // same agent, same conversation and same reminder must answer differently depending on which step
+  // the job is for.
+  test("(#103) the step WITHOUT the opt-out still pauses, on the same agent", async () => {
+    await setAgentSteps([
+      {
+        delayValue: 1,
+        delayUnit: "minutes",
+        instructions: "cobrança de prazo",
+        ignoreAppointmentPause: true,
+      },
+      { delayValue: 1, delayUnit: "days", instructions: "re-engajamento" },
+    ]);
+    await seedConversation(1104, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: new Date(Date.now() - 2 * 60_000),
+    });
+    await withReminder(1104, "ev_103b");
+    const s = stubClient();
+    const result = await followUpHandler(jobFor(1104, 1), appDb, {
+      makeModel: fakeModel,
+      makeClient: s.makeClient,
+      checkpointer: new MemorySaver(),
+      persistUsage: async () => {},
+    });
+    expect(result.outcome).toBe("reschedule");
+    expect(s.sent).toEqual([]);
+  });
+
   // NOTE: Chatwoot ≥ 4.16.2 auto-assigns the connected Agent Bot at conversation creation, so
   // `assignee_type = 'AgentBot'` is the NORMAL bot-owned state — the sweep must treat it exactly
   // like unassigned (shouldBotHandle's `!== 'User'`), or follow-up never fires in ordinary
@@ -785,6 +861,83 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
       persistUsage: async () => {},
     });
     expect(ours.sent).toEqual([[1031, REPLY]]);
+  });
+
+  // The SWEEP is the other half of the same question, and it answers it in SQL rather than in
+  // TypeScript (issue #103). Without it the opt-out is unreachable: a conversation with a live
+  // appointment never gets enqueued, so the handler gate that now honours the flag never runs.
+  // The sweep only ever enqueues STEP 0, so step 0 is the step whose flag it has to read.
+  test("(#103) the sweep enqueues when step 0 opts out of the pause", async () => {
+    await setAgentSteps([
+      {
+        delayValue: 1,
+        delayUnit: "minutes",
+        instructions: "cobrança",
+        ignoreAppointmentPause: true,
+      },
+    ]);
+    await seedConversation(1105, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1105, "ev_103c");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 998n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1105)}`,
+        },
+      }),
+    ).not.toBeNull();
+  });
+
+  // The counter-assertion, and it is the one that proves the SQL reads the flag rather than
+  // dropping the whole appointment fence: same sweep, same reminder, step 0 without the opt-out.
+  test("(#103) the sweep still skips when step 0 does NOT opt out", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "re-engajamento" },
+    ]);
+    await seedConversation(1106, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1106, "ev_103d");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 997n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1106)}`,
+        },
+      }),
+    ).toBeNull();
   });
 
   // NOTE: Firing a reminder marks its row DONE. Suppression anchored on PENDING rows alone goes

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -763,6 +763,31 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     expect(s.sent).toEqual([]);
   });
 
+  // The one behaviour the gate's move DOES change, measured rather than asserted away. The gate used
+  // to run above the step resolution, so a job whose stepIndex is past the end of a shrunk sequence
+  // met the appointment first and was rescheduled, again and again, until the appointment passed —
+  // only to end the sequence the moment it finally got through. Below the resolution it ends the
+  // sequence straight away. Nothing is lost, because there was no step left to send.
+  test("(#103) a job past the end of a shrunk sequence ends it, instead of waiting out the appointment", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "única etapa" },
+    ]);
+    await seedConversation(1107, {
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: new Date(Date.now() - 2 * 60_000),
+    });
+    await withReminder(1107, "ev_103e");
+    const s = stubClient();
+    const result = await followUpHandler(jobFor(1107, 3), appDb, {
+      makeModel: fakeModel,
+      makeClient: s.makeClient,
+      checkpointer: new MemorySaver(),
+      persistUsage: async () => {},
+    });
+    expect(result).toEqual({ outcome: "done" });
+    expect(s.sent).toEqual([]);
+  });
+
   // NOTE: Chatwoot ≥ 4.16.2 auto-assigns the connected Agent Bot at conversation creation, so
   // `assignee_type = 'AgentBot'` is the NORMAL bot-owned state — the sweep must treat it exactly
   // like unassigned (shouldBotHandle's `!== 'User'`), or follow-up never fires in ordinary

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -965,6 +965,167 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     ).toBeNull();
   });
 
+  // Review round 2. The predicate above used to read the step at RAW index 0, which is not the step
+  // the runtime reads: `readFollowUpConfig` drops every non-object entry BEFORE numbering, so its
+  // step 0 is the first OBJECT in the array. Measured live against the dev server, because the
+  // reachability was the whole question: `PATCH /api/v1/agents/:id` types `settings` as an opaque
+  // record (`z.record(z.string(), z.unknown())`), NOT as the MCP behaviour schema, so this bag is
+  // stored exactly as written and answers HTTP 200.
+  //
+  // The predicate is existential now, so there is no index left to disagree about — and this test
+  // is the one that would have caught the positional version.
+  test("(#103) the sweep enqueues when a non-object entry shifts the opted-out step off index 0", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        settings: {
+          followUp: {
+            enabled: true,
+            steps: [
+              7,
+              {
+                delayValue: 1,
+                delayUnit: "minutes",
+                instructions: "cobrança",
+                ignoreAppointmentPause: true,
+              },
+            ],
+          },
+        },
+      },
+    });
+    await seedConversation(1108, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1108, "ev_103f");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 996n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1108)}`,
+        },
+      }),
+    ).not.toBeNull();
+  });
+
+  // And the same shape with the flag NOWHERE: a malformed entry does not by itself lift the fence.
+  // Without this the test above would pass on a predicate that simply gave up on any array holding
+  // something it did not understand.
+  test("(#103) a non-object entry alone does not lift the appointment fence", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        settings: {
+          followUp: {
+            enabled: true,
+            steps: [
+              7,
+              {
+                delayValue: 1,
+                delayUnit: "minutes",
+                instructions: "re-engajamento",
+              },
+            ],
+          },
+        },
+      },
+    });
+    await seedConversation(1109, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1109, "ev_103g");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 995n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1109)}`,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  // The other half of the existential predicate: a LATER step opting out lifts the fence too, and
+  // the handler's own gate is what then holds step 0 back. Enqueue-then-reschedule is the safe
+  // direction and it is what every conversation did before this predicate existed; suppressing
+  // wrongly is the direction where the follow-up never happens at all.
+  test("(#103) a LATER step opting out lets the sweep enqueue, and the handler still holds step 0", async () => {
+    await setAgentSteps([
+      { delayValue: 1, delayUnit: "minutes", instructions: "re-engajamento" },
+      {
+        delayValue: 1,
+        delayUnit: "days",
+        instructions: "cobrança",
+        ignoreAppointmentPause: true,
+      },
+    ]);
+    await seedConversation(1110, {
+      assigneeType: "AgentBot",
+      lastInboundAt: new Date(Date.now() - 5 * 60_000),
+      lastFollowUpAt: null,
+    });
+    await withReminder(1110, "ev_103h");
+    registerFollowUpHandlers();
+    await getJobHandler("FOLLOWUP_SWEEP")?.(
+      {
+        id: 994n,
+        tenantId,
+        kind: "FOLLOWUP_SWEEP",
+        payload: {},
+        attempts: 0,
+        claimSeq: 0,
+      },
+      appDb,
+    );
+    expect(
+      await suDb.schedulerJob.findFirst({
+        where: {
+          tenantId,
+          kind: "FOLLOWUP",
+          dedupeKey: `followup:${threadOf(1110)}`,
+        },
+      }),
+    ).not.toBeNull();
+    const s = stubClient();
+    const result = await followUpHandler(jobFor(1110, 0), appDb, {
+      makeModel: fakeModel,
+      makeClient: s.makeClient,
+      checkpointer: new MemorySaver(),
+      persistUsage: async () => {},
+    });
+    expect(result.outcome).toBe("reschedule");
+    expect(s.sent).toEqual([]);
+  });
+
   // NOTE: Firing a reminder marks its row DONE. Suppression anchored on PENDING rows alone goes
   // blind after the LAST reminder fires while the appointment is still ahead (issue #39) — both
   // the handler re-check and the sweep must treat "DONE with a future start" as a live appointment,

--- a/tests/modules/followup-settings.test.ts
+++ b/tests/modules/followup-settings.test.ts
@@ -89,6 +89,35 @@ describe("readFollowUpConfig", () => {
     expect(cfg.steps[1]?.resolve).toBe(true);
   });
 
+  // The strip above takes `resolve` OFF a step, and everything else has to survive it. It used to
+  // rebuild the step field by field, which meant it listed what to keep — so a step field added
+  // later was dropped here, silently, and only in this one case: a mid-sequence step that happens
+  // to carry `resolve`. `ignoreAppointmentPause` (#103) is the first field that would have hit it.
+  test("stripping resolve keeps every OTHER field of that step", () => {
+    const cfg = readFollowUpConfig({
+      followUp: {
+        steps: [
+          {
+            delayValue: 1,
+            delayUnit: "hours",
+            instructions: "pay to keep the slot",
+            assignLabels: ["awaiting-payment"],
+            resolve: true,
+            ignoreAppointmentPause: true,
+          },
+          { delayValue: 2, delayUnit: "hours" },
+        ],
+      },
+    });
+    expect(cfg.steps[0]).toEqual({
+      delayValue: 1,
+      delayUnit: "hours",
+      instructions: "pay to keep the slot",
+      assignLabels: ["awaiting-payment"],
+      ignoreAppointmentPause: true,
+    });
+  });
+
   test("clamps delayValue to minimum 1 and unit falls back", () => {
     const cfg = readFollowUpConfig({
       followUp: { steps: [{ delayValue: 0, delayUnit: "weeks" }] },

--- a/tests/modules/mcp-settings-schema.test.ts
+++ b/tests/modules/mcp-settings-schema.test.ts
@@ -17,6 +17,7 @@ import { buildMcpServer } from "@/modules/mcp/server";
 import { readMemoryConfig } from "@/modules/memory/settings";
 import { STT_PROVIDER_NAMES } from "@/modules/stt/providers";
 import { VISION_PROVIDER_NAMES } from "@/modules/vision/providers";
+import { followUpStepFields } from "../utils/followup-step-fields";
 
 // Issue #174. The blocks of `agent_settings_set` were `z.record(z.string(), z.unknown())`, so the
 // shape lived in the description and drifted there unwatched: `vision.provider` was published as
@@ -162,8 +163,11 @@ describe("agent_settings_set argument schema", () => {
     );
     const step = BEHAVIOR_PATCH_SHAPE.followUp.unwrap().shape.steps.unwrap()
       .element.shape;
-    expect(Object.keys(step)).toContain("delayValue");
-    expect(Object.keys(step)).toContain("assignLabels");
+    // Compared whole, not by membership: every field of a step is OPTIONAL, so the sweep above,
+    // which reads a DEFAULT bag, never sees one of them. The list comes off the interface itself,
+    // for the same reason the sweep reads the readers — a field added there and not declared here
+    // is a field no caller is ever told about.
+    expect(Object.keys(step).sort()).toEqual(followUpStepFields());
   });
 
   // What the stale prose got wrong, asserted against the registry rather than against a copy of it —

--- a/tests/modules/mcp-tool-descriptions.test.ts
+++ b/tests/modules/mcp-tool-descriptions.test.ts
@@ -143,7 +143,18 @@ const SETTINGS_DESC_CEILING = 2_000;
 // reads as configured and can never run — the same silent-failure shape every raise above paid for.
 // The remaining 527 is the shape (four fields, the provider enum, the nullable wrappers) and does
 // not compress. Headroom over 12,347 stays tighter than a block, as before.
-const SETTINGS_SCHEMA_CEILING = 12_400;
+//
+// RAISED from 12,400 for issue #103, and the trim was measured first, against the 53 characters
+// #143 left. `ignoreAppointmentPause` on a follow-up step costs 201 with the note it was written
+// with; rewriting the note to its shortest honest form buys 48 and lands at 153, which still does
+// not fit. Dropping the note entirely WOULD fit, and that is precisely the trade every raise above
+// refuses: what it says is the one thing a caller cannot get by trying, because the flag is INERT
+// unless `followUp.pauseWhileAppointment` is on. Without it a caller exempts a step, stores a block
+// that reads as configured, and nothing about that step ever fires differently — the same
+// silent-failure shape as `includeMessageText` and the half-named `modelFallback` above. The
+// remaining 153 is the field name, the boolean, and that sentence. Headroom over 12,500 stays
+// tighter than a block, as before.
+const SETTINGS_SCHEMA_CEILING = 12_550;
 
 describe("MCP tool descriptions", () => {
   test("agent_settings_set stays under its ceiling", async () => {
@@ -255,6 +266,10 @@ describe("MCP tool descriptions", () => {
   // description and 41,852 of schema. The DESCRIPTION ceiling therefore does NOT move for #143 —
   // this block publishes a schema and no new tool, so #305's number still has room and raising it
   // would have been a number nobody had measured. The schema ceiling does, to 41,950.
+  //
+  // #103 moves the schema figure again and not the description one, for the same reason: the
+  // follow-up step gains one boolean and its note, and no tool is added. Measured at 42,027 of
+  // schema after the trim documented at SETTINGS_SCHEMA_CEILING, so the ceiling goes to 42,100.
   test("the whole tools/list payload stays under its ceiling", async () => {
     const all = await listed();
     let desc = 0;
@@ -264,7 +279,7 @@ describe("MCP tool descriptions", () => {
       schema += t.schema.length;
     }
     expect(desc).toBeLessThanOrEqual(27_250);
-    expect(schema).toBeLessThanOrEqual(41_950);
+    expect(schema).toBeLessThanOrEqual(42_100);
   });
 
   // Why the document write tools declare `blocks`/`fields` as loose arrays and put the vocabulary in

--- a/tests/utils/followup-step-fields.ts
+++ b/tests/utils/followup-step-fields.ts
@@ -1,0 +1,35 @@
+// The field names declared on the `FollowUpStep` interface, read off the source the runtime
+// consumes rather than copied into a list.
+//
+// A step is a bag of OPTIONAL fields, so no runtime read enumerates it: `readFollowUpConfig({})`
+// answers a default step carrying three keys, and the optional ones only appear when a bag already
+// had them. Every drift check over a step therefore has to name the fields somewhere, and a
+// hand-written list is exactly the thing that goes stale — the field added next is missing from the
+// list AND from the surface, so the two agree and the test passes.
+//
+// Two surfaces consult this: the console's form pair (a field it does not carry is DELETED on the
+// operator's next save) and the MCP/REST patch schema (a field it does not declare is a field no
+// caller is told about, issue #174). The positive control lives HERE rather than in each caller,
+// because a parse that finds nothing hands back a list every assertion passes over.
+
+const SRC = await Bun.file(
+  new URL("../../src/modules/followups/settings.ts", import.meta.url).pathname,
+).text();
+
+export function followUpStepFields(): string[] {
+  const body = SRC.match(
+    /export interface FollowUpStep \{\n([\s\S]*?)\n\}/,
+  )?.[1];
+  if (!body) throw new Error("FollowUpStep interface not found");
+  const names = body
+    .split("\n")
+    .map((l) => l.trim().match(/^([A-Za-z][A-Za-z0-9]*)\??:/)?.[1])
+    .filter((n): n is string => n !== undefined)
+    .sort();
+  if (names.length < 3 || !names.includes("delayValue")) {
+    throw new Error(
+      `FollowUpStep parse found ${names.length} fields: ${names}`,
+    );
+  }
+  return names;
+}


### PR DESCRIPTION
Fixes #103

## What broke

`followUp.pauseWhileAppointment` is per AGENT, and it answers a question the agent cannot answer for a whole sequence: *should re-engagement wait while a booking stands?* Two kinds of step want opposite answers.

A re-engagement nudge ("still there?") wants to be suppressed: the customer just booked, the reminder system owns the conversation. A payment-deadline step wants exactly the reverse. It only means anything **while** the booking is unconfirmed, and it is the step that later frees the slot. Reported from a clinic flow where an appointment is held provisionally until the deposit clears.

Today an operator who needs both in one sequence has only one lever, and it is the wrong size: turning `pauseWhileAppointment` off for the whole agent drops the pause where it was right.

## What this adds

`FollowUpStep.ignoreAppointmentPause`, a per-step opt-out. The agent-wide flag stays the default; a single step can be exempted from it. The deciding pair becomes `(agent, step)` rather than `(agent)`.

Deliberately NOT a notion of "paid" or "confirmed": the platform does not know what those mean for any given operator, and the step that does is the one they wrote.

### One function, three callers

Three independent sites decide whether the pause applies, each reached by a completely different route, each holding a different step:

| site | when it runs | which step it asks about |
|---|---|---|
| the sweep (`followups/handlers.ts`) | deciding whether to enqueue at all | `cfg.steps[0]`, the only step it ever starts a sequence with |
| the handler's gate (`followups/handlers.ts`) | a job about to fire | the step named by `job.payload.stepIndex` |
| the console's "paused" indicator (`conversations/service.ts`) | rendering a conversation | `steps[nextStep - 1]`, the one about to fire |

They do not each spell the condition out. They call `appointmentPauseApplies(cfg, step)` (`followups/appointment-pause.ts`), which is the whole point: three readers that answer the same question differently is exactly the bug this PR would otherwise have shipped, and it is the bug review rounds 2, 3 and 4 each found a different instance of.

The first version of this PR mirrored the decision in the sweep's SQL, as two JSON predicates over `a.settings`. Three rounds in a row found a way for the mirror to disagree with the reader it was copying: raw array index 0 is not the reader's step 0 (non-object entries are dropped **before** numbering), `->>` renders a JSON string `"false"` and a JSON boolean `false` identically while the reader does not, and `jsonb_array_elements` expanded whatever the opaque REST settings write happened to store, per conversation, every minute.

All three are one defect, and the fix is not a fourth patch: the sweep **already** loads every enabled agent's settings and **already** runs `readFollowUpConfig` over them, a few lines above, to compute the cutoff. So the exempt set is computed there and handed to SQL as a `bigint[]`:

```ts
const unfencedAgentIds = configs
  .filter(({ cfg }) => !appointmentPauseApplies(cfg, cfg.steps[0]))
  .map(({ id }) => id);
```

What is left in the query is the liveness of the appointment, which is rows rather than settings. No `jsonb_array_elements`, no `->>`, no ordinality, no cap comparison.

The set is asked only of agents whose follow-up is actually on. That is not redundant with the query: the sweep's SQL never tests `followUp.enabled` — it tests `follow_up_armed_at`, which is stamped on the OFF→ON transition and never cleared on the way back. It also narrows a pre-existing case, since an agent with follow-up off and `pauseWhileAppointment: false` was unfenced on `main` too.

**The handler's gate moved down**, below the step resolution. That is the change, not an accident of diff order: the question it asks is no longer "does this agent pause?" but "does THIS STEP pause?", and the step is not known any earlier.

Moving it is not free, and the console pays the difference. The check that now runs first is the out-of-range one, so a job whose step no longer exists ends the sequence on the handler's very first look. An operator who shortens a sequence with a later-step job still pending leaves exactly that state, and the console read the same job: it would count down to a step that will never fire, print "step 5 of 1", and report the conversation as appointment-paused over a job that is about to end instead. `getConversationDetail` now reaches the same terminal answer, in its own arm ahead of the others, because falling through would offer step 1 -- a countdown for a sequence that is ending.

## A latent bug found next door

`readFollowUpConfig` strips `resolve` from any step that is not the last. It did that by **rebuilding the step field by field**, which means it listed what to keep. Every field added to a step after that code was written would be dropped there, silently, and only in one narrow case: a mid-sequence step that happens to carry `resolve`. `ignoreAppointmentPause` would have been the first to hit it. Replaced with a rest spread, which cannot forget a field, and covered by a test that asserts every OTHER field survives the strip.

The same shape lives in the console: the Behavior save REPLACES the whole `followUp` block with what the form holds, and the form rebuilds each step field by field, so a field the form does not carry is not merely un-editable, it is DELETED on the next save by an operator who never opened that switch. This already happened once to `tts.baseURL`. The follow-up block is now a pair of pure functions (`followUpFormState.ts`, matching the existing `memoryFormState`/`ttsFormState` pattern) with a round-trip test whose field list is read off the `FollowUpStep` interface itself, so the next field added there fails a test instead of disappearing.

## The MCP schema budget

`agent_settings_set` publishes its whole schema in `tools/list`, and the repo caps that payload with a ceiling that carries a written rationale for every raise it has ever taken. #143 (`modelFallback`) raised it to 12,400 and deliberately left 53 characters of headroom.

`ignoreAppointmentPause` does not fit in 53, and the trim was measured before the raise rather than after:

| | `agent_settings_set` schema |
|---|---|
| without the field | 11,690 |
| with the note as first written | 11,891 (costs 201) |
| with the note at its shortest honest form | 11,843 (costs **153**) |

Dropping the note entirely would fit. That is the trade every raise in that comment block refuses, and this field is a clear case for refusing it: the flag is **inert** unless `followUp.pauseWhileAppointment` is on, so a caller who sets it on a step with the agent-wide pause off stores a block that reads as configured and changes nothing — the same silent-failure shape `includeMessageText` and the half-named `modelFallback` each paid a raise for.

So the ceilings move by the measured amount, with the reasoning written where the number lives: 12,550 for the tool and 42,100 for the whole payload.

## Reachability

The field is writable from all three transports: the console (a per-step switch), REST, and MCP (declared in `BEHAVIOR_PATCH_SHAPE`, so `tools/list` publishes it and a caller is told it exists).

The console switch is HIDDEN while `pauseWhileAppointment` is off, because there it decides nothing. Hidden is not off: the value is kept and saved either way, or turning the agent-wide pause off and back on would silently clear every step's exemption.

## What of the report does not hold here

The issue as filed also covered a design gap that no per-step flag can close: an appointment created OUTSIDE the platform has no way to declare itself, so the pause cannot see it at all. That is a different deliverable with a different shape, and it is now #352. This PR closes the half that is closable.

## Validation scope

Proven by test (red before the fix, and each guard proven by mutation):

- the decision table of `appointmentPauseApplies` itself, needing no database: six rows over the `(agent flag, step)` pair, including the absent step (the fail-safe direction: a caller that cannot name a step has not shown an exemption)
- the stored spellings, through the real reader: `pauseWhileAppointment` as `undefined/true/false/null/"false"/"true"/0`, and `ignoreAppointmentPause` as `undefined/true/false/"true"/1`. Only the boolean decides, either way. These are pinned because the deleted SQL mirror got exactly this wrong and lifted its own fence on a spelling
- the sweep enqueues when step 0 opts out, and still skips when it does not (DB-backed, on the same agent); and the agent-wide opt-out case, which had no sweep coverage at all before this PR
- a step with the opt-out fires despite a live appointment; the step WITHOUT it still pauses, on the same agent and the same sequence
- the console does not claim "paused" when the step about to fire opted out, and still does when the NEXT step did not
- a job whose step no longer exists ends the sequence in the console, rather than counting down to it
- an agent whose follow-up is OFF is not exempted from the fence by an exemption retained from when it was on (the sweep's SQL never tests `followUp.enabled`, so nothing downstream would have caught it)
- stripping `resolve` from a mid-sequence step keeps every other field of that step
- the console form round-trips every field the `FollowUpStep` interface declares, including a save made while the switch is hidden
- the MCP/REST patch schema declares every field the interface declares

Mutation battery: 38 mutations across the guards (each gate inverted, each read narrowed, the exempt-set filter negated and emptied, the sweep pointed at the wrong step index, the indicator pointed at step 0, the rebuild put back, the terminal arm removed, the `cfg.enabled` filter dropped and negated). Two survivors, both reported rather than papered over:

- the `resolve`-strip rebuild, which was a real coverage gap and is how the latent bug above was found. Now covered
- `!step?.ignoreAppointmentPause` in place of `!== true`, which is unobservable: `readStep` normalizes the field to boolean-or-absent and the type forbids anything else, so no reachable state separates them

Full suite on the rebased tree: 6174 pass, 0 fail.

Proven live, against a local instance with a real agent and the real database:

- the switch renders per step and only while the agent-wide pause is on
- toggling it and saving writes `ignoreAppointmentPause: true` on that step alone, with no key at all on the others
- turning the agent-wide pause off hides the switch, and a save made in that state keeps the stored exemption
- a value written over REST shows up checked in the console, and survives a console save that touched only an unrelated field

### Live end-to-end, both halves

Run against the local Chatwoot fork (4.16.0) with a real account, a real Agent Bot posting under its own token, and a real OpenAI call. The **same script** was run in a worktree at the PR's base commit (`abed1f7f`) and in the fix worktree, so the comparison is between two codebases and not two scenarios. The scenario is the reported one: `pauseWhileAppointment` ON for the agent, step 0 exempted, a queued `APPOINTMENT_REMINDER` standing for that thread, and a conversation silent for 90 minutes.

| | base (`abed1f7f`) | fix |
|---|---|---|
| sweep enqueued a FOLLOWUP | `false` | `true` |
| handler outcome | `reschedule` (backed off on the appointment) | `done` |
| outgoing messages in Chatwoot | **0** | **1** |

The message read back off Chatwoot's own API on the fix run:

> Lembre-se de que o sinal ainda não foi identificado e a reserva será cancelada se não for pago.

That is the whole issue in one line: on the base, the payment-deadline step is silenced by the very booking it exists to chase, and the customer hears nothing. Both halves fail and pass at both gates the PR touches (the sweep's enqueue decision and the handler's own gate), so neither is carrying the result alone.

Still not covered: the appointment is a `scheduler_jobs` row written the way the appointment system writes it, not one booked through a live Google Calendar round-trip. The fence reads that row and nothing else, so the Calendar leg is out of this change's path.
