### PR TITLE
Say the same thing about a group in the chip that scopes to it as on the group's own card

### DIFF
--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1576,7 +1576,6 @@
     "openConversation": "Open conversation",
     "page": "Page {{n}}",
     "scopedConversation": "Conversation #{{id}}",
-    "scopedTurn": "Turn {{id}}",
     "search": "Search",
     "searchPlaceholder": "Search error messages…",
     "source": {

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1582,7 +1582,6 @@
     "openConversation": "Abrir conversa",
     "page": "Página {{n}}",
     "scopedConversation": "Conversa #{{id}}",
-    "scopedTurn": "Turno {{id}}",
     "search": "Buscar",
     "searchPlaceholder": "Buscar nas mensagens de erro…",
     "source": {

--- a/src/client/pages/LogsPage.tsx
+++ b/src/client/pages/LogsPage.tsx
@@ -400,6 +400,19 @@ export function LogsPage() {
   }, [load]);
 
   const groups = useMemo(() => groupByTurn(items), [items]);
+  // The chip that says what the page is scoped to, when the scope is a `turnId`. It names the group
+  // exactly as the group's own card names it (`logGroupTitle`, issue #357) and adds the id, which is
+  // the thing the chip exists to point at — before issue #374 it said "Turn <id>" whatever the rows
+  // were, so one screen carried two different answers about one group.
+  //
+  // Matched by id rather than taken as the first group: the rows in state still belong to the
+  // PREVIOUS filter for the render between a URL change and its response landing, and naming this id
+  // with that group's answer is the same class of lie in a shorter window. No match is the id alone.
+  const scopedTurnLabel = useMemo(() => {
+    const scoped = groups.find((g) => g.turnId === turnId);
+    if (!scoped) return turnId;
+    return `${groupTitleText(logGroupTitle(scoped), t)} · ${turnId}`;
+  }, [groups, t, turnId]);
   const pageIdx = cursorStack.length - 1;
 
   // The active filters, keyed to the export endpoint's query params (the server bounds + serializes).
@@ -503,7 +516,7 @@ export function LogsPage() {
               ? t("logs.scopedConversation", "Conversation #{{id}}", {
                   id: conversationId,
                 })
-              : t("logs.scopedTurn", "Turn {{id}}", { id: turnId })}
+              : scopedTurnLabel}
             <button
               type="button"
               onClick={() =>

--- a/tests/client/pages/LogsScopeChip.test.tsx
+++ b/tests/client/pages/LogsScopeChip.test.tsx
@@ -1,0 +1,176 @@
+/// <reference lib="dom" />
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { ToastProvider } from "@/client/components";
+import { LogsPage } from "@/client/pages/LogsPage";
+
+// THE OTHER PLACE THE PAGE NAMES A GROUP, AND IT WAS NAMING IT SOMETHING ELSE.
+//
+// #357 taught the group card to say what its rows are; the chip that scopes the whole page to one
+// `turnId` kept saying "Turn {{id}}" unconditionally, so the same group was named twice on one
+// screen and the two disagreed (issue #374). Measured against a running console with a real dead
+// delivery: the card read "Webhook de saída" while the chip above it read "Turno ccfb7540-…".
+//
+// The invariant asserted here is the agreement, not a particular sentence: whatever the card
+// decides this group is, the chip says the same thing and adds the id, which is what the chip
+// exists to name.
+//
+// NOTE: every assertion reduces to a string or a boolean BEFORE expect. A failing expectation still
+// holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
+
+// `mock.module` is process-global in Bun and leaks across files in the same worker, so this file
+// states the i18n surface it needs rather than depending on which file ran first.
+mock.module("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
+      const text = typeof fallback === "string" ? fallback : key;
+      if (!vars) return text;
+      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
+        name in vars ? String(vars[name]) : m,
+      );
+    },
+    i18n: { language: "en" },
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+
+const realFetch = globalThis.fetch;
+
+interface Row {
+  turnId: string;
+  stage: string;
+  conversationId?: string | null;
+  threadId?: string | null;
+}
+
+let items: unknown[] = [];
+
+function row(r: Row): unknown {
+  return {
+    id: `${r.turnId}-${r.stage}`,
+    turnId: r.turnId,
+    conversationId: r.conversationId ?? null,
+    agentId: null,
+    inboxId: null,
+    threadId: r.threadId ?? null,
+    stage: r.stage,
+    level: "info",
+    status: "ok",
+    provider: null,
+    model: null,
+    durationMs: null,
+    source: "inbox",
+    detail: {},
+    errorMessage: null,
+    createdAt: "2026-08-26T12:00:00.000Z",
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const stubFetch = (async (input: unknown) => {
+  const url = String(
+    typeof input === "string" ? input : ((input as Request).url ?? input),
+  );
+  if (url.includes("/logs")) return json({ items, nextCursor: null });
+  return json({ error: "nope" }, 500);
+}) as unknown as typeof globalThis.fetch;
+
+// The two labels on the screen, as text: the scope chip, and the title line of the one group card.
+// Both reduced to strings here so no DOM node reaches an assertion.
+async function labels(
+  scopeTurnId: string,
+  rows: Row[],
+): Promise<{ chip: string; card: string | null }> {
+  items = rows.map(row);
+  const { container } = render(
+    <MemoryRouter initialEntries={[`/logs?turnId=${scopeTurnId}`]}>
+      <TooltipPrimitive.Provider>
+        <ToastProvider>
+          <LogsPage />
+        </ToastProvider>
+      </TooltipPrimitive.Provider>
+    </MemoryRouter>,
+  );
+  return await waitFor(() => {
+    const chipEl = [...container.querySelectorAll("span")].find((s) =>
+      s.querySelector('button[aria-label="Clear filter"]'),
+    );
+    if (!chipEl) throw new Error("no scope chip rendered yet");
+    const clear = chipEl.querySelector("button")?.textContent ?? "";
+    const chip = (chipEl.textContent ?? "")
+      .slice(0, (chipEl.textContent ?? "").length - clear.length)
+      .trim();
+    const card =
+      container.querySelector("button[aria-expanded] span.truncate")
+        ?.textContent ?? null;
+    if (rows.length > 0 && card === null)
+      throw new Error("no group card rendered yet");
+    return { chip, card };
+  });
+}
+
+describe("the chip that scopes the Logs page to one correlation id", () => {
+  test("names a dead outbound delivery by what it is, and keeps the id", async () => {
+    const { chip } = await labels("t-webhook", [
+      { turnId: "t-webhook", stage: "webhook" },
+    ]);
+    expect(chip).toBe("Outbound webhook · t-webhook");
+    expect(/\bTurn\b/.test(chip)).toBe(false);
+  });
+
+  test("says exactly what the group card says, plus the id", async () => {
+    for (const rows of [
+      [{ turnId: "t-1", stage: "webhook" }],
+      [{ turnId: "t-1", stage: "delivery" }],
+      [{ turnId: "t-1", stage: "generate", conversationId: "12" }],
+      [{ turnId: "t-1", stage: "generate", threadId: "1:playground:1:ab" }],
+      // Mixed stages with neither: the card's own answer here is still "Turn", and the point is
+      // that the chip does not get to have a different opinion about the same group.
+      [
+        { turnId: "t-1", stage: "generate" },
+        { turnId: "t-1", stage: "tool" },
+      ],
+    ] satisfies Row[][]) {
+      const { chip, card } = await labels("t-1", rows);
+      expect(chip).toBe(`${card} · t-1`);
+      cleanup();
+    }
+  });
+
+  test("names nothing but the id when no group in hand is the one being scoped to", async () => {
+    // The rows in state can belong to the PREVIOUS filter for one render after the URL changes.
+    // Naming the chip from whatever group happens to be first would label this id with another
+    // group's answer.
+    const { chip } = await labels("t-wanted", [
+      { turnId: "t-other", stage: "webhook" },
+    ]);
+    expect(chip).toBe("t-wanted");
+  });
+});
+
+beforeAll(() => {
+  globalThis.fetch = stubFetch;
+});
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
`LogsPage` names a group by what its rows are since #357/#369: conversation, then thread, then the
stage the rows carry, and only a mix of stages with neither falls through to the word "Turn". The
chip that scopes the whole page to one `turnId` was not part of that change and said `Turn {{id}}`
unconditionally, so one screen carried two different answers about one group.

## What it looked like

A real dead-delivery line, written by `emitDeliveryDead` and read back through
`listExecutionLogs` (stage `webhook`, `conversationId` and `threadId` both null), then
`/logs?turnId=<its turnId>` opened in a browser against a running console, locale pt-BR:

| tree | group card | scope chip |
| --- | --- | --- |
| before #369 | `Turno` | `Turno f433a57c-…` |
| after #369 | `Webhook de saída` | `Turno f433a57c-…` |
| this PR | `Webhook de saída` | `Webhook de saída · f433a57c-…` |

The middle row is the defect: the card was repaired and the chip was not.

## Why the chip is reachable, and not only by hand

Nothing in the console links to `?turnId=`, which is what makes this easy to miss. But `turn_id` is
a documented filter on `logs_query` and `logs_export` (MCP) and on `GET /v1/logs`, and `turnId` is a
column in every CSV export. An operator who reads a turn id there and wants to see it in the console
pastes it into that URL, which is the one screen where the chip is the only label present.

## The change

`logGroupTitle` already decides the four-way answer and `groupTitleText` renders it, so the chip
calls the same pair and appends the id. Two details worth naming:

- **The group is matched BY ID, not taken as the first one**, and that window was measured rather
  than assumed. `items` in state still belong to the previous filter for as long as the new request
  is out, and the cards are a skeleton for that whole time — so the chip is the *only* label on
  screen exactly while the stale group is in hand. Both arms, same tree, same two rows, the same
  client-side `turnId` change (the transport delayed 600 ms so the window is longer than one frame),
  sampled per animation frame:

  | arm | frame 0 | frames 2–38 (the window) | frame 39 |
  | --- | --- | --- | --- |
  | `groups[0]` | `Webhook de saída · 5551c780…` | **`Webhook de saída · e8a784fe…`** | `Entrega interrompida · e8a784fe…` |
  | `find` by id | same | `e8a784fe…` (the id alone) | same |

  The first arm stamps group A's answer on group B's id for the entire load. The second says only
  what it knows.
- **Composed as a template literal, not a new locale key.** Four sites in the client already write
  `translated label · value` this way (`AgentsPage`, `Sidebar`, `SchedulePicker`,
  `ChannelRedirectTab`) and **zero** locale entries hold only placeholders and punctuation. Such a
  key would have been the first, and it would have had to be waived past the
  identical-in-both-languages sweep in `tests/api/error-catalog.test.ts`, raising a ledger that is
  pinned so that appending to it is a deliberate act. `logs.scopedTurn` leaves both catalogs; the
  noun the chip shows still comes from translated keys via `flowStageLabel`.

## What the group is, counted

Seven emit sites synthesize a `turnId` for a line that belongs to no turn, and they are exactly the
lines carrying neither a conversation nor a thread:

| site | stage |
| --- | --- |
| `flowlog/webhook.ts` — a dead delivery, and a requeued one | `webhook` |
| `chatwoot/delivery-sweep.ts` — the stranded line, and the late/consumed one, when the mirror cannot place the conversation | `delivery` |
| `playground/service.ts` — the two file-extraction contexts | `vision` |
| `flowlog/dead-letter.ts` — a unit of work that reached a terminal failure | `dead_letter` |

`route` and `command` are **not** among them: `emitUnroutedMessage` and `emitCommandDropped` both
take a non-null conversation row id, so their groups are named by the conversation and never reach
this branch. Worth stating because #357 named them as examples and they are the two that cannot
happen.

**The fourth stage arrived while this PR was open.** `dead_letter` came in with #368, whose
`emitDeadLetter` builds a context of `tenantId`, `turnId` and `source` and nothing else. Nothing in
this change or in #369 had to learn about it: the label comes from the rows, so a new stage in the
vocabulary is named for free. An enumeration would have been one entry short the day after it was
written, which is the whole argument for deriving the name instead of listing the cases.

## Tests

`tests/client/pages/LogsScopeChip.test.tsx`, driving the real page with the URL scoped:

- a `webhook` group is named by its stage and the chip keeps the id;
- **the chip says exactly what the card says, plus the id**, over five group shapes (`webhook`,
  `delivery`, conversation, thread, and a mix of stages where the card's own answer is still "Turn"
  — the point being that the chip does not get to have a different opinion about the same group);
- rows for another `turnId` in hand produce the id alone.

Red before the change, with the three assertions reading `Turn t-webhook`, `Turn t-1`,
`Turn t-wanted`. Mutation battery, one at a time, on the final shape: taking the first group instead
of matching by id (1 dead), returning the id alone (2), a fixed "Turn" as the label (3), dropping
the id (2), returning empty for no match (1). No survivors, tree verified restored against the
diff snapshot.

## Validation scope

- **Proven by test:** the agreement invariant over five group shapes, the by-id match, and the
  no-match fallback. `bun check` green (6617 pass, 0 fail; lint and type-check clean).
- **Proven live:** the table above. A real `webhook` `ExecutionLog` row written through
  `emitDeliveryDead`, its shape confirmed by reading it back through `listExecutionLogs`
  (`conversationId === null`, `threadId === null`), then both trees served in turn against the same
  database, same session, same URL, and read out of the rendered DOM. The pt-BR label came out
  translated, so this also exercises the catalog path the component test replaces with fallbacks.
- **Also proven live:** the stale-group window above, as an A/B against the same running console.
  Worth naming because it is the one design claim in this PR that a reader cannot check from the
  diff, and because the naive arm is not a hypothetical — it is what the obvious version of this
  change does.
- **Also proven live:** all three of the stages that reach this branch today, each as a real row in
  the console. `webhook` and `delivery` as above, and the playground's `vision` group as **two rows
  under one `turnId`** (the shape `extractPlaygroundFile` writes), which renders `Leitura de imagem`
  on the card and `Leitura de imagem · c891e6f5-…` on the chip — one label for two rows, on both
  surfaces.
- **Not validated:** `dead_letter` was not driven through a browser; it reaches this branch by the
  same route as the other three and takes the same single-stage path. The mixed-stage branch is
  unreachable today by the count above, so its rendering is asserted only against synthetic rows.
  Nothing here exercises a `turnId` change arriving from browser Back/Forward specifically — the
  measurement above drives the same client-side route change the router would receive, without a
  document reload, which is the state the code sees.

Rebased onto `eda224f` (#368). That change is additive where it meets this one — a stage added to
the vocabulary and a `case` added to `flowStageLabel`, no signature and no call site of this PR's —
so the review round on the identical diff still describes this code. Suite re-run on the new base:
6646 pass, 0 fail.

Fixes #374
