### PR TITLE
A query filter is used or refused, never dropped

### DIFF
--- a/docs/api-and-fleet.md
+++ b/docs/api-and-fleet.md
@@ -8,6 +8,8 @@ Versioned, mounted under the `/api` group (so paths are `/api/v1/...`). The same
 
 Current endpoints: `GET /api/v1/meta`, `GET /api/v1/tenants`, `GET /api/v1/tenants/:id`. Conversations/metrics/funnel projections arrive in their phases.
 
+**A query filter is used or refused, never dropped.** Every read surface parses its filters through `src/api/lib/query-filters.ts` (`parseQueryInstant` / `parseQueryId` / `parseQueryCount`), and a value the server cannot use is answered **400 naming the parameter** (`{ error, field }`, key `errors.invalidQueryParam`). The lenient spellings this replaced each had their own wrong answer: `agentId=abc` dropped the filter and returned the tenant's whole table, `cursor=abc` restarted pagination so a client following `nextCursor` never terminated, `since=2026-02-30T00:00:00Z` normalised to March 2 and queried a window nobody asked for, and `limit=abc` reached Prisma as `take: NaN` — a 500 for a caller's typo. Empty is a value, not an absence: `?agentId=` is what a form submits when its input is blank, and reading it as "no filter" is the same widening. The RANGE of a count lives in the SERVICE (`assertUsableCount` in `src/lib/query-param.ts`), not in the parser, so MCP and the console's own service calls are held to it too. An instant filter takes an ISO 8601 instant with an offset; a date alone is refused. Issues #305 / #361 settled this for the delivery ledger and #372 applied it to the rest.
+
 **Isolation-preserving projection.** Fleet-facing surfaces (read API, outbound webhooks, MCP read resources, SUPER_ADMIN cross-tenant) expose metrics + state + control by default, never message bodies or PII. A per-instance toggle opts a tenant into raw detail.
 
 ## Instance identity

--- a/openapi.json
+++ b/openapi.json
@@ -1535,6 +1535,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -2347,6 +2369,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -33570,6 +33614,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {

--- a/openapi.json
+++ b/openapi.json
@@ -1631,6 +1631,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -5394,7 +5416,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "description": "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
               "type": "string"
             }
           },
@@ -5528,7 +5550,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "description": "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
               "type": "string"
             }
           },
@@ -5545,6 +5567,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -5606,7 +5650,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "description": "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
               "type": "string"
             }
           },
@@ -5749,7 +5793,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "description": "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
               "type": "string"
             }
           },
@@ -5766,6 +5810,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -22760,7 +22826,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Lower bound on log time (ISO date).",
+              "description": "Lower bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
               "type": "string"
             }
           },
@@ -22769,7 +22835,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Upper bound on log time (ISO date).",
+              "description": "Upper bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
               "type": "string"
             }
           },
@@ -22972,7 +23038,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Lower bound on log time (ISO date).",
+              "description": "Lower bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
               "type": "string"
             }
           },
@@ -22981,7 +23047,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Upper bound on log time (ISO date).",
+              "description": "Upper bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
               "type": "string"
             }
           },

--- a/src/api/features/admin/admin.controller.ts
+++ b/src/api/features/admin/admin.controller.ts
@@ -90,7 +90,7 @@ export const adminController = new Elysia({
         "Admin stats",
         "Return user and admin counts for the resolved tenant scope.",
       ),
-      response: errors(401, 403),
+      response: errors(400, 401, 403),
     },
   )
   .get(
@@ -367,7 +367,7 @@ export const adminController = new Elysia({
         "List invitations",
         "Return pending invitations for the resolved tenant scope.",
       ),
-      response: errors(401, 403),
+      response: errors(400, 401, 403),
     },
   )
   .delete(

--- a/src/api/features/admin/admin.controller.ts
+++ b/src/api/features/admin/admin.controller.ts
@@ -10,7 +10,7 @@ import {
 import { type AuthUser, authPlugin } from "@/api/lib/auth";
 import { translate } from "@/api/lib/i18n";
 import { doc, errors } from "@/api/lib/openapi";
-import { parseQueryCount } from "@/api/lib/query-filters";
+import { parseQueryCount, parseQueryId } from "@/api/lib/query-filters";
 import config from "@/config";
 import { UnauthorizedError } from "@/lib/errors";
 import {
@@ -37,7 +37,12 @@ function resolveScope(
   paramTenantId: string | undefined,
 ): bigint | null {
   if (user.role === "SUPER_ADMIN") {
-    return paramTenantId ? BigInt(paramTenantId) : null;
+    // NOTE: `=== undefined`, not truthiness. `?tenantId=` is what the Users-tab filter submits when
+    // its select is cleared, and reading it as "no filter" answers a request narrowed to one tenant
+    // with the WHOLE FLEET. And `parseQueryId`, never `BigInt`: that spelling accepts an id past
+    // 2^63-1 and lets Postgres answer the malformed value with a 500.
+    if (paramTenantId === undefined) return null;
+    return parseQueryId(paramTenantId, "tenantId") ?? null;
   }
   return user.tenantId;
 }

--- a/src/api/features/admin/admin.controller.ts
+++ b/src/api/features/admin/admin.controller.ts
@@ -10,6 +10,7 @@ import {
 import { type AuthUser, authPlugin } from "@/api/lib/auth";
 import { translate } from "@/api/lib/i18n";
 import { doc, errors } from "@/api/lib/openapi";
+import { parseQueryCount } from "@/api/lib/query-filters";
 import config from "@/config";
 import { UnauthorizedError } from "@/lib/errors";
 import {
@@ -94,7 +95,7 @@ export const adminController = new Elysia({
       // response stays a single shape and the treaty type for `data.users` is non-optional.
       const user = await getAuthUser();
       if (!user) throw new UnauthorizedError();
-      const page = Number(query.page) || 1;
+      const page = parseQueryCount(query.page, "page") ?? 1;
       const search = query.search?.trim() || undefined;
       const result = await getUsers(
         resolveScope(user, query.tenantId),
@@ -136,7 +137,7 @@ export const adminController = new Elysia({
         "List users",
         "Return a paginated, optionally filtered list of users.",
       ),
-      response: errors(401, 403),
+      response: errors(400, 401, 403),
     },
   )
   .patch(

--- a/src/api/features/admin/admin.service.ts
+++ b/src/api/features/admin/admin.service.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
 import prisma from "@/api/lib/prisma";
+import { badQueryParam } from "@/lib/query-param";
 import { asSuperAdminOn } from "@/lib/tenancy";
 
 // NOTE: roles a tenant admin may assign (never SUPER_ADMIN, which is fleet-level and
@@ -27,6 +28,10 @@ export async function getUsers(
   page = 1,
   search?: string,
 ) {
+  // The RANGE lives here, not in the query parser, so a caller that never sends a query string is
+  // held to it too. Without this a negative page reaches Prisma as a negative `skip` and answers
+  // 500 (measured on `?page=-5`), and a fractional one is echoed back to the client as `page`.
+  if (!Number.isInteger(page) || page < 1) badQueryParam("page");
   const pageSize = 20;
   const skip = (page - 1) * pageSize;
 

--- a/src/api/lib/query-filters.ts
+++ b/src/api/lib/query-filters.ts
@@ -1,0 +1,56 @@
+import { parseDbId } from "@/lib/db-id";
+import { badQueryParam } from "@/lib/query-param";
+import { parseIsoInstant } from "@/modules/flowlog/settings";
+
+// NOTE: the refusal is raised from `src/lib/query-param.ts`, which the API extractor's input glob
+// (`src/api/**/*.ts`) does not reach, so the key is declared HERE — beside the parsers that are the
+// reason it exists, rather than in whichever controller happened to introduce it first. A key the
+// extractor cannot see is pruned from the catalogue and then missing at runtime, silently.
+// translate('errors.invalidQueryParam', 'Invalid value for {{param}}')
+export { badQueryParam };
+
+// Query-string filters, parsed the way the delivery ledger settled it in issue #305 / #361 and now
+// shared by every read surface (issue #372).
+//
+// A filter is something the CALLER TYPED, and the three ways a lenient parse can answer are all
+// wrong answers to it: dropping it widens the result to everything the tenant has, normalising it
+// asks a question nobody asked, and handing `NaN` or an out-of-range id to Prisma answers a caller
+// error with a 500. None of the three is distinguishable by the client from a genuinely empty
+// result, which is what makes refusing the only answer it can act on.
+
+// PRESENT means the caller asked for this filter, and only ABSENT means they did not. `""` is
+// refused exactly like `abc`: it is what a form submits when its input is blank, and reading it as
+// "no filter" answers a narrowed request with the whole table.
+export function parseQueryInstant(
+  s: string | undefined,
+  param: string,
+): Date | undefined {
+  if (s === undefined) return undefined;
+  const d = parseIsoInstant(s);
+  if (d === null) badQueryParam(param);
+  return d;
+}
+
+// `parseDbId`, never `BigInt(s)`: BigInt is arbitrary precision, so an id past 2^63-1 parses here
+// and is refused by POSTGRES when the query binds it — a 500 for a value that is plainly malformed.
+export function parseQueryId(
+  s: string | undefined,
+  param: string,
+): bigint | undefined {
+  if (s === undefined) return undefined;
+  const id = parseDbId(s);
+  if (id === null) badQueryParam(param);
+  return id;
+}
+
+// Syntax only; the RANGE belongs to whichever service owns the parameter, so a caller that never
+// sees a query string (MCP, the console's own service calls) is held to the same bound.
+export function parseQueryCount(
+  s: string | undefined,
+  param: string,
+): number | undefined {
+  if (s === undefined) return undefined;
+  const n = Number(s);
+  if (s.trim() === "" || !Number.isInteger(n)) badQueryParam(param);
+  return n;
+}

--- a/src/api/lib/query-filters.ts
+++ b/src/api/lib/query-filters.ts
@@ -45,12 +45,24 @@ export function parseQueryId(
 
 // Syntax only; the RANGE belongs to whichever service owns the parameter, so a caller that never
 // sees a query string (MCP, the console's own service calls) is held to the same bound.
+//
+// DIGITS, not `Number`, for the same reason `parseDbId` uses a regex: `Number` reads spellings a
+// count parameter does not have, and reads two of them as a DIFFERENT NUMBER. Measured on Bun
+// 1.4.0 — `1e3` → 1000, `0x10` → 16, `0b11` → 3, `0o17` → 15, `+7` → 7, ` 12 ` → 12, `12.0` → 12,
+// and every one of those passes `Number.isInteger`. The one that bites hardest is precision:
+// `9007199254740993` comes back as `...992`, so `?before=9007199254740993` would page from a
+// message the caller never named. `Number.isSafeInteger` closes that, and the regex closes the
+// rest — a sign included, because a count has none and the refusal names the same parameter either
+// way.
+const DECIMAL = /^\d+$/;
+
 export function parseQueryCount(
   s: string | undefined,
   param: string,
 ): number | undefined {
   if (s === undefined) return undefined;
+  if (!DECIMAL.test(s)) badQueryParam(param);
   const n = Number(s);
-  if (s.trim() === "" || !Number.isInteger(n)) badQueryParam(param);
+  if (!Number.isSafeInteger(n)) badQueryParam(param);
   return n;
 }

--- a/src/api/lib/query-filters.ts
+++ b/src/api/lib/query-filters.ts
@@ -56,6 +56,22 @@ export function parseQueryId(
 // way.
 const DECIMAL = /^\d+$/;
 
+// A free-text or closed-vocabulary filter, where the only unusable spelling is the EMPTY one.
+//
+// The value itself is not judged here — an unknown `level` reaches the query and answers zero rows,
+// which is a correct answer to a filter nothing matches. `""` is the one that is not: every service
+// on this surface writes `opts.x ? { x: opts.x } : {}`, so a present-but-empty filter is DROPPED
+// and the caller who narrowed the request gets the tenant's whole table back. Whitespace counts as
+// empty because `listAgentsPaged` already trims before the same truthiness check.
+export function parseQueryText(
+  s: string | undefined,
+  param: string,
+): string | undefined {
+  if (s === undefined) return undefined;
+  if (s.trim() === "") badQueryParam(param);
+  return s;
+}
+
 export function parseQueryCount(
   s: string | undefined,
   param: string,

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { getUserById, verifyPassword } from "@/api/features/auth/auth.service";
 import { doc, errors } from "@/api/lib/openapi";
+import { parseQueryText } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
 import {
@@ -258,7 +259,7 @@ export const agentsController = new Elysia({
       const { agents, total } = await listAgentsPaged(
         ctxOrThrow(tenantContext),
         {
-          q: query.q,
+          q: parseQueryText(query.q, "q"),
           orderBy: query.orderBy,
           order: query.order,
           enabled: query.enabled,

--- a/src/api/v1/audit.controller.ts
+++ b/src/api/v1/audit.controller.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
+import { parseQueryCount } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
@@ -25,7 +26,7 @@ export const auditController = new Elysia({
     async ({ tenantContext, query }) => ({
       instance: instanceIdentity,
       entries: await listAudit(ctxOrThrow(tenantContext), {
-        limit: query.limit ? Number(query.limit) : undefined,
+        limit: parseQueryCount(query.limit, "limit"),
         action: query.action,
       }),
     }),

--- a/src/api/v1/audit.controller.ts
+++ b/src/api/v1/audit.controller.ts
@@ -1,6 +1,6 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
-import { parseQueryCount } from "@/api/lib/query-filters";
+import { parseQueryCount, parseQueryText } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
@@ -27,7 +27,7 @@ export const auditController = new Elysia({
       instance: instanceIdentity,
       entries: await listAudit(ctxOrThrow(tenantContext), {
         limit: parseQueryCount(query.limit, "limit"),
-        action: query.action,
+        action: parseQueryText(query.action, "action"),
       }),
     }),
     {

--- a/src/api/v1/logs.controller.ts
+++ b/src/api/v1/logs.controller.ts
@@ -4,6 +4,7 @@ import {
   parseQueryCount,
   parseQueryId,
   parseQueryInstant,
+  parseQueryText,
 } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
@@ -42,13 +43,13 @@ export const logsController = new Elysia({
       ...(await listExecutionLogs(ctxOrThrow(tenantContext), {
         since: parseQueryInstant(query.since, "since"),
         until: parseQueryInstant(query.until, "until"),
-        level: query.level,
-        stage: query.stage,
+        level: parseQueryText(query.level, "level"),
+        stage: parseQueryText(query.stage, "stage"),
         agentId: parseQueryId(query.agentId, "agentId"),
         conversationId: parseQueryId(query.conversationId, "conversationId"),
-        turnId: query.turnId,
+        turnId: parseQueryText(query.turnId, "turnId"),
         source: query.source,
-        search: query.search,
+        search: parseQueryText(query.search, "search"),
         limit: parseQueryCount(query.limit, "limit"),
         cursor: parseQueryId(query.cursor, "cursor"),
       })),
@@ -122,13 +123,13 @@ export const logsController = new Elysia({
       ...(await exportExecutionLogs(ctxOrThrow(tenantContext), {
         since: parseQueryInstant(query.since, "since"),
         until: parseQueryInstant(query.until, "until"),
-        level: query.level,
-        stage: query.stage,
+        level: parseQueryText(query.level, "level"),
+        stage: parseQueryText(query.stage, "stage"),
         agentId: parseQueryId(query.agentId, "agentId"),
         conversationId: parseQueryId(query.conversationId, "conversationId"),
-        turnId: query.turnId,
+        turnId: parseQueryText(query.turnId, "turnId"),
         source: query.source,
-        search: query.search,
+        search: parseQueryText(query.search, "search"),
         format: parseFormat(query.format),
         maxRows: parseQueryCount(query.maxRows, "maxRows"),
       })),

--- a/src/api/v1/logs.controller.ts
+++ b/src/api/v1/logs.controller.ts
@@ -1,5 +1,10 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
+import {
+  parseQueryCount,
+  parseQueryId,
+  parseQueryInstant,
+} from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
@@ -21,21 +26,6 @@ function ctxOrThrow(ctx: TenantContext | null): TenantContext {
   return ctx;
 }
 
-function parseDate(s?: string): Date | undefined {
-  if (!s) return undefined;
-  const d = new Date(s);
-  return Number.isNaN(d.getTime()) ? undefined : d;
-}
-
-function parseBigInt(s?: string): bigint | undefined {
-  if (!s) return undefined;
-  try {
-    return BigInt(s);
-  } catch {
-    return undefined;
-  }
-}
-
 function parseFormat(s?: string): LogExportFormat {
   return s === "json" ? "json" : "csv";
 }
@@ -50,27 +40,33 @@ export const logsController = new Elysia({
     async ({ tenantContext, query }) => ({
       instance: instanceIdentity,
       ...(await listExecutionLogs(ctxOrThrow(tenantContext), {
-        since: parseDate(query.since),
-        until: parseDate(query.until),
+        since: parseQueryInstant(query.since, "since"),
+        until: parseQueryInstant(query.until, "until"),
         level: query.level,
         stage: query.stage,
-        agentId: parseBigInt(query.agentId),
-        conversationId: parseBigInt(query.conversationId),
+        agentId: parseQueryId(query.agentId, "agentId"),
+        conversationId: parseQueryId(query.conversationId, "conversationId"),
         turnId: query.turnId,
         source: query.source,
         search: query.search,
-        limit: query.limit ? Number(query.limit) : undefined,
-        cursor: parseBigInt(query.cursor),
+        limit: parseQueryCount(query.limit, "limit"),
+        cursor: parseQueryId(query.cursor, "cursor"),
       })),
     }),
     {
       requireRole: "TENANT_ADMIN",
       query: t.Object({
         since: t.Optional(
-          t.String({ description: "Lower bound on log time (ISO date)." }),
+          t.String({
+            description:
+              "Lower bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
+          }),
         ),
         until: t.Optional(
-          t.String({ description: "Upper bound on log time (ISO date)." }),
+          t.String({
+            description:
+              "Upper bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
+          }),
         ),
         level: t.Optional(t.String({ description: "Filter by log level." })),
         stage: t.Optional(
@@ -124,27 +120,33 @@ export const logsController = new Elysia({
     async ({ tenantContext, query }) => ({
       instance: instanceIdentity,
       ...(await exportExecutionLogs(ctxOrThrow(tenantContext), {
-        since: parseDate(query.since),
-        until: parseDate(query.until),
+        since: parseQueryInstant(query.since, "since"),
+        until: parseQueryInstant(query.until, "until"),
         level: query.level,
         stage: query.stage,
-        agentId: parseBigInt(query.agentId),
-        conversationId: parseBigInt(query.conversationId),
+        agentId: parseQueryId(query.agentId, "agentId"),
+        conversationId: parseQueryId(query.conversationId, "conversationId"),
         turnId: query.turnId,
         source: query.source,
         search: query.search,
         format: parseFormat(query.format),
-        maxRows: query.maxRows ? Number(query.maxRows) : undefined,
+        maxRows: parseQueryCount(query.maxRows, "maxRows"),
       })),
     }),
     {
       requireRole: "TENANT_ADMIN",
       query: t.Object({
         since: t.Optional(
-          t.String({ description: "Lower bound on log time (ISO date)." }),
+          t.String({
+            description:
+              "Lower bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
+          }),
         ),
         until: t.Optional(
-          t.String({ description: "Upper bound on log time (ISO date)." }),
+          t.String({
+            description:
+              "Upper bound on log time, as an ISO 8601 instant with an offset (2026-01-01T00:00:00Z). A date alone is rejected with 400.",
+          }),
         ),
         level: t.Optional(t.String({ description: "Filter by log level." })),
         stage: t.Optional(

--- a/src/api/v1/mcp-admin.controller.ts
+++ b/src/api/v1/mcp-admin.controller.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
+import { parseQueryId } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
 import { instanceIdentity } from "@/lib/instance";
@@ -151,10 +152,7 @@ export const mcpAdminController = new Elysia({
     async ({ query }) => ({
       instance: instanceIdentity,
       tokens: await listActiveTokens({
-        tenantId:
-          query.tenantId != null && query.tenantId !== ""
-            ? BigInt(query.tenantId)
-            : null,
+        tenantId: parseQueryId(query.tenantId, "tenantId") ?? null,
       }),
     }),
     {

--- a/src/api/v1/mcp-admin.controller.ts
+++ b/src/api/v1/mcp-admin.controller.ts
@@ -169,7 +169,7 @@ export const mcpAdminController = new Elysia({
           }),
         ),
       }),
-      response: errors(401, 403),
+      response: errors(400, 401, 403),
     },
   )
   .delete(

--- a/src/api/v1/v1.controller.ts
+++ b/src/api/v1/v1.controller.ts
@@ -6,6 +6,7 @@ import {
   parseQueryCount,
   parseQueryId,
   parseQueryInstant,
+  parseQueryText,
 } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
@@ -268,7 +269,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         status: query.status,
         limit: parseQueryCount(query.limit, "limit"),
         cursor: parseQueryId(query.cursor, "cursor"),
-        q: query.q,
+        q: parseQueryText(query.q, "q"),
       });
       return {
         instance: instanceIdentity,

--- a/src/api/v1/v1.controller.ts
+++ b/src/api/v1/v1.controller.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from "elysia";
 import { getUserById, verifyPassword } from "@/api/features/auth/auth.service";
 import { createInvite } from "@/api/features/invitations/invitation.service";
 import { doc, errors } from "@/api/lib/openapi";
+import { parseQueryCount, parseQueryInstant } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
 import { AppError, ForbiddenError } from "@/lib/errors";
@@ -261,7 +262,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, query }) => {
       const page = await listConversations(ctxOrThrow(tenantContext), {
         status: query.status,
-        limit: query.limit ? Number(query.limit) : undefined,
+        limit: parseQueryCount(query.limit, "limit"),
         cursor: query.cursor,
         q: query.q,
       });
@@ -340,10 +341,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
   .get(
     "/conversations/:id/messages",
     async ({ tenantContext, params, query }) => {
-      const before =
-        query.before != null && query.before !== ""
-          ? Number.parseInt(query.before, 10)
-          : undefined;
+      const before = parseQueryCount(query.before, "before");
       return {
         instance: instanceIdentity,
         ...(await getConversationMessages(
@@ -351,7 +349,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
           BigInt(params.id),
           {},
           undefined,
-          Number.isFinite(before) ? before : undefined,
+          before,
         )),
       };
     },
@@ -602,9 +600,9 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
   .get(
     "/metrics",
     async ({ tenantContext, query }) => {
-      const since = query.since ? new Date(query.since) : undefined;
+      const since = parseQueryInstant(query.since, "since");
       const metrics = await getInstanceMetrics(ctxOrThrow(tenantContext), {
-        since: since && !Number.isNaN(since.getTime()) ? since : undefined,
+        since,
         source: query.source,
       });
       return { instance: instanceIdentity, metrics };
@@ -614,7 +612,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         since: t.Optional(
           t.String({
             description:
-              "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
           }),
         ),
         // Usage segment: "inbox" (real) | "playground". Omitted → all sources.
@@ -639,9 +637,9 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
   .get(
     "/metrics/kpis",
     async ({ tenantContext, query }) => {
-      const since = query.since ? new Date(query.since) : undefined;
+      const since = parseQueryInstant(query.since, "since");
       const kpis = await getKpis(ctxOrThrow(tenantContext), {
-        since: since && !Number.isNaN(since.getTime()) ? since : undefined,
+        since,
       });
       return { instance: instanceIdentity, kpis };
     },
@@ -650,7 +648,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         since: t.Optional(
           t.String({
             description:
-              "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
           }),
         ),
       }),
@@ -662,15 +660,15 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(401, 404),
+      response: errors(400, 401, 404),
     },
   )
   .get(
     "/metrics/timeseries",
     async ({ tenantContext, query }) => {
-      const since = query.since ? new Date(query.since) : undefined;
+      const since = parseQueryInstant(query.since, "since");
       const points = await getTimeseries(ctxOrThrow(tenantContext), {
-        since: since && !Number.isNaN(since.getTime()) ? since : undefined,
+        since,
         source: query.source,
         tz: query.tz,
       });
@@ -681,7 +679,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         since: t.Optional(
           t.String({
             description:
-              "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
           }),
         ),
         source: t.Optional(
@@ -711,9 +709,9 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
   .get(
     "/metrics/costs",
     async ({ tenantContext, query }) => {
-      const since = query.since ? new Date(query.since) : undefined;
+      const since = parseQueryInstant(query.since, "since");
       const costs = await getLangfuseCosts(ctxOrThrow(tenantContext), {
-        since: since && !Number.isNaN(since.getTime()) ? since : undefined,
+        since,
       });
       return { instance: instanceIdentity, costs };
     },
@@ -722,7 +720,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         since: t.Optional(
           t.String({
             description:
-              "Optional ISO start timestamp; invalid values are ignored rather than rejected.",
+              "Optional ISO start instant (2026-01-01T00:00:00Z). A value that is not one is refused with a 400 naming the parameter.",
           }),
         ),
       }),
@@ -734,6 +732,6 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         ),
         tags: ["Dashboard"],
       },
-      response: errors(401, 404),
+      response: errors(400, 401, 404),
     },
   );

--- a/src/api/v1/v1.controller.ts
+++ b/src/api/v1/v1.controller.ts
@@ -2,7 +2,11 @@ import { Elysia, t } from "elysia";
 import { getUserById, verifyPassword } from "@/api/features/auth/auth.service";
 import { createInvite } from "@/api/features/invitations/invitation.service";
 import { doc, errors } from "@/api/lib/openapi";
-import { parseQueryCount, parseQueryInstant } from "@/api/lib/query-filters";
+import {
+  parseQueryCount,
+  parseQueryId,
+  parseQueryInstant,
+} from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
 import { AppError, ForbiddenError } from "@/lib/errors";
@@ -263,7 +267,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
       const page = await listConversations(ctxOrThrow(tenantContext), {
         status: query.status,
         limit: parseQueryCount(query.limit, "limit"),
-        cursor: query.cursor,
+        cursor: parseQueryId(query.cursor, "cursor"),
         q: query.q,
       });
       return {

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -1,15 +1,15 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
-import { tenancyPlugin } from "@/api/middlewares/tenancy";
-import { parseDbId, requireDbId } from "@/lib/db-id";
 import {
-  AppError,
-  ForbiddenError,
-  TenantTargetRequiredError,
-} from "@/lib/errors";
+  parseQueryCount,
+  parseQueryId,
+  parseQueryInstant,
+} from "@/api/lib/query-filters";
+import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
+import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
-import { parseIsoInstant } from "@/modules/flowlog/settings";
 import {
   getWebhookDelivery,
   type ListDeliveriesOpts,
@@ -41,59 +41,6 @@ import { sendWebhookTest } from "@/modules/webhooks/outbound/test";
 // translate('errors.webhookDeliveryNotFound', 'Webhook delivery not found')
 // translate('errors.webhookDeliveryNotDead', 'Only a dead delivery can be requeued; this one is {{status}}')
 // translate('errors.unknownDeliveryStatus', 'Unknown delivery status: {{status}}')
-// translate('errors.invalidQueryParam', 'Invalid value for {{param}}')
-
-// A filter value the server cannot parse is a REFUSAL, never a dropped filter. These started as
-// copies of the logs controller's lenient parsers, which answer an unparseable value with
-// `undefined` — and on a LEDGER that is the wrong answer twice over: a malformed `subscriptionId`
-// returns the tenant's whole ledger instead of one subscription's, and a malformed `cursor`
-// restarts pagination, which is a paging loop that never ends. Measured against the real client,
-// the numeric leg is worse than a wrong page: `take: NaN` and an invalid `Date` both reach Prisma
-// and throw (a 500 for a caller error), and `take: 3.5` quietly returns zero rows.
-function badParam(param: string): never {
-  throw new AppError(
-    `invalid value for ${param}`,
-    400,
-    "errors.invalidQueryParam",
-    { param },
-    param,
-  );
-}
-
-// PRESENT means the caller asked for this filter. Only ABSENT means they did not, which is why
-// none of these open with `if (!s)`: `?subscriptionId=` and `?status=` are values a form submits
-// when its input is empty, and treating them as "no filter" answers a narrowed request with the
-// tenant's whole ledger. `""` is refused, exactly like `abc`.
-// `parseIsoInstant`, never `new Date(s)`. `Date.parse` NORMALISES rather than refuses, so
-// `2026-02-30T00:00:00Z` comes back as March 2 and the ledger is quietly queried with a bound the
-// caller never asked for; and it accepts `08/26/2026 10:00`, resolving it against the SERVER's
-// timezone, so the same filter means different instants on two installations. The helper checks
-// the shape, the calendar and the offset on the STRING. The cost is that a date alone is refused:
-// this filter takes an instant, `2026-01-01T00:00:00Z`, and the parameter's description says so.
-function parseDate(s: string | undefined, param: string): Date | undefined {
-  if (s === undefined) return undefined;
-  const d = parseIsoInstant(s);
-  if (d === null) badParam(param);
-  return d;
-}
-
-// `parseDbId`, never `BigInt(s)`: BigInt is arbitrary precision, so an id past 2^63-1 parses here
-// and is refused by POSTGRES when the query binds it — a 500 for a value this route documents as a
-// 400. See lib/db-id.ts, whose own header names `BigInt(params.id)` as the spelling to avoid.
-function parseId(s: string | undefined, param: string): bigint | undefined {
-  if (s === undefined) return undefined;
-  const id = parseDbId(s);
-  if (id === null) badParam(param);
-  return id;
-}
-
-// Syntax only; the range belongs to the service, so MCP is held to the same rule.
-function parseCount(s: string | undefined, param: string): number | undefined {
-  if (s === undefined) return undefined;
-  const n = Number(s);
-  if (s.trim() === "" || !Number.isInteger(n)) badParam(param);
-  return n;
-}
 
 function ctxOrThrow(ctx: TenantContext | null): TenantContext {
   if (!ctx) throw new ForbiddenError();
@@ -114,12 +61,12 @@ export function parseDeliveryQuery(query: {
 }): ListDeliveriesOpts {
   return {
     status: query.status,
-    subscriptionId: parseId(query.subscriptionId, "subscriptionId"),
+    subscriptionId: parseQueryId(query.subscriptionId, "subscriptionId"),
     event: query.event,
-    since: parseDate(query.since, "since"),
-    until: parseDate(query.until, "until"),
-    limit: parseCount(query.limit, "limit"),
-    cursor: parseId(query.cursor, "cursor"),
+    since: parseQueryInstant(query.since, "since"),
+    until: parseQueryInstant(query.until, "until"),
+    limit: parseQueryCount(query.limit, "limit"),
+    cursor: parseQueryId(query.cursor, "cursor"),
   };
 }
 

--- a/src/lib/query-param.ts
+++ b/src/lib/query-param.ts
@@ -1,0 +1,35 @@
+import { AppError } from "@/lib/errors";
+
+// The refusal a caller-supplied filter gets when the server cannot use it, in one place because it
+// is raised from BOTH layers a filter passes through: the query parser (REST only, see
+// api/lib/query-filters.ts) and the service that owns the parameter's range (REST *and* MCP, which
+// never sees a query string). Two spellings of the same refusal would let the two disagree about
+// the same value.
+//
+// The translation key is declared for the extractor in api/v1/webhooks.controller.ts, whose input
+// glob does not reach src/lib or src/modules.
+export function badQueryParam(param: string): never {
+  throw new AppError(
+    `invalid value for ${param}`,
+    400,
+    "errors.invalidQueryParam",
+    { param },
+    param,
+  );
+}
+
+// A count parameter's RANGE: a positive integer, or absent. Lives beside the refusal rather than in
+// each service so the six read surfaces cannot disagree about what `limit=0` means, and lives in a
+// SERVICE-reachable module rather than in the query parser because MCP and the console's own calls
+// reach these services without ever passing through a query string.
+//
+// Zero is refused, not clamped: `limit=0` is a caller asking for nothing, and answering it with the
+// default page is a different question than the one asked. So is a negative — measured before this
+// branch, `?page=-5` reached Prisma as a negative `skip` and answered 500.
+export function assertUsableCount(
+  value: number | undefined,
+  param: string,
+): void {
+  if (value === undefined) return;
+  if (!Number.isInteger(value) || value < 1) badQueryParam(param);
+}

--- a/src/modules/analytics/service.ts
+++ b/src/modules/analytics/service.ts
@@ -1,6 +1,7 @@
 import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { NON_AGENT_TURN_NODES, type UsageSource } from "@/graph/usage";
+import { badQueryParam } from "@/lib/query-param";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { classifyOutcome } from "@/modules/conversations/resolution-origin";
 
@@ -74,14 +75,20 @@ export interface MetricsFilter {
 }
 
 // Validate an IANA timezone before interpolating it into `AT TIME ZONE` (an unknown zone makes
-// Postgres throw). Unknown/missing → "UTC". `Intl.DateTimeFormat` throws RangeError for bad zones.
+// Postgres throw). `Intl.DateTimeFormat` throws RangeError for bad zones.
+//
+// A zone the caller SENT and this cannot read is refused, not replaced (issue #372). The fallback
+// this replaces is the worst shape of the family: `tz=America/Sao_Paolo` (one typo) silently
+// bucketed the dashboard in UTC, so a 21h local turn showed up on tomorrow — the exact bug the
+// zone parameter exists to prevent, with numbers that look right. ABSENT still means UTC, because
+// absent is not a value; `""` is one, and it is what a cleared select submits.
 export function normalizeTimeZone(tz: string | undefined): string {
-  if (!tz) return "UTC";
+  if (tz === undefined) return "UTC";
   try {
     new Intl.DateTimeFormat("en-US", { timeZone: tz });
     return tz;
   } catch {
-    return "UTC";
+    badQueryParam("tz");
   }
 }
 

--- a/src/modules/audit/service.ts
+++ b/src/modules/audit/service.ts
@@ -1,5 +1,6 @@
 import { Prisma, type PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
+import { assertUsableCount } from "@/lib/query-param";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 
 export interface AuditEntry {
@@ -64,7 +65,8 @@ export async function listAudit(
   opts: { limit?: number; action?: string } = {},
   base: PrismaClient = basePrisma,
 ): Promise<AuditLogItem[]> {
-  const take = Math.min(Math.max(opts.limit ?? 100, 1), 500);
+  assertUsableCount(opts.limit, "limit");
+  const take = Math.min(opts.limit ?? 100, 500);
   const rows = await runScopedOn(base, ctx, (db) =>
     db.auditLog.findMany({
       where: opts.action ? { action: opts.action } : {},

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -8,7 +8,7 @@ import {
   NotFoundError,
   TenantTargetRequiredError,
 } from "@/lib/errors";
-import { assertUsableCount } from "@/lib/query-param";
+import { assertUsableCount, badQueryParam } from "@/lib/query-param";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
@@ -65,7 +65,7 @@ export interface ListConversationsFilter {
   limit?: number;
   // Keyset cursor: the id of the last item from the previous page. The next page continues from just
   // past it in the (lastEventAt desc, id desc) ordering.
-  cursor?: string;
+  cursor?: bigint;
   // Free-text search: matches the contact display name or the Chatwoot conversation id (see
   // buildConversationsWhere). No message-body search — the mirror holds metadata only.
   q?: string;
@@ -104,19 +104,16 @@ function clampLimit(limit: number | undefined): number {
   return limit === undefined ? DEFAULT_LIMIT : Math.min(limit, MAX_LIMIT);
 }
 
+// A status outside the closed set is REFUSED, never dropped: dropping it answers a request for one
+// status with every status, which is the widening this whole surface exists to stop. `""` counts as
+// a value the caller sent, exactly as it does for the ids. The check lives here rather than in the
+// controller because MCP and internal callers reach this function without a query string, the same
+// split `assertUsableCount` follows.
 function normalizeStatus(status: string | undefined): string | undefined {
-  return status && (CONVERSATION_STATUSES as readonly string[]).includes(status)
-    ? status
-    : undefined;
-}
-
-function parseCursor(cursor: string | undefined): bigint | null {
-  if (!cursor) return null;
-  try {
-    return BigInt(cursor);
-  } catch {
-    return null;
-  }
+  if (status === undefined) return undefined;
+  if (!(CONVERSATION_STATUSES as readonly string[]).includes(status))
+    badQueryParam("status");
+  return status;
 }
 
 // Combine the status filter with an optional free-text search. Search matches the contact display
@@ -150,7 +147,7 @@ export async function listConversations(
 ): Promise<ConversationsPage> {
   const take = clampLimit(filter.limit);
   const status = normalizeStatus(filter.status);
-  const cursorId = parseCursor(filter.cursor);
+  const cursorId = filter.cursor ?? null;
   const where = buildConversationsWhere(status, filter.q);
   const rows = await runScopedOn(base, ctx, (db) =>
     db.conversation.findMany({

--- a/src/modules/conversations/service.ts
+++ b/src/modules/conversations/service.ts
@@ -8,6 +8,7 @@ import {
   NotFoundError,
   TenantTargetRequiredError,
 } from "@/lib/errors";
+import { assertUsableCount } from "@/lib/query-param";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { loadAppointmentContext } from "@/modules/appointments/context";
 import {
@@ -99,8 +100,8 @@ export interface ConversationsPage {
 }
 
 function clampLimit(limit: number | undefined): number {
-  if (!limit || Number.isNaN(limit)) return DEFAULT_LIMIT;
-  return Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT);
+  assertUsableCount(limit, "limit");
+  return limit === undefined ? DEFAULT_LIMIT : Math.min(limit, MAX_LIMIT);
 }
 
 function normalizeStatus(status: string | undefined): string | undefined {

--- a/src/modules/flowlog/export.ts
+++ b/src/modules/flowlog/export.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
+import { assertUsableCount } from "@/lib/query-param";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
   buildLogWhere,
@@ -98,8 +99,9 @@ export async function exportExecutionLogs(
   base: PrismaClient = basePrisma,
   now: Date = new Date(),
 ): Promise<ExportLogsResult> {
+  assertUsableCount(opts.maxRows, "maxRows");
   const cap = Math.min(
-    Math.max(opts.maxRows ?? MAX_LOG_EXPORT_ROWS, 1),
+    opts.maxRows ?? MAX_LOG_EXPORT_ROWS,
     MAX_LOG_EXPORT_ROWS,
   );
   const where = buildLogWhere(opts);

--- a/src/modules/flowlog/read.ts
+++ b/src/modules/flowlog/read.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
+import { assertUsableCount } from "@/lib/query-param";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 
 // Read surface for the execution-flow log (the Logs page). RLS-scoped to the active tenant. KEYSET
@@ -126,7 +127,8 @@ export async function listExecutionLogs(
   opts: ListLogsOpts = {},
   base: PrismaClient = basePrisma,
 ): Promise<ListLogsResult> {
-  const take = Math.min(Math.max(opts.limit ?? 50, 1), 200);
+  assertUsableCount(opts.limit, "limit");
+  const take = Math.min(opts.limit ?? 50, 200);
   const where = buildLogWhere(opts);
   const rows = await runScopedOn(base, ctx, (db) =>
     db.executionLog.findMany({

--- a/src/modules/webhooks/outbound/deliveries.ts
+++ b/src/modules/webhooks/outbound/deliveries.ts
@@ -1,6 +1,7 @@
 import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { AppError, NotFoundError } from "@/lib/errors";
+import { assertUsableCount, badQueryParam } from "@/lib/query-param";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { emitDeliveryRequeued } from "@/modules/flowlog/webhook";
 
@@ -112,16 +113,6 @@ function toDto(r: DeliveryRow): WebhookDeliveryDto {
   };
 }
 
-function badParam(param: string): never {
-  throw new AppError(
-    `invalid value for ${param}`,
-    400,
-    "errors.invalidQueryParam",
-    { param },
-    param,
-  );
-}
-
 // The RANGE of the filters lives here, not in the controller, so MCP is held to the same rule: its
 // `since`/`until` arrive as `new Date(string)` and its `limit` as a plain number, and both reach
 // Prisma and throw on a value the caller got wrong. A 500 for a caller's typo is the wrong answer
@@ -129,19 +120,15 @@ function badParam(param: string): never {
 function assertUsableFilters(opts: ListDeliveriesOpts): void {
   for (const key of ["since", "until"] as const) {
     const d = opts[key];
-    if (d && Number.isNaN(d.getTime())) badParam(key);
+    if (d && Number.isNaN(d.getTime())) badQueryParam(key);
   }
-  if (
-    opts.limit !== undefined &&
-    (!Number.isInteger(opts.limit) || opts.limit < 1)
-  )
-    badParam("limit");
+  assertUsableCount(opts.limit, "limit");
 }
 
 // An event name is free text (the closed set lives in OUTBOUND_EVENTS, and a delivery can outlive
 // an event being retired), so the only thing to refuse here is the empty one.
 function assertUsableEvent(e: string): string {
-  if (e === "") badParam("event");
+  if (e === "") badQueryParam("event");
   return e;
 }
 

--- a/tests/api/v1/query-filter-refusal.test.ts
+++ b/tests/api/v1/query-filter-refusal.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+import { authPlugin } from "@/api/lib/auth";
+import {
+  type MockUserEntity,
+  mockFindUnique,
+  mockUser,
+  setupPrismaMock,
+} from "@/tests/utils/prisma-mock";
+
+// ── ISSUE #372: A FILTER THE CALLER TYPED IS EITHER USED OR REFUSED ──
+//
+// Driven through the REAL app rather than against the parsers alone, because what the issue is
+// about is the ANSWER the caller gets. Measured against a running instance before this branch, on
+// a tenant holding five log rows across two agents:
+//
+//   agentId=101   -> 200, 3 items          agentId=abc  -> 200, 5 items (the whole tenant)
+//   cursor=360141 -> 200, next=360139      cursor=abc   -> 200, next=360141 (the same page, forever)
+//   limit=abc     -> 500                   page=-5      -> 500 (a negative skip reaches Prisma)
+//
+// The services are stubbed so the assertion is about the boundary, not the query: a request that
+// reaches the stub was ACCEPTED, and what it carries is the filter the handler built.
+
+setupPrismaMock();
+
+const seen: Record<string, unknown> = {};
+const record =
+  (key: string) =>
+  (...args: unknown[]) => {
+    seen[key] = args[1];
+    return Promise.resolve({ items: [], nextCursor: null, entries: [] });
+  };
+
+const flowlogRead = await import("@/modules/flowlog/read");
+mock.module("@/modules/flowlog/read", () => ({
+  ...flowlogRead,
+  listExecutionLogs: mock(record("logs")),
+}));
+const auditService = await import("@/modules/audit/service");
+mock.module("@/modules/audit/service", () => ({
+  ...auditService,
+  listAudit: mock(async (..._a: unknown[]) => []),
+}));
+
+const conversationsService = await import("@/modules/conversations/service");
+mock.module("@/modules/conversations/service", () => ({
+  ...conversationsService,
+  listConversations: mock(record("conversations")),
+}));
+const adminService = await import("@/api/features/admin/admin.service");
+mock.module("@/api/features/admin/admin.service", () => ({
+  ...adminService,
+  getUsers: mock(async (..._a: unknown[]) => ({
+    users: [],
+    total: 0,
+    page: 1,
+    totalPages: 0,
+  })),
+}));
+
+const app = (await import("@/app")).default;
+
+afterAll(() => {
+  mock.module("@/modules/flowlog/read", () => flowlogRead);
+  mock.module("@/modules/audit/service", () => auditService);
+  mock.module("@/modules/conversations/service", () => conversationsService);
+  mock.module("@/api/features/admin/admin.service", () => adminService);
+});
+
+// TENANT_ADMIN, which is what these routes ask for.
+const admin: MockUserEntity = { ...mockUser, role: "TENANT_ADMIN" };
+mockFindUnique.mockImplementation(() => Promise.resolve(admin));
+const tokenApp = new Elysia()
+  .use(authPlugin)
+  .post("/mint", async ({ setAuthCookie }) => ({
+    token: await setAuthCookie(admin),
+  }));
+const { token } = (await (
+  await tokenApp.handle(
+    new Request("http://localhost/mint", { method: "POST" }),
+  )
+).json()) as { token: string };
+
+const BunReq = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
+async function get(path: string): Promise<Response> {
+  return app.handle(
+    new BunReq(`http://localhost/api${path}`, {
+      headers: { cookie: `fazerai_auth_token=${token}` },
+    }),
+  );
+}
+
+// Every leg of the same question, one row per (route, parameter, value).
+const REFUSED: Array<[path: string, param: string]> = [
+  ["/v1/logs?source=all&agentId=abc", "agentId"],
+  ["/v1/logs?source=all&agentId=", "agentId"],
+  ["/v1/logs?source=all&agentId=9223372036854775808", "agentId"],
+  ["/v1/logs?source=all&conversationId=abc", "conversationId"],
+  ["/v1/logs?source=all&cursor=abc", "cursor"],
+  ["/v1/logs?source=all&since=yesterday", "since"],
+  ["/v1/logs?source=all&since=2026-02-30T00:00:00Z", "since"],
+  ["/v1/logs?source=all&since=2026-01-01", "since"],
+  ["/v1/logs?source=all&until=garbage", "until"],
+  ["/v1/logs?source=all&limit=abc", "limit"],
+  ["/v1/logs?source=all&limit=3.5", "limit"],
+  ["/v1/logs/export?source=all&agentId=abc", "agentId"],
+  ["/v1/logs/export?source=all&since=yesterday", "since"],
+  ["/v1/logs/export?source=all&maxRows=abc", "maxRows"],
+  ["/v1/audit?limit=abc", "limit"],
+  ["/v1/conversations?limit=abc", "limit"],
+  ["/v1/conversations?limit=3.5", "limit"],
+  ["/v1/conversations/1/messages?before=abc", "before"],
+  // `page=-5` is a well-formed integer, so it is refused one layer down by the service that owns
+  // the range (see query-param.test.ts) — and `getUsers` is stubbed here, which would make an
+  // assertion about it vacuous. The live A/B in the PR body drives that one end to end.
+  ["/admin/users?page=abc", "page"],
+  ["/admin/users?page=2.5", "page"],
+  ["/v1/metrics?since=garbage", "since"],
+  ["/v1/metrics/kpis?since=2026-02-30T00:00:00Z", "since"],
+  ["/v1/metrics/timeseries?since=08/26/2026 10:00", "since"],
+  ["/v1/metrics/costs?since=2026-01-01", "since"],
+];
+
+describe("a query filter the server cannot use is a 400 that names it", () => {
+  for (const [path, param] of REFUSED) {
+    test(`${path} → 400 on ${param}`, async () => {
+      const res = await get(path);
+      // The status FIRST: 429 would mean the rate limiter answered instead of the boundary.
+      expect(`${path}: ${res.status}`).toBe(`${path}: 400`);
+      const body = (await res.json()) as { field?: string };
+      expect(body.field).toBe(param);
+    });
+  }
+});
+
+describe("a filter the server CAN use still reaches the service", () => {
+  test("every good value arrives parsed, and none of them is dropped", async () => {
+    const res = await get(
+      "/v1/logs?source=all&agentId=101&conversationId=7&cursor=42&since=2026-01-01T00:00:00Z&limit=2",
+    );
+    expect(res.status).toBe(200);
+    expect(seen.logs).toMatchObject({
+      agentId: 101n,
+      conversationId: 7n,
+      cursor: 42n,
+      since: new Date("2026-01-01T00:00:00Z"),
+      limit: 2,
+    });
+  });
+
+  test("an ABSENT filter is not a refusal", async () => {
+    const res = await get("/v1/logs?source=all");
+    expect(res.status).toBe(200);
+    expect(seen.logs).toMatchObject({
+      agentId: undefined,
+      cursor: undefined,
+      since: undefined,
+      limit: undefined,
+    });
+  });
+});

--- a/tests/api/v1/query-filter-refusal.test.ts
+++ b/tests/api/v1/query-filter-refusal.test.ts
@@ -146,6 +146,19 @@ const REFUSED: Array<[path: string, param: string]> = [
   // `9007199254740993` comes back from `Number` as `...992`: a count the caller never named.
   ["/v1/logs?source=all&limit=9007199254740993", "limit"],
   ["/v1/conversations/1/messages?before=9007199254740993", "before"],
+  // Round 3: the EMPTY value in the text and vocabulary filters. An unknown `level` reaches the
+  // query and answers zero rows, which is correct; `level=` is dropped by `buildLogWhere`'s
+  // truthiness and answers the tenant's whole table, which is the widening this branch is about.
+  ["/v1/logs?source=all&level=", "level"],
+  ["/v1/logs?source=all&stage=", "stage"],
+  ["/v1/logs?source=all&turnId=", "turnId"],
+  ["/v1/logs?source=all&search=", "search"],
+  ["/v1/logs?source=all&search=%20%20", "search"],
+  ["/v1/logs/export?source=all&level=", "level"],
+  ["/v1/logs/export?source=all&search=", "search"],
+  ["/v1/audit?action=", "action"],
+  ["/v1/conversations?q=", "q"],
+  ["/v1/agents?q=", "q"],
 ];
 
 describe("a query filter the server cannot use is a 400 that names it", () => {
@@ -156,6 +169,24 @@ describe("a query filter the server cannot use is a 400 that names it", () => {
       expect(`${path}: ${res.status}`).toBe(`${path}: 400`);
       const body = (await res.json()) as { field?: string };
       expect(body.field).toBe(param);
+    });
+  }
+});
+
+describe("an unknown value is not an unusable one", () => {
+  // The line this branch draws: `level=bogus` reaches the query and answers zero rows, which is a
+  // correct answer to a filter nothing matches and is distinguishable by the client from a widened
+  // one. Refusing it would mean the server owning a vocabulary it does not own (`stage`/`level` are
+  // validated Strings on purpose, so a new stage does not need a deploy to be queryable).
+  for (const q of [
+    "level=bogus",
+    "stage=nosuchstage",
+    "turnId=nope",
+    "search=zzz",
+  ]) {
+    test(`${q} is accepted and narrows, not refused`, async () => {
+      const res = await get(`/v1/logs?source=all&${q}`);
+      expect(`${q}: ${res.status}`).toBe(`${q}: 200`);
     });
   }
 });

--- a/tests/api/v1/query-filter-refusal.test.ts
+++ b/tests/api/v1/query-filter-refusal.test.ts
@@ -134,6 +134,18 @@ const REFUSED: Array<[path: string, param: string]> = [
   ["/v1/logs/export?source=all&maxRows=abc", "maxRows"],
   ["/v1/metrics/timeseries?tz=Not/AZone", "tz"],
   ["/v1/metrics/timeseries?tz=", "tz"],
+  // Round 2: `Number` reads spellings a count does not have, and two of them as a DIFFERENT
+  // number. All of these passed `Number.isInteger` before the decimal regex.
+  ["/v1/logs?source=all&limit=1e3", "limit"],
+  ["/v1/logs?source=all&limit=0x10", "limit"],
+  ["/v1/logs?source=all&limit=0b11", "limit"],
+  ["/v1/logs?source=all&limit=%2B7", "limit"],
+  ["/v1/logs?source=all&limit=12.0", "limit"],
+  ["/v1/logs?source=all&limit=%2012%20", "limit"],
+  ["/v1/logs?source=all&limit=-5", "limit"],
+  // `9007199254740993` comes back from `Number` as `...992`: a count the caller never named.
+  ["/v1/logs?source=all&limit=9007199254740993", "limit"],
+  ["/v1/conversations/1/messages?before=9007199254740993", "before"],
 ];
 
 describe("a query filter the server cannot use is a 400 that names it", () => {
@@ -180,12 +192,28 @@ describe("the admin tenant filter, which only a SUPER_ADMIN can send", () => {
     }
   }
 
-  for (const value of ["abc", "", "9223372036854775808"]) {
-    test(`tenantId=${value} → 400`, async () => {
-      const res = await asSuperAdmin(`/admin/users?tenantId=${value}`);
-      expect(`tenantId=${value}: ${res.status}`).toBe(`tenantId=${value}: 400`);
-      expect(((await res.json()) as { field?: string }).field).toBe("tenantId");
-    });
+  // Every route that reads the shared `resolveScope`, not just the one the issue named: round 2 of
+  // review found /admin/stats and /v1/mcp/admin/tokens publishing only 401/403 while their handlers
+  // could now answer 400, and sweeping the callers turned up /admin/invitations as a third.
+  const SUPER_ADMIN_ROUTES = [
+    "/admin/users",
+    "/admin/stats",
+    "/admin/invitations",
+    "/v1/mcp/admin/tokens",
+  ];
+
+  for (const route of SUPER_ADMIN_ROUTES) {
+    for (const value of ["abc", "", "9223372036854775808"]) {
+      test(`${route}?tenantId=${value} → 400`, async () => {
+        const res = await asSuperAdmin(`${route}?tenantId=${value}`);
+        expect(`${route} ${value}: ${res.status}`).toBe(
+          `${route} ${value}: 400`,
+        );
+        expect(((await res.json()) as { field?: string }).field).toBe(
+          "tenantId",
+        );
+      });
+    }
   }
 
   test("a usable tenant id still scopes the listing", async () => {

--- a/tests/api/v1/query-filter-refusal.test.ts
+++ b/tests/api/v1/query-filter-refusal.test.ts
@@ -121,6 +121,19 @@ const REFUSED: Array<[path: string, param: string]> = [
   ["/v1/metrics/kpis?since=2026-02-30T00:00:00Z", "since"],
   ["/v1/metrics/timeseries?since=08/26/2026 10:00", "since"],
   ["/v1/metrics/costs?since=2026-01-01", "since"],
+  // Round 1 of review found these four: the same question in four places the first sweep missed.
+  // A cursor that restarts the page and a status that widens to every status are the two failures
+  // this endpoint's siblings already refuse; `tenantId=` empty is the fleet-wide listing answering
+  // a request narrowed to one tenant.
+  ["/v1/conversations?cursor=abc", "cursor"],
+  ["/v1/conversations?cursor=", "cursor"],
+  ["/v1/conversations?cursor=9223372036854775808", "cursor"],
+  // `status` and `maxRows=0` are refused one layer down, by the services that own the vocabulary
+  // and the range — and those services are stubbed here, so asserting them over HTTP would be
+  // vacuous. service-count-range.test.ts drives both.
+  ["/v1/logs/export?source=all&maxRows=abc", "maxRows"],
+  ["/v1/metrics/timeseries?tz=Not/AZone", "tz"],
+  ["/v1/metrics/timeseries?tz=", "tz"],
 ];
 
 describe("a query filter the server cannot use is a 400 that names it", () => {
@@ -133,6 +146,52 @@ describe("a query filter the server cannot use is a 400 that names it", () => {
       expect(body.field).toBe(param);
     });
   }
+});
+
+describe("the admin tenant filter, which only a SUPER_ADMIN can send", () => {
+  // `resolveScope` reads `tenantId` ONLY for a SUPER_ADMIN; for every other role the parameter is
+  // ignored on purpose (a tenant admin must never be able to aim a read at another tenant). So the
+  // refusal lives in that branch, and asserting it as a TENANT_ADMIN would pass with the parse
+  // deleted.
+  const su: MockUserEntity = {
+    ...mockUser,
+    role: "SUPER_ADMIN",
+    tenantId: null,
+  };
+
+  async function asSuperAdmin(path: string): Promise<Response> {
+    mockFindUnique.mockImplementation(() => Promise.resolve(su));
+    const minted = (await (
+      await new Elysia()
+        .use(authPlugin)
+        .post("/mint", async ({ setAuthCookie }) => ({
+          token: await setAuthCookie(su),
+        }))
+        .handle(new Request("http://localhost/mint", { method: "POST" }))
+    ).json()) as { token: string };
+    try {
+      return await app.handle(
+        new BunReq(`http://localhost/api${path}`, {
+          headers: { cookie: `fazerai_auth_token=${minted.token}` },
+        }),
+      );
+    } finally {
+      mockFindUnique.mockImplementation(() => Promise.resolve(admin));
+    }
+  }
+
+  for (const value of ["abc", "", "9223372036854775808"]) {
+    test(`tenantId=${value} → 400`, async () => {
+      const res = await asSuperAdmin(`/admin/users?tenantId=${value}`);
+      expect(`tenantId=${value}: ${res.status}`).toBe(`tenantId=${value}: 400`);
+      expect(((await res.json()) as { field?: string }).field).toBe("tenantId");
+    });
+  }
+
+  test("a usable tenant id still scopes the listing", async () => {
+    const res = await asSuperAdmin("/admin/users?tenantId=7");
+    expect(res.status).toBe(200);
+  });
 });
 
 describe("a filter the server CAN use still reaches the service", () => {

--- a/tests/lib/query-param.test.ts
+++ b/tests/lib/query-param.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { AppError } from "@/lib/errors";
+import { assertUsableCount, badQueryParam } from "@/lib/query-param";
+
+// The RANGE half of issue #372, kept beside the services rather than in the query parser: MCP and
+// the console's own service calls reach these functions without a query string, so a check that
+// lived only in the parser would hold REST to a rule nothing else obeys.
+
+describe("assertUsableCount", () => {
+  const REFUSED = [0, -1, -5, 1.5, 3.5, Number.NaN, Number.POSITIVE_INFINITY];
+  for (const value of REFUSED) {
+    test(`${value} is refused, naming the parameter`, () => {
+      let err: unknown = null;
+      try {
+        assertUsableCount(value, "limit");
+      } catch (e) {
+        err = e;
+      }
+      expect(`${value}: ${err === null ? "accepted" : "refused"}`).toBe(
+        `${value}: refused`,
+      );
+      expect((err as AppError).statusCode).toBe(400);
+      expect((err as AppError).field).toBe("limit");
+    });
+  }
+
+  test("zero is refused rather than clamped to the default", () => {
+    // The clamps this replaces answered `limit=0` with the default page — a different question
+    // than the one asked, and indistinguishable by the client from having asked for it.
+    expect(() => assertUsableCount(0, "limit")).toThrow(AppError);
+  });
+
+  test("absent is not a value, and a positive integer survives", () => {
+    expect(() => assertUsableCount(undefined, "limit")).not.toThrow();
+    expect(() => assertUsableCount(1, "limit")).not.toThrow();
+    expect(() => assertUsableCount(200, "limit")).not.toThrow();
+  });
+});
+
+describe("badQueryParam", () => {
+  test("carries the 400, the field, and the translation key the API localizes", () => {
+    let err: unknown = null;
+    try {
+      badQueryParam("cursor");
+    } catch (e) {
+      err = e;
+    }
+    const e = err as AppError;
+    expect(e.statusCode).toBe(400);
+    expect(e.field).toBe("cursor");
+    expect(e.translationKey).toBe("errors.invalidQueryParam");
+    expect(e.translationParams).toEqual({ param: "cursor" });
+  });
+});

--- a/tests/lib/query-param.test.ts
+++ b/tests/lib/query-param.test.ts
@@ -37,6 +37,17 @@ describe("assertUsableCount", () => {
   });
 });
 
+describe("assertUsableCount still owns the range a parser cannot see", () => {
+  test("a value that never passed through a query string is still bounded", () => {
+    // MCP hands the service a plain number. `parseQueryCount`'s regex never runs on this path, so
+    // the two halves are not redundant: delete either and one transport stops being held.
+    expect(() => assertUsableCount(0, "limit")).toThrow(AppError);
+    expect(() => assertUsableCount(-1, "limit")).toThrow(AppError);
+    expect(() => assertUsableCount(3.5, "limit")).toThrow(AppError);
+    expect(() => assertUsableCount(1, "limit")).not.toThrow();
+  });
+});
+
 describe("badQueryParam", () => {
   test("carries the 400, the field, and the translation key the API localizes", () => {
     let err: unknown = null;

--- a/tests/modules/conversations.test.ts
+++ b/tests/modules/conversations.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
+import type { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
 import { listConversations } from "@/modules/conversations/service";
 import { seedChatwootInstance } from "../utils/chatwoot";
@@ -165,7 +166,12 @@ describe.skipIf(!dbUp)("listConversations", () => {
     expect(first.nextCursor).toBe(first.items[0]?.id ?? null);
     const second = await listConversations(
       ctx(tenantA),
-      { limit: 1, cursor: first.nextCursor ?? undefined },
+      // `nextCursor` crosses the wire as a string; the caller parses it back, which is what the
+      // REST route now does with `parseQueryId` instead of handing the raw value to the service.
+      {
+        limit: 1,
+        cursor: first.nextCursor ? BigInt(first.nextCursor) : undefined,
+      },
       appDb,
     );
     expect(second.items).toHaveLength(1);
@@ -183,13 +189,19 @@ describe.skipIf(!dbUp)("listConversations", () => {
     expect(open.items[0]?.status).toBe("open");
   });
 
-  test("an unknown status is ignored (returns all)", async () => {
-    const all = await listConversations(
-      ctx(tenantA),
-      { status: "bogus" },
-      appDb,
-    );
-    expect(all.items).toHaveLength(2);
+  test("an unknown status is REFUSED, not ignored", async () => {
+    // Changed in issue #372. The old contract dropped it and returned every conversation, which
+    // answers a request narrowed to one status with the tenant's whole list — and the caller has
+    // no way to tell that from a status that genuinely matches everything.
+    let err: unknown = null;
+    try {
+      await listConversations(ctx(tenantA), { status: "bogus" }, appDb);
+    } catch (e) {
+      err = e;
+    }
+    expect(err === null ? "accepted" : "refused").toBe("refused");
+    expect((err as AppError).statusCode).toBe(400);
+    expect((err as AppError).field).toBe("status");
   });
 
   test("tenant isolation: A never sees B's conversations", async () => {

--- a/tests/modules/service-count-range.test.ts
+++ b/tests/modules/service-count-range.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import type { PrismaClient } from "@/../generated/prisma/client";
+import { getUsers } from "@/api/features/admin/admin.service";
+import type { AppError } from "@/lib/errors";
+import type { TenantContext } from "@/lib/tenancy";
+import { listAudit } from "@/modules/audit/service";
+import { listConversations } from "@/modules/conversations/service";
+import { listExecutionLogs } from "@/modules/flowlog/read";
+
+// ── THE RANGE IS THE SERVICE'S, WHICH IS THE HALF REST CANNOT PROVE ──
+//
+// The query parser refuses a malformed count before any service runs, so an assertion driven over
+// HTTP passes with the service's own check deleted — measured: two mutations survived a green
+// 26-case HTTP matrix. MCP and the console's internal calls arrive HERE with a plain number and no
+// query string, so this is the layer that decides for them.
+//
+// No database: every one of these refuses before it reaches a query, and `base` is a witness to
+// that — a poisoned client that throws if anything touches it.
+const poisoned = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error("the service reached the database before refusing");
+    },
+  },
+) as PrismaClient;
+
+const ctx: TenantContext = { tenantId: 1n, userId: 1n, role: "TENANT_ADMIN" };
+
+const REFUSED = [0, -1, -5, 1.5, Number.NaN];
+
+const CALLS: Array<[name: string, run: (limit: number) => Promise<unknown>]> = [
+  ["listExecutionLogs", (limit) => listExecutionLogs(ctx, { limit }, poisoned)],
+  ["listAudit", (limit) => listAudit(ctx, { limit }, poisoned)],
+  ["listConversations", (limit) => listConversations(ctx, { limit }, poisoned)],
+  ["getUsers page", (page) => getUsers(1n, page)],
+];
+
+describe("a count outside the range is refused by the service, not clamped", () => {
+  for (const [name, run] of CALLS) {
+    for (const value of REFUSED) {
+      test(`${name}(${value}) → 400`, async () => {
+        let err: unknown = null;
+        try {
+          await run(value);
+        } catch (e) {
+          err = e;
+        }
+        expect(
+          `${name}(${value}): ${err === null ? "accepted" : "refused"}`,
+        ).toBe(`${name}(${value}): refused`);
+        expect((err as AppError).statusCode).toBe(400);
+      });
+    }
+  }
+});

--- a/tests/modules/service-count-range.test.ts
+++ b/tests/modules/service-count-range.test.ts
@@ -5,6 +5,7 @@ import type { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
 import { listAudit } from "@/modules/audit/service";
 import { listConversations } from "@/modules/conversations/service";
+import { exportExecutionLogs } from "@/modules/flowlog/export";
 import { listExecutionLogs } from "@/modules/flowlog/read";
 
 // ── THE RANGE IS THE SERVICE'S, WHICH IS THE HALF REST CANNOT PROVE ──
@@ -34,7 +35,45 @@ const CALLS: Array<[name: string, run: (limit: number) => Promise<unknown>]> = [
   ["listAudit", (limit) => listAudit(ctx, { limit }, poisoned)],
   ["listConversations", (limit) => listConversations(ctx, { limit }, poisoned)],
   ["getUsers page", (page) => getUsers(1n, page)],
+  [
+    "exportExecutionLogs maxRows",
+    (maxRows) => exportExecutionLogs(ctx, { maxRows, format: "csv" }, poisoned),
+  ],
 ];
+
+describe("a status outside the closed set is refused, not dropped", () => {
+  // Dropping it answers a request for ONE status with EVERY status. Same layer as the counts and
+  // for the same reason: MCP and the console's internal calls never pass a query string.
+  for (const status of ["bogus", "", "OPEN", "resolved "]) {
+    test(`listConversations({ status: ${JSON.stringify(status)} }) → 400`, async () => {
+      let err: unknown = null;
+      try {
+        await listConversations(ctx, { status }, poisoned);
+      } catch (e) {
+        err = e;
+      }
+      expect(`${status}: ${err === null ? "accepted" : "refused"}`).toBe(
+        `${status}: refused`,
+      );
+      expect((err as AppError).statusCode).toBe(400);
+      expect((err as AppError).field).toBe("status");
+    });
+  }
+
+  test("a status IN the set is not refused (it reaches the query)", async () => {
+    // The poisoned client is what proves it got past the vocabulary check: the throw it raises is
+    // the database, not the refusal.
+    let err: unknown = null;
+    try {
+      await listConversations(ctx, { status: "open" }, poisoned);
+    } catch (e) {
+      err = e;
+    }
+    expect((err as Error).message).toBe(
+      "the service reached the database before refusing",
+    );
+  });
+});
 
 describe("a count outside the range is refused by the service, not clamped", () => {
   for (const [name, run] of CALLS) {

--- a/tests/modules/tier3.test.ts
+++ b/tests/modules/tier3.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
+import type { AppError } from "@/lib/errors";
 import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import {
   getKpis,
@@ -1361,11 +1362,27 @@ describe.skipIf(!dbUp)(
 );
 
 describe("normalizeTimeZone", () => {
-  test("keeps a valid IANA zone, falls back to UTC otherwise", () => {
+  test("keeps a valid IANA zone; ABSENT means UTC", () => {
     expect(normalizeTimeZone("America/Sao_Paulo")).toBe("America/Sao_Paulo");
     expect(normalizeTimeZone(undefined)).toBe("UTC");
-    expect(normalizeTimeZone("")).toBe("UTC");
-    expect(normalizeTimeZone("Not/AZone")).toBe("UTC");
+  });
+
+  test("a zone the caller SENT and this cannot read is refused, not replaced", () => {
+    // Changed in issue #372. The old contract answered "UTC" here, which meant one typo
+    // (`America/Sao_Paolo`) bucketed the dashboard a day off with no way for the caller to tell.
+    for (const bad of ["", "Not/AZone", "America/Sao_Paolo", "UTC+3"]) {
+      let err: unknown = null;
+      try {
+        normalizeTimeZone(bad);
+      } catch (e) {
+        err = e;
+      }
+      expect(`${bad}: ${err === null ? "accepted" : "refused"}`).toBe(
+        `${bad}: refused`,
+      );
+      expect((err as AppError).statusCode).toBe(400);
+      expect((err as AppError).field).toBe("tz");
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #372

The read surfaces parsed their own query strings with helpers that answer `undefined` for anything they cannot read, or with a bare `Number(...)` / `new Date(...)` and nothing checking the result. A filter the caller typed wrong was never refused: it was dropped, normalised into a different filter, or handed to Prisma as `NaN`.

> Three review rounds widened this from the 20 sites the issue listed to **37 parse sites across 7 controllers plus 7 services**, because the sweep kept finding the same question one place further on. The measurements below are all from a running instance, never read off the source.

## Measured over HTTP

A lab tenant with five `execution_logs` rows across two agents and three conversations (open/resolved/pending), authenticated with a real API key.

| request | before | after |
|---|---|---|
| `/v1/logs?agentId=101` (control) | 200, **3** items | 200, **3** items |
| `/v1/logs?agentId=abc` | 200, **5 items** (the whole table) | **400** `agentId` |
| `/v1/logs?agentId=9223372036854775808` | **500** | **400** `agentId` |
| `/v1/logs?cursor=360141` (control) | 200, `next=360139` | 200, `next=360139` |
| `/v1/logs?cursor=abc` | 200, **`next=360141`** — the same page, forever | **400** `cursor` |
| `/v1/logs?since=2026-02-30` | 200, a **March** window | **400** `since` |
| `/v1/logs?since=08/26/2026 10:00` | 200, the **server's** timezone | **400** `since` |
| `/v1/logs?limit=abc` | **500** | **400** `limit` |
| `/v1/logs?level=` | 200, the whole table (truthiness drops it) | **400** `level` |
| `/v1/logs?level=bogus` (control) | 200, 0 rows | 200, 0 rows |
| `/v1/audit?limit=abc` | **500** | **400** `limit` |
| `/v1/audit?action=` | 200, the whole audit page | **400** `action` |
| `/v1/conversations?status=open` (control) | 1 conversation | 1 conversation |
| `/v1/conversations?status=bogus` | 200, **all three** | **400** `status` |
| `/v1/conversations?cursor=abc` | 200, page one again | **400** `cursor` |
| `/v1/logs/export?maxRows=0` | 200, **exported 1 row** | **400** `maxRows` |
| `/v1/logs/export?maxRows=2` (control) | 2 rows | 2 rows |
| `/v1/metrics/timeseries?tz=America/Sao_Paolo` (one typo) | 200, **UTC buckets** | **400** `tz` |
| `/admin/users?page=-5` | **500** (a negative skip reaches Prisma) | **400** `page` |
| `/admin/users?page=2.5` | 200, echoing `"page": 2.5` | **400** `page` |
| `?limit=1e3` / `0x10` / `0b11` / `+7` / `12.0` / `" 12 "` | 200, **accepted and normalised** | **400** `limit` |
| `?before=9007199254740993` | 200, paged from `...992` | **400** `before` |

## Five things the issue got wrong

Re-measuring refuted five of its claims. Each was a guard that already existed one layer on, so the site was not a defect:

1. **`documents?limit` is not a site** — its schema has `pattern: "^[1-9][0-9]*$"` and the route already answers **422 naming the field**.
2. **The four metrics `since` are not "without a NaN check"** — the next line reads `!Number.isNaN(since.getTime()) ? since : undefined`. Only *normalisation* escaped.
3. **`before` never reaches Prisma as `NaN`** — `Number.isFinite(before) ? before : undefined` was already there.
4. **`conversations?limit=abc` was not a 500** — `clampLimit` handled NaN.
5. **`limit=3.5` does not return "0 rows and `hasMore: false`"** — measured: 3 items with a valid cursor (`take: 4.5` truncates, and so does `slice(0, 3.5)`).

`agents.controller` was also audited and left alone: its schema already uses `t.Numeric({minimum, maximum})`, `t.Union([t.Literal])` and `t.Boolean`, which is the shape this is converging on.

## The design

- **One home for the parsers** (`src/api/lib/query-filters.ts`): `parseQueryInstant` / `parseQueryId` / `parseQueryCount` / `parseQueryText`. The delivery ledger's own copies (#361) are deleted and it uses these — a family regrows from the second spelling.
- **The range and the vocabulary live in the SERVICE** (`src/lib/query-param.ts`), not in the parser, so MCP and the console's internal calls are held to them. Load-bearing, not tidy: two mutations survived a green 26-case HTTP matrix *because* the parser refuses first, which is why the service half has its own tests driven with a Proxy `base` that throws if anything touches the database before the refusal.
- **`Number` is not a decimal parse.** It reads `1e3`, `0x10`, `0b11`, `0o17`, `+7`, `" 12 "`, `12.0` — all passing `Number.isInteger` — and reads `9007199254740993` as a *different number*. A decimal regex plus `Number.isSafeInteger`, the same rule `lib/db-id.ts` already applies to ids.
- **Empty is a value; unknown is not the same question.** `?level=` is dropped by truthiness and widens, so it is refused. `?level=bogus` reaches the query and answers zero rows, so it is **accepted** — refusing it would mean owning a vocabulary this surface deliberately does not own (a new `stage` must be queryable without a deploy). Tests pin both sides.
- **Two contract changes, declared.** The four metrics `since` documented "invalid values are ignored rather than rejected" — already false where it mattered, since it ignored `garbage` and *accepted* `2026-02-30`. And `normalizeTimeZone` answered "UTC" for an unreadable zone, which is the worst shape of this family: the numbers come back and look right. Absent still means UTC. Six routes that could already answer 400 now declare it in the OpenAPI.

## Red first, and mutation-tested

The HTTP matrix was written against the base and failed 25/26 (the 26th is the control that a good value still reaches the service). **29 mutations run, 29 killed** — including the two that only the service-level tests catch, the one that proves the `// translate(...)` declaration is load-bearing (without it `i18n:extract` prunes `errors.invalidQueryParam` and the refusal is untranslated at runtime, silently), and the one that makes the text parser refuse *everything*, which the `level=bogus` controls kill.

## The client was audited, and then counted

Round 4 came back clean, so the target moved to the claim in this body with no number behind it: *the console never sends an empty filter*. Closing that count found **12 call sites** into the hardened routes, and every one of them is guarded:

| call site | guard |
|---|---|
| `LogsPage.tsx:377` | `source` fixed; `if (stage)` / `if (level)` / `if (q)` / `if (conversationId)` / `if (turnId)` / `if (cursor)` |
| `LogsExportModal.tsx:78` | spreads on-page filters (a key exists only with a value) + `rangeFor()` → `toISOString()` |
| `DashboardPage.tsx:424,459` | `since ? { since } : {}`; `tz` is `Intl…resolvedOptions().timeZone` |
| `ConversationsPage.tsx:182,203` | `...(status ? {status} : {})`, `...(debouncedSearch ? {q} : {})`, `cursor` only when present |
| `ConversationDetailPage.tsx:1211` | `String(oldest)` behind `if (oldest == null) return` |
| `AgentsPage.tsx:89` | `q: debouncedSearch \|\| undefined`; numeric `page`/`pageSize` |
| `AdminUsersPage.tsx:104,114` | `selectedTenantId ? {tenantId} : {}`; `search`/`tenantId` as `x \|\| undefined` |
| `PendingInvitesCard.tsx:41` | `tenantId ? { tenantId } : {}` |
| `ChannelsTab.tsx:83`, `DocumentsPanel.tsx:185` | literal constants (`pageSize: 100`, `limit: "20"`) |

The count is what made this worth doing: `PendingInvitesCard`'s own comment reads `tenantId; "" = all, fleet-wide` — which describes the component's prop, not the query, and the line below it guards correctly. The one `?? ""` anywhere in the client (`useTenantEvents.ts:120`) targets `/api/realtime/events`, a route this PR does not touch, and is additionally behind an `enabled` flag that requires a tenant.

`bun check` green: **6771 pass / 0 fail**.
