### PR TITLE
Let an operator find and requeue a dead delivery without opening Postgres

### DIFF
--- a/docs/api-and-fleet.md
+++ b/docs/api-and-fleet.md
@@ -57,9 +57,25 @@ TENANT_ADMIN. RLS fences every read/write to the active tenant; the secret value
 - `GET /webhooks/subscriptions` — list this tenant's subscriptions.
 - `POST /webhooks/subscriptions` — create (`url`, `events[]`, optional `secretRef`, `enabled`).
 - `PATCH /webhooks/subscriptions/:id` — update any of those (`secretRef: null` clears it).
-- `DELETE /webhooks/subscriptions/:id` — delete (clears its deliveries first, FK is `Restrict`).
+- `DELETE /webhooks/subscriptions/:id` — delete (clears its deliveries first, in the same scoped transaction).
 
 Validation: each `event` ∈ `OUTBOUND_EVENTS` (unknown → 400 `errors.unknownWebhookEvent`); `url` passes `assertSafeOutboundUrl` (anti-SSRF, https-only) on create/update. A foreign/missing id under RLS yields 404, never a cross-tenant write. UI: the `/webhooks` page (top-level nav, admin-gated).
+
+### Delivery ledger — `/api/v1/webhooks/deliveries*` (`deliveries.ts`)
+
+TENANT_ADMIN, RLS-scoped, keyset paginated by id desc (same shape as `/v1/logs`). Added by issue #305: before it there was no delivery-facing route at all, so watching for events that never arrived meant reading `outbound_webhook_deliveries` in Postgres — a table whose columns the worker owns and changes without a deprecation window.
+
+- `GET /webhooks/deliveries` — filters `status` (`PENDING|SENDING|DELIVERED|DEAD`, unknown → 400), `subscriptionId`, `event`, `since`/`until`, `limit` (default 50, max 200), `cursor`. `status=DEAD` is the dead-letter view.
+- `GET /webhooks/deliveries/:id` — one delivery.
+- `POST /webhooks/deliveries/:id/requeue` — put a **DEAD** delivery back in the worker's queue.
+
+**The payload never crosses this surface.** It is the tenant's own data, it does not go through the PII scrub `execution_logs` rows get at write, and the subscriber already receives it at their endpoint — the ledger answers whether the event arrived, not what was in it. Same call as the dead-delivery alert line (#325).
+
+**Requeue semantics.** `status` → `PENDING`, `attempts` → **0**, `nextAttemptAt` → null, `lastError` kept. The reset is what makes it a requeue: `finalizeFailure` gives up at `attempts + 1 >= MAX_ATTEMPTS`, so a row put back at 8 dies on its first post while the same row at 0 earns the full ladder. The count it died at survives in the `webhook` flow-log line. Only `DEAD` is accepted, and the guard is the `status: "DEAD"` in the update's own `where` rather than a branch above it: `SENDING` means a POST is in flight and a second claim would deliver it twice, `PENDING` is already queued, and replaying a `DELIVERED` event is a different promise. Any other status is refused with 409 naming it. The requeue writes one `info` `webhook` flow-log line (`action: "requeued"`, `attemptsBefore`, `subscriptionEnabled`) — `info` never pages, since `dispatchAlertsForEvent` only routes `warn`/`error`.
+
+`subscriptionEnabled` rides on every delivery DTO because the claim joins `enabled = true`: a delivery on a disabled subscription sits at `PENDING` untouched, and without that field a correct requeue is indistinguishable from one that did nothing.
+
+MCP: `webhook_delivery_list`, `webhook_delivery_get` (`mcp:read`), `webhook_delivery_requeue` (`mcp:write`, dry-run by default and audited on apply).
 
 ### Delivery worker — `src/modules/webhooks/outbound/worker.ts`
 
@@ -74,4 +90,4 @@ Headers: `x-fazerai-delivery` (the delivery id — a **stable dedupe key**, so a
 
 > **Compatibility window.** These headers were named `x-secretaria-*` before the brand rename. Both sets go out on every delivery, carrying identical values, so a receiver configured against either name keeps working. The legacy trio is dropped at `2.0` — point your receivers at `x-fazerai-*` before then.
 
-**Single-replica invariant.** The worker holds a reentrancy guard (`running`) and an interval on `globalThis` (so `bun --hot` does not stack phantom timers); `stopOutboundWorker` runs on `SIGTERM`/`SIGINT`. `FOR UPDATE SKIP LOCKED` already future-proofs the claim, but scaling the app beyond one replica needs a leader election or durable claim before the worker is enabled on every instance. `WebhookSubscription.onDelete` is `Restrict` (never `Cascade`, which would drop in-flight deliveries).
+**Single-replica invariant.** The worker holds a reentrancy guard (`running`) and an interval on `globalThis` (so `bun --hot` does not stack phantom timers); `stopOutboundWorker` runs on `SIGTERM`/`SIGINT`. `FOR UPDATE SKIP LOCKED` already future-proofs the claim, but scaling the app beyond one replica needs a leader election or durable claim before the worker is enabled on every instance. The delivery FK is `ON DELETE CASCADE` at the database (`20260727000000_init`), so what keeps a subscription delete from silently dropping rows the worker is mid-delivery is the service, not the constraint: `deleteWebhookSubscription` clears the deliveries explicitly inside the same RLS-scoped transaction, and that delete is operator-initiated.

--- a/openapi.json
+++ b/openapi.json
@@ -21775,6 +21775,448 @@
         "operationId": "postV1WebhooksSubscriptionsByIdTest"
       }
     },
+    "/v1/webhooks/deliveries": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List webhook deliveries",
+        "description": "Lists this tenant's outbound webhook deliveries newest first, with keyset pagination. Returns delivery state (status, attempts, last error, the event and subscription it belongs to) and never the payload.",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Filter by delivery status: PENDING, SENDING, DELIVERED, DEAD. An unknown value is rejected with 400.",
+              "type": "string"
+            }
+          },
+          {
+            "name": "subscriptionId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Filter by webhook subscription id (BigInt serialized as a string).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "event",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Filter by event name (from GET /events).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Lower bound on enqueue time (ISO date).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Upper bound on enqueue time (ISO date).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Max rows to return (positive integer string, default 50, capped at 200).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Keyset cursor (id of the last row from the previous page).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getV1WebhooksDeliveries"
+      }
+    },
+    "/v1/webhooks/deliveries/{id}": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Get webhook delivery",
+        "description": "Returns one outbound webhook delivery by id; the payload is never included.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Webhook delivery id (BigInt serialized as a string).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "getV1WebhooksDeliveriesById"
+      }
+    },
+    "/v1/webhooks/deliveries/{id}/requeue": {
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Requeue webhook delivery",
+        "description": "Returns a dead delivery to the worker queue with its attempt count reset. Only a delivery in DEAD is accepted; any other status is refused with 409 naming it.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "description": "Webhook delivery id (BigInt serialized as a string).",
+              "type": "string"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "required": true,
+            "description": "SUPER_ADMIN tenant selector (tenant id as a string). Picks the target tenant for this request; ignored for non-super-admin principals, who are pinned to their own tenant. Not truly required — prefilled and marked required here only so Scalar sends it by default.",
+            "schema": {
+              "type": "string",
+              "default": "1"
+            },
+            "example": "1"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized — missing or invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Unauthorized — missing or invalid credentials.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Forbidden — authenticated but not allowed (role or tenant gate).",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — a duplicate or a state conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Conflict — a duplicate or a state conflict.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postV1WebhooksDeliveriesByIdRequeue"
+      }
+    },
     "/v1/api-keys": {
       "get": {
         "tags": [

--- a/openapi.json
+++ b/openapi.json
@@ -21815,7 +21815,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Lower bound on enqueue time (ISO date).",
+              "description": "Lower bound on enqueue time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
               "type": "string"
             }
           },
@@ -21824,7 +21824,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Upper bound on enqueue time (ISO date).",
+              "description": "Upper bound on enqueue time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
               "type": "string"
             }
           },

--- a/prisma/migrations/20260826150000_delivery_ledger_keyset_indexes/migration.sql
+++ b/prisma/migrations/20260826150000_delivery_ledger_keyset_indexes/migration.sql
@@ -1,0 +1,24 @@
+-- The delivery ledger became a read surface in issue #305 (`GET /v1/webhooks/deliveries`, keyset
+-- paginated by id desc, optionally filtered by status), and the indexes the table shipped with were
+-- built for the WORKER: `(tenant_id)` alone, and `(status, next_attempt_at)` for the claim.
+--
+-- Neither serves the operator's page. Measured on a 60k-row table where one tenant's 2,000 rows sit
+-- UNDERNEATH a neighbour's 58,000 — a busy installation, which is the case that matters and the one
+-- a table with the tenant's rows at the end hides:
+--
+--   first page, no filter   3.209 ms / 1038 buffers  ->  0.022 ms /  8 buffers
+--   first page, status=DEAD 0.125 ms /   34 buffers  ->  0.026 ms / 11 buffers
+--
+-- The 1038 is the planner walking the primary key backwards through the neighbour's rows to find
+-- 51 of ours, and it grows with the NEIGHBOUR's traffic, not with the reader's. The dead-letter
+-- page was sorting every matching row on every request.
+--
+-- Ascending, not `id DESC`: the "after" numbers above were taken with these exact definitions, and
+-- the plan reads `Index Only Scan Backward` — a btree walks either way. `(tenant_id)` is left in
+-- place: it is the convention on every model here, and removing an index is a separate decision
+-- from adding one.
+CREATE INDEX "outbound_webhook_deliveries_tenant_id_id_idx"
+  ON "outbound_webhook_deliveries" ("tenant_id", "id");
+
+CREATE INDEX "outbound_webhook_deliveries_tenant_id_status_id_idx"
+  ON "outbound_webhook_deliveries" ("tenant_id", "status", "id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1142,6 +1142,10 @@ model OutboundWebhookDelivery {
 
   @@index([tenantId])
   @@index([status, nextAttemptAt])
+  // The operator's page (issue #305): keyset by id desc, filtered by status for the dead-letter
+  // view. The two above are the WORKER's; see the migration for the measurement.
+  @@index([tenantId, id])
+  @@index([tenantId, status, id])
   @@map("outbound_webhook_deliveries")
 }
 

--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -101,6 +101,7 @@
     "invalidModelConfig": "The model configuration must be an object.",
     "invalidModelConfigDetail": "The model configuration is not valid: {{reason}}",
     "invalidPassword": "Incorrect password",
+    "invalidQueryParam": "Invalid value for {{param}}",
     "invalidRequest": "The request is not valid.",
     "invalidRequestValue": "The value sent in {{field}} is not valid.",
     "invalidSecretType": "That secret type is not valid.",

--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -172,6 +172,7 @@
     "toolGrantUnknownTool": "Unknown {{source}} tool: {{tool}}.",
     "toolNameTaken": "That tool name is already in use.",
     "unauthorized": "Unauthorized",
+    "unknownDeliveryStatus": "Unknown delivery status: {{status}}",
     "unknownFlowStage": "Unknown flow stage: {{stage}}",
     "unknownProvider": "Unknown {{capability}} provider: {{provider}}.",
     "unknownWebhookEvent": "Unknown webhook event: {{event}}",
@@ -191,6 +192,8 @@
     "visionCredentialMissing": "Vision credential not found",
     "visionFailed": "Image/document extraction failed",
     "visionNotConfigured": "Image/document reading is not configured",
+    "webhookDeliveryNotDead": "Only a dead delivery can be requeued; this one is {{status}}",
+    "webhookDeliveryNotFound": "Webhook delivery not found",
     "webhookSubscriptionNotFound": "Webhook subscription not found"
   }
 }

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -101,6 +101,7 @@
     "invalidModelConfig": "A configuração do modelo precisa ser um objeto.",
     "invalidModelConfigDetail": "A configuração do modelo não é válida: {{reason}}",
     "invalidPassword": "Senha incorreta",
+    "invalidQueryParam": "Valor inválido para {{param}}",
     "invalidRequest": "A requisição não é válida.",
     "invalidRequestValue": "O valor enviado em {{field}} não é válido.",
     "invalidSecretType": "Este tipo de segredo não é válido.",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -172,6 +172,7 @@
     "toolGrantUnknownTool": "Ferramenta {{source}} desconhecida: {{tool}}.",
     "toolNameTaken": "Este nome de ferramenta já está em uso.",
     "unauthorized": "Não autorizado",
+    "unknownDeliveryStatus": "Status de entrega desconhecido: {{status}}",
     "unknownFlowStage": "Etapa de fluxo desconhecida: {{stage}}",
     "unknownProvider": "Provedor de {{capability}} desconhecido: {{provider}}.",
     "unknownWebhookEvent": "Evento de webhook desconhecido: {{event}}",
@@ -191,6 +192,8 @@
     "visionCredentialMissing": "Credencial de visão não encontrada",
     "visionFailed": "Falha ao extrair imagem/documento",
     "visionNotConfigured": "A leitura de imagens/documentos não está configurada",
+    "webhookDeliveryNotDead": "Só uma entrega morta pode ser reenfileirada; esta está em {{status}}",
+    "webhookDeliveryNotFound": "Entrega de webhook não encontrada",
     "webhookSubscriptionNotFound": "Assinatura de webhook não encontrada"
   }
 }

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { parseDbId, requireDbId } from "@/lib/db-id";
 import {
   AppError,
   ForbiddenError,
@@ -10,6 +11,7 @@ import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
 import {
   getWebhookDelivery,
+  type ListDeliveriesOpts,
   listWebhookDeliveries,
   OUTBOUND_DELIVERY_STATUSES,
   requeueWebhookDelivery,
@@ -57,27 +59,32 @@ function badParam(param: string): never {
   );
 }
 
+// PRESENT means the caller asked for this filter. Only ABSENT means they did not, which is why
+// none of these open with `if (!s)`: `?subscriptionId=` and `?status=` are values a form submits
+// when its input is empty, and treating them as "no filter" answers a narrowed request with the
+// tenant's whole ledger. `""` is refused, exactly like `abc`.
 function parseDate(s: string | undefined, param: string): Date | undefined {
-  if (!s) return undefined;
+  if (s === undefined) return undefined;
   const d = new Date(s);
   if (Number.isNaN(d.getTime())) badParam(param);
   return d;
 }
 
-function parseBigInt(s: string | undefined, param: string): bigint | undefined {
-  if (!s) return undefined;
-  try {
-    return BigInt(s);
-  } catch {
-    badParam(param);
-  }
+// `parseDbId`, never `BigInt(s)`: BigInt is arbitrary precision, so an id past 2^63-1 parses here
+// and is refused by POSTGRES when the query binds it — a 500 for a value this route documents as a
+// 400. See lib/db-id.ts, whose own header names `BigInt(params.id)` as the spelling to avoid.
+function parseId(s: string | undefined, param: string): bigint | undefined {
+  if (s === undefined) return undefined;
+  const id = parseDbId(s);
+  if (id === null) badParam(param);
+  return id;
 }
 
 // Syntax only; the range belongs to the service, so MCP is held to the same rule.
 function parseCount(s: string | undefined, param: string): number | undefined {
-  if (!s) return undefined;
+  if (s === undefined) return undefined;
   const n = Number(s);
-  if (!Number.isInteger(n)) badParam(param);
+  if (s.trim() === "" || !Number.isInteger(n)) badParam(param);
   return n;
 }
 
@@ -85,6 +92,28 @@ function ctxOrThrow(ctx: TenantContext | null): TenantContext {
   if (!ctx) throw new ForbiddenError();
   if (ctx.tenantId === null) throw new TenantTargetRequiredError();
   return ctx;
+}
+
+// Exported for the drift guard: the refusal matrix is what this route promises, and a test that
+// can only reach it through auth + tenancy would be testing three things to assert one.
+export function parseDeliveryQuery(query: {
+  status?: string;
+  subscriptionId?: string;
+  event?: string;
+  since?: string;
+  until?: string;
+  limit?: string;
+  cursor?: string;
+}): ListDeliveriesOpts {
+  return {
+    status: query.status,
+    subscriptionId: parseId(query.subscriptionId, "subscriptionId"),
+    event: query.event,
+    since: parseDate(query.since, "since"),
+    until: parseDate(query.until, "until"),
+    limit: parseCount(query.limit, "limit"),
+    cursor: parseId(query.cursor, "cursor"),
+  };
 }
 
 export const webhooksController = new Elysia({
@@ -280,15 +309,10 @@ export const webhooksController = new Elysia({
     "/deliveries",
     async ({ tenantContext, query }) => ({
       instance: instanceIdentity,
-      ...(await listWebhookDeliveries(ctxOrThrow(tenantContext), {
-        status: query.status,
-        subscriptionId: parseBigInt(query.subscriptionId, "subscriptionId"),
-        event: query.event,
-        since: parseDate(query.since, "since"),
-        until: parseDate(query.until, "until"),
-        limit: parseCount(query.limit, "limit"),
-        cursor: parseBigInt(query.cursor, "cursor"),
-      })),
+      ...(await listWebhookDeliveries(
+        ctxOrThrow(tenantContext),
+        parseDeliveryQuery(query),
+      )),
     }),
     {
       requireRole: "TENANT_ADMIN",
@@ -339,7 +363,7 @@ export const webhooksController = new Elysia({
       instance: instanceIdentity,
       delivery: await getWebhookDelivery(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id, "deliveryId"),
       ),
     }),
     {
@@ -366,7 +390,7 @@ export const webhooksController = new Elysia({
       instance: instanceIdentity,
       delivery: await requeueWebhookDelivery(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id, "deliveryId"),
       ),
     }),
     {

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -1,7 +1,11 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
-import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
+import {
+  AppError,
+  ForbiddenError,
+  TenantTargetRequiredError,
+} from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
 import {
@@ -34,20 +38,47 @@ import { sendWebhookTest } from "@/modules/webhooks/outbound/test";
 // translate('errors.webhookDeliveryNotFound', 'Webhook delivery not found')
 // translate('errors.webhookDeliveryNotDead', 'Only a dead delivery can be requeued; this one is {{status}}')
 // translate('errors.unknownDeliveryStatus', 'Unknown delivery status: {{status}}')
+// translate('errors.invalidQueryParam', 'Invalid value for {{param}}')
 
-function parseDate(s?: string): Date | undefined {
-  if (!s) return undefined;
-  const d = new Date(s);
-  return Number.isNaN(d.getTime()) ? undefined : d;
+// A filter value the server cannot parse is a REFUSAL, never a dropped filter. These started as
+// copies of the logs controller's lenient parsers, which answer an unparseable value with
+// `undefined` — and on a LEDGER that is the wrong answer twice over: a malformed `subscriptionId`
+// returns the tenant's whole ledger instead of one subscription's, and a malformed `cursor`
+// restarts pagination, which is a paging loop that never ends. Measured against the real client,
+// the numeric leg is worse than a wrong page: `take: NaN` and an invalid `Date` both reach Prisma
+// and throw (a 500 for a caller error), and `take: 3.5` quietly returns zero rows.
+function badParam(param: string): never {
+  throw new AppError(
+    `invalid value for ${param}`,
+    400,
+    "errors.invalidQueryParam",
+    { param },
+    param,
+  );
 }
 
-function parseBigInt(s?: string): bigint | undefined {
+function parseDate(s: string | undefined, param: string): Date | undefined {
+  if (!s) return undefined;
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) badParam(param);
+  return d;
+}
+
+function parseBigInt(s: string | undefined, param: string): bigint | undefined {
   if (!s) return undefined;
   try {
     return BigInt(s);
   } catch {
-    return undefined;
+    badParam(param);
   }
+}
+
+// Syntax only; the range belongs to the service, so MCP is held to the same rule.
+function parseCount(s: string | undefined, param: string): number | undefined {
+  if (!s) return undefined;
+  const n = Number(s);
+  if (!Number.isInteger(n)) badParam(param);
+  return n;
 }
 
 function ctxOrThrow(ctx: TenantContext | null): TenantContext {
@@ -251,12 +282,12 @@ export const webhooksController = new Elysia({
       instance: instanceIdentity,
       ...(await listWebhookDeliveries(ctxOrThrow(tenantContext), {
         status: query.status,
-        subscriptionId: parseBigInt(query.subscriptionId),
+        subscriptionId: parseBigInt(query.subscriptionId, "subscriptionId"),
         event: query.event,
-        since: parseDate(query.since),
-        until: parseDate(query.until),
-        limit: query.limit ? Number(query.limit) : undefined,
-        cursor: parseBigInt(query.cursor),
+        since: parseDate(query.since, "since"),
+        until: parseDate(query.until, "until"),
+        limit: parseCount(query.limit, "limit"),
+        cursor: parseBigInt(query.cursor, "cursor"),
       })),
     }),
     {

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -4,6 +4,12 @@ import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
+import {
+  getWebhookDelivery,
+  listWebhookDeliveries,
+  OUTBOUND_DELIVERY_STATUSES,
+  requeueWebhookDelivery,
+} from "@/modules/webhooks/outbound/deliveries";
 import { OUTBOUND_EVENTS } from "@/modules/webhooks/outbound/events";
 import {
   createWebhookSubscription,
@@ -25,6 +31,24 @@ import { sendWebhookTest } from "@/modules/webhooks/outbound/test";
 // them — its input glob does not reach src/modules.
 // translate('errors.unknownWebhookEvent', 'Unknown webhook event: {{event}}')
 // translate('errors.webhookSubscriptionNotFound', 'Webhook subscription not found')
+// translate('errors.webhookDeliveryNotFound', 'Webhook delivery not found')
+// translate('errors.webhookDeliveryNotDead', 'Only a dead delivery can be requeued; this one is {{status}}')
+// translate('errors.unknownDeliveryStatus', 'Unknown delivery status: {{status}}')
+
+function parseDate(s?: string): Date | undefined {
+  if (!s) return undefined;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+function parseBigInt(s?: string): bigint | undefined {
+  if (!s) return undefined;
+  try {
+    return BigInt(s);
+  } catch {
+    return undefined;
+  }
+}
 
 function ctxOrThrow(ctx: TenantContext | null): TenantContext {
   if (!ctx) throw new ForbiddenError();
@@ -214,5 +238,117 @@ export const webhooksController = new Elysia({
         }),
       }),
       response: errors(400, 401, 403, 404),
+    },
+  )
+  // ── deliveries ──
+  // The delivery ledger, read-only plus one requeue. Before issue #305 there was no delivery-facing
+  // route at all, so an integrator watching for events that never arrived had to read
+  // `outbound_webhook_deliveries` in Postgres — a table whose columns the worker owns and changes.
+  // Keyset pagination by id desc, same shape as /v1/logs. The payload is never returned.
+  .get(
+    "/deliveries",
+    async ({ tenantContext, query }) => ({
+      instance: instanceIdentity,
+      ...(await listWebhookDeliveries(ctxOrThrow(tenantContext), {
+        status: query.status,
+        subscriptionId: parseBigInt(query.subscriptionId),
+        event: query.event,
+        since: parseDate(query.since),
+        until: parseDate(query.until),
+        limit: query.limit ? Number(query.limit) : undefined,
+        cursor: parseBigInt(query.cursor),
+      })),
+    }),
+    {
+      requireRole: "TENANT_ADMIN",
+      query: t.Object({
+        status: t.Optional(
+          t.String({
+            description: `Filter by delivery status: ${OUTBOUND_DELIVERY_STATUSES.join(", ")}. An unknown value is rejected with 400.`,
+          }),
+        ),
+        subscriptionId: t.Optional(
+          t.String({
+            description:
+              "Filter by webhook subscription id (BigInt serialized as a string).",
+          }),
+        ),
+        event: t.Optional(
+          t.String({ description: "Filter by event name (from GET /events)." }),
+        ),
+        since: t.Optional(
+          t.String({ description: "Lower bound on enqueue time (ISO date)." }),
+        ),
+        until: t.Optional(
+          t.String({ description: "Upper bound on enqueue time (ISO date)." }),
+        ),
+        limit: t.Optional(
+          t.String({
+            description:
+              "Max rows to return (positive integer string, default 50, capped at 200).",
+          }),
+        ),
+        cursor: t.Optional(
+          t.String({
+            description:
+              "Keyset cursor (id of the last row from the previous page).",
+          }),
+        ),
+      }),
+      detail: doc(
+        "List webhook deliveries",
+        "Lists this tenant's outbound webhook deliveries newest first, with keyset pagination. Returns delivery state (status, attempts, last error, the event and subscription it belongs to) and never the payload.",
+      ),
+      response: errors(400, 401, 403, 404),
+    },
+  )
+  .get(
+    "/deliveries/:id",
+    async ({ tenantContext, params }) => ({
+      instance: instanceIdentity,
+      delivery: await getWebhookDelivery(
+        ctxOrThrow(tenantContext),
+        BigInt(params.id),
+      ),
+    }),
+    {
+      requireRole: "TENANT_ADMIN",
+      params: t.Object({
+        id: t.String({
+          description: "Webhook delivery id (BigInt serialized as a string).",
+        }),
+      }),
+      detail: doc(
+        "Get webhook delivery",
+        "Returns one outbound webhook delivery by id; the payload is never included.",
+      ),
+      response: errors(400, 401, 403, 404),
+    },
+  )
+  // Puts a DEAD delivery back in the worker's queue: status PENDING, `attempts` reset to 0 so the
+  // retry ladder starts over, next attempt due immediately. Only DEAD can be requeued — a delivery
+  // the worker is currently posting (SENDING) would be at risk of a double delivery, and anything
+  // else is either already queued or already delivered. The refusal names the current status (409).
+  .post(
+    "/deliveries/:id/requeue",
+    async ({ tenantContext, params }) => ({
+      instance: instanceIdentity,
+      delivery: await requeueWebhookDelivery(
+        ctxOrThrow(tenantContext),
+        BigInt(params.id),
+      ),
+    }),
+    {
+      requireRole: "TENANT_ADMIN",
+      params: t.Object({
+        id: t.String({
+          description: "Webhook delivery id (BigInt serialized as a string).",
+        }),
+      }),
+      detail: doc(
+        "Requeue webhook delivery",
+        "Returns a dead delivery to the worker queue with its attempt count reset. Only a delivery in DEAD is accepted; any other status is refused with 409 naming it.",
+      ),
+      response: errors(400, 401, 403, 404, 409),
     },
   );

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
+import { parseIsoInstant } from "@/modules/flowlog/settings";
 import {
   getWebhookDelivery,
   type ListDeliveriesOpts,
@@ -63,10 +64,16 @@ function badParam(param: string): never {
 // none of these open with `if (!s)`: `?subscriptionId=` and `?status=` are values a form submits
 // when its input is empty, and treating them as "no filter" answers a narrowed request with the
 // tenant's whole ledger. `""` is refused, exactly like `abc`.
+// `parseIsoInstant`, never `new Date(s)`. `Date.parse` NORMALISES rather than refuses, so
+// `2026-02-30T00:00:00Z` comes back as March 2 and the ledger is quietly queried with a bound the
+// caller never asked for; and it accepts `08/26/2026 10:00`, resolving it against the SERVER's
+// timezone, so the same filter means different instants on two installations. The helper checks
+// the shape, the calendar and the offset on the STRING. The cost is that a date alone is refused:
+// this filter takes an instant, `2026-01-01T00:00:00Z`, and the parameter's description says so.
 function parseDate(s: string | undefined, param: string): Date | undefined {
   if (s === undefined) return undefined;
-  const d = new Date(s);
-  if (Number.isNaN(d.getTime())) badParam(param);
+  const d = parseIsoInstant(s);
+  if (d === null) badParam(param);
   return d;
 }
 
@@ -332,10 +339,16 @@ export const webhooksController = new Elysia({
           t.String({ description: "Filter by event name (from GET /events)." }),
         ),
         since: t.Optional(
-          t.String({ description: "Lower bound on enqueue time (ISO date)." }),
+          t.String({
+            description:
+              "Lower bound on enqueue time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
+          }),
         ),
         until: t.Optional(
-          t.String({ description: "Upper bound on enqueue time (ISO date)." }),
+          t.String({
+            description:
+              "Upper bound on enqueue time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
+          }),
         ),
         limit: t.Optional(
           t.String({

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -401,10 +401,12 @@ export const webhooksController = new Elysia({
     "/deliveries/:id/requeue",
     async ({ tenantContext, params }) => ({
       instance: instanceIdentity,
-      delivery: await requeueWebhookDelivery(
-        ctxOrThrow(tenantContext),
-        requireDbId(params.id, "deliveryId"),
-      ),
+      delivery: (
+        await requeueWebhookDelivery(
+          ctxOrThrow(tenantContext),
+          requireDbId(params.id, "deliveryId"),
+        )
+      ).delivery,
     }),
     {
       requireRole: "TENANT_ADMIN",

--- a/src/modules/flowlog/webhook.ts
+++ b/src/modules/flowlog/webhook.ts
@@ -62,3 +62,56 @@ export function emitDeliveryDead(args: {
     },
   );
 }
+
+// THE SAME DELIVERY, PUT BACK IN THE QUEUE BY AN OPERATOR (issue #305).
+//
+// It sits next to the death line for one reason: without it, the requeue is a silent mutation of
+// the very row whose silence #325 was about. The ledger has to read "gave up after 8 attempts" and
+// then "sent back to the queue", or the operator who did neither cannot tell a delivery that was
+// never retried from one that was retried and died again.
+//
+// `info`, and that is not a softer `warn`: a requeue is somebody doing their job, not a failure.
+// The level also decides the blast radius, because `dispatchAlertsForEvent` only routes `warn` and
+// `error` — an `info` line lands in the Logs page and pages nobody, which is what an operator
+// clearing a hundred dead deliveries needs it to do.
+//
+// `attemptsBefore` is the count the row died at, and the line is where it survives: the requeue
+// resets `attempts` to 0 so the retry ladder starts over, so a minute later the row itself can no
+// longer say how hard the bus already tried. `subscriptionEnabled` is here because a requeue into
+// a disabled subscription is legal and does nothing until it is re-enabled (the worker's claim
+// joins `enabled = true`) — the one case where a correct requeue looks like an ignored one.
+//
+// WHO did it is deliberately absent. This line is the delivery's history, not the actor's; the
+// actor ledger is `audit_logs`, and that REST mutations do not reach it is issue #306, not
+// something to patch one endpoint at a time.
+export function emitDeliveryRequeued(args: {
+  tenantId: bigint;
+  deliveryId: bigint;
+  subscriptionId: bigint;
+  event: string;
+  attemptsBefore: number;
+  subscriptionEnabled: boolean;
+  base?: PrismaClient;
+}): void {
+  emitFlowEvent(
+    {
+      tenantId: args.tenantId,
+      turnId: crypto.randomUUID(),
+      source: "inbox",
+      base: args.base,
+    },
+    {
+      stage: "webhook",
+      level: "info",
+      status: "ok",
+      detail: {
+        deliveryId: String(args.deliveryId),
+        subscriptionId: String(args.subscriptionId),
+        event: args.event,
+        action: "requeued",
+        attemptsBefore: args.attemptsBefore,
+        subscriptionEnabled: args.subscriptionEnabled,
+      },
+    },
+  );
+}

--- a/src/modules/mcp/read.ts
+++ b/src/modules/mcp/read.ts
@@ -61,6 +61,10 @@ import {
   vaultNameByRef,
   vaultReferences,
 } from "@/modules/vault/service";
+import {
+  getWebhookDelivery,
+  listWebhookDeliveries,
+} from "@/modules/webhooks/outbound/deliveries";
 import { OUTBOUND_EVENTS } from "@/modules/webhooks/outbound/events";
 import { listWebhookSubscriptions } from "@/modules/webhooks/outbound/subscriptions";
 import type { VerifiedToken } from "./oauth/tokens";
@@ -490,6 +494,69 @@ export async function webhookEventsList(
   const ctx = readGate(principal);
   if ("ok" in ctx) return ctx;
   return ok({ events: [...OUTBOUND_EVENTS] });
+}
+
+// ── outbound webhook deliveries ──
+// The ledger the worker writes as it delivers. Read-only here; the requeue is a write tool
+// (`webhook_delivery_requeue`). The payload never crosses this surface — see `deliveries.ts`.
+
+export interface WebhookDeliveryListArgs {
+  status?: string;
+  subscription_id?: string;
+  event?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export async function webhookDeliveryList(
+  principal: VerifiedToken,
+  args: WebhookDeliveryListArgs = {},
+  deps: WriteDeps = {},
+): Promise<WriteResult> {
+  const base = deps.base ?? basePrisma;
+  const ctx = readGate(principal);
+  if ("ok" in ctx) return ctx;
+  const opts: Parameters<typeof listWebhookDeliveries>[1] = {};
+  if (args.status) opts.status = args.status;
+  if (args.event) opts.event = args.event;
+  if (args.since) opts.since = new Date(args.since);
+  if (args.until) opts.until = new Date(args.until);
+  if (args.limit !== undefined) opts.limit = args.limit;
+  if (args.subscription_id) {
+    const v = parseMcpId(args.subscription_id, "subscription_id");
+    if (typeof v !== "bigint") return v;
+    opts.subscriptionId = v;
+  }
+  if (args.cursor) {
+    const v = parseMcpId(args.cursor, "cursor");
+    if (typeof v !== "bigint") return v;
+    opts.cursor = v;
+  }
+  try {
+    const res = await listWebhookDeliveries(ctx, opts, base);
+    return ok({ items: res.items, nextCursor: res.nextCursor });
+  } catch (e) {
+    return failOf(e);
+  }
+}
+
+export async function webhookDeliveryGet(
+  principal: VerifiedToken,
+  args: { delivery_id: string },
+  deps: WriteDeps = {},
+): Promise<WriteResult> {
+  const base = deps.base ?? basePrisma;
+  const ctx = readGate(principal);
+  if ("ok" in ctx) return ctx;
+  const id = parseMcpId(args.delivery_id, "delivery_id");
+  if (typeof id !== "bigint") return id;
+  try {
+    return ok({ delivery: await getWebhookDelivery(ctx, id, base) });
+  } catch (e) {
+    return failOf(e);
+  }
 }
 
 // ── alert channels ──

--- a/src/modules/mcp/read.ts
+++ b/src/modules/mcp/read.ts
@@ -518,18 +518,21 @@ export async function webhookDeliveryList(
   const base = deps.base ?? basePrisma;
   const ctx = readGate(principal);
   if ("ok" in ctx) return ctx;
+  // `!== undefined` on every filter, so an argument the caller SENT as empty is refused by the
+  // service instead of being dropped here and widening the page. The truthiness spelling is what
+  // makes `status: ""` mean "every status".
   const opts: Parameters<typeof listWebhookDeliveries>[1] = {};
-  if (args.status) opts.status = args.status;
-  if (args.event) opts.event = args.event;
-  if (args.since) opts.since = new Date(args.since);
-  if (args.until) opts.until = new Date(args.until);
+  if (args.status !== undefined) opts.status = args.status;
+  if (args.event !== undefined) opts.event = args.event;
+  if (args.since !== undefined) opts.since = new Date(args.since);
+  if (args.until !== undefined) opts.until = new Date(args.until);
   if (args.limit !== undefined) opts.limit = args.limit;
-  if (args.subscription_id) {
+  if (args.subscription_id !== undefined) {
     const v = parseMcpId(args.subscription_id, "subscription_id");
     if (typeof v !== "bigint") return v;
     opts.subscriptionId = v;
   }
-  if (args.cursor) {
+  if (args.cursor !== undefined) {
     const v = parseMcpId(args.cursor, "cursor");
     if (typeof v !== "bigint") return v;
     opts.cursor = v;

--- a/src/modules/mcp/read.ts
+++ b/src/modules/mcp/read.ts
@@ -39,6 +39,7 @@ import {
 import { listAlertChannels } from "@/modules/flowlog/channels";
 import { exportExecutionLogs } from "@/modules/flowlog/export";
 import { listExecutionLogs } from "@/modules/flowlog/read";
+import { parseIsoInstant } from "@/modules/flowlog/settings";
 import { FLOW_LEVELS, FLOW_STAGES } from "@/modules/flowlog/stages";
 import {
   listCatalog,
@@ -524,8 +525,16 @@ export async function webhookDeliveryList(
   const opts: Parameters<typeof listWebhookDeliveries>[1] = {};
   if (args.status !== undefined) opts.status = args.status;
   if (args.event !== undefined) opts.event = args.event;
-  if (args.since !== undefined) opts.since = new Date(args.since);
-  if (args.until !== undefined) opts.until = new Date(args.until);
+  // The same parse the REST filter uses, for the same reason: `new Date` normalises February 30
+  // into March 2 and resolves a non-ISO string against the server's timezone, and a filter that
+  // silently means something else is worse than one that is refused.
+  for (const key of ["since", "until"] as const) {
+    const raw = args[key];
+    if (raw === undefined) continue;
+    const d = parseIsoInstant(raw);
+    if (d === null) return err(`invalid ${key}`);
+    opts[key] = d;
+  }
   if (args.limit !== undefined) opts.limit = args.limit;
   if (args.subscription_id !== undefined) {
     const v = parseMcpId(args.subscription_id, "subscription_id");

--- a/src/modules/mcp/server.ts
+++ b/src/modules/mcp/server.ts
@@ -19,6 +19,7 @@ import {
   runPlaygroundFileTurn,
   runPlaygroundTurn,
 } from "@/modules/playground/service";
+import { OUTBOUND_DELIVERY_STATUSES } from "@/modules/webhooks/outbound/deliveries";
 import { hasScope, type VerifiedToken } from "./oauth/tokens";
 import {
   agentGet,
@@ -57,6 +58,8 @@ import {
   toolList,
   vaultList,
   vaultReferencesGet,
+  webhookDeliveryGet,
+  webhookDeliveryList,
   webhookEventsList,
   webhookList,
 } from "./read";
@@ -150,6 +153,7 @@ import {
   integrationUpdate,
   webhookCreate,
   webhookDelete,
+  webhookDeliveryRequeue,
   webhookTest,
   webhookUpdate,
 } from "./write-webhooks";
@@ -821,6 +825,59 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
         inputSchema: {},
       },
       async (_args, eff) => writeContent(await webhookEventsList(eff)),
+    );
+
+    registerTenantTool(
+      server,
+      principal,
+      "webhook_delivery_list",
+      {
+        description:
+          "List outbound webhook DELIVERIES (id, subscriptionId, subscriptionEnabled, event, status, attempts, nextAttemptAt, deliveredAt, lastError), newest first. status=DEAD is the dead-letter view: what the worker gave up on. The payload is never returned. Keyset paginated via cursor; limit max 200. Requeue a dead one with webhook_delivery_requeue.",
+        inputSchema: {
+          // NOTE: derived from the module's vocabulary, never hand-listed — the enum on the model
+          // also carries FAILED, which only the inbound side writes, and a hand copy is how a
+          // filter ends up advertising a value that can never match.
+          status: z.enum(OUTBOUND_DELIVERY_STATUSES).optional(),
+          subscription_id: z.string().optional(),
+          event: z.string().optional(),
+          since: z
+            .string()
+            .optional()
+            .describe("ISO date, lower bound on enqueue time."),
+          until: z
+            .string()
+            .optional()
+            .describe("ISO date, upper bound on enqueue time."),
+          limit: z.number().int().optional(),
+          cursor: z.string().optional(),
+        },
+      },
+      async (
+        args: {
+          status?: string;
+          subscription_id?: string;
+          event?: string;
+          since?: string;
+          until?: string;
+          limit?: number;
+          cursor?: string;
+        },
+        eff,
+      ) => writeContent(await webhookDeliveryList(eff, args)),
+    );
+
+    registerTenantTool(
+      server,
+      principal,
+      "webhook_delivery_get",
+      {
+        description:
+          "Get one outbound webhook delivery by id. Same fields as webhook_delivery_list; the payload is never returned.",
+        inputSchema: { delivery_id: z.string() },
+      },
+      async (args: { delivery_id: string }, eff) =>
+        writeContent(await webhookDeliveryGet(eff, args)),
     );
 
     registerTenantTool(
@@ -1904,6 +1961,22 @@ export function buildMcpServer(principal: VerifiedToken): McpServer {
       },
       async (args: { webhook_id: string; dry_run?: boolean }, eff) =>
         writeContent(await webhookDelete(eff, args)),
+    );
+
+    registerTenantTool(
+      server,
+      principal,
+      "webhook_delivery_requeue",
+      {
+        description:
+          "Put a DEAD outbound webhook delivery back in the worker queue: status returns to PENDING and attempts resets to 0, so the full retry ladder runs again. Only DEAD is accepted — any other status is refused, naming it. Previews the row and changes NOTHING unless dry_run is false.",
+        inputSchema: {
+          delivery_id: z.string(),
+          dry_run: z.boolean().optional(),
+        },
+      },
+      async (args: { delivery_id: string; dry_run?: boolean }, eff) =>
+        writeContent(await webhookDeliveryRequeue(eff, args)),
     );
 
     registerTenantTool(

--- a/src/modules/mcp/write-webhooks.ts
+++ b/src/modules/mcp/write-webhooks.ts
@@ -293,16 +293,21 @@ export async function webhookDeliveryRequeue(
         },
       });
     }
-    const after = await requeueWebhookDelivery(ctx, id, base);
+    // `before` comes from the service's own LOCKED read, never from `current` above: between that
+    // read and the write, another operator can requeue this row and the worker can drive it back
+    // to DEAD (one tick, for a URL the SSRF guard refuses), and the audit would then describe the
+    // previous death instead of the one this call undid.
+    const { delivery: after, before } = await requeueWebhookDelivery(
+      ctx,
+      id,
+      base,
+    );
     await recordMcpAudit(ctx, base, {
       actorId: principal.userId,
       actorType: "mcp",
       action: "mcp.webhook_delivery_requeue",
       target,
-      before: truncForAudit({
-        status: current.status,
-        attempts: current.attempts,
-      }),
+      before: truncForAudit(before),
       after: truncForAudit({ status: after.status, attempts: after.attempts }),
     });
     return ok({ dryRun: false, applied: true, target, delivery: after });

--- a/src/modules/mcp/write-webhooks.ts
+++ b/src/modules/mcp/write-webhooks.ts
@@ -14,6 +14,10 @@ import {
   getIntegrationInstance,
   updateIntegrationInstance,
 } from "@/modules/integrations/service";
+import {
+  getWebhookDelivery,
+  requeueWebhookDelivery,
+} from "@/modules/webhooks/outbound/deliveries";
 import { isOutboundEvent } from "@/modules/webhooks/outbound/events";
 import {
   createWebhookSubscription,
@@ -238,6 +242,70 @@ export async function webhookDelete(
       after: null,
     });
     return ok({ dryRun: false, applied: true, target });
+  } catch (e) {
+    return failOf(e);
+  }
+}
+
+// Put a DEAD outbound delivery back in the worker's queue (issue #305). The state change is the
+// service's; what this adds is the MCP contract around it.
+//
+// The dry run READS THE ROW instead of echoing the argument back, and that is the whole point of
+// it here: the only way this call fails is the row not being DEAD, so a preview built from the id
+// alone would approve exactly the requests the apply refuses. It answers with the same refusal, on
+// the same read, one step earlier.
+export async function webhookDeliveryRequeue(
+  principal: VerifiedToken,
+  args: { delivery_id: string; dry_run?: boolean },
+  deps: WriteDeps = {},
+): Promise<WriteResult> {
+  const base = deps.base ?? basePrisma;
+  const ctx = gate(principal);
+  if ("ok" in ctx) return ctx;
+  const id = parseMcpId(args.delivery_id, "delivery_id");
+  if (typeof id !== "bigint") return id;
+  const target = `webhook_delivery:${id}`;
+  try {
+    const current = await getWebhookDelivery(ctx, id, base);
+    if (current.status !== "DEAD")
+      return err(
+        `only a dead delivery can be requeued (this one is ${current.status})`,
+      );
+    if (args.dry_run !== false) {
+      return ok({
+        dryRun: true,
+        action: "requeue",
+        target,
+        current: {
+          id: current.id,
+          status: current.status,
+          attempts: current.attempts,
+          event: current.event,
+          subscriptionId: current.subscriptionId,
+          subscriptionEnabled: current.subscriptionEnabled,
+        },
+        // Named rather than implied: `attempts` going back to 0 is what buys a full retry ladder
+        // instead of a single post, and a disabled subscription means the queue holds the row.
+        preview: {
+          status: "PENDING",
+          attempts: 0,
+          willBeClaimed: current.subscriptionEnabled,
+        },
+      });
+    }
+    const after = await requeueWebhookDelivery(ctx, id, base);
+    await recordMcpAudit(ctx, base, {
+      actorId: principal.userId,
+      actorType: "mcp",
+      action: "mcp.webhook_delivery_requeue",
+      target,
+      before: truncForAudit({
+        status: current.status,
+        attempts: current.attempts,
+      }),
+      after: truncForAudit({ status: after.status, attempts: after.attempts }),
+    });
+    return ok({ dryRun: false, applied: true, target, delivery: after });
   } catch (e) {
     return failOf(e);
   }

--- a/src/modules/mcp/write-webhooks.ts
+++ b/src/modules/mcp/write-webhooks.ts
@@ -266,12 +266,18 @@ export async function webhookDeliveryRequeue(
   if (typeof id !== "bigint") return id;
   const target = `webhook_delivery:${id}`;
   try {
-    const current = await getWebhookDelivery(ctx, id, base);
-    if (current.status !== "DEAD")
-      return err(
-        `only a dead delivery can be requeued (this one is ${current.status})`,
-      );
+    // The preview reads the row; the APPLY does not. They are different questions: a preview says
+    // what would happen if the write ran now, and an unlocked read is the only thing it can say it
+    // from — while an apply that repeated that read would refuse cases the service accepts. The
+    // worker turning SENDING into DEAD is the case: uncommitted, it still reads SENDING here, and
+    // the service is built to wait on that transition and requeue the row that comes out of it.
+    // So the apply defers to the locked check, and its refusal is the service's own.
     if (args.dry_run !== false) {
+      const current = await getWebhookDelivery(ctx, id, base);
+      if (current.status !== "DEAD")
+        return err(
+          `only a dead delivery can be requeued (this one is ${current.status})`,
+        );
       return ok({
         dryRun: true,
         action: "requeue",
@@ -293,10 +299,9 @@ export async function webhookDeliveryRequeue(
         },
       });
     }
-    // `before` comes from the service's own LOCKED read, never from `current` above: between that
-    // read and the write, another operator can requeue this row and the worker can drive it back
-    // to DEAD (one tick, for a URL the SSRF guard refuses), and the audit would then describe the
-    // previous death instead of the one this call undid.
+    // `before` is the service's own LOCKED read, which is what makes the audit describe the write
+    // that happened: any read this tool took first would be one the row can move away from, and
+    // for a URL the SSRF guard refuses that takes a single tick.
     const { delivery: after, before } = await requeueWebhookDelivery(
       ctx,
       id,

--- a/src/modules/webhooks/outbound/deliveries.ts
+++ b/src/modules/webhooks/outbound/deliveries.ts
@@ -35,6 +35,12 @@ export interface WebhookDeliveryDto {
   updatedAt: string;
 }
 
+export interface RequeuedDelivery {
+  delivery: WebhookDeliveryDto;
+  // What the row was when the lock was taken, i.e. what this requeue actually undid.
+  before: { status: string; attempts: number };
+}
+
 export interface ListDeliveriesOpts {
   status?: string;
   subscriptionId?: bigint;
@@ -232,12 +238,18 @@ export async function getWebhookDelivery(
 // again. Refusing in the same statement that writes means no reader-then-writer gap to lose the
 // race in. PENDING is already queued, and replaying a DELIVERED event is a different promise with
 // a different consequence — re-sending data the receiver already took.
+// The pre-state travels back with the row, and it is the LOCKED read rather than a caller's own
+// earlier look. A caller that audits this mutation (the MCP tool does, and the contract in
+// docs/mcp.md requires `before`/`after` to describe the write that happened) would otherwise have
+// to read the row itself, outside the lock — and between that read and this one the row can have
+// been requeued by somebody else and died again, which for an SSRF-refused URL takes one tick. The
+// `before` it recorded would then belong to the previous death.
 export async function requeueWebhookDelivery(
   ctx: TenantContext,
   id: bigint,
   base: PrismaClient = basePrisma,
-): Promise<WebhookDeliveryDto> {
-  const { row, attemptsBefore } = await runScopedOn(base, ctx, async (db) => {
+): Promise<RequeuedDelivery> {
+  const { row, before } = await runScopedOn(base, ctx, async (db) => {
     // `FOR UPDATE`, and the lock is the design of this function rather than an optimisation. Two
     // writers reach this row: another operator requeueing it, and the WORKER finishing with it.
     // Without the lock, both things this function then says can be stale by the time it says them
@@ -276,7 +288,10 @@ export async function requeueWebhookDelivery(
       data: { status: "PENDING", attempts: 0, nextAttemptAt: null },
       select: SELECT,
     });
-    return { row: updated, attemptsBefore: current.attempts };
+    return {
+      row: updated,
+      before: { status: current.status, attempts: current.attempts },
+    };
   });
   if (!row)
     throw new NotFoundError(
@@ -290,10 +305,12 @@ export async function requeueWebhookDelivery(
       deliveryId: id,
       subscriptionId: BigInt(dto.subscriptionId),
       event: dto.event,
-      attemptsBefore,
+      attemptsBefore: before.attempts,
       subscriptionEnabled: dto.subscriptionEnabled,
       base,
     });
   }
-  return dto;
+  // `before` is what the LOCKED read returned, not the constant "DEAD" the guard above proved it
+  // to be. The two are the same value and only one of them is evidence.
+  return { delivery: dto, before };
 }

--- a/src/modules/webhooks/outbound/deliveries.ts
+++ b/src/modules/webhooks/outbound/deliveries.ts
@@ -238,43 +238,42 @@ export async function requeueWebhookDelivery(
   base: PrismaClient = basePrisma,
 ): Promise<WebhookDeliveryDto> {
   const { row, attemptsBefore } = await runScopedOn(base, ctx, async (db) => {
-    const current = await db.outboundWebhookDelivery.findFirst({
-      where: { id },
-      select: { id: true, status: true, attempts: true },
-    });
+    // `FOR UPDATE`, and the lock is the design of this function rather than an optimisation. Two
+    // writers reach this row: another operator requeueing it, and the WORKER finishing with it.
+    // Without the lock, both things this function then says can be stale by the time it says them
+    // — the status it refuses on (two operators both read DEAD; the second's update matches
+    // nothing and it would answer "this one is DEAD" about a row already PENDING) and the count it
+    // logs (a read of SENDING/7 while the worker is committing DEAD/8 still passes the update, and
+    // the line preserves 7 for a delivery that died at 8). Taking the lock first collapses both:
+    // whatever this reads is what the row is, and nobody can move it until this transaction ends.
+    //
+    // RLS is active on this connection (`runScopedOn`), so a foreign id selects nothing here — the
+    // same 404 a foreign id gets from every other read on this surface.
+    const locked = await db.$queryRaw<
+      Array<{ status: string; attempts: number }>
+    >`
+      SELECT status::text AS status, attempts
+      FROM outbound_webhook_deliveries
+      WHERE id = ${id}
+      FOR UPDATE
+    `;
+    const current = locked[0];
     if (!current)
       throw new NotFoundError(
         "webhook delivery not found",
         "errors.webhookDeliveryNotFound",
       );
-    const res = await db.outboundWebhookDelivery.updateMany({
-      where: { id, status: "DEAD" },
-      data: { status: "PENDING", attempts: 0, nextAttemptAt: null },
-    });
-    // count 0 = it was not DEAD when the write ran. The status to report is re-read rather than
-    // taken from the check above, because the two disagree in exactly the case that matters: two
-    // operators requeueing the same dead delivery both read DEAD, the second update blocks on the
-    // first and then matches nothing, and reporting the stale read would answer "this one is DEAD"
-    // about a row that is now PENDING — the one refusal a caller would be right to retry.
-    if (res.count === 0) {
-      const now = await db.outboundWebhookDelivery.findFirst({
-        where: { id },
-        select: { status: true },
-      });
-      if (!now)
-        throw new NotFoundError(
-          "webhook delivery not found",
-          "errors.webhookDeliveryNotFound",
-        );
+    if (current.status !== "DEAD")
       throw new AppError(
-        `only a dead delivery can be requeued (this one is ${now.status})`,
+        `only a dead delivery can be requeued (this one is ${current.status})`,
         409,
         "errors.webhookDeliveryNotDead",
-        { status: now.status },
+        { status: current.status },
+        "status",
       );
-    }
-    const updated = await db.outboundWebhookDelivery.findFirst({
+    const updated = await db.outboundWebhookDelivery.update({
       where: { id },
+      data: { status: "PENDING", attempts: 0, nextAttemptAt: null },
       select: SELECT,
     });
     return { row: updated, attemptsBefore: current.attempts };

--- a/src/modules/webhooks/outbound/deliveries.ts
+++ b/src/modules/webhooks/outbound/deliveries.ts
@@ -1,0 +1,244 @@
+import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
+import basePrisma from "@/api/lib/prisma";
+import { AppError, NotFoundError } from "@/lib/errors";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import { emitDeliveryRequeued } from "@/modules/flowlog/webhook";
+
+// THE DELIVERY LEDGER AS A SUPPORTED SURFACE (issue #305).
+//
+// The worker's side of this table is `worker.ts`; this is the operator's side. It exists because
+// the only way to see a delivery that reached `DEAD` was to open Postgres and read
+// `outbound_webhook_deliveries` with a read-only role — which works, and which we answered we
+// cannot promise to keep: `attempts` and `lastError` are owned by the worker, and the outbound
+// headers were renamed inside one cycle without anything announcing it to a table reader.
+//
+// The payload never crosses this surface. It is the tenant's own data, it does NOT go through the
+// PII scrub that `execution_logs` rows get at write, and the subscriber already receives it at
+// their endpoint — a ledger answers whether the event arrived, not what was in it. The same call
+// was made for the dead-delivery alert line in #325.
+
+export interface WebhookDeliveryDto {
+  id: string;
+  subscriptionId: string;
+  // Whether the subscription is currently enabled, and it is here rather than one join away for a
+  // reason: the worker's claim joins `enabled = true`, so a delivery belonging to a disabled
+  // subscription sits at PENDING and is never picked up. Without this field a requeue into a
+  // disabled subscription looks exactly like a requeue that did nothing.
+  subscriptionEnabled: boolean;
+  event: string;
+  status: string;
+  attempts: number;
+  nextAttemptAt: string | null;
+  deliveredAt: string | null;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListDeliveriesOpts {
+  status?: string;
+  subscriptionId?: bigint;
+  event?: string;
+  since?: Date;
+  until?: Date;
+  limit?: number;
+  // Keyset: return rows with id < cursor.
+  cursor?: bigint;
+}
+
+export interface ListDeliveriesResult {
+  items: WebhookDeliveryDto[];
+  // Pass back as `cursor` to fetch the next (older) page; null when no more rows.
+  nextCursor: string | null;
+}
+
+// Every column except `payload`. Written as an explicit projection rather than an omit so that a
+// column added to the model later does not silently join this surface.
+const SELECT = {
+  id: true,
+  subscriptionId: true,
+  event: true,
+  status: true,
+  attempts: true,
+  nextAttemptAt: true,
+  deliveredAt: true,
+  lastError: true,
+  createdAt: true,
+  updatedAt: true,
+  subscription: { select: { enabled: true } },
+} as const;
+
+type DeliveryRow = Prisma.OutboundWebhookDeliveryGetPayload<{
+  select: typeof SELECT;
+}>;
+
+// The four statuses an OUTBOUND delivery can actually hold. `WebhookDeliveryStatus` also carries
+// `FAILED`, which only the inbound side writes: accepting it here would answer "no rows" to a
+// filter that can never match, so it is refused as an unknown status instead.
+export const OUTBOUND_DELIVERY_STATUSES = [
+  "PENDING",
+  "SENDING",
+  "DELIVERED",
+  "DEAD",
+] as const;
+export type OutboundDeliveryStatus =
+  (typeof OUTBOUND_DELIVERY_STATUSES)[number];
+
+export function isOutboundDeliveryStatus(
+  s: string,
+): s is OutboundDeliveryStatus {
+  return (OUTBOUND_DELIVERY_STATUSES as readonly string[]).includes(s);
+}
+
+function toDto(r: DeliveryRow): WebhookDeliveryDto {
+  return {
+    id: String(r.id),
+    subscriptionId: String(r.subscriptionId),
+    subscriptionEnabled: r.subscription.enabled,
+    event: r.event,
+    status: r.status,
+    attempts: r.attempts,
+    nextAttemptAt: r.nextAttemptAt?.toISOString() ?? null,
+    deliveredAt: r.deliveredAt?.toISOString() ?? null,
+    lastError: r.lastError,
+    createdAt: r.createdAt.toISOString(),
+    updatedAt: r.updatedAt.toISOString(),
+  };
+}
+
+function assertKnownStatus(s: string): OutboundDeliveryStatus {
+  if (!isOutboundDeliveryStatus(s)) {
+    throw new AppError(
+      `unknown delivery status: ${s}`,
+      400,
+      "errors.unknownDeliveryStatus",
+      { status: s },
+    );
+  }
+  return s;
+}
+
+export async function listWebhookDeliveries(
+  ctx: TenantContext,
+  opts: ListDeliveriesOpts = {},
+  base: PrismaClient = basePrisma,
+): Promise<ListDeliveriesResult> {
+  const take = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+  const createdAt: Prisma.DateTimeFilter = {};
+  if (opts.since) createdAt.gte = opts.since;
+  if (opts.until) createdAt.lte = opts.until;
+  const where: Prisma.OutboundWebhookDeliveryWhereInput = {
+    ...(opts.since || opts.until ? { createdAt } : {}),
+    ...(opts.status ? { status: assertKnownStatus(opts.status) } : {}),
+    ...(opts.subscriptionId !== undefined
+      ? { subscriptionId: opts.subscriptionId }
+      : {}),
+    ...(opts.event ? { event: opts.event } : {}),
+    ...(opts.cursor !== undefined ? { id: { lt: opts.cursor } } : {}),
+  };
+  const rows = await runScopedOn(base, ctx, (db) =>
+    db.outboundWebhookDelivery.findMany({
+      where,
+      orderBy: { id: "desc" },
+      take: take + 1, // one extra row tells us whether a next page exists
+      select: SELECT,
+    }),
+  );
+  const hasMore = rows.length > take;
+  const page = hasMore ? rows.slice(0, take) : rows;
+  return {
+    items: page.map(toDto),
+    nextCursor: hasMore ? String(page[page.length - 1]?.id) : null,
+  };
+}
+
+export async function getWebhookDelivery(
+  ctx: TenantContext,
+  id: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<WebhookDeliveryDto> {
+  const row = await runScopedOn(base, ctx, (db) =>
+    db.outboundWebhookDelivery.findFirst({ where: { id }, select: SELECT }),
+  );
+  // RLS makes a foreign id indistinguishable from a missing one, which is the point.
+  if (!row)
+    throw new NotFoundError(
+      "webhook delivery not found",
+      "errors.webhookDeliveryNotFound",
+    );
+  return toDto(row);
+}
+
+// PUT A DEAD DELIVERY BACK IN THE WORKER'S QUEUE.
+//
+// `attempts` goes back to 0, and that is the whole difference between a requeue and a gesture.
+// Measured against the real worker with a receiver answering 500: a DEAD row at `attempts: 8`
+// flipped to PENDING with its count untouched comes back DEAD on the FIRST post (`attempts: 9`),
+// because `finalizeFailure` gives up at `attempts + 1 >= MAX_ATTEMPTS`. The same row with the
+// count zeroed goes back to PENDING with a fresh backoff (`attempts: 1`). Anything that does not
+// reset buys exactly one attempt, which is not what "reprocess" means to anyone asking for it.
+//
+// `lastError` is kept on purpose. It is not stale state: a row retrying today already carries the
+// error of its last failure while sitting at PENDING, so this matches what the ledger already
+// means. The count the row died at is not lost either — it is in the `webhook` log line #325
+// writes at death, and it is repeated in the line this function emits.
+//
+// DEAD is the ONLY status that can be requeued, and the guard is the `status: "DEAD"` in the
+// update's own `where`, not a branch above it. SENDING is why: the worker is holding that row with
+// a POST in flight, and putting it back to PENDING opens a window for a second claim to deliver it
+// again. Refusing in the same statement that writes means no reader-then-writer gap to lose the
+// race in. PENDING is already queued, and replaying a DELIVERED event is a different promise with
+// a different consequence — re-sending data the receiver already took.
+export async function requeueWebhookDelivery(
+  ctx: TenantContext,
+  id: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<WebhookDeliveryDto> {
+  const { row, attemptsBefore } = await runScopedOn(base, ctx, async (db) => {
+    const current = await db.outboundWebhookDelivery.findFirst({
+      where: { id },
+      select: { id: true, status: true, attempts: true },
+    });
+    if (!current)
+      throw new NotFoundError(
+        "webhook delivery not found",
+        "errors.webhookDeliveryNotFound",
+      );
+    const res = await db.outboundWebhookDelivery.updateMany({
+      where: { id, status: "DEAD" },
+      data: { status: "PENDING", attempts: 0, nextAttemptAt: null },
+    });
+    // count 0 = it was not DEAD when the write ran, whether the read above already said so or
+    // another requeue got there first. One refusal, one message, naming what it is now.
+    if (res.count === 0)
+      throw new AppError(
+        `only a dead delivery can be requeued (this one is ${current.status})`,
+        409,
+        "errors.webhookDeliveryNotDead",
+        { status: current.status },
+      );
+    const updated = await db.outboundWebhookDelivery.findFirst({
+      where: { id },
+      select: SELECT,
+    });
+    return { row: updated, attemptsBefore: current.attempts };
+  });
+  if (!row)
+    throw new NotFoundError(
+      "webhook delivery not found",
+      "errors.webhookDeliveryNotFound",
+    );
+  const dto = toDto(row);
+  if (ctx.tenantId !== null) {
+    emitDeliveryRequeued({
+      tenantId: ctx.tenantId,
+      deliveryId: id,
+      subscriptionId: BigInt(dto.subscriptionId),
+      event: dto.event,
+      attemptsBefore,
+      subscriptionEnabled: dto.subscriptionEnabled,
+      base,
+    });
+  }
+  return dto;
+}

--- a/src/modules/webhooks/outbound/deliveries.ts
+++ b/src/modules/webhooks/outbound/deliveries.ts
@@ -106,6 +106,32 @@ function toDto(r: DeliveryRow): WebhookDeliveryDto {
   };
 }
 
+function badParam(param: string): never {
+  throw new AppError(
+    `invalid value for ${param}`,
+    400,
+    "errors.invalidQueryParam",
+    { param },
+    param,
+  );
+}
+
+// The RANGE of the filters lives here, not in the controller, so MCP is held to the same rule: its
+// `since`/`until` arrive as `new Date(string)` and its `limit` as a plain number, and both reach
+// Prisma and throw on a value the caller got wrong. A 500 for a caller's typo is the wrong answer
+// however the call arrived.
+function assertUsableFilters(opts: ListDeliveriesOpts): void {
+  for (const key of ["since", "until"] as const) {
+    const d = opts[key];
+    if (d && Number.isNaN(d.getTime())) badParam(key);
+  }
+  if (
+    opts.limit !== undefined &&
+    (!Number.isInteger(opts.limit) || opts.limit < 1)
+  )
+    badParam("limit");
+}
+
 function assertKnownStatus(s: string): OutboundDeliveryStatus {
   if (!isOutboundDeliveryStatus(s)) {
     throw new AppError(
@@ -123,7 +149,8 @@ export async function listWebhookDeliveries(
   opts: ListDeliveriesOpts = {},
   base: PrismaClient = basePrisma,
 ): Promise<ListDeliveriesResult> {
-  const take = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+  assertUsableFilters(opts);
+  const take = Math.min(opts.limit ?? 50, 200);
   const createdAt: Prisma.DateTimeFilter = {};
   if (opts.since) createdAt.gte = opts.since;
   if (opts.until) createdAt.lte = opts.until;
@@ -208,15 +235,28 @@ export async function requeueWebhookDelivery(
       where: { id, status: "DEAD" },
       data: { status: "PENDING", attempts: 0, nextAttemptAt: null },
     });
-    // count 0 = it was not DEAD when the write ran, whether the read above already said so or
-    // another requeue got there first. One refusal, one message, naming what it is now.
-    if (res.count === 0)
+    // count 0 = it was not DEAD when the write ran. The status to report is re-read rather than
+    // taken from the check above, because the two disagree in exactly the case that matters: two
+    // operators requeueing the same dead delivery both read DEAD, the second update blocks on the
+    // first and then matches nothing, and reporting the stale read would answer "this one is DEAD"
+    // about a row that is now PENDING — the one refusal a caller would be right to retry.
+    if (res.count === 0) {
+      const now = await db.outboundWebhookDelivery.findFirst({
+        where: { id },
+        select: { status: true },
+      });
+      if (!now)
+        throw new NotFoundError(
+          "webhook delivery not found",
+          "errors.webhookDeliveryNotFound",
+        );
       throw new AppError(
-        `only a dead delivery can be requeued (this one is ${current.status})`,
+        `only a dead delivery can be requeued (this one is ${now.status})`,
         409,
         "errors.webhookDeliveryNotDead",
-        { status: current.status },
+        { status: now.status },
       );
+    }
     const updated = await db.outboundWebhookDelivery.findFirst({
       where: { id },
       select: SELECT,

--- a/src/modules/webhooks/outbound/deliveries.ts
+++ b/src/modules/webhooks/outbound/deliveries.ts
@@ -132,6 +132,13 @@ function assertUsableFilters(opts: ListDeliveriesOpts): void {
     badParam("limit");
 }
 
+// An event name is free text (the closed set lives in OUTBOUND_EVENTS, and a delivery can outlive
+// an event being retired), so the only thing to refuse here is the empty one.
+function assertUsableEvent(e: string): string {
+  if (e === "") badParam("event");
+  return e;
+}
+
 function assertKnownStatus(s: string): OutboundDeliveryStatus {
   if (!isOutboundDeliveryStatus(s)) {
     throw new AppError(
@@ -139,6 +146,7 @@ function assertKnownStatus(s: string): OutboundDeliveryStatus {
       400,
       "errors.unknownDeliveryStatus",
       { status: s },
+      "status",
     );
   }
   return s;
@@ -156,11 +164,19 @@ export async function listWebhookDeliveries(
   if (opts.until) createdAt.lte = opts.until;
   const where: Prisma.OutboundWebhookDeliveryWhereInput = {
     ...(opts.since || opts.until ? { createdAt } : {}),
-    ...(opts.status ? { status: assertKnownStatus(opts.status) } : {}),
+    // `!== undefined`, never truthiness: a filter the caller SENT is a filter, and an empty one is
+    // unusable rather than absent. `status: ""` under a truthiness check answers a request for one
+    // status with every status, which is the same widening the id parsers refuse one layer up —
+    // and this is the layer MCP arrives at, so the rule has to live here to hold for both.
+    ...(opts.status !== undefined
+      ? { status: assertKnownStatus(opts.status) }
+      : {}),
     ...(opts.subscriptionId !== undefined
       ? { subscriptionId: opts.subscriptionId }
       : {}),
-    ...(opts.event ? { event: opts.event } : {}),
+    ...(opts.event !== undefined
+      ? { event: assertUsableEvent(opts.event) }
+      : {}),
     ...(opts.cursor !== undefined ? { id: { lt: opts.cursor } } : {}),
   };
   const rows = await runScopedOn(base, ctx, (db) =>

--- a/src/modules/webhooks/outbound/subscriptions.ts
+++ b/src/modules/webhooks/outbound/subscriptions.ts
@@ -206,10 +206,11 @@ export async function deleteWebhookSubscription(
   id: bigint,
   base: PrismaClient = basePrisma,
 ): Promise<void> {
-  // The delivery FK is onDelete: Restrict (never Cascade — a Cascade would silently drop in-flight
-  // rows the worker is mid-delivery). Clear this subscription's deliveries first inside the same
-  // scoped tx (RLS-fenced), then remove the subscription. Operator-initiated, so dropping its
-  // delivery ledger is acceptable.
+  // The delivery FK is ON DELETE CASCADE at the database (20260727000000_init), so what keeps this
+  // from silently dropping rows the worker is mid-delivery is THIS function, not the constraint:
+  // clear the subscription's deliveries first inside the same scoped tx (RLS-fenced), then remove
+  // the subscription. Operator-initiated, so dropping its delivery ledger is acceptable — and it is
+  // now a ledger somebody may be reading (issue #305), which is why the order is written down.
   const count = await runScopedOn(base, ctx, async (db) => {
     await db.outboundWebhookDelivery.deleteMany({
       where: { subscriptionId: id },

--- a/tests/api/v1/webhook-delivery-filters.test.ts
+++ b/tests/api/v1/webhook-delivery-filters.test.ts
@@ -21,8 +21,18 @@ const VALUES: Record<string, string[]> = {
   // answers a narrowed request with the tenant's whole ledger.
   subscriptionId: ["", "abc", "-1", "1.5", "9223372036854775808"],
   cursor: ["", "abc", "9223372036854775808"],
-  since: ["", "garbage", "not-a-date"],
-  until: ["", "garbage"],
+  // The last three are the ones `new Date` ACCEPTS: February 30 normalises to March 2, a US-format
+  // string resolves against the server's timezone, and a date alone has no instant at all. A filter
+  // that silently means something else is worse than one that is refused.
+  since: [
+    "",
+    "garbage",
+    "not-a-date",
+    "2026-02-30T00:00:00Z",
+    "08/26/2026 10:00",
+    "2026-01-01",
+  ],
+  until: ["", "garbage", "2026-13-01T00:00:00Z"],
   // Syntax only here; `-2` is a well-formed integer and is refused one layer down, by the range
   // check the service owns so that MCP is held to it too (see the second describe).
   limit: ["", " ", "abc", "3.5"],
@@ -71,6 +81,12 @@ describe("the delivery query parser refuses what it cannot use", () => {
     expect(parsed.cursor).toBe(7n);
     expect(parsed.limit).toBe(10);
     expect(parsed.since?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+    // An offset that crosses midnight is a valid instant, not a malformed date.
+    expect(
+      parseDeliveryQuery({
+        until: "2026-08-25T23:00:00-03:00",
+      }).until?.toISOString(),
+    ).toBe("2026-08-26T02:00:00.000Z");
   });
 });
 

--- a/tests/api/v1/webhook-delivery-filters.test.ts
+++ b/tests/api/v1/webhook-delivery-filters.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { parseDeliveryQuery } from "@/api/v1/webhooks.controller";
+import { AppError } from "@/lib/errors";
+import {
+  type ListDeliveriesOpts,
+  listWebhookDeliveries,
+} from "@/modules/webhooks/outbound/deliveries";
+
+// ── AN UNUSABLE FILTER IS A REFUSAL, NEVER A DROPPED FILTER ──
+//
+// Written as a matrix rather than a case per bug because three review rounds found three legs of
+// the same question — unparseable, out of range, explicitly empty — and each leg was a different
+// input. What the endpoint promises is the whole matrix, so the whole matrix is what is asserted.
+//
+// The two halves are the two layers a value passes through, and both are load-bearing: the query
+// parser turns strings into the service's types (REST only), and the service owns the ranges and
+// the vocabulary (REST **and** MCP, which never sees a query string).
+
+const VALUES: Record<string, string[]> = {
+  // Empty is not absent: a form submits it when its input is blank, and treating it as "no filter"
+  // answers a narrowed request with the tenant's whole ledger.
+  subscriptionId: ["", "abc", "-1", "1.5", "9223372036854775808"],
+  cursor: ["", "abc", "9223372036854775808"],
+  since: ["", "garbage", "not-a-date"],
+  until: ["", "garbage"],
+  // Syntax only here; `-2` is a well-formed integer and is refused one layer down, by the range
+  // check the service owns so that MCP is held to it too (see the second describe).
+  limit: ["", " ", "abc", "3.5"],
+};
+
+describe("the delivery query parser refuses what it cannot use", () => {
+  test("every unusable value is a 400 that names the parameter", () => {
+    for (const [param, values] of Object.entries(VALUES)) {
+      for (const value of values) {
+        const err = (() => {
+          try {
+            parseDeliveryQuery({ [param]: value });
+            return null;
+          } catch (e) {
+            return e;
+          }
+        })();
+        expect(
+          `${param}=${value}: ${err === null ? "accepted" : "refused"}`,
+        ).toBe(`${param}=${value}: refused`);
+        expect((err as AppError).statusCode).toBe(400);
+        expect((err as AppError).field).toBe(param);
+      }
+    }
+  });
+
+  test("an absent parameter is not a filter, and a good one survives", () => {
+    expect(parseDeliveryQuery({})).toEqual({
+      status: undefined,
+      subscriptionId: undefined,
+      event: undefined,
+      since: undefined,
+      until: undefined,
+      limit: undefined,
+      cursor: undefined,
+    });
+    const parsed = parseDeliveryQuery({
+      subscriptionId: "42",
+      cursor: "7",
+      since: "2026-01-01T00:00:00Z",
+      limit: "10",
+      status: "DEAD",
+      event: "conversion",
+    });
+    expect(parsed.subscriptionId).toBe(42n);
+    expect(parsed.cursor).toBe(7n);
+    expect(parsed.limit).toBe(10);
+    expect(parsed.since?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+});
+
+// No DB needed: every case here is refused before a query is built, which is the point — the check
+// belongs to the filter, not to whatever rows happen to exist.
+describe("the service refuses what it cannot use, whichever transport asked", () => {
+  const CASES: Array<[string, ListDeliveriesOpts]> = [
+    // `status: ""` under a truthiness check means "every status", which is the opposite of asking.
+    ["status", { status: "" }],
+    // FAILED is real on the shared Prisma enum and only the INBOUND side writes it: accepting it
+    // would answer "no deliveries" to a filter that can never match.
+    ["status", { status: "FAILED" }],
+    ["status", { status: "dead" }],
+    ["status", { status: "nope" }],
+    ["event", { event: "" }],
+    ["since", { since: new Date("garbage") }],
+    ["until", { until: new Date("garbage") }],
+    ["limit", { limit: Number.NaN }],
+    ["limit", { limit: 3.5 }],
+    ["limit", { limit: 0 }],
+    ["limit", { limit: -1 }],
+  ];
+
+  test("every case is a 400 naming the filter", async () => {
+    for (const [param, opts] of CASES) {
+      const err = await listWebhookDeliveries(
+        { tenantId: 1n, userId: null, role: "TENANT_ADMIN" },
+        opts,
+      ).catch((e: unknown) => e);
+      expect(
+        `${param}=${JSON.stringify(opts)}: ${err instanceof AppError ? "refused" : "accepted"}`,
+      ).toBe(`${param}=${JSON.stringify(opts)}: refused`);
+      expect((err as AppError).statusCode).toBe(400);
+      expect((err as AppError).field).toBe(param);
+    }
+  });
+});

--- a/tests/lib/astral-cap-sweep.test.ts
+++ b/tests/lib/astral-cap-sweep.test.ts
@@ -418,6 +418,9 @@ const BARE_SLICES: Record<
   // Read only to be substring-matched against the provider's auth-failure shapes, then dropped:
   // never stored, never shown, never sent anywhere.
   "src/modules/vault/secret-test.ts": [1, "parse-only"],
+  // The page's own overshoot row, dropped: the list takes `limit + 1` to learn whether a next page
+  // exists. Same shape as flowlog/read.ts, and it cuts an array of rows, never a string.
+  "src/modules/webhooks/outbound/deliveries.ts": [1, "array"],
 };
 
 describe("every bare cut left in src/ is accounted for", () => {

--- a/tests/lib/storable-write-sweep.test.ts
+++ b/tests/lib/storable-write-sweep.test.ts
@@ -357,6 +357,10 @@ const ERROR_COLUMN_LINES: Record<string, [number, ErrorSite | string]> = {
   "src/modules/vision/service.ts": [2, "flow-event"],
   // Was 4 until issue #325 collapsed the two DEAD writes into `finalizeDead`; the line that went
   // is the duplicate, not a guard.
+  // Three reads of `lastError`, and none of them a write: the DTO field, the projection that feeds
+  // it, and the type. The ledger surfaces the column an operator uses to decide whether to requeue
+  // (issue #305); the value was sanitized where the worker stored it.
+  "src/modules/webhooks/outbound/deliveries.ts": [3, "read"],
   "src/modules/webhooks/outbound/worker.ts": [3, "guarded + cleared"],
 };
 

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -182,6 +182,7 @@ const FLOWLOG_READERS: Record<string, number> = {
   "tests/modules/tts.test.ts": 2,
   "tests/modules/vision-retry.test.ts": 1,
   "tests/modules/webhooks-outbound-dead-alert.test.ts": 1,
+  "tests/modules/webhooks-outbound-deliveries.test.ts": 1,
 };
 
 // Lives beside the rest of the flowlog family rather than in tests/tooling/, which the manifest

--- a/tests/modules/mcp-tool-descriptions.test.ts
+++ b/tests/modules/mcp-tool-descriptions.test.ts
@@ -224,6 +224,17 @@ describe("MCP tool descriptions", () => {
   // rather than trimmed: nothing here grew, the total simply now includes a block that was not in it
   // when the number was taken, and cutting a document description to fit an unrelated arrival is
   // cutting what is easiest rather than what is cheapest.
+  //
+  // The description figure moved again for issue #305, which added three tools (delivery list, get
+  // and requeue) at 748 characters against 467 of headroom. Raised deliberately, and only after the
+  // two that could be trimmed without costing the model anything were: `_get` stopped restating the
+  // field list that `_list` publishes one line above it. The delivery ledger is a surface an
+  // operator agent needs to be able to find, so the alternative here was not a smaller number, it
+  // was a tool nobody can call. The schema figure moved with it, by 345: most of that is
+  // `webhook_delivery_list`, whose seven filters and four-value status enum are the whole point of
+  // a dead-letter view, and the enum is derived from the module's vocabulary rather than hand-typed
+  // (see the note at its registration) so shrinking it here would mean advertising fewer statuses
+  // than the surface accepts.
   test("the whole tools/list payload stays under its ceiling", async () => {
     const all = await listed();
     let desc = 0;
@@ -232,8 +243,8 @@ describe("MCP tool descriptions", () => {
       desc += t.description.length;
       schema += t.schema.length;
     }
-    expect(desc).toBeLessThanOrEqual(26_500);
-    expect(schema).toBeLessThanOrEqual(40_850);
+    expect(desc).toBeLessThanOrEqual(27_250);
+    expect(schema).toBeLessThanOrEqual(41_650);
   });
 
   // Why the document write tools declare `blocks`/`fields` as loose arrays and put the vocabulary in

--- a/tests/modules/mcp-webhook-deliveries.test.ts
+++ b/tests/modules/mcp-webhook-deliveries.test.ts
@@ -188,6 +188,44 @@ describe.skipIf(!dbUp)("MCP delivery tools (DB)", () => {
     expect([row.status, row.attempts]).toEqual(["SENDING", 3]);
   });
 
+  test("an apply waits for the worker to finish dying instead of refusing", async () => {
+    // The row the tool must NOT refuse: the worker has decided it is dead and has not committed
+    // yet, so an unlocked read still answers SENDING. The service is built to wait on exactly that
+    // transition, so the apply defers to its locked check rather than repeating the read — a
+    // preview may say SENDING here, but an apply that did would refuse a delivery that is dead by
+    // the time it would have written.
+    const id = await seed("SENDING", 7);
+    const holder = suDb.$transaction(
+      async (tx) => {
+        await tx.$executeRawUnsafe(
+          `UPDATE outbound_webhook_deliveries SET status = 'DEAD', attempts = 8 WHERE id = ${id}`,
+        );
+        await Bun.sleep(500);
+      },
+      { timeout: 10_000 },
+    );
+    await Bun.sleep(120);
+    const [, r] = await Promise.all([
+      holder,
+      webhookDeliveryRequeue(
+        principal({ tenantId }),
+        { delivery_id: String(id), dry_run: false },
+        { base: appDb },
+      ),
+    ]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.applied).toBe(true);
+    const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+      where: { id },
+    });
+    expect([row.status, row.attempts]).toEqual(["PENDING", 0]);
+    const audit = await suDb.auditLog.findFirstOrThrow({
+      where: { tenantId, target: `webhook_delivery:${id}` },
+      orderBy: { id: "desc" },
+    });
+    expect(audit.before).toMatchObject({ status: "DEAD", attempts: 8 });
+  });
+
   test("the audit records the state the LOCKED write undid, not an earlier look", async () => {
     // The window: the tool reads the row to build its preview, and between that read and the write
     // the row can move — another operator requeues it and the worker kills it again, which for a

--- a/tests/modules/mcp-webhook-deliveries.test.ts
+++ b/tests/modules/mcp-webhook-deliveries.test.ts
@@ -1,0 +1,213 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
+import { webhookDeliveryGet, webhookDeliveryList } from "@/modules/mcp/read";
+import { webhookDeliveryRequeue } from "@/modules/mcp/write-webhooks";
+
+// ── THE DELIVERY LEDGER ON MCP (issue #305) ──
+// The REST half is covered in webhooks-outbound-deliveries.test.ts; this drives what MCP adds on
+// top of the same service: the scope gate, the dry run, and the audit row.
+//
+// The dry run gets its own case for the reason it exists: the only way this call can fail is the
+// row not being DEAD, so a preview built from the id alone would approve exactly the requests the
+// apply refuses.
+
+function principal(over: Partial<VerifiedToken> = {}): VerifiedToken {
+  return {
+    userId: 1n,
+    tenantId: 1n,
+    role: "TENANT_ADMIN",
+    scopes: ["mcp:read", "mcp:write"],
+    clientId: "c",
+    jti: "j",
+    ...over,
+  };
+}
+
+describe("MCP delivery tools gate (no DB)", () => {
+  test("webhook_delivery_list without mcp:read → insufficient_scope", async () => {
+    const r = await webhookDeliveryList(principal({ scopes: [] }), {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("insufficient_scope");
+  });
+
+  test("webhook_delivery_requeue without mcp:write → insufficient_scope", async () => {
+    const r = await webhookDeliveryRequeue(
+      principal({ scopes: ["mcp:read"] }),
+      {
+        delivery_id: "1",
+      },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("insufficient_scope");
+  });
+});
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const PAYLOAD_MARKER = "sk-live-PAYLOAD-MUST-NOT-LEAK-305-mcp";
+
+describe.skipIf(!dbUp)("MCP delivery tools (DB)", () => {
+  let tenantId = 0n;
+  let subId = 0n;
+
+  async function seed(
+    status: "PENDING" | "SENDING" | "DELIVERED" | "DEAD",
+    attempts: number,
+  ): Promise<bigint> {
+    const row = await suDb.outboundWebhookDelivery.create({
+      data: {
+        tenantId,
+        subscriptionId: subId,
+        event: "conversion",
+        payload: { token: PAYLOAD_MARKER },
+        status,
+        attempts,
+        lastError: "non-2xx response: 500",
+      },
+    });
+    return row.id;
+  }
+
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "MWD", slug: `mwd-${process.pid}` },
+    });
+    tenantId = t.id;
+    subId = (
+      await suDb.webhookSubscription.create({
+        data: {
+          tenantId,
+          url: "https://example.com/mcp",
+          events: ["conversion"],
+          enabled: true,
+        },
+      })
+    ).id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM audit_logs WHERE tenant_id = ${tenantId}`,
+      );
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  test("webhook_delivery_list and _get return delivery state, never the payload", async () => {
+    const id = await seed("DEAD", 8);
+    const p = principal({ tenantId });
+    const list = await webhookDeliveryList(
+      p,
+      { status: "DEAD" },
+      {
+        base: appDb,
+      },
+    );
+    expect(list.ok).toBe(true);
+    if (list.ok) {
+      expect(JSON.stringify(list.data)).not.toContain(PAYLOAD_MARKER);
+      const items = list.data.items as Array<{ id: string }>;
+      expect(items.map((i) => i.id)).toContain(String(id));
+    }
+    const one = await webhookDeliveryGet(
+      p,
+      { delivery_id: String(id) },
+      { base: appDb },
+    );
+    expect(one.ok).toBe(true);
+    if (one.ok) expect(JSON.stringify(one.data)).not.toContain(PAYLOAD_MARKER);
+  });
+
+  test("the dry run is the default and changes nothing", async () => {
+    const id = await seed("DEAD", 8);
+    const r = await webhookDeliveryRequeue(
+      principal({ tenantId }),
+      { delivery_id: String(id) },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.data.dryRun).toBe(true);
+      expect(r.data.current).toMatchObject({ status: "DEAD", attempts: 8 });
+      // The preview names what the apply will write, including the number that decides whether
+      // this buys a full ladder or a single post.
+      expect(r.data.preview).toEqual({
+        status: "PENDING",
+        attempts: 0,
+        willBeClaimed: true,
+      });
+    }
+    const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+      where: { id },
+    });
+    expect([row.status, row.attempts]).toEqual(["DEAD", 8]);
+  });
+
+  test("the dry run refuses exactly what the apply refuses", async () => {
+    const id = await seed("SENDING", 3);
+    for (const dry_run of [true, false]) {
+      const r = await webhookDeliveryRequeue(
+        principal({ tenantId }),
+        { delivery_id: String(id), dry_run },
+        { base: appDb },
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("SENDING");
+    }
+    const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+      where: { id },
+    });
+    expect([row.status, row.attempts]).toEqual(["SENDING", 3]);
+  });
+
+  test("the apply requeues the row and records who did it", async () => {
+    const id = await seed("DEAD", 8);
+    const r = await webhookDeliveryRequeue(
+      principal({ tenantId }),
+      { delivery_id: String(id), dry_run: false },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.applied).toBe(true);
+    const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+      where: { id },
+    });
+    expect([row.status, row.attempts]).toEqual(["PENDING", 0]);
+    const audit = await suDb.auditLog.findFirst({
+      where: {
+        tenantId,
+        action: "mcp.webhook_delivery_requeue",
+        target: `webhook_delivery:${id}`,
+      },
+    });
+    expect(audit).not.toBeNull();
+  });
+});

--- a/tests/modules/mcp-webhook-deliveries.test.ts
+++ b/tests/modules/mcp-webhook-deliveries.test.ts
@@ -188,6 +188,40 @@ describe.skipIf(!dbUp)("MCP delivery tools (DB)", () => {
     expect([row.status, row.attempts]).toEqual(["SENDING", 3]);
   });
 
+  test("the audit records the state the LOCKED write undid, not an earlier look", async () => {
+    // The window: the tool reads the row to build its preview, and between that read and the write
+    // the row can move — another operator requeues it and the worker kills it again, which for a
+    // URL the SSRF guard refuses takes one tick. Held open here by a transaction that changes the
+    // attempt count and commits only after the tool's `FOR UPDATE` is already waiting on it, so
+    // the unlocked read sees 8 and the locked one sees 1. The audit has to describe the second.
+    const id = await seed("DEAD", 8);
+    const holder = suDb.$transaction(
+      async (tx) => {
+        await tx.$executeRawUnsafe(
+          `UPDATE outbound_webhook_deliveries SET attempts = 1 WHERE id = ${id}`,
+        );
+        await Bun.sleep(500);
+      },
+      { timeout: 10_000 },
+    );
+    await Bun.sleep(120);
+    const [, r] = await Promise.all([
+      holder,
+      webhookDeliveryRequeue(
+        principal({ tenantId }),
+        { delivery_id: String(id), dry_run: false },
+        { base: appDb },
+      ),
+    ]);
+    expect(r.ok).toBe(true);
+    const audit = await suDb.auditLog.findFirstOrThrow({
+      where: { tenantId, target: `webhook_delivery:${id}` },
+      orderBy: { id: "desc" },
+    });
+    expect(audit.before).toMatchObject({ status: "DEAD", attempts: 1 });
+    expect(audit.after).toMatchObject({ status: "PENDING", attempts: 0 });
+  });
+
   test("the apply requeues the row and records who did it", async () => {
     const id = await seed("DEAD", 8);
     const r = await webhookDeliveryRequeue(

--- a/tests/modules/webhooks-outbound-deliveries.test.ts
+++ b/tests/modules/webhooks-outbound-deliveries.test.ts
@@ -5,6 +5,7 @@ import { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
 import {
   getWebhookDelivery,
+  type ListDeliveriesOpts,
   listWebhookDeliveries,
   requeueWebhookDelivery,
 } from "@/modules/webhooks/outbound/deliveries";
@@ -213,6 +214,28 @@ describe.skipIf(!dbUp)("outbound webhook delivery ledger", () => {
       ).toEqual([String(onDisabled)]);
     });
 
+    test("a filter value the server cannot parse is refused, not dropped", async () => {
+      // Dropping it is the wrong answer twice: a bad `subscriptionId` would widen the page to the
+      // whole tenant, and a bad `limit` reaches Prisma, where NaN throws and 3.5 quietly returns
+      // nothing. The service owns the range so MCP, which never goes through the query parser, is
+      // held to the same rule.
+      const bad: Array<[string, ListDeliveriesOpts]> = [
+        ["since", { since: new Date("garbage") }],
+        ["until", { until: new Date("garbage") }],
+        ["limit", { limit: Number.NaN }],
+        ["limit", { limit: 3.5 }],
+        ["limit", { limit: 0 }],
+      ];
+      for (const [param, opts] of bad) {
+        const err = await listWebhookDeliveries(ctx(), opts, appDb).catch(
+          (e: unknown) => e,
+        );
+        expect(err).toBeInstanceOf(AppError);
+        expect((err as AppError).statusCode).toBe(400);
+        expect((err as AppError).field).toBe(param);
+      }
+    });
+
     test("an unknown status is refused, not answered with an empty page", async () => {
       // FAILED is the trap: it is a real value of the shared Prisma enum that only the INBOUND side
       // writes, so accepting it would answer "no deliveries" to a filter that can never match.
@@ -366,6 +389,34 @@ describe.skipIf(!dbUp)("outbound webhook delivery ledger", () => {
         where: { id },
       });
       expect([row.status, row.attempts]).toEqual(["SENDING", 3]);
+    });
+
+    test("a requeue that loses the race names the status the row has NOW", async () => {
+      // Two operators clearing the same dead-letter page. Both transactions read DEAD, the losers
+      // block on the winner and then match nothing — and the status to report is the one after
+      // that wait, not the one from before it. Reporting the stale read answers "this one is DEAD"
+      // about a row that is already PENDING, which is the single refusal a caller would be right
+      // to retry.
+      await clearDeliveries();
+      const id = await seed({ status: "DEAD", attempts: 8 });
+      const outcomes = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          requeueWebhookDelivery(ctx(), id, appDb).catch((e: unknown) => e),
+        ),
+      );
+      const won = outcomes.filter((o) => !(o instanceof Error));
+      const lost = outcomes.filter((o) => o instanceof AppError) as AppError[];
+      expect(won).toHaveLength(1);
+      expect(lost).toHaveLength(7);
+      for (const e of lost) {
+        expect(e.statusCode).toBe(409);
+        expect(e.message).toContain("PENDING");
+        expect(e.message).not.toContain("DEAD");
+      }
+      const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id },
+      });
+      expect([row.status, row.attempts]).toEqual(["PENDING", 0]);
     });
 
     test("PENDING and DELIVERED are refused too, each naming itself", async () => {

--- a/tests/modules/webhooks-outbound-deliveries.test.ts
+++ b/tests/modules/webhooks-outbound-deliveries.test.ts
@@ -305,7 +305,13 @@ describe.skipIf(!dbUp)("outbound webhook delivery ledger", () => {
     test("a dead delivery goes back to PENDING with its attempt count reset", async () => {
       await clearDeliveries();
       const id = await seed({ status: "DEAD", attempts: 8 });
-      const d = await requeueWebhookDelivery(ctx(), id, appDb);
+      const { delivery: d, before } = await requeueWebhookDelivery(
+        ctx(),
+        id,
+        appDb,
+      );
+      // What the requeue undid, read under the lock — the audit trail's `before` comes from here.
+      expect(before).toEqual({ status: "DEAD", attempts: 8 });
       expect(d).toMatchObject({
         status: "PENDING",
         attempts: 0,
@@ -399,8 +405,9 @@ describe.skipIf(!dbUp)("outbound webhook delivery ledger", () => {
         holder,
         requeueWebhookDelivery(ctx(), id, appDb),
       ]);
-      expect(requeued.status).toBe("PENDING");
-      expect(requeued.attempts).toBe(0);
+      expect(requeued.delivery.status).toBe("PENDING");
+      expect(requeued.delivery.attempts).toBe(0);
+      expect(requeued.before).toEqual({ status: "DEAD", attempts: 8 });
       const [line] = await webhookLines(1);
       expect(line?.detail).toMatchObject({
         action: "requeued",
@@ -499,7 +506,7 @@ describe.skipIf(!dbUp)("outbound webhook delivery ledger", () => {
     test("a requeue into a disabled subscription succeeds and says the queue is holding it", async () => {
       await clearDeliveries();
       const id = await seed({ sub: disabledSub, status: "DEAD", attempts: 8 });
-      const d = await requeueWebhookDelivery(ctx(), id, appDb);
+      const { delivery: d } = await requeueWebhookDelivery(ctx(), id, appDb);
       expect(d.status).toBe("PENDING");
       expect(d.subscriptionEnabled).toBe(false);
       const summary = await processOutboundBatch({

--- a/tests/modules/webhooks-outbound-deliveries.test.ts
+++ b/tests/modules/webhooks-outbound-deliveries.test.ts
@@ -1,0 +1,458 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { AppError } from "@/lib/errors";
+import type { TenantContext } from "@/lib/tenancy";
+import {
+  getWebhookDelivery,
+  listWebhookDeliveries,
+  requeueWebhookDelivery,
+} from "@/modules/webhooks/outbound/deliveries";
+import { processOutboundBatch } from "@/modules/webhooks/outbound/worker";
+
+// ── THE DELIVERY LEDGER AS A SUPPORTED SURFACE (issue #305) ──
+// Integration, real DB, real RLS: every call goes through `runScopedOn` exactly as the controller
+// and the MCP tools reach it, so a cross-tenant read fails here the way it would in production
+// rather than the way a mocked client would let it.
+//
+// The effect asserted for the requeue is never the returned DTO alone: a requeue that does not put
+// the row where the WORKER will pick it up is a status change and nothing more. So the worker runs
+// for real (claim, backoff, outcome) and the assertion is that the receiver was posted to.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+// A secret-looking string inside the stored payload, so "the payload does not cross this surface"
+// is something the test can catch rather than something the reviewer has to trust.
+const PAYLOAD_MARKER = "sk-live-PAYLOAD-MUST-NOT-LEAK-305";
+
+let tenantId = 0n;
+let otherTenantId = 0n;
+let liveSub = 0n;
+let disabledSub = 0n;
+let otherSub = 0n;
+
+function ctxOf(id: bigint): TenantContext {
+  return { tenantId: id, userId: null, role: "TENANT_ADMIN" };
+}
+const ctx = () => ctxOf(tenantId);
+
+async function seed(
+  opts: {
+    sub?: bigint;
+    tenant?: bigint;
+    status?: "PENDING" | "SENDING" | "DELIVERED" | "DEAD";
+    attempts?: number;
+    event?: string;
+    lastError?: string | null;
+  } = {},
+): Promise<bigint> {
+  const row = await suDb.outboundWebhookDelivery.create({
+    data: {
+      tenantId: opts.tenant ?? tenantId,
+      subscriptionId: opts.sub ?? liveSub,
+      event: opts.event ?? "conversion",
+      payload: { value: 42, token: PAYLOAD_MARKER },
+      status: opts.status ?? "DEAD",
+      attempts: opts.attempts ?? 8,
+      lastError:
+        opts.lastError === undefined ? "non-2xx response: 500" : opts.lastError,
+    },
+  });
+  return row.id;
+}
+
+async function clearDeliveries() {
+  await suDb.$executeRawUnsafe(
+    `DELETE FROM outbound_webhook_deliveries WHERE tenant_id IN (${tenantId}, ${otherTenantId})`,
+  );
+}
+
+// The emit is fire-and-forget, so the line lands after the call returned. Poll for it rather than
+// sleeping a fixed amount: a fixed sleep is either flaky or slow and never says which.
+async function webhookLines(expected: number, waitMs = 3000) {
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    // flowlog-scope: tenant-wide — the subject is HOW MANY lines a requeue writes, so scoping the
+    // read to a turn would answer a different question and stay green with a second row present.
+    // The tenant is this file's own and the rows are cleared before each case that reads them.
+    const rows = await suDb.executionLog.findMany({
+      where: { tenantId, stage: "webhook" },
+      orderBy: { id: "asc" },
+    });
+    if (rows.length >= expected) return rows;
+    if (Date.now() > deadline) return rows;
+    await Bun.sleep(50);
+  }
+}
+
+describe.skipIf(!dbUp)("outbound webhook delivery ledger", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "WDL", slug: `wdl-${process.pid}` },
+    });
+    tenantId = t.id;
+    const o = await suDb.tenant.create({
+      data: { name: "WDLO", slug: `wdlo-${process.pid}` },
+    });
+    otherTenantId = o.id;
+    liveSub = (
+      await suDb.webhookSubscription.create({
+        data: {
+          tenantId,
+          url: "https://example.com/live",
+          events: ["conversion"],
+          enabled: true,
+        },
+      })
+    ).id;
+    disabledSub = (
+      await suDb.webhookSubscription.create({
+        data: {
+          tenantId,
+          url: "https://example.com/off",
+          events: ["conversion"],
+          enabled: false,
+        },
+      })
+    ).id;
+    otherSub = (
+      await suDb.webhookSubscription.create({
+        data: {
+          tenantId: otherTenantId,
+          url: "https://example.com/other",
+          events: ["conversion"],
+          enabled: true,
+        },
+      })
+    ).id;
+  });
+
+  afterAll(async () => {
+    if (tenantId)
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    if (otherTenantId)
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${otherTenantId}`,
+      );
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  describe("list", () => {
+    test("returns the tenant's deliveries newest first, and never the payload", async () => {
+      await clearDeliveries();
+      const first = await seed({ event: "conversion" });
+      const second = await seed({ event: "heartbeat", status: "DELIVERED" });
+      const res = await listWebhookDeliveries(ctx(), {}, appDb);
+      expect(res.items.map((d) => d.id)).toEqual([
+        String(second),
+        String(first),
+      ]);
+      // The whole serialized page, not a key check on one item: a payload leaking through a nested
+      // relation would pass `"payload" in item` and still ship the customer's data.
+      const wire = JSON.stringify(res);
+      expect(wire).not.toContain(PAYLOAD_MARKER);
+      expect(wire).not.toContain("payload");
+      expect(res.items[0]).toMatchObject({
+        subscriptionId: String(liveSub),
+        subscriptionEnabled: true,
+        event: "heartbeat",
+        status: "DELIVERED",
+        attempts: 8,
+        lastError: "non-2xx response: 500",
+      });
+    });
+
+    test("filters by status, subscription and event", async () => {
+      await clearDeliveries();
+      const dead = await seed({ status: "DEAD" });
+      await seed({ status: "PENDING" });
+      const onDisabled = await seed({ sub: disabledSub, event: "heartbeat" });
+
+      expect(
+        (await listWebhookDeliveries(ctx(), { status: "DEAD" }, appDb)).items
+          .map((d) => d.id)
+          .sort(),
+      ).toEqual([String(dead), String(onDisabled)].sort());
+      expect(
+        (
+          await listWebhookDeliveries(
+            ctx(),
+            { subscriptionId: disabledSub },
+            appDb,
+          )
+        ).items.map((d) => d.id),
+      ).toEqual([String(onDisabled)]);
+      expect(
+        (
+          await listWebhookDeliveries(ctx(), { event: "heartbeat" }, appDb)
+        ).items.map((d) => d.id),
+      ).toEqual([String(onDisabled)]);
+    });
+
+    test("an unknown status is refused, not answered with an empty page", async () => {
+      // FAILED is the trap: it is a real value of the shared Prisma enum that only the INBOUND side
+      // writes, so accepting it would answer "no deliveries" to a filter that can never match.
+      for (const bad of ["FAILED", "dead", "nope"]) {
+        const err = await listWebhookDeliveries(
+          ctx(),
+          { status: bad },
+          appDb,
+        ).catch((e: unknown) => e);
+        expect(err).toBeInstanceOf(AppError);
+        expect((err as AppError).statusCode).toBe(400);
+      }
+    });
+
+    test("keyset pagination walks the whole ledger without repeating a row", async () => {
+      await clearDeliveries();
+      const ids: string[] = [];
+      for (let i = 0; i < 5; i++) ids.push(String(await seed({})));
+      const page1 = await listWebhookDeliveries(ctx(), { limit: 2 }, appDb);
+      expect(page1.items).toHaveLength(2);
+      expect(page1.nextCursor).toBe(page1.items[1]?.id ?? null);
+      const page2 = await listWebhookDeliveries(
+        ctx(),
+        { limit: 2, cursor: BigInt(page1.nextCursor as string) },
+        appDb,
+      );
+      const page3 = await listWebhookDeliveries(
+        ctx(),
+        { limit: 2, cursor: BigInt(page2.nextCursor as string) },
+        appDb,
+      );
+      const walked = [...page1.items, ...page2.items, ...page3.items].map(
+        (d) => d.id,
+      );
+      expect(walked).toEqual([...ids].reverse());
+      expect(page3.nextCursor).toBeNull();
+    });
+
+    test("subscriptionEnabled tells a queued delivery from a parked one", async () => {
+      await clearDeliveries();
+      await seed({ sub: disabledSub, status: "PENDING" });
+      const [item] = (await listWebhookDeliveries(ctx(), {}, appDb)).items;
+      expect(item?.status).toBe("PENDING");
+      expect(item?.subscriptionEnabled).toBe(false);
+    });
+  });
+
+  describe("get", () => {
+    test("returns one delivery by id", async () => {
+      await clearDeliveries();
+      const id = await seed({});
+      const d = await getWebhookDelivery(ctx(), id, appDb);
+      expect(d.id).toBe(String(id));
+      expect(JSON.stringify(d)).not.toContain(PAYLOAD_MARKER);
+    });
+
+    test("a missing id is a 404", async () => {
+      const err = await getWebhookDelivery(ctx(), 999_999_999n, appDb).catch(
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).statusCode).toBe(404);
+    });
+  });
+
+  describe("requeue", () => {
+    test("a dead delivery goes back to PENDING with its attempt count reset", async () => {
+      await clearDeliveries();
+      const id = await seed({ status: "DEAD", attempts: 8 });
+      const d = await requeueWebhookDelivery(ctx(), id, appDb);
+      expect(d).toMatchObject({
+        status: "PENDING",
+        attempts: 0,
+        nextAttemptAt: null,
+        // Kept, not cleared: a row retrying today already carries its last error while PENDING.
+        lastError: "non-2xx response: 500",
+      });
+      const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id },
+      });
+      expect(row.status).toBe("PENDING");
+      expect(row.attempts).toBe(0);
+    });
+
+    test("the requeued delivery is actually claimed and posted by the worker", async () => {
+      await clearDeliveries();
+      const id = await seed({ status: "DEAD", attempts: 8 });
+      await requeueWebhookDelivery(ctx(), id, appDb);
+      const posted: string[] = [];
+      const summary = await processOutboundBatch({
+        base: suDb,
+        tenantId,
+        assertSafe: async (u: string) => new URL(u),
+        fetchImpl: (async (url: string) => {
+          posted.push(String(url));
+          return { status: 200 } as Response;
+        }) as unknown as typeof fetch,
+      });
+      // The effect, not the return value: the receiver was posted to and the row is DELIVERED.
+      expect(posted).toEqual(["https://example.com/live"]);
+      expect(summary.delivered).toBe(1);
+      const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id },
+      });
+      expect(row.status).toBe("DELIVERED");
+      expect(row.attempts).toBe(1);
+    });
+
+    test("a requeue keeping the attempt count would buy ONE post, which is why it resets", async () => {
+      // The measurement behind the design, run as a test so it cannot quietly stop being true:
+      // `finalizeFailure` gives up at attempts + 1 >= MAX_ATTEMPTS, so a row put back at 8 dies on
+      // the first failure while the same row put back at 0 earns a fresh ladder.
+      await clearDeliveries();
+      const withCount = await seed({ status: "DEAD", attempts: 8 });
+      await suDb.outboundWebhookDelivery.update({
+        where: { id: withCount },
+        data: { status: "PENDING", nextAttemptAt: null },
+      });
+      const reset = await seed({ status: "DEAD", attempts: 8 });
+      await requeueWebhookDelivery(ctx(), reset, appDb);
+      await processOutboundBatch({
+        base: suDb,
+        tenantId,
+        assertSafe: async (u: string) => new URL(u),
+        fetchImpl: (async () =>
+          ({ status: 500 }) as Response) as unknown as typeof fetch,
+      });
+      const kept = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id: withCount },
+      });
+      const fresh = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id: reset },
+      });
+      expect([kept.status, kept.attempts]).toEqual(["DEAD", 9]);
+      expect([fresh.status, fresh.attempts]).toEqual(["PENDING", 1]);
+      expect(fresh.nextAttemptAt).not.toBeNull();
+    });
+
+    test("a delivery the worker is holding (SENDING) is refused, untouched", async () => {
+      // The one that matters for safety: SENDING means a POST is in flight, and putting the row
+      // back to PENDING would let a second claim deliver it again.
+      await clearDeliveries();
+      const id = await seed({ status: "SENDING", attempts: 3 });
+      const err = await requeueWebhookDelivery(ctx(), id, appDb).catch(
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).statusCode).toBe(409);
+      expect((err as AppError).message).toContain("SENDING");
+      const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id },
+      });
+      expect([row.status, row.attempts]).toEqual(["SENDING", 3]);
+    });
+
+    test("PENDING and DELIVERED are refused too, each naming itself", async () => {
+      await clearDeliveries();
+      for (const status of ["PENDING", "DELIVERED"] as const) {
+        const id = await seed({ status, attempts: 1 });
+        const err = await requeueWebhookDelivery(ctx(), id, appDb).catch(
+          (e: unknown) => e,
+        );
+        expect((err as AppError).statusCode).toBe(409);
+        expect((err as AppError).message).toContain(status);
+      }
+    });
+
+    test("the requeue writes one info line that keeps the count the row died at", async () => {
+      await clearDeliveries();
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM execution_logs WHERE tenant_id = ${tenantId}`,
+      );
+      const id = await seed({ status: "DEAD", attempts: 8 });
+      await requeueWebhookDelivery(ctx(), id, appDb);
+      const [line, ...rest] = await webhookLines(1);
+      expect(rest).toHaveLength(0);
+      expect(line?.level).toBe("info");
+      expect(line?.status).toBe("ok");
+      expect(line?.source).toBe("inbox");
+      expect(line?.detail).toMatchObject({
+        deliveryId: String(id),
+        subscriptionId: String(liveSub),
+        event: "conversion",
+        action: "requeued",
+        // The row is at 0 by now, so this line is the only place the number survives.
+        attemptsBefore: 8,
+        subscriptionEnabled: true,
+      });
+      // The row carries bigint columns, which JSON.stringify refuses outright.
+      const asText = JSON.stringify(line, (_k, v) =>
+        typeof v === "bigint" ? String(v) : v,
+      );
+      expect(asText).not.toContain(PAYLOAD_MARKER);
+      // info never pages: `dispatchAlertsForEvent` only routes warn and error.
+      const alerts = await suDb.alertDelivery.findMany({ where: { tenantId } });
+      expect(alerts).toHaveLength(0);
+    });
+
+    test("a requeue into a disabled subscription succeeds and says the queue is holding it", async () => {
+      await clearDeliveries();
+      const id = await seed({ sub: disabledSub, status: "DEAD", attempts: 8 });
+      const d = await requeueWebhookDelivery(ctx(), id, appDb);
+      expect(d.status).toBe("PENDING");
+      expect(d.subscriptionEnabled).toBe(false);
+      const summary = await processOutboundBatch({
+        base: suDb,
+        tenantId,
+        assertSafe: async (u: string) => new URL(u),
+        fetchImpl: (async () => {
+          throw new Error("a disabled subscription must not be posted to");
+        }) as unknown as typeof fetch,
+      });
+      expect(summary.claimed).toBe(0);
+      const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id },
+      });
+      expect(row.status).toBe("PENDING");
+    });
+  });
+
+  describe("tenant isolation", () => {
+    test("another tenant's delivery is invisible to list, get and requeue", async () => {
+      await clearDeliveries();
+      const mine = await seed({});
+      const theirs = await seed({ tenant: otherTenantId, sub: otherSub });
+      expect(
+        (await listWebhookDeliveries(ctx(), {}, appDb)).items.map((d) => d.id),
+      ).toEqual([String(mine)]);
+      for (const call of [
+        () => getWebhookDelivery(ctx(), theirs, appDb),
+        () => requeueWebhookDelivery(ctx(), theirs, appDb),
+      ]) {
+        const err = await call().catch((e: unknown) => e);
+        expect((err as AppError).statusCode).toBe(404);
+      }
+      // And the row is still theirs, untouched.
+      const row = await suDb.outboundWebhookDelivery.findUniqueOrThrow({
+        where: { id: theirs },
+      });
+      expect(row.status).toBe("DEAD");
+    });
+  });
+});

--- a/tests/modules/webhooks-outbound-deliveries.test.ts
+++ b/tests/modules/webhooks-outbound-deliveries.test.ts
@@ -374,6 +374,40 @@ describe.skipIf(!dbUp)("outbound webhook delivery ledger", () => {
       expect(fresh.nextAttemptAt).not.toBeNull();
     });
 
+    test("a requeue that arrives as the worker is dying reads the count it died at", async () => {
+      // The narrow window the lock exists for. The worker is mid-outcome: the row still reads
+      // SENDING/7 to anyone who looks without a lock, and the transaction that will commit DEAD/8
+      // is already holding it. A requeue that reads before that commit would either refuse a row
+      // that is about to be dead, or requeue it while writing 7 into the line meant to preserve
+      // the count the delivery died at. `FOR UPDATE` makes it wait and then read the truth.
+      await clearDeliveries();
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM execution_logs WHERE tenant_id = ${tenantId}`,
+      );
+      const id = await seed({ status: "SENDING", attempts: 7 });
+      const holder = suDb.$transaction(
+        async (tx) => {
+          await tx.$executeRawUnsafe(
+            `UPDATE outbound_webhook_deliveries SET status = 'DEAD', attempts = 8 WHERE id = ${id}`,
+          );
+          await Bun.sleep(500);
+        },
+        { timeout: 10_000 },
+      );
+      await Bun.sleep(120);
+      const [, requeued] = await Promise.all([
+        holder,
+        requeueWebhookDelivery(ctx(), id, appDb),
+      ]);
+      expect(requeued.status).toBe("PENDING");
+      expect(requeued.attempts).toBe(0);
+      const [line] = await webhookLines(1);
+      expect(line?.detail).toMatchObject({
+        action: "requeued",
+        attemptsBefore: 8,
+      });
+    });
+
     test("a delivery the worker is holding (SENDING) is refused, untouched", async () => {
       // The one that matters for safety: SENDING means a POST is in flight, and putting the row
       // back to PENDING would let a second claim deliver it again.


### PR DESCRIPTION
Fixes #305.

An integrator running the event bus over signed webhooks asked for an API to list, inspect and requeue deliveries, because the only way to watch for `DEAD` was reading `outbound_webhook_deliveries` in Postgres with a read-only role. We answered that those tables are not a contract we can keep, which is exactly why the gap is worth closing.

## The gap, measured

Both routes against the code the reporter is running, with a positive control so "no route" is not confused with "auth said no":

```
404  /api/v1/webhooks/deliveries?status=DEAD
404  /api/v1/webhooks/deliveries/1
401  /api/v1/webhooks/subscriptions      <- the route exists, it just wants a key
```

There was no delivery-facing route at all, so reading the table directly was not a workaround anyone chose over an API. It was the only path.

## What this adds

REST, `TENANT_ADMIN`, RLS-scoped, keyset paginated by id desc (same shape as `/v1/logs`):

- `GET /v1/webhooks/deliveries` — filters `status`, `subscriptionId`, `event`, `since`/`until`, `limit` (default 50, max 200), `cursor`. `status=DEAD` is the dead-letter view.
- `GET /v1/webhooks/deliveries/:id`
- `POST /v1/webhooks/deliveries/:id/requeue`

MCP gets the same surface, since the webhook family already has `webhook_create`/`webhook_delete`/`webhook_test` there and a ledger only in REST would be the one part an operator agent cannot see: `webhook_delivery_list`, `webhook_delivery_get` (`mcp:read`), `webhook_delivery_requeue` (`mcp:write`, dry-run by default, audited on apply).

Two indexes come with it, because the table shipped with the worker's and not the reader's.

## The decisions, and the numbers behind them

**The requeue resets `attempts`, and that is the whole difference between a requeue and a gesture.** Measured against the real worker with a receiver answering 500, a `DEAD` row at `attempts: 8`:

| put back as | worker tick | row after |
| --- | --- | --- |
| `PENDING`, count untouched | `claimed: 1, retried: 0, dead: 1` | `DEAD`, `attempts: 9` |
| `PENDING`, count reset to 0 | `claimed: 1, retried: 1, dead: 0` | `PENDING`, `attempts: 1`, backoff set |

`finalizeFailure` gives up at `attempts + 1 >= MAX_ATTEMPTS`, so a requeue that does not reset buys exactly one post. `lastError` is kept: a row retrying today already carries its last error while sitting at `PENDING`.

**The requeue takes `SELECT ... FOR UPDATE` before it decides anything.** Two writers reach that row — another operator, and the worker finishing with it — and without the lock both things the function says can be stale by the time it says them: the status it refuses on, and the attempt count it writes into the line meant to preserve what the delivery died at. Only `DEAD` is accepted; `SENDING` means a POST is in flight and a second claim would deliver it twice, `PENDING` is already queued, and replaying a `DELIVERED` event is a different promise. Any other status is a 409 naming it.

**An unusable filter is a refusal, never a dropped filter.** Dropping it is the wrong answer twice on a ledger: a bad `subscriptionId` widens the page to the whole tenant and a bad `cursor` restarts pagination, which is a paging loop that never ends. Presence decides whether a filter was asked for, not truthiness, so `?status=` is refused rather than read as "every status". Ids go through `parseDbId`/`requireDbId` (`BigInt` is arbitrary precision, so `9223372036854775808` parsed and was refused by *Postgres* — a 500 for a documented 400), and dates through `parseIsoInstant` (`new Date` normalises `2026-02-30` into March 2 and resolves `08/26/2026 10:00` against the *server's* timezone, so the same filter would mean different instants on two installations). The rule lives in the service as well as the query parser, because MCP never sees a query string.

**The payload never crosses this surface.** It is the tenant's own data, it does not go through the PII scrub `execution_logs` rows get at write, and the subscriber already receives it at their endpoint. The reporter's own list was status, attempts, last error, event and subscription. Same call as the dead-delivery alert line in #325.

**`subscriptionEnabled` is on every delivery DTO** because the worker's claim joins `enabled = true`: a delivery on a disabled subscription sits at `PENDING` untouched, and without that field a correct requeue is indistinguishable from one that did nothing.

**The requeue writes one `info` `webhook` flow-log line.** Without it the requeue would be a silent mutation of the very row whose silence #325 was about, and it is the only place the count the row died at survives the reset. `info` pages nobody — `dispatchAlertsForEvent` only routes `warn` and `error` — so clearing a hundred dead deliveries is a hundred log lines and zero alerts.

**Indexes for the page the operator asks for.** The table had `(tenant_id)` and `(status, next_attempt_at)`, both built for the claim. Measured on 60k rows with one tenant's 2,000 sitting *underneath* a neighbour's 58,000:

```
first page, no filter    3.209 ms / 1038 buffers  ->  0.022 ms /  8 buffers
first page, status=DEAD  0.125 ms /   34 buffers  ->  0.026 ms / 11 buffers
```

The 1038 is the planner walking the primary key backwards through the neighbour's rows to reach 51 of ours, and it grows with the *neighbour's* traffic rather than the reader's.

**No bulk requeue, and this is the number behind that call.** 200 dead deliveries, over real HTTP, sequentially, no concurrency: the page lists in **47 ms** and all 200 requeue in **1,678 ms** (8.4 ms each), leaving 0 `DEAD`. One row per call keeps every refusal able to name the status it is about; a monitor already iterates the page it just fetched.

## Validation scope

### Live, against the real app over real HTTP

Real Elysia app on a socket, real API key, a real local receiver, the real worker, the real SSRF guard and signing. Nothing injected.

```
worker tick 1 (receiver 500): { claimed: 1, delivered: 0, retried: 0, dead: 1 }
receiver saw: 1 post, x-fazerai-delivery: 19057

GET /deliveries?status=DEAD -> 200
  { id: 19057, status: DEAD, attempts: 8, lastError: "non-2xx response: 500",
    subscriptionEnabled: true }        <- no payload key anywhere in the page

POST /deliveries/19057/requeue -> 200
  { status: PENDING, attempts: 0, nextAttemptAt: null, lastError: "non-2xx response: 500" }

worker tick 2 (receiver 200): { claimed: 1, delivered: 1 }
receiver saw: 2 posts; the event actually arrived
GET /deliveries/19057 -> 200  { status: DELIVERED, attempts: 1, deliveredAt: ..., lastError: null }

POST /deliveries/19057/requeue -> 409
  { "error": "Only a dead delivery can be requeued; this one is DELIVERED" }
```

Every refusal, over the same wire:

```
subscriptionId=abc                  400 {"error":"Invalid value for subscriptionId","field":"subscriptionId"}
subscriptionId=                     400 {"error":"Invalid value for subscriptionId","field":"subscriptionId"}
subscriptionId=9223372036854775808  400 {"error":"Invalid value for subscriptionId","field":"subscriptionId"}
cursor=not-an-id                    400 {"error":"Invalid value for cursor","field":"cursor"}
since=garbage                       400 {"error":"Invalid value for since","field":"since"}
since=2026-02-30T00:00:00Z          400 {"error":"Invalid value for since","field":"since"}
since=08/26/2026 10:00              400 {"error":"Invalid value for since","field":"since"}
limit=3.5                           400 {"error":"Invalid value for limit","field":"limit"}
limit=0                             400 {"error":"Invalid value for limit","field":"limit"}
status=FAILED                       400 {"error":"Unknown delivery status: FAILED","field":"status"}
status=                             400 {"error":"Unknown delivery status: ","field":"status"}
/deliveries/9223372036854775808     400 {"error":"Not a valid deliveryId"}
subscriptionId=<real>               200  1 row
```

And the ledger afterwards:

```json
[{ "level": "error", "detail": { "attempts": 8, "deliveryId": "19057" },
   "errorMessage": "non-2xx response: 500" },
 { "level": "info",  "detail": { "action": "requeued", "attemptsBefore": 8,
   "subscriptionEnabled": true, "deliveryId": "19057" } }]
```

### Proved by test (red first)

30 tests across three files, DB-backed where the effect is a row. Control run first, so an empty result cannot read as a clean one:

```
CONTROL (no mutation)                       30 pass  0 fail
M1  requeue keeps attempts                       4 fail
M2  requeue accepts any status                   3 fail
M3  payload reaches the DTO                      3 fail
M4  unknown status accepted                      1 fail
M5  keyset walks the wrong way                   1 fail
M6  subscriptionEnabled hardcoded true           2 fail
M7  requeue emits nothing                        1 fail
M8  mcp dry run skips the status check           1 fail
M9  filters unvalidated                          1 fail
M10 loser reports the stale read                 1 fail
M11 requeue reads without the lock               2 fail
M12 empty status = every status                  1 fail
M13 date parsed with new Date                    1 fail
M14 id parsed unbounded                          1 fail
M15 audit from the unlocked pre-read             1 fail
M16 apply repeats the unlocked read              1 fail
```

M3 is worth naming: the first version of it only added `payload` to the Prisma projection and *survived*, because `toDto` drops what it does not name. A projection mutation is a no-op against a mapped DTO; the mutation that counts is the one where the payload reaches the object that ships.

The three concurrency cases (M11, M15, M16) are driven by a transaction that holds the row and commits only after the locked read is already waiting on it, so the unlocked read and the locked one genuinely disagree. They are interleavings, not timing hopes.

### Not validated, and not built

- **The index numbers are from a synthetic 60k-row table**, not from a production instance. The shape (one tenant's older rows under a busier neighbour) is chosen to be the bad case, not an observed one.
- **No console page.** The issue's scope is the API; the `/webhooks` page still lists subscriptions only.
- **No replay of `DELIVERED`.** Re-sending data a receiver already took is a different promise and belongs in its own issue.
- **`?since=` takes an instant, not a date.** `2026-01-01` is refused; the parameter's description says so. That is the cost of refusing the strings `new Date` would have silently reinterpreted.

## Two things carried along

**The MCP tools/list ceilings moved**, deliberately and after trimming what could be trimmed: descriptions 26,500 → 27,250, schemas 40,850 → 41,650. Three tools cost 748 characters against 467 of headroom. `webhook_delivery_get` stopped restating the field list `webhook_delivery_list` publishes a line above it; the status enum stays derived from the module's vocabulary rather than hand-typed, so shrinking it would mean advertising fewer statuses than the surface accepts.

**A vestigial claim about the delivery FK is corrected in three places.** `deleteWebhookSubscription` and two lines of `docs/api-and-fleet.md` said the FK is `ON DELETE RESTRICT`. The only migration that creates it says `ON DELETE CASCADE`, and nothing alters it since. Behaviour is unchanged and was never wrong — the service already clears the deliveries explicitly inside the same scoped transaction — but what protects an in-flight row is that code, not the constraint, and the docs now say so.
