### PR TITLE
Judge a calendar write against the availability it would have offered

### DIFF
--- a/src/modules/integrations/toolpacks/calendar-slots.ts
+++ b/src/modules/integrations/toolpacks/calendar-slots.ts
@@ -222,19 +222,30 @@ function tzOffsetMs(at: number, tz: string): number {
   return asUtc - at;
 }
 
-// The UTC instant a LOCAL wall clock names in an IANA timezone (DST-correct: one refinement pass
-// covers an offset shift between the UTC guess and the target instant). NaN when the string is not
-// a wall clock at all, so callers can tell "unreadable" from a real instant.
-export function zonedWallClockMs(local: string, tz: string): number {
+// The UTC instant a LOCAL wall clock names in an IANA timezone, and whether that wall clock EXISTS.
+// One refinement pass covers an offset shift between the UTC guess and the target instant, which is
+// DST-correct everywhere except the hour a spring-forward SKIPS: 02:30 on a day whose clocks jump
+// 02:00 → 03:00 is not a time, and `ms` is then the instant the shift landed on.
+//
+// The two callers want opposite things with that, which is why it is reported instead of decided
+// here. A day boundary still exists on a day that starts at 01:00, so midnight takes the instant.
+// An appointment does not: guessing which instant Google will pick for a time that does not exist
+// is the divergence between judge and store that this whole path exists to remove.
+export function zonedWallClock(
+  local: string,
+  tz: string,
+): { ms: number; exists: boolean } {
   const utcGuess = Date.parse(`${local}Z`);
-  if (Number.isNaN(utcGuess)) return Number.NaN;
+  if (Number.isNaN(utcGuess)) return { ms: Number.NaN, exists: false };
   const first = utcGuess - tzOffsetMs(utcGuess, tz);
-  return utcGuess - tzOffsetMs(first, tz);
+  const ms = utcGuess - tzOffsetMs(first, tz);
+  // Round trip: read `ms` back as a wall clock. A skipped hour comes back as a different one.
+  return { ms, exists: ms + tzOffsetMs(ms, tz) === utcGuess };
 }
 
 // The UTC instant of local midnight for a YYYY-MM-DD in an IANA timezone.
 export function zonedMidnightMs(date: string, tz: string): number {
-  return zonedWallClockMs(`${date}T00:00:00`, tz);
+  return zonedWallClock(`${date}T00:00:00`, tz).ms;
 }
 
 // How many bookable times a refusal offers back. Enough for the model to propose a real choice,
@@ -258,12 +269,16 @@ export interface BookingVerdict {
 }
 
 // The local day containing an instant, as the range the availability read has to cover. The END is
-// widened by the appointment itself, so a booking that runs past local midnight is still judged
-// whole instead of being cut by the window that was supposed to hold it. The start needs no such
-// guard: local midnight of the day holding an instant is never after it.
+// widened by one SLOT, so a booking that runs past local midnight is still judged whole instead of
+// being cut by the window that was supposed to hold it. The start needs no such guard: local
+// midnight of the day holding an instant is never after it.
+//
+// One slot, not the requested span: the span is a model argument and nothing bounds it, so widening
+// by it would let a `end` years after `start` turn a one-day freeBusy query into a decades-long one
+// before anything had a chance to refuse it. A request longer than a slot is not a slot either way.
 export function bookingWindow(
   startMs: number,
-  endMs: number,
+  slotMs: number,
   timezone: string,
 ): { timeMin: string; timeMax: string } {
   const dayStart = zonedMidnightMs(
@@ -277,7 +292,7 @@ export function bookingWindow(
   );
   return {
     timeMin: new Date(dayStart).toISOString(),
-    timeMax: new Date(Math.max(dayEnd, endMs)).toISOString(),
+    timeMax: new Date(Math.max(dayEnd, startMs + slotMs)).toISOString(),
   };
 }
 
@@ -294,7 +309,11 @@ export function bookingWindow(
 // availability read that answers the question already covers the whole day.
 export function judgeBooking(input: BookingInput): BookingVerdict {
   const { startMs, endMs, ...slotInput } = input;
-  const window = bookingWindow(startMs, endMs, input.schedule.timezone);
+  const window = bookingWindow(
+    startMs,
+    input.slotMinutes * 60_000,
+    input.schedule.timezone,
+  );
   const offered = computeAvailableSlots({ ...slotInput, ...window });
   const bookable = offered.some(
     (s) => Date.parse(s.start) === startMs && Date.parse(s.end) === endMs,

--- a/src/modules/integrations/toolpacks/calendar-slots.ts
+++ b/src/modules/integrations/toolpacks/calendar-slots.ts
@@ -222,12 +222,19 @@ function tzOffsetMs(at: number, tz: string): number {
   return asUtc - at;
 }
 
-// The UTC instant of local midnight for a YYYY-MM-DD in an IANA timezone (DST-correct: one
-// refinement pass covers an offset shift between the UTC guess and the target instant).
-export function zonedMidnightMs(date: string, tz: string): number {
-  const utcGuess = Date.parse(`${date}T00:00:00Z`);
+// The UTC instant a LOCAL wall clock names in an IANA timezone (DST-correct: one refinement pass
+// covers an offset shift between the UTC guess and the target instant). NaN when the string is not
+// a wall clock at all, so callers can tell "unreadable" from a real instant.
+export function zonedWallClockMs(local: string, tz: string): number {
+  const utcGuess = Date.parse(`${local}Z`);
+  if (Number.isNaN(utcGuess)) return Number.NaN;
   const first = utcGuess - tzOffsetMs(utcGuess, tz);
   return utcGuess - tzOffsetMs(first, tz);
+}
+
+// The UTC instant of local midnight for a YYYY-MM-DD in an IANA timezone.
+export function zonedMidnightMs(date: string, tz: string): number {
+  return zonedWallClockMs(`${date}T00:00:00`, tz);
 }
 
 // How many bookable times a refusal offers back. Enough for the model to propose a real choice,
@@ -235,9 +242,12 @@ export function zonedMidnightMs(date: string, tz: string): number {
 const MAX_ALTERNATIVES = 6;
 
 export interface BookingInput extends Omit<SlotInput, "timeMin" | "timeMax"> {
-  // The requested appointment, as the write tools received it.
-  start: string;
-  end: string;
+  // The requested appointment as INSTANTS, already resolved by the caller. Not the strings it
+  // received: an offset-less `dateTime` is a wall clock in the calendar's timezone, and re-parsing
+  // it here would read it in the server's instead — which is exactly the divergence the caller
+  // resolved it to avoid. One parse, at the boundary.
+  startMs: number;
+  endMs: number;
 }
 
 export interface BookingVerdict {
@@ -283,9 +293,7 @@ export function bookingWindow(
 // the times it CAN offer are what lets the turn recover, and they cost nothing extra because the
 // availability read that answers the question already covers the whole day.
 export function judgeBooking(input: BookingInput): BookingVerdict {
-  const { start, end, ...slotInput } = input;
-  const startMs = Date.parse(start);
-  const endMs = Date.parse(end);
+  const { startMs, endMs, ...slotInput } = input;
   const window = bookingWindow(startMs, endMs, input.schedule.timezone);
   const offered = computeAvailableSlots({ ...slotInput, ...window });
   const bookable = offered.some(
@@ -308,6 +316,14 @@ export function judgeBooking(input: BookingInput): BookingVerdict {
 // that matches the event's hour exactly is NOT enough, because freeBusy MERGES adjacent busy blocks:
 // an appointment at 14:00-15:00 followed by another at 15:00-16:00 comes back as one 14:00-16:00
 // block, and an equality test would leave the whole fused block standing.
+//
+// Apply it to the calendar's OWN bookings only. Applied to the assembled busy list it would punch
+// the same hole through an operator closure that happens to cover the appointment's hour, which is
+// not the appointment and does not move with it. One residual is unavoidable at this resolution:
+// freeBusy carries no event identity, so an event that genuinely OVERLAPS the one being moved loses
+// coverage over the overlap. That is bounded to the span being vacated, on a calendar that was
+// already double-booked there; separating them would mean reading the events themselves, which
+// would put other customers' appointments in reach of a path that today only ever sees busy/free.
 export function subtractWindow(
   busy: { start: string; end: string }[],
   cut: { start: string; end: string } | null,

--- a/src/modules/integrations/toolpacks/calendar-slots.ts
+++ b/src/modules/integrations/toolpacks/calendar-slots.ts
@@ -1,5 +1,6 @@
 import {
   fitsWithinWindows,
+  localDateKey,
   type Schedule,
 } from "@/modules/business-hours/hours";
 
@@ -192,4 +193,140 @@ export function computeAggregatedSlots(input: AggregateInput): AggregateResult {
     i = j;
   }
   return { slots };
+}
+
+// The UTC offset of an instant in an IANA timezone, in ms (positive east of UTC). Lives here rather
+// than at the call site because both the blocking-calendar reader and the booking rule below need
+// "local midnight of a date", and two copies of zone math is one copy too many.
+function tzOffsetMs(at: number, tz: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date(at));
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? "0");
+  const asUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour") % 24,
+    get("minute"),
+    get("second"),
+  );
+  return asUtc - at;
+}
+
+// The UTC instant of local midnight for a YYYY-MM-DD in an IANA timezone (DST-correct: one
+// refinement pass covers an offset shift between the UTC guess and the target instant).
+export function zonedMidnightMs(date: string, tz: string): number {
+  const utcGuess = Date.parse(`${date}T00:00:00Z`);
+  const first = utcGuess - tzOffsetMs(utcGuess, tz);
+  return utcGuess - tzOffsetMs(first, tz);
+}
+
+// How many bookable times a refusal offers back. Enough for the model to propose a real choice,
+// small enough that the refusal stays a sentence and not a listing.
+const MAX_ALTERNATIVES = 6;
+
+export interface BookingInput extends Omit<SlotInput, "timeMin" | "timeMax"> {
+  // The requested appointment, as the write tools received it.
+  start: string;
+  end: string;
+}
+
+export interface BookingVerdict {
+  bookable: boolean;
+  // Bookable times in the same local day, nearest to the request first. Empty when the day is full
+  // or closed; that is a real answer, not a failure.
+  alternatives: Slot[];
+}
+
+// The local day containing an instant, as the range the availability read has to cover. The END is
+// widened by the appointment itself, so a booking that runs past local midnight is still judged
+// whole instead of being cut by the window that was supposed to hold it. The start needs no such
+// guard: local midnight of the day holding an instant is never after it.
+export function bookingWindow(
+  startMs: number,
+  endMs: number,
+  timezone: string,
+): { timeMin: string; timeMax: string } {
+  const dayStart = zonedMidnightMs(
+    localDateKey(new Date(startMs), timezone),
+    timezone,
+  );
+  // 36h from local midnight lands inside the next local day whether it is 23, 24 or 25 hours long.
+  const dayEnd = zonedMidnightMs(
+    localDateKey(new Date(dayStart + 36 * 3_600_000), timezone),
+    timezone,
+  );
+  return {
+    timeMin: new Date(dayStart).toISOString(),
+    timeMax: new Date(Math.max(dayEnd, endMs)).toISOString(),
+  };
+}
+
+// THE RULE the write path enforces (issue #345), in one sentence: an appointment may only be written
+// on a (start, end) pair that `calendar_check_availability` would have returned for that day.
+//
+// It is expressed as membership in the generated list, not as a second copy of the four conditions
+// (service hours, slot grid, minimum lead, existing bookings). A re-implementation is how the two
+// paths drift: the write would keep honouring a rule the availability path had already changed, and
+// nothing would be red. Here there is one generator, and the write asks it a question.
+//
+// The same list is the refusal's content. A bare "not available" makes the agent apologise and stop;
+// the times it CAN offer are what lets the turn recover, and they cost nothing extra because the
+// availability read that answers the question already covers the whole day.
+export function judgeBooking(input: BookingInput): BookingVerdict {
+  const { start, end, ...slotInput } = input;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  const window = bookingWindow(startMs, endMs, input.schedule.timezone);
+  const offered = computeAvailableSlots({ ...slotInput, ...window });
+  const bookable = offered.some(
+    (s) => Date.parse(s.start) === startMs && Date.parse(s.end) === endMs,
+  );
+  if (bookable) return { bookable: true, alternatives: [] };
+  const alternatives = offered
+    .map((s) => ({ s, d: Math.abs(Date.parse(s.start) - startMs) }))
+    .sort((a, b) => a.d - b.d)
+    .slice(0, MAX_ALTERNATIVES)
+    .map((x) => x.s)
+    .sort((a, b) => Date.parse(a.start) - Date.parse(b.start));
+  return { bookable: false, alternatives };
+}
+
+// Removes one interval from a busy list, splitting any interval that strictly contains it.
+//
+// It exists for the reschedule: the appointment being moved is itself busy, so judging the new time
+// against a raw freeBusy answer refuses every move as a collision with itself. Dropping the interval
+// that matches the event's hour exactly is NOT enough, because freeBusy MERGES adjacent busy blocks:
+// an appointment at 14:00-15:00 followed by another at 15:00-16:00 comes back as one 14:00-16:00
+// block, and an equality test would leave the whole fused block standing.
+export function subtractWindow(
+  busy: { start: string; end: string }[],
+  cut: { start: string; end: string } | null,
+): { start: string; end: string }[] {
+  if (!cut) return busy;
+  const cs = Date.parse(cut.start);
+  const ce = Date.parse(cut.end);
+  if (Number.isNaN(cs) || Number.isNaN(ce) || ce <= cs) return busy;
+  const out: { start: string; end: string }[] = [];
+  for (const b of busy) {
+    const bs = Date.parse(b.start);
+    const be = Date.parse(b.end);
+    if (Number.isNaN(bs) || Number.isNaN(be) || be <= bs) continue;
+    if (ce <= bs || cs >= be) {
+      out.push(b);
+      continue;
+    }
+    if (bs < cs) out.push({ start: b.start, end: new Date(cs).toISOString() });
+    if (ce < be) out.push({ start: new Date(ce).toISOString(), end: b.end });
+  }
+  return out;
 }

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -408,10 +408,14 @@ function toEventTimePatch(
   return { ...toEventTime(value, timeZone), date: null };
 }
 
-// A blocking-calendar event as a busy window. Timed events parse as-is; an all-day `date` widens to
-// local midnight in the integration timezone (Google's all-day end.date is already exclusive).
-// Unparseable shapes → null (skipped defensively).
-function blockingBusyWindow(
+// The span an event OCCUPIES. Timed events parse as-is; an all-day `date` widens to local midnight
+// in the integration timezone (Google's all-day end.date is already exclusive). Unparseable shapes
+// → null (skipped defensively).
+//
+// Two callers, and the all-day half is load-bearing for both: a holiday is the all-day shape, and
+// so is a legacy appointment being converted to a timed slot, whose own day-long busy window has to
+// come out of its way or every same-day conversion collides with itself.
+function eventBusyWindow(
   ev: Record<string, unknown>,
   timeZone: string,
 ): { start: string; end: string } | null {
@@ -916,7 +920,7 @@ async function readBlockingWindows(
     const items = Array.isArray(evData.items) ? evData.items : [];
     const windows: BusyWindow[] = [];
     for (const ev of items) {
-      const w = blockingBusyWindow(
+      const w = eventBusyWindow(
         (ev ?? {}) as Record<string, unknown>,
         timeZone,
       );
@@ -1086,11 +1090,13 @@ function notBookableMessage(alternatives: Slot[]): string {
   if (alternatives.length === 0) {
     return "That time is not a bookable appointment slot, and nothing else is bookable that day. Call calendar_check_availability for another day and offer the customer a time from it.";
   }
-  return `That time is not a bookable appointment slot. Bookable times that day: ${alternatives
-    .map((s) => s.label)
-    .join(
-      ", ",
-    )}. Offer one of these to the customer and use its exact start and end.`;
+  // The exact start/end travel with the label, in the same shape calendar_check_availability
+  // returns. A label alone carries no year and no offset, and across a DST fallback two different
+  // slots wear the same one — so a refusal that only named them would be asking the model to
+  // reconstruct a timestamp this very tool refuses to guess at.
+  return `That time is not a bookable appointment slot. These are: ${JSON.stringify(
+    alternatives,
+  )}. Offer one to the customer and pass its start and end back unchanged.`;
 }
 
 // The availability read failed, so whether the time is free is unknown. Writing anyway is the double
@@ -1423,15 +1429,10 @@ function buildUpdateEventTool(
           businessHoursId,
           start: nextStart,
           end: nextEnd,
-          // The appointment being moved: its own booking comes back as busy, and leaving it in place
-          // would make every reschedule collide with itself.
-          excludeBusy:
-            currentStart &&
-            currentEnd &&
-            at(currentStart) !== null &&
-            at(currentEnd) !== null
-              ? { start: currentStart, end: currentEnd }
-              : null,
+          // The appointment being moved: its own booking comes back as busy, and leaving it in
+          // place would make every reschedule collide with itself. Read from the EVENT, not from
+          // the request, so a legacy all-day appointment contributes the days it really occupies.
+          excludeBusy: eventBusyWindow(ownerEv, timeZone),
         });
         if (!judged.ok) return judged.refusal;
       }

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -14,6 +14,7 @@ import {
   type Slot,
   subtractWindow,
   zonedMidnightMs,
+  zonedWallClockMs,
 } from "./calendar-slots";
 import {
   type IntegrationSelection,
@@ -1050,13 +1051,22 @@ function buildCheckAvailabilityTool(
   );
 }
 
-// The instant a Calendar start/end names, or null when it names a whole DAY instead. Same shape test
-// as toEventTime, so "what Google would store as all-day" and "what the booking rule cannot judge"
-// are the same question answered once.
-function timedInstantMs(value: string): number | null {
+const ALL_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const HAS_OFFSET_RE = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+// The instant a Calendar start/end names, or null when it names a whole DAY or nothing readable.
+//
+// A value WITHOUT an offset is a local wall clock, and the zone that resolves it has to be the zone
+// GOOGLE resolves it with: the event's own `timeZone`, which toEventTime always sets to the
+// integration's. `Date.parse` would read it in the SERVER's zone instead, so a UTC deployment
+// serving a São Paulo calendar judges "18:00" as 15:00 and stores it as 18:00 — three hours of
+// service hours and bookings the rule never looked at.
+function timedInstantMs(value: string, timeZone: string): number | null {
   const v = value.trim();
-  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return null;
-  const ms = Date.parse(v);
+  if (ALL_DAY_RE.test(v)) return null;
+  const ms = HAS_OFFSET_RE.test(v)
+    ? Date.parse(v)
+    : zonedWallClockMs(v, timeZone);
   return Number.isNaN(ms) ? null : ms;
 }
 
@@ -1065,6 +1075,8 @@ function timedInstantMs(value: string): number | null {
 // the one shape of write that skips the rule entirely (issue #345).
 const NOT_A_TIMED_EVENT =
   "An appointment needs a start and end time, not a whole day. Pass ISO 8601 timestamps with an offset (e.g. 2026-06-20T14:00:00-03:00).";
+const UNREADABLE_TIME =
+  "Start and end must be ISO 8601 timestamps with an offset (e.g. 2026-06-20T14:00:00-03:00).";
 
 // The requested time is not one availability would have offered. The times that ARE bookable travel
 // with the refusal: a bare "unavailable" makes the agent apologise and end the turn, while a list of
@@ -1107,10 +1119,15 @@ async function judgeWrite(opts: {
   end: string;
   excludeBusy: BusyWindow | null;
 }): Promise<{ ok: true } | { ok: false; refusal: string | ToolFailure }> {
-  const startMs = timedInstantMs(opts.start);
-  const endMs = timedInstantMs(opts.end);
+  const startMs = timedInstantMs(opts.start, opts.timeZone);
+  const endMs = timedInstantMs(opts.end, opts.timeZone);
   if (startMs === null || endMs === null) {
-    return { ok: false, refusal: NOT_A_TIMED_EVENT };
+    const wholeDay =
+      ALL_DAY_RE.test(opts.start.trim()) || ALL_DAY_RE.test(opts.end.trim());
+    return {
+      ok: false,
+      refusal: wholeDay ? NOT_A_TIMED_EVENT : UNREADABLE_TIME,
+    };
   }
   if (endMs <= startMs) {
     return {
@@ -1154,17 +1171,17 @@ async function judgeWrite(opts: {
     return { ok: false, refusal: unverifiableMessage(blocked.refusal) };
   }
   const source = read.sources[0] as CalendarSource;
-  const busy = subtractWindow(
-    busyForSource(source, blocked.windows),
-    opts.excludeBusy,
+  const busy = busyForSource(
+    { ...source, busy: subtractWindow(source.busy, opts.excludeBusy) },
+    blocked.windows,
   );
   // The appointment length the operator sells: pinned by config when there is one, otherwise the
   // length the model asked for. Both go through resolveSlotDuration so the write is judged against
   // the very same clamping the availability answer was built with.
   const preset = configuredSlotDuration(opts.sel.config);
   const verdict = judgeBooking({
-    start: opts.start,
-    end: opts.end,
+    startMs,
+    endMs,
     now: new Date(),
     schedule: effective,
     busy,
@@ -1375,11 +1392,21 @@ function buildUpdateEventTool(
       // A move is judged by the same rule a create is (issue #345). Only a move: an edit that leaves
       // start and end alone changes nothing availability has an opinion about, and paying a read to
       // rename an appointment would be a request for nothing.
-      if (input.start !== undefined || input.end !== undefined) {
-        const currentStart = flattenTime(ownerEv.start);
-        const currentEnd = flattenTime(ownerEv.end);
-        const nextStart = input.start ?? currentStart;
-        const nextEnd = input.end ?? currentEnd;
+      //
+      // "A move" is the INSTANTS differing, not the fields being present. A caller that resends the
+      // times it already has while changing the summary is renaming, and judging that would refuse
+      // the rename because the appointment is now in the past, or inside the minimum notice, or
+      // outside service hours the operator changed after it was booked.
+      const currentStart = flattenTime(ownerEv.start);
+      const currentEnd = flattenTime(ownerEv.end);
+      const nextStart = input.start ?? currentStart;
+      const nextEnd = input.end ?? currentEnd;
+      const at = (v: string | null) =>
+        v === null ? null : timedInstantMs(v, timeZone);
+      const moved =
+        (input.start !== undefined || input.end !== undefined) &&
+        (at(nextStart) !== at(currentStart) || at(nextEnd) !== at(currentEnd));
+      if (moved) {
         if (nextStart === null || nextEnd === null) {
           return toolFailure(
             "Google Calendar did not return the appointment's current times, so the new time cannot be checked. Try again shortly.",
@@ -1401,8 +1428,8 @@ function buildUpdateEventTool(
           excludeBusy:
             currentStart &&
             currentEnd &&
-            timedInstantMs(currentStart) !== null &&
-            timedInstantMs(currentEnd) !== null
+            at(currentStart) !== null &&
+            at(currentEnd) !== null
               ? { start: currentStart, end: currentEnd }
               : null,
         });

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -1421,9 +1421,18 @@ function buildUpdateEventTool(
       const nextEnd = input.end ?? currentEnd;
       const at = (v: string | null) =>
         v === null ? null : timedInstantMs(v, timeZone);
+      // Two values are the same time when they resolve to the same INSTANT, or, for a shape that
+      // has no instant (a legacy all-day date), when they are the same string. Comparing instants
+      // alone makes every all-day value equal to every other, so moving an appointment from
+      // 2099-06-22 to 2099-06-23 read as "nothing changed" and was dropped without a word.
+      const sameTime = (a: string | null, b: string | null) => {
+        if (a === b) return true;
+        const ai = at(a);
+        return ai !== null && ai === at(b);
+      };
       const moved =
         (input.start !== undefined || input.end !== undefined) &&
-        (at(nextStart) !== at(currentStart) || at(nextEnd) !== at(currentEnd));
+        (!sameTime(nextStart, currentStart) || !sameTime(nextEnd, currentEnd));
       // The times go in the patch only when they MOVED, which is the same condition that decides
       // whether to judge them. Echoing an unchanged value back would rewrite its representation for
       // no reason, and for a legacy all-day appointment that rewrite is invalid: `toEventTimePatch`

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -1,11 +1,20 @@
 import type { StructuredToolInterface } from "@langchain/core/tools";
 import { z } from "zod";
 import logger from "@/api/lib/logger";
-import { failableTool, toolFailure } from "@/graph/tools/failure";
+import { failableTool, ToolFailure, toolFailure } from "@/graph/tools/failure";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { xmlAttr } from "@/lib/xml";
 import { readAppointmentReminderConfig } from "@/modules/appointments/settings";
-import { type CalendarSource, computeAggregatedSlots } from "./calendar-slots";
+import type { Schedule } from "@/modules/business-hours/hours";
+import {
+  bookingWindow,
+  type CalendarSource,
+  computeAggregatedSlots,
+  judgeBooking,
+  type Slot,
+  subtractWindow,
+  zonedMidnightMs,
+} from "./calendar-slots";
 import {
   type IntegrationSelection,
   registerToolpack,
@@ -381,57 +390,21 @@ function eventStamp(ev: Record<string, unknown>): string | null {
   return typeof v === "string" ? v : null;
 }
 
-// A Calendar start/end: a bare date (YYYY-MM-DD) is an all-day event; anything else is treated as a
-// timed RFC3339 `dateTime` (carrying the config/default timeZone).
+// A Calendar start/end, always a timed RFC3339 `dateTime` carrying the config/default timeZone.
+// All-day has no shape here since #345: an appointment is judged against the bookable slots of a
+// day, a whole day is never one of them, and the write tools refuse a bare date before reaching this.
 function toEventTime(value: string, timeZone: string): Record<string, string> {
-  const v = value.trim();
-  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return { date: v };
-  return { dateTime: v, timeZone };
+  return { dateTime: value.trim(), timeZone };
 }
 
 // PATCH merges what we send, so a patch carrying only `dateTime` leaves the event's existing `date`
-// in place — and Google rejects an event holding both (HTTP 400), which makes every all-day ⇄ timed
-// conversion fail. Sending the opposite field as null clears it, so the patch replaces the time
-// representation instead of mixing the two.
+// in place — and Google rejects an event holding both (HTTP 400). An all-day event created before
+// #345 can still be MOVED onto a bookable slot, so the patch has to clear the `date` it replaces.
 function toEventTimePatch(
   value: string,
   timeZone: string,
 ): Record<string, string | null> {
-  const t = toEventTime(value, timeZone);
-  return "date" in t ? { ...t, dateTime: null } : { ...t, date: null };
-}
-
-// The timezone's UTC offset (ms) at an instant, via Intl (Temporal is unavailable in Bun).
-function tzOffsetMs(at: number, tz: string): number {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: tz,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  }).formatToParts(new Date(at));
-  const get = (type: string) =>
-    Number(parts.find((p) => p.type === type)?.value ?? "0");
-  const asUtc = Date.UTC(
-    get("year"),
-    get("month") - 1,
-    get("day"),
-    get("hour") % 24,
-    get("minute"),
-    get("second"),
-  );
-  return asUtc - at;
-}
-
-// The UTC instant of local midnight for a YYYY-MM-DD in an IANA timezone (DST-correct: one
-// refinement pass covers an offset shift between the UTC guess and the target instant).
-function zonedMidnightMs(date: string, tz: string): number {
-  const utcGuess = Date.parse(`${date}T00:00:00Z`);
-  const first = utcGuess - tzOffsetMs(utcGuess, tz);
-  return utcGuess - tzOffsetMs(first, tz);
+  return { ...toEventTime(value, timeZone), date: null };
 }
 
 // A blocking-calendar event as a busy window. Timed events parse as-is; an all-day `date` widens to
@@ -608,7 +581,9 @@ const CREATE_EVENT_SCHEMA = z.object({
   start: z
     .string()
     .min(1)
-    .describe("Start, ISO 8601 datetime (timed) or YYYY-MM-DD (all-day)."),
+    .describe(
+      "Start, ISO 8601 datetime with an offset (e.g. 2026-06-20T14:00:00-03:00). A bare date is refused: an appointment occupies a slot, not a whole day.",
+    ),
   end: z.string().min(1).describe("End, same format as start."),
   description: z.string().max(2000).optional().describe("Event details."),
   calendarId: z.string().optional().describe(CALENDAR_ID_DESC),
@@ -617,8 +592,8 @@ const CREATE_EVENT_SCHEMA = z.object({
 const UPDATE_EVENT_SCHEMA = z.object({
   eventId: z.string().min(1).describe("The event id to update."),
   summary: z.string().min(1).optional().describe("New title."),
-  start: z.string().optional().describe("New start (ISO 8601 or date)."),
-  end: z.string().optional().describe("New end (ISO 8601 or date)."),
+  start: z.string().optional().describe("New start, ISO 8601 with an offset."),
+  end: z.string().optional().describe("New end, same format as start."),
   description: z.string().max(2000).optional().describe("New details."),
   calendarId: z.string().optional().describe(CALENDAR_ID_DESC),
 });
@@ -729,6 +704,242 @@ function buildListEventsTool(
   );
 }
 
+// A busy interval, as both the freeBusy answer and the blocking-calendar reader express it.
+type BusyWindow = { start: string; end: string };
+
+// The availability read, shared by the tool that ANSWERS "when can I come?" and the tools that WRITE
+// the answer down. Extracted for issue #345: the write path has to judge a requested time against
+// the same busy windows the availability path uses, and a second copy of this reader is how the two
+// would start disagreeing about what "busy" means.
+type BusySources =
+  | { ok: true; sources: CalendarSource[]; unreadable: string[] }
+  | { ok: false; refusal: string | ToolFailure };
+
+async function readBusySources(
+  calendarIds: string[],
+  labels: Record<string, string>,
+  timeMin: string,
+  timeMax: string,
+  timeZone: string,
+  token: string,
+  ctx: ToolpackCtx,
+): Promise<BusySources> {
+  // NOTE: freeBusy takes N calendars per request and keys the answer by id, so the whole clinic
+  // costs at most five requests (see FREEBUSY_BATCH_SIZE and MAX_AGGREGATE_CALENDARS), not one
+  // per professional the way the model had to do it before.
+  const batches: string[][] = [];
+  for (let i = 0; i < calendarIds.length; i += FREEBUSY_BATCH_SIZE) {
+    batches.push(calendarIds.slice(i, i + FREEBUSY_BATCH_SIZE));
+  }
+  // NOTE: allSettled, not all: gcalFetch THROWS on a timeout or a network error, and a single
+  // rejection would discard every batch that answered fine. Non-2xx already degraded per batch;
+  // a thrown one has to degrade the same way or the contract is a coin flip on failure mode.
+  // Concurrency needs no separate bound: MAX_AGGREGATE_CALENDARS caps this at five requests.
+  const batchRes = await Promise.allSettled(
+    batches.map((ids) =>
+      gcalFetch(
+        "/freeBusy",
+        {
+          method: "POST",
+          token,
+          body: {
+            timeMin,
+            timeMax,
+            timeZone,
+            items: ids.map((id) => ({ id })),
+          },
+        },
+        ctx,
+      ),
+    ),
+  );
+  // NOTE: A batch that failed contributes no entries, so its calendars fall through the same
+  // "unreadable" path as a calendar Google refused individually. Only a total failure surfaces
+  // the HTTP status, which keeps the single-batch case answering exactly as it always did.
+  const calendars: Record<string, unknown> = {};
+  let lastStatus: number | null = null;
+  let threw = false;
+  for (const r of batchRes) {
+    if (r.status === "rejected") {
+      logger.warn({ err: r.reason }, "gcal: freeBusy batch failed");
+      threw = true;
+      continue;
+    }
+    if (r.value.status < 200 || r.value.status >= 300) {
+      lastStatus = r.value.status;
+      continue;
+    }
+    const d = (r.value.json ?? {}) as Record<string, unknown>;
+    Object.assign(calendars, (d.calendars ?? {}) as Record<string, unknown>);
+  }
+  // NOTE: Nothing came back at all, and the three ways that happens stay distinguishable, exactly
+  // as the single-batch path always reported them. The last one is a 2xx whose body was empty,
+  // malformed, or truncated by MAX_RESPONSE_CHARS before parsing: there is no status to quote
+  // (saying "HTTP null" is worse than saying nothing), and it is retriable, so it reads as such.
+  if (Object.keys(calendars).length === 0) {
+    if (lastStatus !== null) {
+      return {
+        ok: false,
+        refusal: toolFailure(`Google Calendar returned HTTP ${lastStatus}.`),
+      };
+    }
+    return {
+      ok: false,
+      refusal: toolFailure(
+        threw
+          ? "Failed to reach Google Calendar. Try again shortly."
+          : "Google Calendar's availability response could not be read. Try again shortly.",
+      ),
+    };
+  }
+  // NOTE: Per-calendar outcome. freeBusy answers 200 and reports a calendar it could not read as a
+  // per-calendar `errors` array (a revoked share, a deleted calendar), so the failure is INSIDE a
+  // successful response. Such a calendar is dropped, never carried with an empty busy list: empty
+  // busy means "free all day", and offering a professional whose bookings we cannot see is a
+  // double booking. Dropping it only under-offers, and the caller is told which ones went missing
+  // so the reply can say so instead of pretending the clinic is smaller than it is.
+  const sources: CalendarSource[] = [];
+  const unreadable: string[] = [];
+  for (const id of calendarIds) {
+    const entry = (calendars[id] ?? null) as Record<string, unknown> | null;
+    const errors = entry && Array.isArray(entry.errors) ? entry.errors : [];
+    if (!entry || errors.length > 0) {
+      unreadable.push(labels[id] ?? id);
+      continue;
+    }
+    const busy = (Array.isArray(entry.busy) ? entry.busy : [])
+      .map((b) => (b ?? {}) as Record<string, unknown>)
+      .filter((b) => typeof b.start === "string" && typeof b.end === "string")
+      .map((b) => ({ start: b.start as string, end: b.end as string }));
+    sources.push({
+      calendarId: id,
+      calendarLabel: labels[id] ?? null,
+      busy,
+    });
+  }
+  // NOTE: Nothing readable at all: an empty slot list would read as "fully booked", which sends the
+  // customer away from a clinic that is open. Say we could not check instead.
+  if (sources.length === 0) {
+    return {
+      ok: false,
+      refusal: toolFailure(
+        `Availability cannot be verified right now: no configured calendar could be read (${unreadable.join(", ")}).`,
+      ),
+    };
+  }
+  return { ok: true, sources, unreadable };
+}
+
+type BlockingRead =
+  | { ok: true; windows: Array<{ id: string; windows: BusyWindow[] }> }
+  | { ok: false; refusal: string | ToolFailure };
+
+// Blocking calendars (holidays, closures) count as busy too, read via events.list, NOT
+// freeBusy: all-day events (the typical holiday shape) default to transparency "transparent"
+// ("Free") and freeBusy silently ignores them, which is exactly the calendar the operator
+// expects to block. Only start/end are requested (no titles or attendees reach the model).
+// Fail-closed: a blocking calendar we cannot read could be hiding a closure, so refusing
+// beats offering a slot the operator explicitly blocked.
+async function readBlockingWindows(
+  blockingIds: string[],
+  sources: CalendarSource[],
+  timeMin: string,
+  timeMax: string,
+  timeZone: string,
+  token: string,
+  ctx: ToolpackCtx,
+): Promise<BlockingRead> {
+  // Which blocking calendars have to be READ. A blocker is skipped only when the query covers
+  // nothing but that same calendar: its own bookings already arrive via freeBusy, and reading it
+  // as a blocker would turn its transparent events into blocks of itself. With siblings in the
+  // query it MUST be read, because a calendar can be operable and still carry closures its
+  // siblings have to respect. Dropping it whenever it appeared in the query (an earlier revision
+  // of this change) made an all-day closure on a doubly-listed calendar invisible to everyone.
+  const out: Array<{ id: string; windows: BusyWindow[] }> = [];
+  const blocking = blockingIds.filter((id) =>
+    sources.some((s) => s.calendarId !== id),
+  );
+  if (blocking.length > MAX_BLOCKING_CALENDARS) {
+    return {
+      ok: false,
+      refusal: `Too many blocking calendars are configured (${blocking.length}; the limit is ${MAX_BLOCKING_CALENDARS}), so availability cannot be verified. Reduce the blocking calendars in the integration settings.`,
+    };
+  }
+  if (blocking.length === 0) return { ok: true, windows: out };
+  const evParams = new URLSearchParams({
+    singleEvents: "true",
+    timeMin,
+    timeMax,
+    maxResults: "50",
+    fields: "items(start,end),nextPageToken",
+  });
+  let blockingRes: GcalResponse[];
+  try {
+    blockingRes = await Promise.all(
+      blocking.map((id) =>
+        gcalFetch(
+          `/calendars/${encodeURIComponent(id)}/events?${evParams.toString()}`,
+          { method: "GET", token },
+          ctx,
+        ),
+      ),
+    );
+  } catch (err) {
+    logger.warn({ err }, "gcal: blocking calendars request failed");
+    return {
+      ok: false,
+      refusal: toolFailure(
+        "Failed to read a blocking calendar (holidays/closures), so availability cannot be verified right now. Try again shortly.",
+      ),
+    };
+  }
+  for (const [i, r] of blockingRes.entries()) {
+    if (r.status < 200 || r.status >= 300) {
+      return {
+        ok: false,
+        refusal: toolFailure(
+          `Google Calendar returned HTTP ${r.status} for a blocking calendar, so availability cannot be verified right now.`,
+        ),
+      };
+    }
+    const evData = (r.json ?? {}) as Record<string, unknown>;
+    // A nextPageToken means the window holds more events than the cap covers; treating the
+    // partial page as complete could offer a slot the operator explicitly blocked.
+    if (typeof evData.nextPageToken === "string") {
+      return {
+        ok: false,
+        refusal:
+          "A blocking calendar has more events in this range than can be checked at once, so availability cannot be verified right now. Try a narrower range.",
+      };
+    }
+    const items = Array.isArray(evData.items) ? evData.items : [];
+    const windows: BusyWindow[] = [];
+    for (const ev of items) {
+      const w = blockingBusyWindow(
+        (ev ?? {}) as Record<string, unknown>,
+        timeZone,
+      );
+      if (w) windows.push(w);
+    }
+    out.push({ id: blocking[i] as string, windows });
+  }
+  return { ok: true, windows: out };
+}
+
+// Everything that counts as busy for ONE calendar over one range: its own bookings plus every
+// blocking calendar except itself.
+function busyForSource(
+  source: CalendarSource,
+  blockingWindows: Array<{ id: string; windows: BusyWindow[] }>,
+): BusyWindow[] {
+  return [
+    ...source.busy,
+    ...blockingWindows
+      .filter((b) => b.id !== source.calendarId)
+      .flatMap((b) => b.windows),
+  ];
+}
+
 function buildCheckAvailabilityTool(
   sel: IntegrationSelection,
   ctx: ToolpackCtx,
@@ -762,176 +973,28 @@ function buildCheckAvailabilityTool(
       if (calendarIds.length > MAX_AGGREGATE_CALENDARS) {
         return `Too many calendars are configured to search at once (${calendarIds.length}; the limit is ${MAX_AGGREGATE_CALENDARS}). Pass calendarId to check one calendar, or reduce the calendars in the integration settings.`;
       }
-      // NOTE: freeBusy takes N calendars per request and keys the answer by id, so the whole clinic
-      // costs at most five requests (see FREEBUSY_BATCH_SIZE and MAX_AGGREGATE_CALENDARS), not one
-      // per professional the way the model had to do it before.
-      const batches: string[][] = [];
-      for (let i = 0; i < calendarIds.length; i += FREEBUSY_BATCH_SIZE) {
-        batches.push(calendarIds.slice(i, i + FREEBUSY_BATCH_SIZE));
-      }
-      // NOTE: allSettled, not all: gcalFetch THROWS on a timeout or a network error, and a single
-      // rejection would discard every batch that answered fine. Non-2xx already degraded per batch;
-      // a thrown one has to degrade the same way or the contract is a coin flip on failure mode.
-      // Concurrency needs no separate bound: MAX_AGGREGATE_CALENDARS caps this at five requests.
-      const batchRes = await Promise.allSettled(
-        batches.map((ids) =>
-          gcalFetch(
-            "/freeBusy",
-            {
-              method: "POST",
-              token,
-              body: {
-                timeMin: input.timeMin,
-                timeMax: input.timeMax,
-                timeZone,
-                items: ids.map((id) => ({ id })),
-              },
-            },
-            ctx,
-          ),
-        ),
+      const read = await readBusySources(
+        calendarIds,
+        labels,
+        input.timeMin,
+        input.timeMax,
+        timeZone,
+        token,
+        ctx,
       );
-      // NOTE: A batch that failed contributes no entries, so its calendars fall through the same
-      // "unreadable" path as a calendar Google refused individually. Only a total failure surfaces
-      // the HTTP status, which keeps the single-batch case answering exactly as it always did.
-      const calendars: Record<string, unknown> = {};
-      let lastStatus: number | null = null;
-      let threw = false;
-      for (const r of batchRes) {
-        if (r.status === "rejected") {
-          logger.warn({ err: r.reason }, "gcal: freeBusy batch failed");
-          threw = true;
-          continue;
-        }
-        if (r.value.status < 200 || r.value.status >= 300) {
-          lastStatus = r.value.status;
-          continue;
-        }
-        const d = (r.value.json ?? {}) as Record<string, unknown>;
-        Object.assign(
-          calendars,
-          (d.calendars ?? {}) as Record<string, unknown>,
-        );
-      }
-      // NOTE: Nothing came back at all, and the three ways that happens stay distinguishable, exactly
-      // as the single-batch path always reported them. The last one is a 2xx whose body was empty,
-      // malformed, or truncated by MAX_RESPONSE_CHARS before parsing: there is no status to quote
-      // (saying "HTTP null" is worse than saying nothing), and it is retriable, so it reads as such.
-      if (Object.keys(calendars).length === 0) {
-        if (lastStatus !== null) {
-          return toolFailure(`Google Calendar returned HTTP ${lastStatus}.`);
-        }
-        return toolFailure(
-          threw
-            ? "Failed to reach Google Calendar. Try again shortly."
-            : "Google Calendar's availability response could not be read. Try again shortly.",
-        );
-      }
-      // NOTE: Per-calendar outcome. freeBusy answers 200 and reports a calendar it could not read as a
-      // per-calendar `errors` array (a revoked share, a deleted calendar), so the failure is INSIDE a
-      // successful response. Such a calendar is dropped, never carried with an empty busy list: empty
-      // busy means "free all day", and offering a professional whose bookings we cannot see is a
-      // double booking. Dropping it only under-offers, and the caller is told which ones went missing
-      // so the reply can say so instead of pretending the clinic is smaller than it is.
-      const sources: CalendarSource[] = [];
-      const unreadable: string[] = [];
-      for (const id of calendarIds) {
-        const entry = (calendars[id] ?? null) as Record<string, unknown> | null;
-        const errors = entry && Array.isArray(entry.errors) ? entry.errors : [];
-        if (!entry || errors.length > 0) {
-          unreadable.push(labels[id] ?? id);
-          continue;
-        }
-        const busy = (Array.isArray(entry.busy) ? entry.busy : [])
-          .map((b) => (b ?? {}) as Record<string, unknown>)
-          .filter(
-            (b) => typeof b.start === "string" && typeof b.end === "string",
-          )
-          .map((b) => ({ start: b.start as string, end: b.end as string }));
-        sources.push({
-          calendarId: id,
-          calendarLabel: labels[id] ?? null,
-          busy,
-        });
-      }
-      // NOTE: Nothing readable at all: an empty slot list would read as "fully booked", which sends the
-      // customer away from a clinic that is open. Say we could not check instead.
-      if (sources.length === 0) {
-        return toolFailure(
-          `Availability cannot be verified right now: no configured calendar could be read (${unreadable.join(", ")}).`,
-        );
-      }
-      // Blocking calendars (holidays, closures) count as busy too, read via events.list, NOT
-      // freeBusy: all-day events (the typical holiday shape) default to transparency "transparent"
-      // ("Free") and freeBusy silently ignores them, which is exactly the calendar the operator
-      // expects to block. Only start/end are requested (no titles or attendees reach the model).
-      // Fail-closed: a blocking calendar we cannot read could be hiding a closure, so refusing
-      // beats offering a slot the operator explicitly blocked.
-      // Which blocking calendars have to be READ. A blocker is skipped only when the query covers
-      // nothing but that same calendar: its own bookings already arrive via freeBusy, and reading it
-      // as a blocker would turn its transparent events into blocks of itself. With siblings in the
-      // query it MUST be read, because a calendar can be operable and still carry closures its
-      // siblings have to respect. Dropping it whenever it appeared in the query (an earlier revision
-      // of this change) made an all-day closure on a doubly-listed calendar invisible to everyone.
-      const blockingWindows: Array<{
-        id: string;
-        windows: { start: string; end: string }[];
-      }> = [];
-      const blocking = blockingIds.filter((id) =>
-        sources.some((s) => s.calendarId !== id),
+      if (!read.ok) return read.refusal;
+      const { sources, unreadable } = read;
+      const blocked = await readBlockingWindows(
+        blockingIds,
+        sources,
+        input.timeMin,
+        input.timeMax,
+        timeZone,
+        token,
+        ctx,
       );
-      if (blocking.length > MAX_BLOCKING_CALENDARS) {
-        return `Too many blocking calendars are configured (${blocking.length}; the limit is ${MAX_BLOCKING_CALENDARS}), so availability cannot be verified. Reduce the blocking calendars in the integration settings.`;
-      }
-      if (blocking.length > 0) {
-        const evParams = new URLSearchParams({
-          singleEvents: "true",
-          timeMin: input.timeMin,
-          timeMax: input.timeMax,
-          maxResults: "50",
-          fields: "items(start,end),nextPageToken",
-        });
-        let blockingRes: GcalResponse[];
-        try {
-          blockingRes = await Promise.all(
-            blocking.map((id) =>
-              gcalFetch(
-                `/calendars/${encodeURIComponent(id)}/events?${evParams.toString()}`,
-                { method: "GET", token },
-                ctx,
-              ),
-            ),
-          );
-        } catch (err) {
-          logger.warn({ err }, "gcal: blocking calendars request failed");
-          return toolFailure(
-            "Failed to read a blocking calendar (holidays/closures), so availability cannot be verified right now. Try again shortly.",
-          );
-        }
-        for (const [i, r] of blockingRes.entries()) {
-          if (r.status < 200 || r.status >= 300) {
-            return toolFailure(
-              `Google Calendar returned HTTP ${r.status} for a blocking calendar, so availability cannot be verified right now.`,
-            );
-          }
-          const evData = (r.json ?? {}) as Record<string, unknown>;
-          // A nextPageToken means the window holds more events than the cap covers; treating the
-          // partial page as complete could offer a slot the operator explicitly blocked.
-          if (typeof evData.nextPageToken === "string") {
-            return "A blocking calendar has more events in this range than can be checked at once, so availability cannot be verified right now. Try a narrower range.";
-          }
-          const items = Array.isArray(evData.items) ? evData.items : [];
-          const windows: { start: string; end: string }[] = [];
-          for (const ev of items) {
-            const w = blockingBusyWindow(
-              (ev ?? {}) as Record<string, unknown>,
-              timeZone,
-            );
-            if (w) windows.push(w);
-          }
-          blockingWindows.push({ id: blocking[i] as string, windows });
-        }
-      }
+      if (!blocked.ok) return blocked.refusal;
+      const blockingWindows = blocked.windows;
       // The service hours bounding bookable slots: the integration's chosen BusinessHours (windows +
       // its own timezone). Unset/missing ⇒ no time-of-day filter ("always on"); we then fall back to
       // the integration's display timezone for the slot labels.
@@ -949,16 +1012,9 @@ function buildCheckAvailabilityTool(
           exceptions: [],
           timezone: timeZone,
         },
-        // NOTE: Each source's busy list is assembled HERE: its own bookings plus every blocking calendar
-        // except itself.
         sources: sources.map((src) => ({
           ...src,
-          busy: [
-            ...src.busy,
-            ...blockingWindows
-              .filter((b) => b.id !== src.calendarId)
-              .flatMap((b) => b.windows),
-          ],
+          busy: busyForSource(src, blockingWindows),
         })),
         slotMinutes: resolveSlotDuration(sel.config, input.slotDurationMinutes),
         granularityMinutes: resolveSlotGranularity(sel.config),
@@ -994,6 +1050,135 @@ function buildCheckAvailabilityTool(
   );
 }
 
+// The instant a Calendar start/end names, or null when it names a whole DAY instead. Same shape test
+// as toEventTime, so "what Google would store as all-day" and "what the booking rule cannot judge"
+// are the same question answered once.
+function timedInstantMs(value: string): number | null {
+  const v = value.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v)) return null;
+  const ms = Date.parse(v);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+// A Calendar start/end the booking rule can judge: a real instant, not an all-day date. All-day is
+// refused rather than exempted — availability never offers a whole day, so exempting it would leave
+// the one shape of write that skips the rule entirely (issue #345).
+const NOT_A_TIMED_EVENT =
+  "An appointment needs a start and end time, not a whole day. Pass ISO 8601 timestamps with an offset (e.g. 2026-06-20T14:00:00-03:00).";
+
+// The requested time is not one availability would have offered. The times that ARE bookable travel
+// with the refusal: a bare "unavailable" makes the agent apologise and end the turn, while a list of
+// real starts lets it propose one, and they cost nothing extra because the read that answered the
+// question already covered the whole day.
+function notBookableMessage(alternatives: Slot[]): string {
+  if (alternatives.length === 0) {
+    return "That time is not a bookable appointment slot, and nothing else is bookable that day. Call calendar_check_availability for another day and offer the customer a time from it.";
+  }
+  return `That time is not a bookable appointment slot. Bookable times that day: ${alternatives
+    .map((s) => s.label)
+    .join(
+      ", ",
+    )}. Offer one of these to the customer and use its exact start and end.`;
+}
+
+// The availability read failed, so whether the time is free is unknown. Writing anyway is the double
+// booking this rule exists to prevent, so the write is refused and the reason is carried through.
+function unverifiableMessage(
+  refusal: string | ToolFailure,
+): string | ToolFailure {
+  const detail = refusal instanceof ToolFailure ? refusal.message : refusal;
+  const text = `The appointment was not saved: availability cannot be verified right now. ${detail}`;
+  return refusal instanceof ToolFailure ? toolFailure(text) : text;
+}
+
+// Judges a requested appointment against the same availability the read tool answers with, for ONE
+// calendar over the local day that holds it. `excludeBusy` is the appointment being moved: its own
+// booking comes back in freeBusy, and a reschedule that did not remove it would collide with itself.
+async function judgeWrite(opts: {
+  sel: IntegrationSelection;
+  ctx: ToolpackCtx;
+  token: string;
+  calendarId: string;
+  labels: Record<string, string>;
+  timeZone: string;
+  blockingIds: string[];
+  businessHoursId: string | null;
+  start: string;
+  end: string;
+  excludeBusy: BusyWindow | null;
+}): Promise<{ ok: true } | { ok: false; refusal: string | ToolFailure }> {
+  const startMs = timedInstantMs(opts.start);
+  const endMs = timedInstantMs(opts.end);
+  if (startMs === null || endMs === null) {
+    return { ok: false, refusal: NOT_A_TIMED_EVENT };
+  }
+  if (endMs <= startMs) {
+    return {
+      ok: false,
+      refusal: "The appointment must end after it starts.",
+    };
+  }
+  const schedule =
+    opts.businessHoursId && opts.ctx.resolveBusinessHours
+      ? await opts.ctx.resolveBusinessHours(opts.businessHoursId)
+      : null;
+  // No schedule ⇒ always on, judged in the integration's display timezone, exactly as the
+  // availability tool treats an unset businessHoursId.
+  const effective: Schedule = schedule ?? {
+    windows: [],
+    exceptions: [],
+    timezone: opts.timeZone,
+  };
+  const window = bookingWindow(startMs, endMs, effective.timezone);
+  const read = await readBusySources(
+    [opts.calendarId],
+    opts.labels,
+    window.timeMin,
+    window.timeMax,
+    opts.timeZone,
+    opts.token,
+    opts.ctx,
+  );
+  if (!read.ok)
+    return { ok: false, refusal: unverifiableMessage(read.refusal) };
+  const blocked = await readBlockingWindows(
+    opts.blockingIds,
+    read.sources,
+    window.timeMin,
+    window.timeMax,
+    opts.timeZone,
+    opts.token,
+    opts.ctx,
+  );
+  if (!blocked.ok) {
+    return { ok: false, refusal: unverifiableMessage(blocked.refusal) };
+  }
+  const source = read.sources[0] as CalendarSource;
+  const busy = subtractWindow(
+    busyForSource(source, blocked.windows),
+    opts.excludeBusy,
+  );
+  // The appointment length the operator sells: pinned by config when there is one, otherwise the
+  // length the model asked for. Both go through resolveSlotDuration so the write is judged against
+  // the very same clamping the availability answer was built with.
+  const preset = configuredSlotDuration(opts.sel.config);
+  const verdict = judgeBooking({
+    start: opts.start,
+    end: opts.end,
+    now: new Date(),
+    schedule: effective,
+    busy,
+    slotMinutes: resolveSlotDuration(
+      opts.sel.config,
+      preset === null ? (endMs - startMs) / 60_000 : undefined,
+    ),
+    granularityMinutes: resolveSlotGranularity(opts.sel.config),
+    minLeadMinutes: resolveMinLead(opts.sel.config),
+  });
+  if (verdict.bookable) return { ok: true };
+  return { ok: false, refusal: notBookableMessage(verdict.alternatives) };
+}
+
 function buildCreateEventTool(
   sel: IntegrationSelection,
   ctx: ToolpackCtx,
@@ -1002,6 +1187,8 @@ function buildCreateEventTool(
   const labels = resolveCalendarLabels(sel.config);
   const timeZone = resolveTimeZone(sel.config);
   const meetEnabled = resolveCreateMeetLink(sel.config);
+  const blockingIds = resolveBlockingCalendarIds(sel.config);
+  const businessHoursId = resolveBusinessHoursId(sel.config);
   return failableTool(
     async (input: {
       summary: string;
@@ -1017,6 +1204,20 @@ function buildCreateEventTool(
       const pick = pickCalendarId(allowed, labels, input.calendarId);
       if ("error" in pick) return pick.error;
       const calendarId = pick.id;
+      const judged = await judgeWrite({
+        sel,
+        ctx,
+        token,
+        calendarId,
+        labels,
+        timeZone,
+        blockingIds,
+        businessHoursId,
+        start: input.start,
+        end: input.end,
+        excludeBusy: null,
+      });
+      if (!judged.ok) return judged.refusal;
       const body: Record<string, unknown> = {
         summary: input.summary,
         start: toEventTime(input.start, timeZone),
@@ -1107,7 +1308,7 @@ function buildCreateEventTool(
     {
       name: "calendar_create_event",
       description: withCalendarContext(
-        `Create an appointment for THIS customer on the calendar (it is automatically tagged to this customer, so only they can later see or change it). Provide a summary plus start and end. Use ISO 8601 with an offset for timed events (e.g. 2026-06-20T14:00:00-03:00) or a bare date (2026-06-20) for an all-day event. Returns the created appointment's id and links${meetEnabled ? "; share meetLink (the Google Meet room) with the customer — htmlLink is only the calendar page" : ""}.`,
+        `Create an appointment for THIS customer on the calendar (it is automatically tagged to this customer, so only they can later see or change it). Provide a summary plus start and end, as ISO 8601 with an offset (e.g. 2026-06-20T14:00:00-03:00). The requested time is CHECKED against the same availability calendar_check_availability answers with — the service hours, the appointment length, the start times the business offers, the minimum notice and the existing bookings — and a time that tool would not have offered is refused, with the bookable times of that day in the refusal so you can offer one instead. So book a slot exactly as availability returned it: never round it, shift it or invent a time in between. Returns the created appointment's id and links${meetEnabled ? "; share meetLink (the Google Meet room) with the customer — htmlLink is only the calendar page" : ""}.`,
         calendarContextXml(allowed, labels),
       ),
       schema: calendarArgSchema(CREATE_EVENT_SCHEMA, allowed),
@@ -1122,6 +1323,8 @@ function buildUpdateEventTool(
   const allowed = resolveAllowedCalendarIds(sel.config);
   const labels = resolveCalendarLabels(sel.config);
   const timeZone = resolveTimeZone(sel.config);
+  const blockingIds = resolveBlockingCalendarIds(sel.config);
+  const businessHoursId = resolveBusinessHoursId(sel.config);
   return failableTool(
     async (input: {
       eventId: string;
@@ -1153,7 +1356,7 @@ function buildUpdateEventTool(
       let owner: GcalResponse;
       try {
         owner = await gcalFetch(
-          `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(input.eventId)}?fields=extendedProperties`,
+          `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(input.eventId)}?fields=extendedProperties,start,end`,
           { method: "GET", token },
           ctx,
         );
@@ -1169,6 +1372,42 @@ function buildUpdateEventTool(
       }
       const ownerEv = (owner.json ?? {}) as Record<string, unknown>;
       if (eventStamp(ownerEv) !== stamp) return FOREIGN_EVENT;
+      // A move is judged by the same rule a create is (issue #345). Only a move: an edit that leaves
+      // start and end alone changes nothing availability has an opinion about, and paying a read to
+      // rename an appointment would be a request for nothing.
+      if (input.start !== undefined || input.end !== undefined) {
+        const currentStart = flattenTime(ownerEv.start);
+        const currentEnd = flattenTime(ownerEv.end);
+        const nextStart = input.start ?? currentStart;
+        const nextEnd = input.end ?? currentEnd;
+        if (nextStart === null || nextEnd === null) {
+          return toolFailure(
+            "Google Calendar did not return the appointment's current times, so the new time cannot be checked. Try again shortly.",
+          );
+        }
+        const judged = await judgeWrite({
+          sel,
+          ctx,
+          token,
+          calendarId,
+          labels,
+          timeZone,
+          blockingIds,
+          businessHoursId,
+          start: nextStart,
+          end: nextEnd,
+          // The appointment being moved: its own booking comes back as busy, and leaving it in place
+          // would make every reschedule collide with itself.
+          excludeBusy:
+            currentStart &&
+            currentEnd &&
+            timedInstantMs(currentStart) !== null &&
+            timedInstantMs(currentEnd) !== null
+              ? { start: currentStart, end: currentEnd }
+              : null,
+        });
+        if (!judged.ok) return judged.refusal;
+      }
       let res: GcalResponse;
       try {
         res = await gcalFetch(
@@ -1220,7 +1459,7 @@ function buildUpdateEventTool(
     {
       name: "calendar_update_event",
       description: withCalendarContext(
-        `Reschedule or edit THIS customer's appointment (by its id, e.g. from calendar_list_events). Only an appointment belonging to this customer can be changed. Provide ONLY the fields to change. Dates use the same ISO 8601 / all-day format as create.`,
+        `Reschedule or edit THIS customer's appointment (by its id, e.g. from calendar_list_events). Only an appointment belonging to this customer can be changed. Provide ONLY the fields to change; times use the same ISO 8601 format as create. A new start or end is checked against availability exactly as a create is, so a time it would not have offered is refused — an edit that leaves the time alone is never checked.`,
         calendarContextXml(allowed, labels),
       ),
       schema: calendarArgSchema(UPDATE_EVENT_SCHEMA, allowed),

--- a/src/modules/integrations/toolpacks/google-calendar.ts
+++ b/src/modules/integrations/toolpacks/google-calendar.ts
@@ -14,7 +14,7 @@ import {
   type Slot,
   subtractWindow,
   zonedMidnightMs,
-  zonedWallClockMs,
+  zonedWallClock,
 } from "./calendar-slots";
 import {
   type IntegrationSelection,
@@ -1068,10 +1068,15 @@ const HAS_OFFSET_RE = /(?:Z|[+-]\d{2}:?\d{2})$/i;
 function timedInstantMs(value: string, timeZone: string): number | null {
   const v = value.trim();
   if (ALL_DAY_RE.test(v)) return null;
-  const ms = HAS_OFFSET_RE.test(v)
-    ? Date.parse(v)
-    : zonedWallClockMs(v, timeZone);
-  return Number.isNaN(ms) ? null : ms;
+  if (HAS_OFFSET_RE.test(v)) {
+    const ms = Date.parse(v);
+    return Number.isNaN(ms) ? null : ms;
+  }
+  // A wall clock the timezone SKIPS (the spring-forward hour) names no instant. Refusing it is the
+  // same rule as everywhere else here: this tool does not guess a timestamp, and an explicit offset
+  // is always available to say exactly which side of the shift was meant.
+  const { ms, exists } = zonedWallClock(v, timeZone);
+  return exists && !Number.isNaN(ms) ? ms : null;
 }
 
 // A Calendar start/end the booking rule can judge: a real instant, not an all-day date. All-day is
@@ -1152,7 +1157,20 @@ async function judgeWrite(opts: {
     exceptions: [],
     timezone: opts.timeZone,
   };
-  const window = bookingWindow(startMs, endMs, effective.timezone);
+  // The appointment length the operator sells: pinned by config when there is one, otherwise the
+  // length the model asked for. Both go through resolveSlotDuration so the write is judged against
+  // the very same clamping the availability answer was built with. Resolved BEFORE the read,
+  // because it is what bounds the range the read asks Google for.
+  const preset = configuredSlotDuration(opts.sel.config);
+  const slotMinutes = resolveSlotDuration(
+    opts.sel.config,
+    preset === null ? (endMs - startMs) / 60_000 : undefined,
+  );
+  const window = bookingWindow(
+    startMs,
+    slotMinutes * 60_000,
+    effective.timezone,
+  );
   const read = await readBusySources(
     [opts.calendarId],
     opts.labels,
@@ -1181,20 +1199,13 @@ async function judgeWrite(opts: {
     { ...source, busy: subtractWindow(source.busy, opts.excludeBusy) },
     blocked.windows,
   );
-  // The appointment length the operator sells: pinned by config when there is one, otherwise the
-  // length the model asked for. Both go through resolveSlotDuration so the write is judged against
-  // the very same clamping the availability answer was built with.
-  const preset = configuredSlotDuration(opts.sel.config);
   const verdict = judgeBooking({
     startMs,
     endMs,
     now: new Date(),
     schedule: effective,
     busy,
-    slotMinutes: resolveSlotDuration(
-      opts.sel.config,
-      preset === null ? (endMs - startMs) / 60_000 : undefined,
-    ),
+    slotMinutes,
     granularityMinutes: resolveSlotGranularity(opts.sel.config),
     minLeadMinutes: resolveMinLead(opts.sel.config),
   });
@@ -1367,11 +1378,12 @@ function buildUpdateEventTool(
       const body: Record<string, unknown> = {};
       if (input.summary !== undefined) body.summary = input.summary;
       if (input.description !== undefined) body.description = input.description;
-      if (input.start !== undefined)
-        body.start = toEventTimePatch(input.start, timeZone);
-      if (input.end !== undefined)
-        body.end = toEventTimePatch(input.end, timeZone);
-      if (Object.keys(body).length === 0) {
+      if (
+        input.summary === undefined &&
+        input.description === undefined &&
+        input.start === undefined &&
+        input.end === undefined
+      ) {
         return "No fields provided. Set at least one of summary, start, end or description.";
       }
       // Ownership gate: re-fetch the event and refuse unless it carries THIS customer's stamp, so the
@@ -1412,7 +1424,16 @@ function buildUpdateEventTool(
       const moved =
         (input.start !== undefined || input.end !== undefined) &&
         (at(nextStart) !== at(currentStart) || at(nextEnd) !== at(currentEnd));
+      // The times go in the patch only when they MOVED, which is the same condition that decides
+      // whether to judge them. Echoing an unchanged value back would rewrite its representation for
+      // no reason, and for a legacy all-day appointment that rewrite is invalid: `toEventTimePatch`
+      // emits the timed shape, so a bare `YYYY-MM-DD` resent alongside a rename would reach Google
+      // as a `dateTime` of "2099-06-22" with the `date` cleared, and be rejected.
       if (moved) {
+        if (input.start !== undefined)
+          body.start = toEventTimePatch(input.start, timeZone);
+        if (input.end !== undefined)
+          body.end = toEventTimePatch(input.end, timeZone);
         if (nextStart === null || nextEnd === null) {
           return toolFailure(
             "Google Calendar did not return the appointment's current times, so the new time cannot be checked. Try again shortly.",
@@ -1435,6 +1456,9 @@ function buildUpdateEventTool(
           excludeBusy: eventBusyWindow(ownerEv, timeZone),
         });
         if (!judged.ok) return judged.refusal;
+      }
+      if (Object.keys(body).length === 0) {
+        return "The appointment already has those times, and nothing else was given to change.";
       }
       let res: GcalResponse;
       try {

--- a/tests/lib/astral-cap-sweep.test.ts
+++ b/tests/lib/astral-cap-sweep.test.ts
@@ -405,6 +405,9 @@ const BARE_SLICES: Record<
     2,
     "parse-only + fixed-format",
   ],
+  // The refusal a calendar write answers with lists the nearest bookable slots; the cut bounds that
+  // LIST, and each entry is a slot object this code built, never received text.
+  "src/modules/integrations/toolpacks/calendar-slots.ts": [1, "array"],
   "src/modules/integrations/toolpacks/google-calendar.ts": [1, "parse-only"],
   "src/modules/integrations/toolpacks/google-drive.ts": [1, "parse-only"],
   // Zod issue PATHS, which name our own schema's keys, never the received values.

--- a/tests/modules/calendar-slots.test.ts
+++ b/tests/modules/calendar-slots.test.ts
@@ -448,8 +448,8 @@ describe("judgeBooking — the rule a calendar write has to pass", () => {
       const v = judgeBooking({
         ...hourly,
         ...c.over,
-        start: c.start,
-        end: c.end,
+        startMs: Date.parse(c.start),
+        endMs: Date.parse(c.end),
       });
       expect(v.bookable).toBe(c.bookable);
       if (c.offers !== undefined) {
@@ -464,8 +464,8 @@ describe("judgeBooking — the rule a calendar write has to pass", () => {
     const v = judgeBooking({
       ...hourly,
       busy: [{ start: iso("14:00"), end: iso("15:00") }],
-      start: iso("14:15"),
-      end: iso("15:15"),
+      startMs: Date.parse(iso("14:15")),
+      endMs: Date.parse(iso("15:15")),
     });
     expect(v.bookable).toBe(false);
     expect(v.alternatives.map((s) => localHM(s.start))).not.toContain("14:00");
@@ -474,8 +474,8 @@ describe("judgeBooking — the rule a calendar write has to pass", () => {
         judgeBooking({
           ...hourly,
           busy: [{ start: iso("14:00"), end: iso("15:00") }],
-          start: alt.start,
-          end: alt.end,
+          startMs: Date.parse(alt.start),
+          endMs: Date.parse(alt.end),
         }).bookable,
       ).toBe(true);
     }
@@ -489,8 +489,8 @@ describe("judgeBooking — the rule a calendar write has to pass", () => {
       schedule: { ...schedule, windows: [] },
       granularityMinutes: 60,
       slotMinutes: 120,
-      start: iso("23:00"),
-      end: "2026-06-23T01:00:00-03:00",
+      startMs: Date.parse(iso("23:00")),
+      endMs: Date.parse("2026-06-23T01:00:00-03:00"),
     });
     expect(v.bookable).toBe(true);
   });

--- a/tests/modules/calendar-slots.test.ts
+++ b/tests/modules/calendar-slots.test.ts
@@ -7,6 +7,8 @@ import type {
 import {
   computeAggregatedSlots,
   computeAvailableSlots,
+  judgeBooking,
+  subtractWindow,
 } from "@/modules/integrations/toolpacks/calendar-slots";
 
 // America/Sao_Paulo is a fixed UTC-3 (no DST since 2019), so -03:00 ISO offsets are stable here.
@@ -342,5 +344,192 @@ describe("computeAggregatedSlots", () => {
     });
     expect(r.slots).toHaveLength(2);
     expect(localHM(r.coveredUntil as string)).toBe("09:30");
+  });
+});
+
+// Issue #345: the write path judges a requested appointment by asking the SAME generator the
+// availability tool answers with. A decision table pins the rule; the toolpack tests pin that the
+// write tools consult it.
+describe("judgeBooking — the rule a calendar write has to pass", () => {
+  const schedule: Schedule = {
+    windows: [{ day: DAY, start: "09:00", end: "18:00" }],
+    exceptions: [],
+    timezone: TZ,
+  };
+  const hourly = {
+    now: farPast,
+    schedule,
+    busy: [] as { start: string; end: string }[],
+    slotMinutes: 60,
+    granularityMinutes: 60,
+    minLeadMinutes: 0,
+  };
+
+  const cases: Array<{
+    name: string;
+    start: string;
+    end: string;
+    over?: Partial<typeof hourly>;
+    bookable: boolean;
+    // The local starts the refusal offers back, when the case checks them.
+    offers?: string[];
+  }> = [
+    {
+      name: "a start availability offers, at the length it offers",
+      start: iso("14:00"),
+      end: iso("15:00"),
+      bookable: true,
+    },
+    {
+      name: "a start between the offered ones (the 14:15 of the report)",
+      start: iso("14:15"),
+      end: iso("15:15"),
+      bookable: false,
+      // The six nearest bookable starts, chronological. 14:00 and 15:00 straddle the request.
+      offers: ["12:00", "13:00", "14:00", "15:00", "16:00", "17:00"],
+    },
+    {
+      name: "the offered start, at a length the business does not sell",
+      start: iso("14:00"),
+      end: iso("14:30"),
+      bookable: false,
+    },
+    {
+      name: "outside the service hours",
+      start: iso("20:00"),
+      end: iso("21:00"),
+      bookable: false,
+    },
+    {
+      name: "on a day the weekly grid closes",
+      start: iso("14:00"),
+      end: iso("15:00"),
+      over: { schedule: { ...schedule, windows: [] as WindowSpec[] } },
+      bookable: true,
+    },
+    {
+      name: "inside the minimum notice",
+      start: iso("14:00"),
+      end: iso("15:00"),
+      over: { now: new Date(iso("13:30")), minLeadMinutes: 120 },
+      bookable: false,
+    },
+    {
+      name: "already taken by another booking",
+      start: iso("14:00"),
+      end: iso("15:00"),
+      over: { busy: [{ start: iso("14:30"), end: iso("15:30") }] },
+      bookable: false,
+    },
+    {
+      name: "in the past",
+      start: iso("14:00"),
+      end: iso("15:00"),
+      over: { now: new Date(iso("16:00")) },
+      bookable: false,
+    },
+    {
+      name: "on a date exception that closes the day",
+      start: iso("14:00"),
+      end: iso("15:00"),
+      over: {
+        schedule: {
+          ...schedule,
+          exceptions: [{ date: "2026-06-22", ranges: [] } as ScheduleException],
+        },
+      },
+      bookable: false,
+      offers: [],
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      const v = judgeBooking({
+        ...hourly,
+        ...c.over,
+        start: c.start,
+        end: c.end,
+      });
+      expect(v.bookable).toBe(c.bookable);
+      if (c.offers !== undefined) {
+        expect(v.alternatives.map((s) => localHM(s.start))).toEqual(c.offers);
+      }
+      // A bookable request carries no alternatives: there is nothing to offer instead.
+      if (c.bookable) expect(v.alternatives).toEqual([]);
+    });
+  }
+
+  test("the alternatives are bookable themselves, not just nearby", () => {
+    const v = judgeBooking({
+      ...hourly,
+      busy: [{ start: iso("14:00"), end: iso("15:00") }],
+      start: iso("14:15"),
+      end: iso("15:15"),
+    });
+    expect(v.bookable).toBe(false);
+    expect(v.alternatives.map((s) => localHM(s.start))).not.toContain("14:00");
+    for (const alt of v.alternatives) {
+      expect(
+        judgeBooking({
+          ...hourly,
+          busy: [{ start: iso("14:00"), end: iso("15:00") }],
+          start: alt.start,
+          end: alt.end,
+        }).bookable,
+      ).toBe(true);
+    }
+  });
+
+  test("an appointment running past local midnight is still judged whole", () => {
+    // The day window has to be widened by the request, or the slot the rule is asked about falls
+    // outside the range that was supposed to contain it and every late booking reads as unavailable.
+    const v = judgeBooking({
+      ...hourly,
+      schedule: { ...schedule, windows: [] },
+      granularityMinutes: 60,
+      slotMinutes: 120,
+      start: iso("23:00"),
+      end: "2026-06-23T01:00:00-03:00",
+    });
+    expect(v.bookable).toBe(true);
+  });
+});
+
+describe("subtractWindow — the appointment being moved gets out of its own way", () => {
+  const b = (s: string, e: string) => ({ start: iso(s), end: iso(e) });
+  const hm = (w: { start: string; end: string }) =>
+    `${localHM(w.start)}-${localHM(w.end)}`;
+
+  test("no cut leaves the list untouched", () => {
+    expect(subtractWindow([b("14:00", "15:00")], null).map(hm)).toEqual([
+      "14:00-15:00",
+    ]);
+  });
+
+  test("an interval that IS the cut disappears", () => {
+    expect(
+      subtractWindow([b("14:00", "15:00")], b("14:00", "15:00")).map(hm),
+    ).toEqual([]);
+  });
+
+  test("a merged block splits around the cut", () => {
+    // freeBusy merges adjacent bookings, so the appointment's own hour arrives fused to its
+    // neighbours. Removing only an exact match would leave the whole block standing.
+    expect(
+      subtractWindow([b("13:00", "17:00")], b("14:00", "15:00")).map(hm),
+    ).toEqual(["13:00-14:00", "15:00-17:00"]);
+  });
+
+  test("an overlap at one end is trimmed, not dropped", () => {
+    expect(
+      subtractWindow([b("14:30", "16:00")], b("14:00", "15:00")).map(hm),
+    ).toEqual(["15:00-16:00"]);
+  });
+
+  test("a disjoint interval survives whole", () => {
+    expect(
+      subtractWindow([b("16:00", "17:00")], b("14:00", "15:00")).map(hm),
+    ).toEqual(["16:00-17:00"]);
   });
 });

--- a/tests/modules/calendar-write-honors-availability.test.ts
+++ b/tests/modules/calendar-write-honors-availability.test.ts
@@ -444,6 +444,67 @@ describe("calendar writes honor availability — round 1 (#345)", () => {
     expect(out).toContain("not a bookable");
   });
 
+  test("a legacy all-day appointment can still be converted to a timed slot on its own day", async () => {
+    // freeBusy reports the all-day event as a day-long busy interval. Read from the request, its
+    // span is unrepresentable (a bare date is not an instant), so it stayed in the busy list and
+    // every same-day conversion collided with the very event being converted.
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return {
+          json: {
+            calendars: {
+              primary: {
+                busy: [
+                  {
+                    start: `${DAY}T00:00:00-03:00`,
+                    end: "2099-06-23T00:00:00-03:00",
+                  },
+                ],
+              },
+            },
+          },
+        };
+      if (init.method === "GET")
+        return {
+          json: {
+            id: "ev_legacy",
+            extendedProperties: stampedExt,
+            start: { date: DAY },
+            end: { date: "2099-06-23" },
+          },
+        };
+      return { json: { id: "ev_legacy" } };
+    });
+    await toolFor(
+      "calendar_update_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_legacy",
+      start: AT("14:00"),
+      end: AT("15:00"),
+    });
+    expect(writes(calls)).toHaveLength(1);
+    expect(writes(calls)[0]?.init.method).toBe("PATCH");
+  });
+
+  test("the refusal carries each alternative's exact instants, not only its label", async () => {
+    // The label has no year and no offset, and across a DST fallback two distinct slots wear the
+    // same one. The tool refuses to guess a timestamp, so it cannot ask the model to build one.
+    const { impl } = freeCalendar();
+    const out = (await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:15"),
+      end: AT("15:15"),
+    })) as string;
+    expect(out).toContain(new Date(Date.parse(AT("14:00"))).toISOString());
+    expect(out).toContain(new Date(Date.parse(AT("15:00"))).toISOString());
+  });
+
   test("resending the same times while renaming is not a move, and is not checked", async () => {
     // The appointment is in the past, so judging it would refuse. The tool promises an edit that
     // leaves the time alone is never checked, and a caller that echoes back the times it already

--- a/tests/modules/calendar-write-honors-availability.test.ts
+++ b/tests/modules/calendar-write-honors-availability.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, test } from "bun:test";
+import type { PrismaClient } from "@/../generated/prisma/client";
+import { googleCalendarToolpack } from "@/modules/integrations/toolpacks/google-calendar";
+import type {
+  IntegrationSelection,
+  ToolpackCtx,
+} from "@/modules/integrations/toolpacks/types";
+
+// Issue #345: `calendar_create_event` (and `calendar_update_event`) wrote any `start` they were
+// handed. `calendar_check_availability` enforces the service hours, the slot grid, the minimum lead
+// and the existing bookings; the write path enforced none of them, so a time availability would
+// never offer was still bookable and the operator only found out when someone showed up.
+//
+// The rule these tests pin is ONE sentence: a write only lands on a (start, end) pair that
+// `calendar_check_availability` would have returned for that window. Every case below is a way of
+// not being on that list.
+
+const TZ = "America/Sao_Paulo";
+const WD: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+function spWeekday(isoStr: string): number {
+  const s = new Intl.DateTimeFormat("en-US", {
+    timeZone: TZ,
+    weekday: "short",
+  }).format(new Date(isoStr));
+  return WD[s] ?? 0;
+}
+
+type Call = { url: string; init: RequestInit };
+
+// A fetch stub that answers per request instead of returning one canned body: the write path now
+// READS before it writes, so a single canned response cannot represent both halves.
+function routeFetch(
+  handler: (
+    url: string,
+    init: RequestInit,
+  ) => { status?: number; json: unknown },
+) {
+  const calls: Call[] = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const i = init ?? {};
+    calls.push({ url: u, init: i });
+    const r = handler(u, i);
+    return new Response(JSON.stringify(r.json), {
+      status: r.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+// The requests that actually MUTATE the calendar. The read half of the write path also touches
+// /events (blocking calendars are read with events.list), so the method is what separates them.
+function writes(calls: Call[]): Call[] {
+  return calls.filter(
+    (c) =>
+      c.url.includes("/events") &&
+      (c.init.method === "POST" || c.init.method === "PATCH"),
+  );
+}
+
+const STAMP = "1:7";
+const stampedExt = { private: { secv4Contact: STAMP } };
+const noopAssert = async () => undefined;
+
+function baseCtx(over: Partial<ToolpackCtx> = {}): ToolpackCtx {
+  return {
+    tenantId: 1n,
+    base: undefined as unknown as PrismaClient,
+    threadId: "1:1:1",
+    contactDbId: 7n,
+    resolveCredential: async () => "tok_live",
+    assertSafe: noopAssert,
+    ...over,
+  };
+}
+
+function sel(over: Partial<IntegrationSelection> = {}): IntegrationSelection {
+  return {
+    instanceId: 1n,
+    catalogType: "GOOGLE_CALENDAR",
+    config: {},
+    credentialRef: "gcal-cred",
+    enabledTools: [],
+    ...over,
+  };
+}
+
+function toolFor(
+  name: string,
+  config: Record<string, unknown>,
+  ctx: ToolpackCtx,
+) {
+  return googleCalendarToolpack.build(
+    sel({
+      enabledTools: [name],
+      config: { calendarIds: ["primary"], ...config },
+    }),
+    ctx,
+  )[0];
+}
+
+// One-hour appointments offered on the hour: the configuration the issue describes, where a 14:15
+// start is a time the business does not sell.
+const HOURLY = { slotDurationMinutes: 60, slotGranularityMinutes: 60 };
+
+// Far enough out that the real clock never makes these cases about the lead time.
+const DAY = "2099-06-22";
+const AT = (hm: string) => `${DAY}T${hm}:00-03:00`;
+
+// freeBusy answers empty, everything else is a successful write.
+function freeCalendar(busy: { start: string; end: string }[] = []) {
+  return routeFetch((url) =>
+    url.includes("/freeBusy")
+      ? { json: { calendars: { primary: { busy } } } }
+      : { json: { id: "ev_1", start: { dateTime: AT("14:00") } } },
+  );
+}
+
+describe("calendar writes honor availability (#345)", () => {
+  test("a start off the operator's grid is refused, and nothing is written", async () => {
+    const { impl, calls } = freeCalendar();
+    const out = (await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:15"),
+      end: AT("15:15"),
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("not a bookable");
+  });
+
+  test("the refusal names bookable times, so the turn can recover", async () => {
+    const { impl } = freeCalendar();
+    const out = (await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:15"),
+      end: AT("15:15"),
+    })) as string;
+    // 14:00 and 15:00 are on the grid and free; the refusal has to offer them.
+    expect(out).toContain("14:00");
+    expect(out).toContain("15:00");
+  });
+
+  test("a start already taken by another booking is refused (no double booking)", async () => {
+    const { impl, calls } = freeCalendar([
+      { start: AT("14:00"), end: AT("15:00") },
+    ]);
+    const out = (await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:00"),
+      end: AT("15:00"),
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("not a bookable");
+  });
+
+  test("a start outside the service hours is refused", async () => {
+    const { impl, calls } = freeCalendar();
+    const day = spWeekday(AT("09:00"));
+    const out = (await toolFor(
+      "calendar_create_event",
+      { ...HOURLY, businessHoursId: "5" },
+      baseCtx({
+        fetchImpl: impl,
+        resolveBusinessHours: async () => ({
+          windows: [{ day, start: "09:00", end: "12:00" }],
+          exceptions: [],
+          timezone: TZ,
+        }),
+      }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:00"),
+      end: AT("15:00"),
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("not a bookable");
+  });
+
+  test("a start inside the minimum lead is refused", async () => {
+    const { impl, calls } = routeFetch((url) =>
+      url.includes("/freeBusy")
+        ? { json: { calendars: { primary: { busy: [] } } } }
+        : { json: { id: "ev_1" } },
+    );
+    // The next hour boundary at least 30 minutes out, against a four-hour lead.
+    const soon = Math.ceil((Date.now() + 30 * 60_000) / 3_600_000) * 3_600_000;
+    const out = (await toolFor(
+      "calendar_create_event",
+      { ...HOURLY, minLeadMinutes: 240 },
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: new Date(soon).toISOString(),
+      end: new Date(soon + 3_600_000).toISOString(),
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("not a bookable");
+  });
+
+  test("an all-day event is refused: availability never offers one", async () => {
+    const { impl, calls } = freeCalendar();
+    const out = (await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: DAY,
+      end: "2099-06-23",
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("start and end time");
+  });
+
+  test("an availability read that fails refuses the write instead of writing blind", async () => {
+    const { impl, calls } = routeFetch((url) =>
+      url.includes("/freeBusy")
+        ? { status: 401, json: { error: "nope" } }
+        : { json: { id: "ev_1" } },
+    );
+    const out = (await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:00"),
+      end: AT("15:00"),
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("cannot be verified");
+  });
+
+  test("a bookable start still writes (the control: the rule refuses, it does not block)", async () => {
+    const { impl, calls } = freeCalendar();
+    await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:00"),
+      end: AT("15:00"),
+    });
+    expect(writes(calls)).toHaveLength(1);
+    expect(writes(calls)[0]?.init.method).toBe("POST");
+  });
+
+  test("rescheduling to a time off the grid is refused, and nothing is patched", async () => {
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return { json: { calendars: { primary: { busy: [] } } } };
+      if (init.method === "GET")
+        return {
+          json: {
+            id: "ev_1",
+            extendedProperties: stampedExt,
+            start: { dateTime: AT("14:00") },
+            end: { dateTime: AT("15:00") },
+          },
+        };
+      return { json: { id: "ev_1" } };
+    });
+    const out = (await toolFor(
+      "calendar_update_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_1",
+      start: AT("16:15"),
+      end: AT("17:15"),
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("not a bookable");
+  });
+
+  test("rescheduling does not collide with the appointment being moved", async () => {
+    // The event's own 14:00-15:00 window comes back in freeBusy. Moving it to 14:00 + one grid step
+    // overlaps that window, so a check that forgets to drop it refuses every reschedule.
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return {
+          json: {
+            calendars: {
+              primary: { busy: [{ start: AT("14:00"), end: AT("15:00") }] },
+            },
+          },
+        };
+      if (init.method === "GET")
+        return {
+          json: {
+            id: "ev_1",
+            extendedProperties: stampedExt,
+            start: { dateTime: AT("14:00") },
+            end: { dateTime: AT("15:00") },
+          },
+        };
+      return { json: { id: "ev_1" } };
+    });
+    await toolFor(
+      "calendar_update_event",
+      // A half-hour grid, so 14:30 IS a start the operator sells: the only thing that could refuse
+      // this move is the appointment's own window, which is what the test is about.
+      { slotDurationMinutes: 60, slotGranularityMinutes: 30 },
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_1",
+      start: AT("14:30"),
+      end: AT("15:30"),
+    });
+    expect(writes(calls)).toHaveLength(1);
+    expect(writes(calls)[0]?.init.method).toBe("PATCH");
+  });
+
+  test("an edit that does not move the appointment needs no availability read", async () => {
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return { json: { calendars: { primary: { busy: [] } } } };
+      if (init.method === "GET")
+        return { json: { id: "ev_1", extendedProperties: stampedExt } };
+      return { json: { id: "ev_1" } };
+    });
+    await toolFor(
+      "calendar_update_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({ eventId: "ev_1", summary: "Consulta (remarcada)" });
+    expect(writes(calls)).toHaveLength(1);
+    expect(calls.filter((c) => c.url.includes("/freeBusy"))).toHaveLength(0);
+  });
+});

--- a/tests/modules/calendar-write-honors-availability.test.ts
+++ b/tests/modules/calendar-write-honors-availability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { PrismaClient } from "@/../generated/prisma/client";
+import { zonedWallClock } from "@/modules/integrations/toolpacks/calendar-slots";
 import { googleCalendarToolpack } from "@/modules/integrations/toolpacks/google-calendar";
 import type {
   IntegrationSelection,
@@ -537,5 +538,100 @@ describe("calendar writes honor availability — round 1 (#345)", () => {
     });
     expect(writes(calls)).toHaveLength(1);
     expect(calls.filter((c) => c.url.includes("/freeBusy"))).toHaveLength(0);
+  });
+});
+
+// Round 2 and 3 of the review: three ways the boundary between the string the model sends and the
+// instant the rule judges leaked.
+describe("calendar writes honor availability — round 3 (#345)", () => {
+  test("unchanged all-day values are left out of the patch, not reshaped", async () => {
+    // The timed patch shape would reach Google as a `dateTime` of "2099-06-22" with `date` cleared,
+    // and be rejected — an edit that changes nothing about the time breaking the rename it carried.
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return { json: { calendars: { primary: { busy: [] } } } };
+      if (init.method === "GET")
+        return {
+          json: {
+            id: "ev_legacy",
+            extendedProperties: stampedExt,
+            start: { date: DAY },
+            end: { date: "2099-06-23" },
+          },
+        };
+      return { json: { id: "ev_legacy" } };
+    });
+    await toolFor(
+      "calendar_update_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_legacy",
+      summary: "Feriado (nome novo)",
+      start: DAY,
+      end: "2099-06-23",
+    });
+    const patch = writes(calls)[0];
+    expect(patch).toBeDefined();
+    const body = JSON.parse(String(patch?.init.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(body.summary).toBe("Feriado (nome novo)");
+    expect(body.start).toBeUndefined();
+    expect(body.end).toBeUndefined();
+  });
+
+  test("a runaway end does not widen the range the availability read asks Google for", async () => {
+    // `end` is a model argument and nothing bounds it. Widening the window by the requested span
+    // would turn one day of freeBusy into centuries before anything got the chance to refuse it.
+    const { impl, calls } = freeCalendar();
+    const out = (await toolFor(
+      "calendar_create_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: AT("14:00"),
+      end: "2200-06-22T15:00:00-03:00",
+    })) as string;
+    const freeBusy = calls.find((c) => c.url.includes("/freeBusy"));
+    const range = JSON.parse(String(freeBusy?.init.body)) as {
+      timeMin: string;
+      timeMax: string;
+    };
+    expect(Date.parse(range.timeMax) - Date.parse(range.timeMin)).toBeLessThan(
+      36 * 3_600_000,
+    );
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("not a bookable");
+  });
+
+  test("a wall clock the timezone skips is refused before any request", async () => {
+    // 02:30 does not exist on the day New York jumps 02:00 to 03:00. Resolving it anyway lands on a
+    // different instant than the string Google receives, which is the divergence being removed.
+    const { impl, calls } = freeCalendar();
+    const out = (await toolFor(
+      "calendar_create_event",
+      { ...HOURLY, timeZone: "America/New_York" },
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      summary: "Consulta",
+      start: "2026-03-08T02:30:00",
+      end: "2026-03-08T03:30:00",
+    })) as string;
+    expect(calls).toHaveLength(0);
+    expect(out).toContain("ISO 8601 timestamps with an offset");
+  });
+
+  test("a wall clock the timezone keeps is still accepted", () => {
+    // The control: the refusal above has to be about the skipped hour, not about offset-less input.
+    expect(zonedWallClock("2026-03-08T04:30:00", "America/New_York")).toEqual({
+      ms: Date.parse("2026-03-08T04:30:00-04:00"),
+      exists: true,
+    });
+    expect(
+      zonedWallClock("2026-03-08T02:30:00", "America/New_York").exists,
+    ).toBe(false);
   });
 });

--- a/tests/modules/calendar-write-honors-availability.test.ts
+++ b/tests/modules/calendar-write-honors-availability.test.ts
@@ -350,3 +350,131 @@ describe("calendar writes honor availability (#345)", () => {
     expect(calls.filter((c) => c.url.includes("/freeBusy"))).toHaveLength(0);
   });
 });
+
+// The three defects round 1 of the review found, each as the case that separates the two behaviours.
+describe("calendar writes honor availability — round 1 (#345)", () => {
+  function tzWeekday(isoStr: string, tz: string): number {
+    const s = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      weekday: "short",
+    }).format(new Date(isoStr));
+    return WD[s] ?? 0;
+  }
+
+  test("a start with no offset is read in the calendar's timezone, not the server's", async () => {
+    // Google resolves an offset-less `dateTime` with the event's own timeZone, so the rule has to
+    // resolve it the same way. Date.parse would read it in the SERVER's zone: 10:00 judged as 22:00
+    // in Tokyo (from a -03:00 runner) or 19:00 (from a UTC one), both outside the service hours.
+    const TOKYO = "Asia/Tokyo";
+    const day = tzWeekday("2099-06-22T10:00:00+09:00", TOKYO);
+    const { impl, calls } = routeFetch((url) =>
+      url.includes("/freeBusy")
+        ? { json: { calendars: { primary: { busy: [] } } } }
+        : { json: { id: "ev_tz" } },
+    );
+    const out = (await toolFor(
+      "calendar_create_event",
+      { ...HOURLY, timeZone: TOKYO, businessHoursId: "5" },
+      baseCtx({
+        fetchImpl: impl,
+        resolveBusinessHours: async () => ({
+          windows: [{ day, start: "09:00", end: "18:00" }],
+          exceptions: [],
+          timezone: TOKYO,
+        }),
+      }),
+    )?.invoke({
+      summary: "Consulta",
+      start: "2099-06-22T10:00:00",
+      end: "2099-06-22T11:00:00",
+    })) as string;
+    expect(out).not.toContain("not a bookable");
+    expect(writes(calls)).toHaveLength(1);
+  });
+
+  test("an operator closure is not punched through by the appointment being moved", async () => {
+    // The appointment moves; the closure does not. Subtracting the event's span from the ASSEMBLED
+    // busy list took an hour out of a blocking calendar's event, and the reschedule landed inside a
+    // closure the operator had declared.
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return {
+          json: {
+            calendars: {
+              primary: { busy: [{ start: AT("14:00"), end: AT("15:00") }] },
+            },
+          },
+        };
+      if (url.includes("holidays") && init.method === "GET")
+        return {
+          json: {
+            items: [
+              {
+                start: { dateTime: AT("13:00") },
+                end: { dateTime: AT("16:00") },
+              },
+            ],
+          },
+        };
+      if (init.method === "GET")
+        return {
+          json: {
+            id: "ev_1",
+            extendedProperties: stampedExt,
+            start: { dateTime: AT("14:00") },
+            end: { dateTime: AT("15:00") },
+          },
+        };
+      return { json: { id: "ev_1" } };
+    });
+    const out = (await toolFor(
+      "calendar_update_event",
+      {
+        slotDurationMinutes: 30,
+        slotGranularityMinutes: 30,
+        blockingCalendarIds: ["holidays@demo"],
+      },
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_1",
+      start: AT("14:00"),
+      end: AT("14:30"),
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("not a bookable");
+  });
+
+  test("resending the same times while renaming is not a move, and is not checked", async () => {
+    // The appointment is in the past, so judging it would refuse. The tool promises an edit that
+    // leaves the time alone is never checked, and a caller that echoes back the times it already
+    // has is doing exactly that.
+    const PAST_START = "2020-06-22T14:00:00-03:00";
+    const PAST_END = "2020-06-22T15:00:00-03:00";
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return { json: { calendars: { primary: { busy: [] } } } };
+      if (init.method === "GET")
+        return {
+          json: {
+            id: "ev_1",
+            extendedProperties: stampedExt,
+            start: { dateTime: PAST_START },
+            end: { dateTime: PAST_END },
+          },
+        };
+      return { json: { id: "ev_1" } };
+    });
+    await toolFor(
+      "calendar_update_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_1",
+      summary: "Consulta (nome novo)",
+      start: PAST_START,
+      end: PAST_END,
+    });
+    expect(writes(calls)).toHaveLength(1);
+    expect(calls.filter((c) => c.url.includes("/freeBusy"))).toHaveLength(0);
+  });
+});

--- a/tests/modules/calendar-write-honors-availability.test.ts
+++ b/tests/modules/calendar-write-honors-availability.test.ts
@@ -635,3 +635,35 @@ describe("calendar writes honor availability — round 3 (#345)", () => {
     ).toBe(false);
   });
 });
+
+describe("calendar writes honor availability — round 4 (#345)", () => {
+  test("changing a legacy all-day date reaches the refusal instead of being dropped", async () => {
+    // Both bare dates resolve to no instant, so comparing instants alone made every all-day value
+    // equal to every other: the move was classified as "nothing changed" and silently discarded.
+    const { impl, calls } = routeFetch((url, init) => {
+      if (url.includes("/freeBusy"))
+        return { json: { calendars: { primary: { busy: [] } } } };
+      if (init.method === "GET")
+        return {
+          json: {
+            id: "ev_legacy",
+            extendedProperties: stampedExt,
+            start: { date: DAY },
+            end: { date: "2099-06-23" },
+          },
+        };
+      return { json: { id: "ev_legacy" } };
+    });
+    const out = (await toolFor(
+      "calendar_update_event",
+      HOURLY,
+      baseCtx({ fetchImpl: impl }),
+    )?.invoke({
+      eventId: "ev_legacy",
+      start: "2099-06-23",
+      end: "2099-06-24",
+    })) as string;
+    expect(writes(calls)).toHaveLength(0);
+    expect(out).toContain("start and end time");
+  });
+});

--- a/tests/modules/toolpacks-google-calendar.test.ts
+++ b/tests/modules/toolpacks-google-calendar.test.ts
@@ -20,6 +20,52 @@ function stubFetch(status: number, json: unknown) {
   return { impl, calls };
 }
 
+// Since #345 the write tools READ availability before writing, so a create/update fixture has to
+// answer the freeBusy query too. Free by default: these tests are about what the write SENDS, not
+// about the booking rule (that one has its own file).
+function stubWriteFetch(
+  json: unknown,
+  busy: { start: string; end: string }[] = [],
+) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    const i = init ?? {};
+    calls.push({ url: u, init: i });
+    let body = json;
+    if (u.includes("/freeBusy")) {
+      const items = (JSON.parse(String(i.body)) as { items: { id: string }[] })
+        .items;
+      const calendars: Record<string, { busy: unknown }> = {};
+      for (const it of items) calendars[it.id] = { busy };
+      body = { calendars };
+    }
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+// The requests that MUTATE, past the availability reads that now precede them.
+function writeCalls(calls: Array<{ url: string; init: RequestInit }>) {
+  return calls.filter(
+    (c) =>
+      c.url.includes("/events") &&
+      (c.init.method === "POST" || c.init.method === "PATCH"),
+  );
+}
+
+// The request that MUTATES, past the availability read that now precedes it.
+function writeCall(calls: Array<{ url: string; init: RequestInit }>) {
+  return calls.find(
+    (c) =>
+      c.url.includes("/events") &&
+      (c.init.method === "POST" || c.init.method === "PATCH"),
+  ) as { url: string; init: RequestInit };
+}
+
 const noopAssert = async () => undefined;
 
 // América/Sao_Paulo is a fixed UTC-3 (no DST since 2019). Helpers to assert on slot wall-times.
@@ -382,19 +428,19 @@ describe("google calendar toolpack — per-contact isolation", () => {
   });
 
   test("create stamps the event with the contact and never sends attendees", async () => {
-    const { impl, calls } = stubFetch(200, { id: "ev_1" });
+    const { impl, calls } = stubWriteFetch({ id: "ev_1" });
     await toolFor(
       "calendar_create_event",
       {},
       baseCtx({ fetchImpl: impl }),
     )?.invoke({
       summary: "Consulta",
-      start: "2026-06-20T14:00:00-03:00",
-      end: "2026-06-20T15:00:00-03:00",
+      start: "2099-06-22T14:00:00-03:00",
+      end: "2099-06-22T15:00:00-03:00",
       // attendees is no longer in the schema; even if passed, it must never reach Google.
       attendees: ["lead@example.com"],
     });
-    const body = bodyOf(calls[0] as { init: RequestInit });
+    const body = bodyOf(writeCall(calls));
     expect(body.extendedProperties).toEqual(stampedExt);
     expect(body.attendees).toBeUndefined();
   });
@@ -519,9 +565,9 @@ describe("google calendar toolpack — per-contact isolation", () => {
 
 describe("google calendar toolpack — appointment reminders + confirmation", () => {
   test("create arms reminders via ctx (eventId + calendarId + startISO)", async () => {
-    const { impl } = stubFetch(200, {
+    const { impl } = stubWriteFetch({
       id: "ev_1",
-      start: { dateTime: "2026-06-25T10:00:00-03:00" },
+      start: { dateTime: "2099-06-23T10:00:00-03:00" },
     });
     const scheduled: Array<{
       eventId: string;
@@ -548,24 +594,24 @@ describe("google calendar toolpack — appointment reminders + confirmation", ()
       }),
     )?.invoke({
       summary: "Consulta",
-      start: "2026-06-25T10:00:00-03:00",
-      end: "2026-06-25T11:00:00-03:00",
+      start: "2099-06-23T10:00:00-03:00",
+      end: "2099-06-23T11:00:00-03:00",
     });
     expect(scheduled).toHaveLength(1);
     // The policy (offsets + confirmation) flows from the integration config, not the agent.
     expect(scheduled[0]).toMatchObject({
       eventId: "ev_1",
       calendarId: "primary",
-      startISO: "2026-06-25T10:00:00-03:00",
+      startISO: "2099-06-23T10:00:00-03:00",
       offsetsHours: [24, 1],
       askConfirmationOnLast: true,
     });
   });
 
   test("create does NOT arm reminders when the integration has them disabled", async () => {
-    const { impl } = stubFetch(200, {
+    const { impl, calls } = stubWriteFetch({
       id: "ev_2",
-      start: { dateTime: "2026-06-25T10:00:00-03:00" },
+      start: { dateTime: "2099-06-23T10:00:00-03:00" },
     });
     let armed = false;
     await toolFor(
@@ -579,9 +625,11 @@ describe("google calendar toolpack — appointment reminders + confirmation", ()
       }),
     )?.invoke({
       summary: "Consulta",
-      start: "2026-06-25T10:00:00-03:00",
-      end: "2026-06-25T11:00:00-03:00",
+      start: "2099-06-23T10:00:00-03:00",
+      end: "2099-06-23T11:00:00-03:00",
     });
+    // The create has to LAND, or "no reminder was armed" would be true of a refused write too.
+    expect(writeCall(calls)).toBeDefined();
     expect(armed).toBe(false);
   });
 
@@ -659,11 +707,11 @@ describe("google calendar toolpack — appointment reminders + confirmation", ()
 
 describe("google calendar toolpack — event date shaping + default timezone", () => {
   test("create: a timed start/end becomes dateTime + the config timeZone", async () => {
-    const { impl, calls } = stubFetch(200, {
+    const { impl, calls } = stubWriteFetch({
       id: "ev_1",
       summary: "Call",
-      start: { dateTime: "2026-06-20T14:00:00-03:00" },
-      end: { dateTime: "2026-06-20T15:00:00-03:00" },
+      start: { dateTime: "2099-06-22T14:00:00-03:00" },
+      end: { dateTime: "2099-06-22T15:00:00-03:00" },
       htmlLink: "https://cal/ev_1",
     });
     const out = (await toolFor(
@@ -672,51 +720,50 @@ describe("google calendar toolpack — event date shaping + default timezone", (
       baseCtx({ fetchImpl: impl }),
     )?.invoke({
       summary: "Call",
-      start: "2026-06-20T14:00:00-03:00",
-      end: "2026-06-20T15:00:00-03:00",
+      start: "2099-06-22T14:00:00-03:00",
+      end: "2099-06-22T15:00:00-03:00",
     })) as string;
-    const body = bodyOf(calls[0] as { init: RequestInit });
+    const body = bodyOf(writeCall(calls));
     expect(body.start).toEqual({
-      dateTime: "2026-06-20T14:00:00-03:00",
+      dateTime: "2099-06-22T14:00:00-03:00",
       timeZone: "America/Bahia",
     });
     expect(JSON.parse(out)).toMatchObject({
       id: "ev_1",
-      start: "2026-06-20T14:00:00-03:00",
+      start: "2099-06-22T14:00:00-03:00",
       htmlLink: "https://cal/ev_1",
     });
   });
 
-  test("create: a bare date is an all-day event (date, no timeZone)", async () => {
-    const { impl, calls } = stubFetch(200, { id: "ev_2" });
-    await toolFor(
+  test("create: a bare date is refused — a whole day is never a bookable slot", async () => {
+    const { impl, calls } = stubWriteFetch({ id: "ev_2" });
+    const out = (await toolFor(
       "calendar_create_event",
       {},
       baseCtx({ fetchImpl: impl }),
     )?.invoke({
       summary: "Holiday",
-      start: "2026-06-20",
-      end: "2026-06-21",
-    });
-    const body = bodyOf(calls[0] as { init: RequestInit });
-    expect(body.start).toEqual({ date: "2026-06-20" });
-    expect(body.end).toEqual({ date: "2026-06-21" });
+      start: "2099-06-22",
+      end: "2099-06-23",
+    })) as string;
+    expect(writeCall(calls)).toBeUndefined();
+    expect(out).toContain("start and end time");
   });
 
   test("create: with no configured timeZone, timed events anchor to São Paulo", async () => {
-    const { impl, calls } = stubFetch(200, { id: "ev_4" });
+    const { impl, calls } = stubWriteFetch({ id: "ev_4" });
     await toolFor(
       "calendar_create_event",
       {},
       baseCtx({ fetchImpl: impl }),
     )?.invoke({
       summary: "Call",
-      start: "2026-06-20T14:00:00",
-      end: "2026-06-20T15:00:00",
+      start: "2099-06-22T14:00:00-03:00",
+      end: "2099-06-22T15:00:00-03:00",
     });
-    const body = bodyOf(calls[0] as { init: RequestInit });
+    const body = bodyOf(writeCall(calls));
     expect(body.start).toEqual({
-      dateTime: "2026-06-20T14:00:00",
+      dateTime: "2099-06-22T14:00:00-03:00",
       timeZone: "America/Sao_Paulo",
     });
   });
@@ -724,11 +771,13 @@ describe("google calendar toolpack — event date shaping + default timezone", (
   // A patch that sets only dateTime leaves the all-day `date` on the event, and Google rejects an
   // event carrying both (HTTP 400). Both directions must null the field they replace.
   test("update: all-day → timed nulls the date field", async () => {
-    const { impl, calls } = stubFetch(200, {
+    // An all-day event created before #345 can still be MOVED onto a bookable slot, and the patch
+    // has to clear the `date` it replaces (Google rejects an event carrying both, HTTP 400).
+    const { impl, calls } = stubWriteFetch({
       id: "ev_5",
       extendedProperties: stampedExt,
-      start: { dateTime: "2026-06-20T00:00:00-03:00" },
-      end: { dateTime: "2026-06-20T23:59:00-03:00" },
+      start: { date: "2099-06-22" },
+      end: { date: "2099-06-23" },
     });
     await toolFor(
       "calendar_update_event",
@@ -736,42 +785,40 @@ describe("google calendar toolpack — event date shaping + default timezone", (
       baseCtx({ fetchImpl: impl }),
     )?.invoke({
       eventId: "ev_5",
-      start: "2026-06-20T00:00:00-03:00",
-      end: "2026-06-20T23:59:00-03:00",
+      start: "2099-06-22T14:00:00-03:00",
+      end: "2099-06-22T15:00:00-03:00",
     });
-    // calls[0] is the ownership re-fetch; calls[1] is the PATCH.
-    const body = bodyOf(calls[1] as { init: RequestInit });
+    const body = bodyOf(writeCall(calls));
     expect(body.start).toEqual({
-      dateTime: "2026-06-20T00:00:00-03:00",
+      dateTime: "2099-06-22T14:00:00-03:00",
       timeZone: "America/Sao_Paulo",
       date: null,
     });
     expect(body.end).toEqual({
-      dateTime: "2026-06-20T23:59:00-03:00",
+      dateTime: "2099-06-22T15:00:00-03:00",
       timeZone: "America/Sao_Paulo",
       date: null,
     });
   });
 
-  test("update: timed → all-day nulls the dateTime field", async () => {
-    const { impl, calls } = stubFetch(200, {
+  test("update: a move to a whole day is refused, and nothing is patched", async () => {
+    const { impl, calls } = stubWriteFetch({
       id: "ev_6",
       extendedProperties: stampedExt,
-      start: { date: "2026-06-20" },
-      end: { date: "2026-06-21" },
+      start: { dateTime: "2099-06-22T14:00:00-03:00" },
+      end: { dateTime: "2099-06-22T15:00:00-03:00" },
     });
-    await toolFor(
+    const out = (await toolFor(
       "calendar_update_event",
       {},
       baseCtx({ fetchImpl: impl }),
     )?.invoke({
       eventId: "ev_6",
-      start: "2026-06-20",
-      end: "2026-06-21",
-    });
-    const body = bodyOf(calls[1] as { init: RequestInit });
-    expect(body.start).toEqual({ date: "2026-06-20", dateTime: null });
-    expect(body.end).toEqual({ date: "2026-06-21", dateTime: null });
+      start: "2099-06-22",
+      end: "2099-06-23",
+    })) as string;
+    expect(writeCall(calls)).toBeUndefined();
+    expect(out).toContain("start and end time");
   });
 });
 
@@ -1290,26 +1337,26 @@ describe("google calendar toolpack — Meet room on create", () => {
   const CREATED = {
     id: "ev9",
     summary: "Demo",
-    start: { dateTime: "2026-08-10T14:00:00-03:00" },
-    end: { dateTime: "2026-08-10T15:00:00-03:00" },
+    start: { dateTime: "2099-06-22T14:00:00-03:00" },
+    end: { dateTime: "2099-06-22T15:00:00-03:00" },
     htmlLink: "https://cal/ev9",
     hangoutLink: "https://meet.google.com/abc-defg-hij",
   };
   const INPUT = {
     summary: "Demo",
-    start: "2026-08-10T14:00:00-03:00",
-    end: "2026-08-10T15:00:00-03:00",
+    start: "2099-06-22T14:00:00-03:00",
+    end: "2099-06-22T15:00:00-03:00",
   };
 
   test("create asks Google for a Meet room by default (body + conferenceDataVersion=1)", async () => {
-    const { impl, calls } = stubFetch(200, CREATED);
+    const { impl, calls } = stubWriteFetch(CREATED);
     await toolFor(
       "calendar_create_event",
       {},
       baseCtx({ fetchImpl: impl }),
     )?.invoke(INPUT);
-    expect(calls[0]?.url).toContain("conferenceDataVersion=1");
-    const body = bodyOf(calls[0] as { init: RequestInit });
+    expect(writeCall(calls).url).toContain("conferenceDataVersion=1");
+    const body = bodyOf(writeCall(calls));
     const conf = body.conferenceData as {
       createRequest?: {
         requestId?: string;
@@ -1323,7 +1370,7 @@ describe("google calendar toolpack — Meet room on create", () => {
   });
 
   test("each create uses a fresh requestId", async () => {
-    const { impl, calls } = stubFetch(200, CREATED);
+    const { impl, calls } = stubWriteFetch(CREATED);
     const tool = toolFor(
       "calendar_create_event",
       {},
@@ -1333,7 +1380,8 @@ describe("google calendar toolpack — Meet room on create", () => {
     await tool?.invoke(INPUT);
     const rid = (i: number) =>
       (
-        bodyOf(calls[i] as { init: RequestInit }).conferenceData as {
+        bodyOf(writeCalls(calls)[i] as { init: RequestInit })
+          .conferenceData as {
           createRequest?: { requestId?: string };
         }
       )?.createRequest?.requestId;
@@ -1343,7 +1391,7 @@ describe("google calendar toolpack — Meet room on create", () => {
   });
 
   test("the returned event exposes meetLink (hangoutLink), the link to hand the customer", async () => {
-    const { impl } = stubFetch(200, CREATED);
+    const { impl } = stubWriteFetch(CREATED);
     const out = (await toolFor(
       "calendar_create_event",
       {},
@@ -1356,36 +1404,35 @@ describe("google calendar toolpack — Meet room on create", () => {
   });
 
   test("createMeetLink: false keeps today's body and URL (calendar as a pure busy-block)", async () => {
-    const { impl, calls } = stubFetch(200, { id: "ev9" });
+    const { impl, calls } = stubWriteFetch({ id: "ev9" });
     await toolFor(
       "calendar_create_event",
       { createMeetLink: false },
       baseCtx({ fetchImpl: impl }),
     )?.invoke(INPUT);
-    expect(calls[0]?.url).not.toContain("conferenceDataVersion");
-    expect(
-      bodyOf(calls[0] as { init: RequestInit }).conferenceData,
-    ).toBeUndefined();
+    expect(writeCall(calls).url).not.toContain("conferenceDataVersion");
+    expect(bodyOf(writeCall(calls)).conferenceData).toBeUndefined();
   });
 
   test("a pending room is re-read once so the reply still carries meetLink", async () => {
     // NOTE: the POST answers without hangoutLink (createRequest still pending); one follow-up GET has it.
     const calls: Array<{ url: string; init: RequestInit }> = [];
-    const responses: unknown[] = [
-      {
-        ...CREATED,
-        hangoutLink: undefined,
-        conferenceData: {
-          createRequest: { status: { statusCode: "pending" } },
-        },
+    const pending = {
+      ...CREATED,
+      hangoutLink: undefined,
+      conferenceData: {
+        createRequest: { status: { statusCode: "pending" } },
       },
-      CREATED,
-    ];
-    let n = 0;
+    };
     const impl = (async (url: string | URL | Request, init?: RequestInit) => {
-      calls.push({ url: String(url), init: init ?? {} });
-      const body = responses[Math.min(n, responses.length - 1)];
-      n += 1;
+      const u = String(url);
+      const i = init ?? {};
+      calls.push({ url: u, init: i });
+      const body = u.includes("/freeBusy")
+        ? { calendars: { primary: { busy: [] } } }
+        : i.method === "POST"
+          ? pending
+          : CREATED;
       return new Response(JSON.stringify(body), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -1396,8 +1443,9 @@ describe("google calendar toolpack — Meet room on create", () => {
       {},
       baseCtx({ fetchImpl: impl }),
     )?.invoke(INPUT)) as string;
-    expect(calls).toHaveLength(2);
-    expect(calls[1]?.init.method).toBe("GET");
+    const after = calls.slice(calls.indexOf(writeCall(calls)));
+    expect(after).toHaveLength(2);
+    expect(after[1]?.init.method).toBe("GET");
     expect(JSON.parse(out)).toMatchObject({
       meetLink: "https://meet.google.com/abc-defg-hij",
     });


### PR DESCRIPTION
`calendar_check_availability` enforces the service hours, the appointment length, the start times the operator sells, the minimum notice and the existing bookings. `calendar_create_event` and `calendar_update_event` enforced none of them and wrote whatever `start` string they were handed, so a time availability would never offer was still bookable and the operator found out when someone showed up.

Measured against Google's real API, with the real integration config out of the dev database (a 60-minute appointment offered on the hour, two blocking calendars). Every attempt reached the insert endpoint:

```
POST /calendars/clinica%40demo.local/events  start=2099-06-22T14:15:00-03:00   -> HTTP 401   # off the operator's own grid
POST /calendars/clinica%40demo.local/events  start=2099-06-22T15:00:00-03:00   -> HTTP 401   # an hour freeBusy reports as busy
POST /calendars/clinica%40demo.local/events  start={"date":"2099-06-22"}       -> HTTP 401   # a whole day
```

The 401 is the credential wall and nothing else: the request was built, addressed and sent. With a live token each of those creates an appointment.

## The rule

A write may only land on a `(start, end)` pair that `calendar_check_availability` would have returned for that day.

It is one sentence on purpose, and it is expressed as **membership in the generated list**, not as a second copy of the four conditions. Re-implementing them is how the two paths drift: the write would go on honouring a rule the availability path had already changed, and nothing would be red. So `judgeBooking` (in `calendar-slots.ts`, pure, no I/O) runs the same generator the read tool answers with over the local day holding the request, and asks whether the requested pair is in the output.

The list it gets back is also the refusal's content, in the same shape `calendar_check_availability` returns:

```
That time is not a bookable appointment slot. These are:
[{"start":"2099-06-22T14:00:00.000Z","end":"2099-06-22T15:00:00.000Z","label":"seg 22/06 11:00"}, …].
Offer one to the customer and pass its start and end back unchanged.
```

A bare "unavailable" makes the agent apologise and end the turn; the times it *can* offer are what lets it recover, and they cost nothing extra because the read that answered the question already covered the whole day. The exact instants travel with the label because a label carries no year and no offset, and across a DST fallback two distinct slots wear the same one.

## The boundary between the string and the instant

Half of what this change had to get right is not the rule, it is turning what the model sent into the instant the rule judges, **the same way Google will**:

- **An offset-less `dateTime` is a wall clock in the event's `timeZone`.** `Date.parse` reads it in the *server's* zone instead, so a UTC deployment serving a São Paulo calendar judges `18:00` as 15:00 and stores it as 18:00: three hours of service hours and bookings the rule never looked at. It is resolved once, at the boundary, and `judgeBooking` takes instants rather than strings so there is no second parse to disagree.
- **A wall clock the timezone SKIPS names no instant.** `2026-03-08T02:30:00` in `America/New_York` is in the hour the clocks jump over; resolving it anyway lands on 01:30, and the judge would approve one instant while Google receives a string that means another. `zonedWallClock` reports whether the wall clock exists, and the two callers take opposite decisions on purpose: a day boundary keeps the instant (a day still starts on a day that starts at 01:00), an appointment is refused.
- **All-day is refused, not exempted.** Availability never offers a whole day, so exempting it would have left the one shape of write that skips the rule entirely. That removes a capability the description advertised, so the description and the argument schema say so, and `toEventTime`/`toEventTimePatch` lost the branches only that shape reached. A legacy all-day appointment can still be **moved** onto a bookable slot (that patch clears the `date` it replaces), and moving one to a *different* whole day is refused rather than silently dropped.

## Cost

`create` goes from 1 request to 2: one `freeBusy` over the local day, plus one `events.list` per configured blocking calendar (default 0, capped at 10). `update` goes from 2 to 3, and only when the start or end **instants** actually differ from the event's own — an edit that renames an appointment is not checked, and the unchanged times are left out of the patch entirely rather than rewritten into a shape Google would reject.

The read is against **one** calendar, not the allowlist: a create targets a single calendar, so the `MAX_AGGREGATE_CALENDARS` fan-out of the availability tool does not apply. Its range is the local day widened by **one slot**, never by the requested span: `end` is a model argument and nothing bounds it, so widening by it would let an `end` centuries after `start` turn a one-day `freeBusy` into a decades-long query before anything got the chance to refuse it.

Two details that are load-bearing:

- **The appointment being moved gets out of its own way.** Its booking comes back in `freeBusy`, so a reschedule would collide with itself. Its span is read from the **event**, not from the request, so a legacy all-day appointment contributes the days it really occupies; and the subtraction is applied to the calendar's **own** bookings only, never to the assembled list, because the appointment moves and an operator closure does not. Removing the interval that matches its hour exactly is not enough either: `freeBusy` MERGES adjacent busy blocks, so a 14:00-15:00 appointment followed by a 15:00-16:00 one arrives as one 14:00-16:00 block, and `subtractWindow` splits the block around it.
- **A failed availability read refuses the write.** Whether the time is free is then unknown, and writing anyway is the double booking the rule exists to prevent. Same fail-closed stance the availability tool already takes.

## What this does NOT make impossible, deliberately

Google has no conditional insert. Two conversations answered concurrently can both pass the check while `freeBusy` still reports the slot empty, and both write. The window goes from "always" to the milliseconds between the read and the write; this is a guard, not a lock.

Closing it is a separate piece of work, not a line in this PR, and the cheap version would be worse than none. An in-process mutex reads as a solution and fails exactly where it matters, because the web tier scales — that is the shape of #203, where the in-flight turn fence is already process-local. The cross-process version is a Postgres advisory lock held **across two to three Google calls**, each with a 12-second timeout, which is the pool-draining pattern this codebase has already been bitten by. Either belongs to an issue that can weigh it, with a decision about reservations that survives a replica dying mid-booking.

One residual is unavoidable at this resolution and is written into `subtractWindow`: `freeBusy` carries no event identity, so an event that genuinely **overlaps** the one being moved loses coverage over the overlap. That is bounded to the span being vacated, on a calendar that was already double-booked there; separating them would mean reading the events themselves, which would put other customers' appointments in reach of a path that today only ever sees busy/free.

## Diff size

`google-calendar.ts` shows a large changed-line count, and most of it is a move, not new logic: the `freeBusy` read and the blocking-calendar read were inline in `calendar_check_availability` and are now `readBusySources` / `readBlockingWindows`, called by both the read tool and the write path. A second copy of "what counts as busy" is exactly how the two would start disagreeing.

## Validation scope

**Proved by test** (142 in the three calendar suites; `bun check` green at 6171):

- a decision table over `judgeBooking`: the offered start passes; the 14:15 between two offered ones fails; the offered start at a length the business does not sell fails; outside the service hours, inside the minimum notice, in the past, on a booked hour, and on a date exception that closes the day all fail; an unset business-hours config is "always on"; an appointment running past local midnight is still judged whole;
- the alternatives a refusal carries are themselves bookable, not merely nearby, and carry exact instants;
- a decision table over `subtractWindow`: exact match, merged block splitting in two, an overlap at one end trimmed, a disjoint interval untouched, and no cut at all;
- the boundary: an offset-less start is read in the calendar's timezone (a Tokyo calendar, from a runner in another zone), a wall clock the zone skips is refused before any request, and the wall clock beside it is still accepted;
- at the tool level: each way to miss the list refuses **and sends no POST/PATCH**, a bookable start still writes, an all-day input refuses before any request, a failed availability read refuses, a reschedule does not collide with itself, an operator closure is not punched through by the appointment being moved, a legacy all-day appointment can still be converted to a timed slot on its own day, changing it to another whole day is refused, resending unchanged times while renaming performs no availability read and leaves the times out of the patch, and a runaway `end` does not widen the range asked of Google.

**Mutation battery**, one mutation at a time, restored from a `cp` backup with the tree diffed against the pre-battery patch afterwards. Every rule has a test that falls when it is removed:

| mutation | tests that fell |
| --- | --- |
| `bookable` always true | 14 |
| membership ignores `end` (any length passes) | 1 |
| `subtractWindow` returns the list unchanged | 4 |
| the subtraction is applied to the assembled busy list | 1 |
| the moved event's span is read from the request, not the event | 1 |
| the day window is not widened by the slot | 1 |
| the day window is widened by the requested span | 1 |
| a bare date is treated as an instant | 3 |
| an offset-less value is parsed with `Date.parse` | 1 |
| a skipped wall clock is accepted | 1 |
| `create` does not act on the verdict | 8 |
| `update` does not act on the verdict | 2 |
| `update` checks even when the time did not change | 1 |
| the patch carries the times even when they did not move | 1 |
| "same time" compares instants only | 1 |
| a failed availability read passes instead of refusing | 1 |
| the refusal lists labels without instants | 1 |

One mutation survived: widening the window's **start** by the request. It is dead by construction (local midnight of the day holding an instant is never after it), so the guard was removed rather than tested.

**Proved live**, against `www.googleapis.com/calendar/v3`, driving the toolpack with the `IntegrationInstance` row from the dev database (`slotDurationMinutes: 60`, `slotGranularityMinutes: 60`, one operable calendar, two blocking calendars) and logging every request on the wire:

| attempt | before | after |
| --- | --- | --- |
| `14:15` (off the grid) | `POST …/events -> 401` | refused, no write, listing the bookable slots of that day with their exact instants |
| `15:00` (an hour freeBusy reports busy) | `POST …/events -> 401` | refused, no write; the alternatives skip 15:00 |
| `2099-06-22` (all day) | `POST …/events -> 401` | refused with zero requests on the wire |
| `14:00` (on the grid, free) | `POST …/events -> 401` | `POST /freeBusy -> 200`, two blocking reads, then `POST …/events -> 401` — it writes |

The window the read asks for is the local day: `timeMin=2099-06-22T03:00:00.000Z` is midnight in São Paulo.

**Not validated live**: the `freeBusy` and blocking-calendar responses in that run were served from Google-shaped bodies rather than fetched, because the dev vault holds a stub `google_oauth` credential and a real Calendar token needs a consent flow against a Cloud OAuth client that does not exist yet. Creating one is a change to a shared Google Cloud project and was not in scope here. So what is proved against the real API is the **write half** (which requests leave, with which body, in which order) and what is proved against Google-shaped data is the **decision**. No appointment was created on a real calendar, and `calendar_update_event` was exercised only by test, not on the wire.

Fixes #345
