### PR TITLE
Name a Logs group by what it is, instead of calling every group a turn

### DIFF
--- a/src/client/lib/logGroupTitle.ts
+++ b/src/client/lib/logGroupTitle.ts
@@ -1,0 +1,39 @@
+// WHAT ONE LOGS GROUP CALLS ITSELF, AND WHY THE ANSWER IS NOT ALWAYS "TURN".
+//
+// The page groups rows by `turnId`, which is a CORRELATION id and not a claim that a turn happened:
+// `route`, `command` and `webhook` each synthesize one precisely because they have no turn to belong
+// to. Until issue #357 the name fell through conversation → thread → the literal word "Turn", so a
+// group that is not a turn announced itself as one — and the stage that always landed there is the
+// one that can never be a turn: a dead or requeued outbound delivery happens on a worker tick long
+// after whatever produced the event, with no conversation, no contact and no thread.
+//
+// Measured before the fix (development database, read-only, `conversation_id IS NULL`): 5 groups, 3
+// carrying a thread and 2 carrying neither, which is the branch that reaches the word. No `webhook`
+// row was among them only because no delivery had died there yet; by construction every one would.
+export type LogGroupTitle =
+  | { kind: "conversation"; conversationId: string }
+  | { kind: "thread"; threadId: string }
+  | { kind: "stage"; stage: string }
+  | { kind: "turn" };
+
+export function logGroupTitle(group: {
+  conversationId: string | null;
+  threadId: string | null;
+  rows: readonly { stage: string }[];
+}): LogGroupTitle {
+  if (group.conversationId)
+    return { kind: "conversation", conversationId: group.conversationId };
+  if (group.threadId) return { kind: "thread", threadId: group.threadId };
+  // One stage across the whole group: name it by that stage, which is a fact the rows carry rather
+  // than an inference about them. This is the branch a `webhook` group takes — its emit gives every
+  // line its own `turnId`, so it is always a group of one.
+  const first = group.rows[0]?.stage;
+  if (first !== undefined && group.rows.every((r) => r.stage === first))
+    return { kind: "stage", stage: first };
+  // Mixed stages, no conversation and no thread — and "Turn" is honest HERE. The other two stages
+  // that hang off no turn cannot reach this branch: `route` and `command` both take a non-null
+  // conversation row id (`emitUnroutedMessage`, `emitCommandDropped`), and `webhook` is alone in its
+  // group, so what is left is made of turn steps. An empty group takes it too, which no reader can
+  // produce (a group exists because a row made it) and which is why this is not an assertion.
+  return { kind: "turn" };
+}

--- a/src/client/pages/LogsPage.tsx
+++ b/src/client/pages/LogsPage.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from "i18next";
 import {
   ChevronDown,
   ChevronLeft,
@@ -24,6 +25,7 @@ import {
 import { Tooltip } from "@/client/components/Tooltip";
 import { api } from "@/client/lib/api";
 import { flowLevelLabel, flowStageLabel } from "@/client/lib/flowLabels";
+import { type LogGroupTitle, logGroupTitle } from "@/client/lib/logGroupTitle";
 import { cn, formatDateTime } from "@/client/lib/utils";
 import { FLOW_LEVELS, FLOW_STAGES } from "@/modules/flowlog/stages";
 import { LogsExportModal } from "./LogsExportModal";
@@ -201,6 +203,24 @@ function StageRow({ row }: { row: LogItem }) {
   );
 }
 
+// The group's name, rendered. `logGroupTitle` decides WHICH of the four it is (issue #357); this
+// only turns that answer into text, so a stage that has no `case` in `flowStageLabel` degrades to
+// its slug here exactly as it does on every row.
+function groupTitleText(title: LogGroupTitle, t: TFunction): string {
+  switch (title.kind) {
+    case "conversation":
+      return t("logs.conversation", "Conversation #{{id}}", {
+        id: title.conversationId,
+      });
+    case "thread":
+      return title.threadId;
+    case "stage":
+      return flowStageLabel(title.stage, t);
+    case "turn":
+      return t("logs.turn", "Turn");
+  }
+}
+
 // One turn group: a controlled disclosure (chevron inline, no native triangle) plus per-group
 // actions when the turn is tied to a conversation — filter the log list to it (C2) or jump to the
 // conversation (C3). Error groups start expanded.
@@ -235,11 +255,7 @@ function TurnGroupCard({
           )}
           <LevelPill level={group.worstLevel} />
           <span className="truncate text-sm text-text-secondary">
-            {group.conversationId
-              ? t("logs.conversation", "Conversation #{{id}}", {
-                  id: group.conversationId,
-                })
-              : (group.threadId ?? t("logs.turn", "Turn"))}
+            {groupTitleText(logGroupTitle(group), t)}
           </span>
           <span className="text-text-muted text-xs">
             {t("logs.steps", "{{n}} steps", { n: group.rows.length })}

--- a/tests/client/lib/logGroupTitle.test.ts
+++ b/tests/client/lib/logGroupTitle.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { type LogGroupTitle, logGroupTitle } from "@/client/lib/logGroupTitle";
+import { FLOW_STAGES } from "@/modules/flowlog/stages";
+
+// Issue #357: the Logs page groups by `turnId`, which is a correlation id and not a claim that a
+// turn happened, and the group's name fell through to the literal word "Turn" whenever there was
+// neither a conversation nor a thread. Every row here is one line of the decision, so a change to
+// the ordering of the four answers shows up as a named case rather than as a rendering difference.
+
+interface Row {
+  name: string;
+  conversationId: string | null;
+  threadId: string | null;
+  stages: string[];
+  expected: LogGroupTitle;
+}
+
+const TABLE: Row[] = [
+  {
+    name: "a conversation wins over everything else it carries",
+    conversationId: "12",
+    threadId: "1:playground:1:ab",
+    stages: ["generate", "tool"],
+    expected: { kind: "conversation", conversationId: "12" },
+  },
+  {
+    name: "no conversation, a thread: the thread names it",
+    conversationId: null,
+    threadId: "1:playground:1:ab",
+    stages: ["generate", "tool"],
+    expected: { kind: "thread", threadId: "1:playground:1:ab" },
+  },
+  {
+    name: "a dead outbound delivery is named by its stage",
+    conversationId: null,
+    threadId: null,
+    stages: ["webhook"],
+    expected: { kind: "stage", stage: "webhook" },
+  },
+  {
+    name: "repeats of one stage are still that stage",
+    conversationId: null,
+    threadId: null,
+    stages: ["webhook", "webhook"],
+    expected: { kind: "stage", stage: "webhook" },
+  },
+  {
+    name: "a turn step with neither is named by the step, not by 'Turn'",
+    conversationId: null,
+    threadId: null,
+    stages: ["generate"],
+    expected: { kind: "stage", stage: "generate" },
+  },
+  {
+    name: "mixed stages with neither: 'Turn', the one place it is true",
+    conversationId: null,
+    threadId: null,
+    stages: ["generate", "tool"],
+    expected: { kind: "turn" },
+  },
+  {
+    name: "an empty conversation id is absent, not a name",
+    conversationId: "",
+    threadId: null,
+    stages: ["webhook"],
+    expected: { kind: "stage", stage: "webhook" },
+  },
+  {
+    name: "an empty thread id is absent too",
+    conversationId: null,
+    threadId: "",
+    stages: ["generate"],
+    expected: { kind: "stage", stage: "generate" },
+  },
+];
+
+describe("what a Logs group is called", () => {
+  for (const r of TABLE) {
+    test(r.name, () => {
+      expect(
+        logGroupTitle({
+          conversationId: r.conversationId,
+          threadId: r.threadId,
+          rows: r.stages.map((stage) => ({ stage })),
+        }),
+      ).toEqual(r.expected);
+    });
+  }
+
+  // The `stage` answer is only worth having if the vocabulary can actually produce it: a group of
+  // one row is what every conversation-less emit writes (its own synthesized `turnId`), so each
+  // stage has to come back as itself rather than as "Turn".
+  test("every stage in the vocabulary can name a group of its own", () => {
+    const named = FLOW_STAGES.map(
+      (stage) =>
+        logGroupTitle({
+          conversationId: null,
+          threadId: null,
+          rows: [{ stage }],
+        }).kind,
+    );
+    expect(named).toEqual(FLOW_STAGES.map(() => "stage"));
+  });
+});

--- a/tests/client/pages/LogsGroupTitle.test.tsx
+++ b/tests/client/pages/LogsGroupTitle.test.tsx
@@ -1,0 +1,144 @@
+/// <reference lib="dom" />
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { ToastProvider } from "@/client/components";
+import { LogsPage } from "@/client/pages/LogsPage";
+
+// Issue #357: a Logs group whose rows have no conversation announces itself as "Turn", and the one
+// stage that can NEVER be a turn (`webhook`: an outbound delivery on a worker tick, long after
+// whatever produced the event) is exactly the one that always lands there. So this asserts what the
+// operator reads on the card, not that the card exists: a group that renders and lies about what it
+// is passes any structural test and fails the issue.
+//
+// NOTE: every assertion reduces to a string or a boolean BEFORE expect. A failing expectation still
+// holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
+
+// `mock.module` is process-global in Bun and leaks across files in the same worker; another file's
+// `t` returns the key rather than the default string, which would make an assertion about the
+// rendered label fail on a translation detail instead of on the label. Declared here, interpolating,
+// so this file states the surface it needs instead of depending on which file ran first.
+mock.module("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
+      const text = typeof fallback === "string" ? fallback : key;
+      if (!vars) return text;
+      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
+        name in vars ? String(vars[name]) : m,
+      );
+    },
+    i18n: { language: "en" },
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+const realFetch = globalThis.fetch;
+
+interface Row {
+  turnId: string;
+  stage: string;
+  conversationId?: string | null;
+  threadId?: string | null;
+}
+
+let items: unknown[] = [];
+
+function row(r: Row): unknown {
+  return {
+    id: `${r.turnId}-${r.stage}`,
+    turnId: r.turnId,
+    conversationId: r.conversationId ?? null,
+    agentId: null,
+    inboxId: null,
+    threadId: r.threadId ?? null,
+    stage: r.stage,
+    level: "info",
+    status: "ok",
+    provider: null,
+    model: null,
+    durationMs: null,
+    source: "inbox",
+    detail: {},
+    errorMessage: null,
+    createdAt: "2026-08-26T12:00:00.000Z",
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const stubFetch = (async (input: unknown) => {
+  const url = String(
+    typeof input === "string" ? input : ((input as Request).url ?? input),
+  );
+  if (url.includes("/logs")) return json({ items, nextCursor: null });
+  return json({ error: "nope" }, 500);
+}) as unknown as typeof globalThis.fetch;
+
+// The group card's own title line: the <button> that toggles the disclosure. Reduced to its text
+// before it leaves this helper, so no DOM node reaches an assertion.
+async function titles(rows: Row[]): Promise<string[]> {
+  items = rows.map(row);
+  render(
+    <MemoryRouter>
+      <TooltipPrimitive.Provider>
+        <ToastProvider>
+          <LogsPage />
+        </ToastProvider>
+      </TooltipPrimitive.Provider>
+    </MemoryRouter>,
+  );
+  return await waitFor(() => {
+    const found = screen
+      .getAllByRole("button", { expanded: false })
+      .map((b) => (b.textContent ?? "").trim());
+    if (found.length === 0) throw new Error("no group card rendered yet");
+    return found;
+  });
+}
+
+beforeAll(() => {
+  globalThis.fetch = stubFetch;
+});
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe("what a Logs group calls itself", () => {
+  test("a dead outbound delivery is named by its stage, never 'Turn'", async () => {
+    const [title] = await titles([{ turnId: "t-webhook", stage: "webhook" }]);
+    expect(title ?? "").toContain("Outbound webhook");
+    expect(/\bTurn\b/.test(title ?? "")).toBe(false);
+  });
+
+  test("a group tied to a conversation still names the conversation", async () => {
+    const [title] = await titles([
+      { turnId: "t-conv", stage: "generate", conversationId: "12" },
+    ]);
+    expect(title ?? "").toContain("Conversation #12");
+  });
+
+  test("a playground turn keeps naming its thread", async () => {
+    const [title] = await titles([
+      { turnId: "t-thread", stage: "generate", threadId: "1:playground:1:ab" },
+    ]);
+    expect(title ?? "").toContain("1:playground:1:ab");
+  });
+});


### PR DESCRIPTION
## What was wrong

The Logs page groups rows by `turnId` and named each group by falling through conversation → thread
→ the literal word "Turn". But `turnId` is a **correlation id**, not a claim that a turn happened:
`route`, `command` and `webhook` each synthesize one precisely *because* they have no turn to belong
to. So a group that is not a turn announced itself as one.

The stage that always lands there is the one that can never be a turn. `emitDeliveryDead` /
`emitDeliveryRequeued` (`src/modules/flowlog/webhook.ts`) run on a worker tick long after whatever
produced the event, with no conversation, no contact and no thread, and each writes its line under
its own `crypto.randomUUID()`. Every one of those groups read `Turn`.

## What was measured

Read-only against a development database, grouped by `turnId` over rows with `conversation_id IS
NULL`: **5 groups, 3 of them carrying a thread** (playground turns, and one `guardrail` line) **and 2
carrying neither** — the branch that reaches the word. No `webhook` row was among them only because
no delivery had died there yet.

Reading the emitters closes the other half. `emitUnroutedMessage` and `emitCommandDropped` both take
a **non-null** `conversationRowId`, so `route` and `command` never reach the fallback at all — which
is what makes the last branch decidable rather than a guess (below).

## What changed

`logGroupTitle()` (`src/client/lib/logGroupTitle.ts`) is the rule of what a group is *called*, as a
pure function returning a tagged descriptor; `LogsPage` renders the answer instead of deriving it.

| conversation | thread | stages in the group | title |
| --- | --- | --- | --- |
| present | — | — | `Conversation #N` |
| absent | present | — | the thread |
| absent | absent | all the same | that stage's own label (`Outbound webhook`, `Generation`, …) |
| absent | absent | mixed | `Turn` |

The last row is the issue's open question, and it is answerable rather than arbitrary: the two other
turnless stages cannot reach it (`route` and `command` always carry a conversation; a `webhook` group
is always a group of one), so a mixed group with neither is made of turn steps and `Turn` is true
there. That keeps the word in the one place it is honest instead of deleting it and inventing a
generic.

`flowStageLabel` already had a case for every stage in the closed vocabulary, fenced by
`tests/modules/flowlog-stage-labels.test.ts`, so this needs no new translation key: a stage added
tomorrow gets a group title the same round it gets a row badge.

## Validation scope

**Proved by test**

- `tests/client/lib/logGroupTitle.test.ts` — decision table, one row per line of the rule above,
  plus a sweep asserting every stage in `FLOW_STAGES` can name a group of its own.
- `tests/client/pages/LogsGroupTitle.test.tsx` — renders the real `LogsPage` and asserts the text on
  the group card: a `webhook` group reads `Outbound webhook` and does **not** contain the word
  `Turn`; a group with a conversation and a group with a thread still read as before. The first case
  is the red one — before the fix it rendered `InfoTurn1 steps…`; the other two passed already, which
  is what makes them controls rather than decoration.
- Mutation battery on the rule (one mutation at a time): swapping the conversation/thread order,
  deleting the single-stage branch, `every` → `some`, and truthiness → `!== null` on either id each
  killed at least one test; replacing the rendered stage label with `Turn` killed the render test.

**Proved by measurement** — the 5 conversation-less groups above, and the emitter signatures for
`route` / `command` / `webhook`.

**Not validated**

- No live traffic: the development database held no `webhook` row, so the branch that motivated the
  change is proved by construction and by the rendered test, not by a dead delivery observed in the
  wild.
- The thread branch is untouched. A playground group still renders its raw thread id
  (`1:playground:1:…`), which is unlovely but identifies the session; changing it is not this issue.
- Nothing about how groups are *built* changed — `groupByTurn` still keys on `turnId`.

Fixes #357
