### PR TITLE
Name the contact a redirect link is for, so a moved identifier cannot split the lead in two

### DIFF
--- a/src/modules/channel-redirect/gate.ts
+++ b/src/modules/channel-redirect/gate.ts
@@ -158,6 +158,9 @@ export async function resolveRedirectLink(
     const { token, websiteUrl } = await admin.mintRedirectToken({
       inboxId: p.widgetInboxId,
       identifier,
+      // The contact, alongside the value it carries: the identifier says WHAT to identify as and this
+      // says WHO, which is the half a moved identifier loses (issue #286).
+      contactId: p.chatwootContactId,
       message: p.clonedMessage,
       ttlSeconds: p.ttlSeconds,
       originDisplayId: p.originDisplayId,

--- a/src/modules/chatwoot/client.ts
+++ b/src/modules/chatwoot/client.ts
@@ -1067,6 +1067,13 @@ export class ChatwootClient {
   async mintRedirectToken(p: {
     inboxId: number;
     identifier: string;
+    // WHOSE identity this link carries. The identifier cannot answer it: `fzwa:<X>` is derived from a
+    // sequential contact id, so it is guessable, and it can move off the contact between the mint and
+    // a click a day later. When it has moved, the widget side finds nobody holding it and hands the
+    // value to the browser session instead of merging onto this lead, which leaves the lead with two
+    // contacts and lets the second one squat the identifier every later redirect needs (issue #286).
+    // The mint is admin-authenticated, so naming the contact here is a fact the widget side can spend.
+    contactId: number;
     message?: string;
     ttlSeconds?: number;
     originDisplayId?: number;
@@ -1078,6 +1085,7 @@ export class ChatwootClient {
       {
         inbox_id: p.inboxId,
         identifier: p.identifier,
+        contact_id: p.contactId,
         message: p.message,
         ttl_seconds: p.ttlSeconds,
         origin_display_id: p.originDisplayId,

--- a/tests/modules/channel-redirect-gate.test.ts
+++ b/tests/modules/channel-redirect-gate.test.ts
@@ -77,6 +77,9 @@ const calls: {
   // the two halves of an episode are known together, so a token minted without it produces a link
   // whose episode can never be paired.
   mintedOrigin: Array<number | undefined>;
+  // The CONTACT each token names (fazer-ai/agents#286). The identifier is guessable and can move, so
+  // it cannot say whose identity the link carries; the mint is admin-authenticated and can.
+  mintedContact: Array<number | undefined>;
   selfReads: number;
 } = {
   merges: [],
@@ -85,6 +88,7 @@ const calls: {
   unlinks: 0,
   mintedFor: [],
   mintedOrigin: [],
+  mintedContact: [],
   selfReads: 0,
 };
 // The race the recovery has to survive: the holder released the identifier between the 422 and the
@@ -129,6 +133,9 @@ function installChatwootDouble(): void {
         body.origin_display_id === undefined
           ? undefined
           : Number(body.origin_display_id),
+      );
+      calls.mintedContact.push(
+        body.contact_id === undefined ? undefined : Number(body.contact_id),
       );
       return json({
         token: "tok-123",
@@ -305,6 +312,7 @@ describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
     calls.unlinks = 0;
     calls.mintedFor = [];
     calls.mintedOrigin = [];
+    calls.mintedContact = [];
     calls.selfReads = 0;
     releaseHolderAfterCollision = false;
     failStampWith = null;
@@ -419,6 +427,10 @@ describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
     expect(calls.mintedFor).toEqual([`fzwa:${conv.chatwootContactId}`]);
     // The token names the conversation the gate is running on, which IS the episode's entry half.
     expect(calls.mintedOrigin).toEqual([7305]);
+    // And WHOSE identity it carries. Without this the widget side has only the identifier to go on,
+    // and an identifier that has moved off the contact makes it create a second one for this lead
+    // instead of merging onto it (#286).
+    expect(calls.mintedContact).toEqual([conv.chatwootContactId]);
   });
   test("a WhatsApp contact that already carries another identifier still ends up holding ours", async () => {
     const conv = await seedConversation(7306);
@@ -455,6 +467,9 @@ describe.skipIf(!dbUp)("runRedirectGate delivery accounting", () => {
       new RegExp(`^fzwa:${conv.chatwootContactId}:[0-9a-f]{8}$`),
     );
     expect(calls.mintedFor).toEqual([taken as string]);
+    // The VALUE moved; whose link it is did not. A token naming the squatter — or naming none — would
+    // send the widget to unify this lead onto somebody else, or onto nobody (#286).
+    expect(calls.mintedContact).toEqual([conv.chatwootContactId]);
     // The holder keeps what it had; nothing here writes to a contact that is not ours.
     expect(contacts.get(99003)?.identifier).toBe(
       `fzwa:${conv.chatwootContactId}`,


### PR DESCRIPTION
## What breaks

A lead that crosses from WhatsApp into the website chat is meant to come out the other side as one
person. Sometimes it comes out as two: the WhatsApp contact it keeps writing on, plus a widget contact
holding the identifier that belonged to the first one — carrying a slice of history connected to
nothing, and squatting the value every later redirect for that lead needs.

`resolveRedirectLink` mints a token carrying only the `identifier`, and the widget side identifies
with that value. Chatwoot's `ContactIdentifyAction` **merges** the visitor onto whoever holds the
identifier and **assigns** the identifier to the visitor when nobody does. `fzwa:<X>` is derived from
a sequential contact id and can move off the contact between the mint and a click up to 24h later, so
the assigning half is reachable — and when it runs, the lead is split in two.

## Measured

Reproduced against the fork's own resolve endpoint (RSpec, real DB), which is what #272 recorded it
could not do:

| at resolve time | contacts left |
| --- | --- |
| the contact holds the identifier | **1** — the visitor is merged and destroyed |
| **nobody holds it** | **2** — the lead carries no identifier, the visitor holds `fzwa:<lead id>` |

The second row is the orphan the report on #269 measured in production: a `fzwa:` contact holding the
identifier of a WhatsApp contact. Once it exists, #272's recovery keeps the funnel alive by taking
`fzwa:<X>:<random>` instead — so the lead is served, permanently, as two contacts.

## The fix

The mint is the one moment the two halves are known together, and it is admin-authenticated, so what
it is told is a fact rather than a claim. `mintRedirectToken` now names the contact as well as the
value, and the widget side merges onto **that contact** instead of onto whoever the identifier
currently points at.

Nothing else changes here: the identifier is still settled the way #272 settled it, and the token
still names the origin conversation.

The receiving half is fazer-ai/chatwoot#425. An older Chatwoot drops an unpermitted parameter
silently, so this side is safe to ship first and simply has no effect until that lands.

## Validation scope

**Proved by test** — `tests/modules/channel-redirect-gate.test.ts`, against the Chatwoot double that
implements the fork's real identity rules: the token names the lead's contact on the ordinary path,
and still names it when the identifier had to move to `fzwa:<X>:<random>` (a token naming the squatter,
or naming none, would unify the lead onto somebody else or onto nobody). Removing the one line that
carries it turns 2 tests red.

**Proved by measurement** — the resolve-side table above, run against the fork.

**Not validated** — no live traffic. The end-to-end repair only exists once fazer-ai/chatwoot#425 is
deployed; until then this is a field nothing reads.

Fixes #286
