### PR TITLE
A route id is parsed, never cast

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2003,6 +2003,28 @@
           }
         },
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -13922,6 +13944,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -17427,7 +17471,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -17726,7 +17769,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -17744,6 +17786,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -17794,28 +17858,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -17849,7 +17891,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -17867,6 +17908,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -17917,28 +17980,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -18216,7 +18257,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -18420,7 +18460,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -18624,7 +18663,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -18714,28 +18752,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -18769,7 +18785,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -18859,28 +18874,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -19013,7 +19006,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -19103,28 +19095,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -19180,7 +19150,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -19270,28 +19239,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -19325,7 +19272,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
               "description": "Vault entry id (BigInt serialized as a decimal string).",
               "type": "string"
             }
@@ -19415,28 +19361,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -30135,7 +30059,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^[0-9]+$",
               "description": "Template id (BigInt string).",
               "type": "string"
             }
@@ -30240,28 +30163,6 @@
                 }
               }
             }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
           }
         },
         "operationId": "getV1Document-templatesById"
@@ -30278,7 +30179,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^[0-9]+$",
               "description": "Template id (BigInt string).",
               "type": "string"
             }
@@ -30685,7 +30585,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^[0-9]+$",
               "description": "Template id (BigInt string).",
               "type": "string"
             }
@@ -30775,28 +30674,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -30830,7 +30707,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^[0-9]+$",
               "description": "Template id (BigInt string).",
               "type": "string"
             }
@@ -30920,28 +30796,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -31419,7 +31273,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^[0-9]+$",
               "description": "Document id (BigInt string).",
               "type": "string"
             }
@@ -31509,28 +31362,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -31564,7 +31395,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^[0-9]+$",
               "description": "Document id (BigInt string).",
               "type": "string"
             }
@@ -31654,28 +31484,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"
@@ -33866,7 +33674,6 @@
             "in": "path",
             "required": true,
             "schema": {
-              "pattern": "^[0-9]+$",
               "description": "The approval id.",
               "type": "string"
             }
@@ -33884,6 +33691,28 @@
           }
         ],
         "responses": {
+          "400": {
+            "description": "Bad request — validation failed or the input was malformed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Bad request — validation failed or the input was malformed.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized — missing or invalid credentials.",
             "content": {
@@ -33934,28 +33763,6 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
-                  "type": "object",
-                  "required": [
-                    "error"
-                  ],
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    },
-                    "field": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
                   "type": "object",
                   "required": [
                     "error"

--- a/src/api/features/admin/admin.controller.ts
+++ b/src/api/features/admin/admin.controller.ts
@@ -12,6 +12,7 @@ import { translate } from "@/api/lib/i18n";
 import { doc, errors } from "@/api/lib/openapi";
 import { parseQueryCount, parseQueryId } from "@/api/lib/query-filters";
 import config from "@/config";
+import { requireDbId } from "@/lib/db-id";
 import { UnauthorizedError } from "@/lib/errors";
 import {
   CannotDeleteSelfError,
@@ -153,7 +154,11 @@ export const adminController = new Elysia({
         set.status = 401;
         return { error: translate("errors.unauthorized", "Unauthorized") };
       }
-      if (user.id.toString() === params.id && body.role === "AGENT") {
+      // NOTE: the PARSED id, not the path segment. `parseDbId` accepts leading zeros, so `007`
+      // addresses row 7 while failing string equality against `"7"`, and comparing the raw segment
+      // let a caller past the guard that exists to stop them locking themselves out. Issue #371.
+      const targetId = requireDbId(params.id);
+      if (user.id === targetId && body.role === "AGENT") {
         set.status = 403;
         return {
           error: translate("errors.cannotDemoteSelf", "Cannot demote yourself"),
@@ -164,7 +169,7 @@ export const adminController = new Elysia({
         // a TENANT_ADMIN is fenced to its own tenant.
         const updated = await updateUserRole(
           user.tenantId,
-          BigInt(params.id),
+          targetId,
           body.role,
         );
         return {
@@ -223,7 +228,7 @@ export const adminController = new Elysia({
       try {
         await deleteUser(
           resolveScope(user, undefined),
-          BigInt(params.id),
+          requireDbId(params.id),
           user.id,
         );
         return { success: true };
@@ -267,7 +272,7 @@ export const adminController = new Elysia({
         "Delete user",
         "Permanently delete a user within the caller's tenant scope. Requires the acting admin's password; cannot delete yourself or the last admin.",
       ),
-      response: errors(401, 403, 404, 409, 422),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   // Invite a user into a tenant. A SUPER_ADMIN targets one explicitly via body.tenantId (400 if
@@ -376,7 +381,7 @@ export const adminController = new Elysia({
       const user = await getAuthUser();
       try {
         // SUPER_ADMIN may revoke any invite (own tenant null → unscoped); others are fenced.
-        await revokeInvite(user?.tenantId ?? null, BigInt(params.id));
+        await revokeInvite(user?.tenantId ?? null, requireDbId(params.id));
         return { success: true };
       } catch (error) {
         if (error instanceof InviteNotFoundError) {

--- a/src/api/middlewares/tenancy.ts
+++ b/src/api/middlewares/tenancy.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { authPlugin } from "@/api/lib/auth";
 import logger from "@/api/lib/logger";
+import { requireDbId } from "@/lib/db-id";
 import { resolveRequestTenantContext } from "@/lib/tenancy";
 
 // Elysia boundary that turns the authenticated user + X-Tenant-Id selector into a
@@ -10,10 +11,17 @@ export const tenancyPlugin = new Elysia({ name: "tenancy" })
   .use(authPlugin)
   .derive({ as: "global" }, async ({ getAuthUser, headers }) => {
     const user = await getAuthUser();
-    const { context, anomaly } = resolveRequestTenantContext(
+    const { context, anomaly, malformedSelector } = resolveRequestTenantContext(
       user,
       headers["x-tenant-id"],
     );
+    // NOTE: refused here, not folded into "no target". This is the same refusal a path id gets, in
+    // the same vocabulary, for the same reason: the value names a row and does not spell one. The
+    // three routes measured in lib/tenancy.ts answered a mistyped selector three different ways,
+    // one of them a 200. Issue #371.
+    if (malformedSelector !== undefined) {
+      requireDbId(malformedSelector, "X-Tenant-Id");
+    }
     // Tag audit attribution when the principal came from a Bearer API key (vs the cookie session).
     if (context && user?.isApiKey) context.actorType = "api_key";
     if (anomaly && user) {

--- a/src/api/v1/agents.controller.ts
+++ b/src/api/v1/agents.controller.ts
@@ -4,6 +4,7 @@ import { doc, errors } from "@/api/lib/openapi";
 import { parseQueryText } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
+import { requireDbId } from "@/lib/db-id";
 import {
   AppError,
   ForbiddenError,
@@ -323,7 +324,7 @@ export const agentsController = new Elysia({
     "/:id",
     async ({ tenantContext, params }) => ({
       instance: instanceIdentity,
-      agent: await getAgent(ctxOrThrow(tenantContext), BigInt(params.id)),
+      agent: await getAgent(ctxOrThrow(tenantContext), requireDbId(params.id)),
     }),
     {
       detail: doc("Get agent", "Returns a single agent by id."),
@@ -346,7 +347,7 @@ export const agentsController = new Elysia({
       windowHours: GUARDRAIL_HEALTH_WINDOW_HOURS,
       ...(await readGuardrailHealth(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         guardrailHealthWindowStart(),
       )),
     }),
@@ -373,7 +374,7 @@ export const agentsController = new Elysia({
       instance: instanceIdentity,
       inboxes: await listOutOfOfficeInboxes(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -468,7 +469,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         agent: await updateAgent(
           ctxOrThrow(tenantContext),
-          BigInt(params.id),
+          requireDbId(params.id),
           patch,
           undefined,
           { expectedUpdatedAt },
@@ -558,7 +559,7 @@ export const agentsController = new Elysia({
     async ({ tenantContext, params, body }) => {
       const ctx = ctxOrThrow(tenantContext);
       const b = body as { confirmName: string; password: string };
-      const agent = await getAgent(ctx, BigInt(params.id));
+      const agent = await getAgent(ctx, requireDbId(params.id));
       if (b.confirmName.trim() !== agent.name) {
         throw new AppError(
           "name confirmation does not match",
@@ -573,7 +574,7 @@ export const agentsController = new Elysia({
       ) {
         throw new AppError("Incorrect password", 403, "errors.invalidPassword");
       }
-      await deleteAgent(ctx, BigInt(params.id));
+      await deleteAgent(ctx, requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {
@@ -605,7 +606,7 @@ export const agentsController = new Elysia({
       instance: instanceIdentity,
       agent: await cloneAgent(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         (body as { name?: string }).name,
       ),
     }),
@@ -636,7 +637,7 @@ export const agentsController = new Elysia({
       instance: instanceIdentity,
       export: await exportAgent(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         undefined,
         {
           // `?components=true` bundles the full HTTP-tool / MCP / integration defs + KB metadata so
@@ -707,7 +708,7 @@ export const agentsController = new Elysia({
       instance: instanceIdentity,
       ...(await getAgentToolSelections(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       )),
     }),
     {
@@ -741,7 +742,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         ...(await runPlaygroundTurn({
           ctx,
-          agentId: BigInt(params.id),
+          agentId: requireDbId(params.id),
           message: b.message,
           threadId: b.threadId,
           overrides: b.draft,
@@ -775,7 +776,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         tools: await listPlaygroundTools({
           ctx,
-          agentId: BigInt(params.id),
+          agentId: requireDbId(params.id),
         }),
       };
     },
@@ -809,7 +810,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         ...(await runPlaygroundFollowup({
           ctx,
-          agentId: BigInt(params.id),
+          agentId: requireDbId(params.id),
           threadId: b.threadId,
           context: b.context,
           overrides: b.draft,
@@ -844,7 +845,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         ...(await runPlaygroundTranscribe({
           ctx,
-          agentId: BigInt(params.id),
+          agentId: requireDbId(params.id),
           file: b.file,
           overrides: parseDraft(b.draft),
         })),
@@ -895,7 +896,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         ...(await runPlaygroundAudioTurn({
           ctx,
-          agentId: BigInt(params.id),
+          agentId: requireDbId(params.id),
           file: b.file,
           threadId: b.threadId,
           overrides,
@@ -965,7 +966,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         ...(await runPlaygroundExtract({
           ctx,
-          agentId: BigInt(params.id),
+          agentId: requireDbId(params.id),
           file: b.file,
           overrides: parseDraft(b.draft),
         })),
@@ -1017,7 +1018,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         ...(await runPlaygroundFileTurn({
           ctx,
-          agentId: BigInt(params.id),
+          agentId: requireDbId(params.id),
           file: b.file,
           threadId: b.threadId,
           overrides,
@@ -1086,14 +1087,13 @@ export const agentsController = new Elysia({
     "/:id/playground/media/:mediaId",
     async ({ tenantContext, params, set }) => {
       const ctx = ctxOrThrow(tenantContext);
-      let mediaId: bigint;
-      try {
-        mediaId = BigInt(params.mediaId);
-      } catch {
-        set.status = 404;
-        return { error: "Not Found" };
-      }
-      const blob = await getPlaygroundMedia(ctx, mediaId);
+      // NOTE: refused, not answered 404. A media id that is not an id is a malformed request, and
+      // this route used to answer it as "no such blob": the one spelling of the rule in this app
+      // that told the caller their id was fine and the row was gone. Issue #371.
+      const blob = await getPlaygroundMedia(
+        ctx,
+        requireDbId(params.mediaId, "mediaId"),
+      );
       if (!blob) {
         set.status = 404;
         return { error: "Not Found" };
@@ -1129,7 +1129,7 @@ export const agentsController = new Elysia({
       const ctx = ctxOrThrow(tenantContext);
       return {
         instance: instanceIdentity,
-        sessions: await listPlaygroundSessions(ctx, BigInt(params.id)),
+        sessions: await listPlaygroundSessions(ctx, requireDbId(params.id)),
       };
     },
     {
@@ -1154,7 +1154,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         turns: await getPlaygroundSessionTurns(
           ctx,
-          BigInt(params.id),
+          requireDbId(params.id),
           params.threadId,
         ),
       };
@@ -1181,7 +1181,11 @@ export const agentsController = new Elysia({
     "/:id/playground/sessions/:threadId",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      await deletePlaygroundSession(ctx, BigInt(params.id), params.threadId);
+      await deletePlaygroundSession(
+        ctx,
+        requireDbId(params.id),
+        params.threadId,
+      );
       return { instance: instanceIdentity, ok: true };
     },
     {
@@ -1322,7 +1326,7 @@ export const agentsController = new Elysia({
         instance: instanceIdentity,
         ...(await replaceAgentToolSelections(
           ctxOrThrow(tenantContext),
-          BigInt(params.id),
+          requireDbId(params.id),
           b.grants,
           undefined,
           { expectedUpdatedAt: parseExpectedUpdatedAt(b.expectedUpdatedAt) },

--- a/src/api/v1/alert-channels.controller.ts
+++ b/src/api/v1/alert-channels.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -126,7 +127,7 @@ export const alertChannelsController = new Elysia({
       instance: instanceIdentity,
       channel: await updateAlertChannel(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body as AlertChannelUpdate,
       ),
     }),
@@ -197,7 +198,10 @@ export const alertChannelsController = new Elysia({
   .delete(
     "/:id",
     async ({ tenantContext, params }) => {
-      await deleteAlertChannel(ctxOrThrow(tenantContext), BigInt(params.id));
+      await deleteAlertChannel(
+        ctxOrThrow(tenantContext),
+        requireDbId(params.id),
+      );
       return { instance: instanceIdentity, success: true };
     },
     {

--- a/src/api/v1/api-keys.controller.ts
+++ b/src/api/v1/api-keys.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -80,7 +81,7 @@ export const apiKeysController = new Elysia({
   .delete(
     "/:id",
     async ({ tenantContext, params }) => {
-      await revokeApiKey(ctxOrThrow(tenantContext), BigInt(params.id));
+      await revokeApiKey(ctxOrThrow(tenantContext), requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {

--- a/src/api/v1/business-hours.controller.ts
+++ b/src/api/v1/business-hours.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -155,7 +156,7 @@ export const businessHoursController = new Elysia({
       instance: instanceIdentity,
       businessHours: await getBusinessHours(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -197,7 +198,7 @@ export const businessHoursController = new Elysia({
       instance: instanceIdentity,
       businessHours: await updateBusinessHours(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body as BusinessHoursUpdate,
       ),
     }),
@@ -219,7 +220,10 @@ export const businessHoursController = new Elysia({
   .delete(
     "/:id",
     async ({ tenantContext, params }) => {
-      await deleteBusinessHours(ctxOrThrow(tenantContext), BigInt(params.id));
+      await deleteBusinessHours(
+        ctxOrThrow(tenantContext),
+        requireDbId(params.id),
+      );
       return { instance: instanceIdentity, success: true };
     },
     {

--- a/src/api/v1/chatwoot-admin.controller.ts
+++ b/src/api/v1/chatwoot-admin.controller.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from "elysia";
 import { getUserById, verifyPassword } from "@/api/features/auth/auth.service";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import {
   AppError,
   ForbiddenError,
@@ -257,7 +258,7 @@ export const chatwootAdminController = new Elysia({
     async ({ tenantContext, params }) => {
       await softDisconnectChatwootInstance(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       return { instance: instanceIdentity, success: true };
     },
@@ -279,7 +280,7 @@ export const chatwootAdminController = new Elysia({
       instance: instanceIdentity,
       result: await reconnectChatwootInstance(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -302,7 +303,7 @@ export const chatwootAdminController = new Elysia({
     async ({ tenantContext, params, body }) => {
       const ctx = ctxOrThrow(tenantContext);
       const b = body as { confirmName: string; password: string };
-      const id = BigInt(params.id);
+      const id = requireDbId(params.id);
       const instance = await getChatwootInstance(ctx, id);
       const expected = instance.accountName ?? String(instance.accountId);
       if (b.confirmName.trim() !== expected) {
@@ -347,7 +348,10 @@ export const chatwootAdminController = new Elysia({
     "/instances/:id/sync-inboxes",
     async ({ tenantContext, params }) => ({
       instance: instanceIdentity,
-      result: await syncInboxes(ctxOrThrow(tenantContext), BigInt(params.id)),
+      result: await syncInboxes(
+        ctxOrThrow(tenantContext),
+        requireDbId(params.id),
+      ),
     }),
     {
       requireRole: "TENANT_ADMIN",
@@ -403,7 +407,7 @@ export const chatwootAdminController = new Elysia({
       instance: instanceIdentity,
       ...(await getWidgetInboxHealth(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       )),
     }),
     {
@@ -428,7 +432,7 @@ export const chatwootAdminController = new Elysia({
       instance: instanceIdentity,
       ...(await listAgentsAndTeams(
         ctxOrThrow(tenantContext),
-        BigInt(params.agentId),
+        requireDbId(params.agentId, "agentId"),
       )),
     }),
     {
@@ -451,7 +455,7 @@ export const chatwootAdminController = new Elysia({
       instance: instanceIdentity,
       ...(await listServiceWindowTemplates(
         ctxOrThrow(tenantContext),
-        BigInt(params.agentId),
+        requireDbId(params.agentId, "agentId"),
       )),
     }),
     {
@@ -474,7 +478,7 @@ export const chatwootAdminController = new Elysia({
       instance: instanceIdentity,
       ...(await listInboxLabels(
         ctxOrThrow(tenantContext),
-        BigInt(params.agentId),
+        requireDbId(params.agentId, "agentId"),
       )),
     }),
     {
@@ -497,7 +501,7 @@ export const chatwootAdminController = new Elysia({
       instance: instanceIdentity,
       ...(await listInboxCustomAttributes(
         ctxOrThrow(tenantContext),
-        BigInt(params.agentId),
+        requireDbId(params.agentId, "agentId"),
       )),
     }),
     {
@@ -524,7 +528,7 @@ export const chatwootAdminController = new Elysia({
         instance: instanceIdentity,
         inbox: await bindInbox(
           ctxOrThrow(tenantContext),
-          BigInt(params.id),
+          requireDbId(params.id),
           agentId,
         ),
       };
@@ -553,7 +557,7 @@ export const chatwootAdminController = new Elysia({
   .delete(
     "/inboxes/:id",
     async ({ tenantContext, params }) => {
-      await removeInbox(ctxOrThrow(tenantContext), BigInt(params.id));
+      await removeInbox(ctxOrThrow(tenantContext), requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {
@@ -574,7 +578,10 @@ export const chatwootAdminController = new Elysia({
     "/inboxes/:id/reconnect",
     async ({ tenantContext, params }) => ({
       instance: instanceIdentity,
-      inbox: await reconnectInbox(ctxOrThrow(tenantContext), BigInt(params.id)),
+      inbox: await reconnectInbox(
+        ctxOrThrow(tenantContext),
+        requireDbId(params.id),
+      ),
     }),
     {
       requireRole: "TENANT_ADMIN",

--- a/src/api/v1/document-templates.controller.ts
+++ b/src/api/v1/document-templates.controller.ts
@@ -245,12 +245,11 @@ export const documentTemplatesController = new Elysia({
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
-          pattern: "^[0-9]+$",
           description: "Template id (BigInt string).",
         }),
       }),
       detail: doc("Get document template", "Returns one document template."),
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   )
   .get(
@@ -266,7 +265,6 @@ export const documentTemplatesController = new Elysia({
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
-          pattern: "^[0-9]+$",
           description: "Template id (BigInt string).",
         }),
       }),
@@ -274,7 +272,7 @@ export const documentTemplatesController = new Elysia({
         "List template references",
         "Agents that were granted this template, so deletion can warn first.",
       ),
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   )
   .patch(
@@ -291,7 +289,6 @@ export const documentTemplatesController = new Elysia({
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
-          pattern: "^[0-9]+$",
           description: "Template id (BigInt string).",
         }),
       }),
@@ -317,7 +314,6 @@ export const documentTemplatesController = new Elysia({
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
-          pattern: "^[0-9]+$",
           description: "Template id (BigInt string).",
         }),
       }),
@@ -325,6 +321,6 @@ export const documentTemplatesController = new Elysia({
         "Delete document template",
         "Deletes a document template. Documents already issued from it keep their own copy.",
       ),
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   );

--- a/src/api/v1/documents.controller.ts
+++ b/src/api/v1/documents.controller.ts
@@ -202,7 +202,6 @@ export const documentsController = new Elysia({
       requireRole: "TENANT_ADMIN",
       params: t.Object({
         id: t.String({
-          pattern: "^[0-9]+$",
           description: "Document id (BigInt string).",
         }),
       }),
@@ -210,7 +209,7 @@ export const documentsController = new Elysia({
         "Revoke document",
         "Revokes an issued document; its PDF stops being served.",
       ),
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   )
   .get(
@@ -239,7 +238,6 @@ export const documentsController = new Elysia({
       requireAuth: true,
       params: t.Object({
         id: t.String({
-          pattern: "^[0-9]+$",
           description: "Document id (BigInt string).",
         }),
       }),
@@ -247,6 +245,6 @@ export const documentsController = new Elysia({
         "Download document PDF",
         "Streams the rendered PDF for inline viewing.",
       ),
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   );

--- a/src/api/v1/experiments.controller.ts
+++ b/src/api/v1/experiments.controller.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -91,7 +92,7 @@ export const experimentsController = new Elysia({
     async ({ tenantContext, params }) => ({
       instance: instanceIdentity,
       experiment: ser(
-        await getExperiment(ctxOrThrow(tenantContext), BigInt(params.id)),
+        await getExperiment(ctxOrThrow(tenantContext), requireDbId(params.id)),
       ),
     }),
     {
@@ -109,7 +110,7 @@ export const experimentsController = new Elysia({
       instance: instanceIdentity,
       results: await experimentResults(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -185,7 +186,7 @@ export const experimentsController = new Elysia({
       };
       const updated = await updateExperiment({
         ctx: ctxOrThrow(tenantContext),
-        id: BigInt(params.id),
+        id: requireDbId(params.id),
         name: b.name,
         agentId:
           b.agentId === undefined
@@ -239,7 +240,7 @@ export const experimentsController = new Elysia({
   .delete(
     "/:id",
     async ({ tenantContext, params }) => {
-      await deleteExperiment(ctxOrThrow(tenantContext), BigInt(params.id));
+      await deleteExperiment(ctxOrThrow(tenantContext), requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {

--- a/src/api/v1/integrations-admin.controller.ts
+++ b/src/api/v1/integrations-admin.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -156,7 +157,7 @@ export const integrationsAdminController = new Elysia({
         instance: instanceIdentity,
         integration: await getIntegrationInstance(
           ctxOrThrow(tenantContext),
-          BigInt(params.id),
+          requireDbId(params.id),
         ),
       };
     },
@@ -245,7 +246,7 @@ export const integrationsAdminController = new Elysia({
       instance: instanceIdentity,
       integration: await updateIntegrationInstance(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body as {
           name?: string;
           enabled?: boolean;
@@ -312,7 +313,7 @@ export const integrationsAdminController = new Elysia({
       instance: instanceIdentity,
       ...(await rotateIntegrationRouteToken(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       )),
     }),
     {
@@ -335,7 +336,7 @@ export const integrationsAdminController = new Elysia({
     async ({ tenantContext, params }) => {
       await deleteIntegrationInstance(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       return { instance: instanceIdentity, success: true };
     },

--- a/src/api/v1/knowledge.controller.ts
+++ b/src/api/v1/knowledge.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -152,7 +153,7 @@ export const knowledgeController = new Elysia({
     async ({ tenantContext, params }) => {
       const kb = await getKnowledgeBase({
         ctx: ctxOrThrow(tenantContext),
-        id: BigInt(params.id),
+        id: requireDbId(params.id),
       });
       return {
         instance: instanceIdentity,
@@ -175,7 +176,7 @@ export const knowledgeController = new Elysia({
     async ({ tenantContext, params, body }) => {
       await updateKnowledgeBase({
         ctx: ctxOrThrow(tenantContext),
-        id: BigInt(params.id),
+        id: requireDbId(params.id),
         name: body.name,
         description: body.description,
         chunkSize: body.chunkSize,
@@ -231,7 +232,7 @@ export const knowledgeController = new Elysia({
     async ({ tenantContext, params }) => {
       await deleteKnowledgeBase({
         ctx: ctxOrThrow(tenantContext),
-        id: BigInt(params.id),
+        id: requireDbId(params.id),
       });
       return { instance: instanceIdentity, success: true };
     },
@@ -275,7 +276,7 @@ export const knowledgeController = new Elysia({
     "/bases/:id/documents",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      const docs = await listDocuments(ctx, BigInt(params.id));
+      const docs = await listDocuments(ctx, requireDbId(params.id));
       const block = await readEmbeddingBlock(ctx);
       return {
         instance: instanceIdentity,
@@ -307,7 +308,7 @@ export const knowledgeController = new Elysia({
     async ({ tenantContext, params, body }) => {
       const doc = await createDocument({
         ctx: ctxOrThrow(tenantContext),
-        knowledgeBaseId: BigInt(params.id),
+        knowledgeBaseId: requireDbId(params.id),
         title: body.title,
         text: body.text,
         sourceType: "text",
@@ -353,7 +354,7 @@ export const knowledgeController = new Elysia({
       });
       const doc = await createDocument({
         ctx: ctxOrThrow(tenantContext),
-        knowledgeBaseId: BigInt(params.id),
+        knowledgeBaseId: requireDbId(params.id),
         title: body.title ?? file.name,
         text,
         sourceType: "file",
@@ -395,7 +396,7 @@ export const knowledgeController = new Elysia({
     async ({ tenantContext, params }) => {
       const doc = await getDocument(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       return {
         instance: instanceIdentity,
@@ -423,7 +424,7 @@ export const knowledgeController = new Elysia({
     async ({ tenantContext, params, body }) => {
       const doc = await updateDocument(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         {
           title: body.title,
           text: body.text,
@@ -463,7 +464,7 @@ export const knowledgeController = new Elysia({
   .delete(
     "/documents/:id",
     async ({ tenantContext, params }) => {
-      await deleteDocument(ctxOrThrow(tenantContext), BigInt(params.id));
+      await deleteDocument(ctxOrThrow(tenantContext), requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {
@@ -481,7 +482,7 @@ export const knowledgeController = new Elysia({
   .post(
     "/documents/:id/retry",
     async ({ tenantContext, params }) => {
-      await retryDocument(ctxOrThrow(tenantContext), BigInt(params.id));
+      await retryDocument(ctxOrThrow(tenantContext), requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {
@@ -501,7 +502,7 @@ export const knowledgeController = new Elysia({
     async ({ tenantContext, params, query }) => {
       const result = await reindexKnowledgeBase(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         undefined,
         { includeFailed: query.includeFailed === true },
       );
@@ -628,7 +629,7 @@ export const knowledgeController = new Elysia({
       instance: instanceIdentity,
       result: await editApprovalItem({
         ctx: ctxOrThrow(tenantContext),
-        id: BigInt(params.id),
+        id: requireDbId(params.id),
         proposedTitle: body.title,
         proposedContent: body.content,
         rationale: body.rationale,
@@ -663,7 +664,7 @@ export const knowledgeController = new Elysia({
       instance: instanceIdentity,
       result: await approveApprovalItem({
         ctx: ctxOrThrow(tenantContext),
-        id: BigInt(params.id),
+        id: requireDbId(params.id),
       }),
     }),
     {
@@ -684,7 +685,7 @@ export const knowledgeController = new Elysia({
       instance: instanceIdentity,
       result: await rejectApprovalItem({
         ctx: ctxOrThrow(tenantContext),
-        id: BigInt(params.id),
+        id: requireDbId(params.id),
       }),
     }),
     {

--- a/src/api/v1/mcp-admin.controller.ts
+++ b/src/api/v1/mcp-admin.controller.ts
@@ -3,6 +3,7 @@ import { doc, errors } from "@/api/lib/openapi";
 import { parseQueryId } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
+import { requireDbId } from "@/lib/db-id";
 import { instanceIdentity } from "@/lib/instance";
 import {
   type CreateClientInput,
@@ -208,7 +209,7 @@ export const mcpAdminController = new Elysia({
   .delete(
     "/approvals/:id",
     async ({ params }) => {
-      await deleteClientApproval(BigInt(params.id));
+      await deleteClientApproval(requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {
@@ -219,10 +220,9 @@ export const mcpAdminController = new Elysia({
       ),
       params: t.Object({
         id: t.String({
-          pattern: "^[0-9]+$",
           description: "The approval id.",
         }),
       }),
-      response: errors(401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   );

--- a/src/api/v1/mcp-connections.controller.ts
+++ b/src/api/v1/mcp-connections.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -121,7 +122,7 @@ export const mcpConnectionsController = new Elysia({
       instance: instanceIdentity,
       connection: await getMcpConnection(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -131,7 +132,7 @@ export const mcpConnectionsController = new Elysia({
         "Returns a single consumed MCP server connection by id.",
       ),
       params: idParams,
-      response: errors(401, 403, 404),
+      response: errors(400, 401, 403, 404),
     },
   )
   .get(
@@ -140,7 +141,7 @@ export const mcpConnectionsController = new Elysia({
       instance: instanceIdentity,
       references: await mcpReferences(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -178,7 +179,7 @@ export const mcpConnectionsController = new Elysia({
       instance: instanceIdentity,
       connection: await updateMcpConnection(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body as McpConnectionUpdate,
       ),
     }),
@@ -196,7 +197,10 @@ export const mcpConnectionsController = new Elysia({
   .delete(
     "/:id",
     async ({ tenantContext, params }) => {
-      await deleteMcpConnection(ctxOrThrow(tenantContext), BigInt(params.id));
+      await deleteMcpConnection(
+        ctxOrThrow(tenantContext),
+        requireDbId(params.id),
+      );
       return { instance: instanceIdentity, success: true };
     },
     {
@@ -214,7 +218,7 @@ export const mcpConnectionsController = new Elysia({
     async ({ tenantContext, params }) => {
       const discovered = await discoverMcpTools(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       return {
         instance: instanceIdentity,

--- a/src/api/v1/n8n-export.controller.ts
+++ b/src/api/v1/n8n-export.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -27,7 +28,7 @@ export const n8nExportController = new Elysia({
       instance: instanceIdentity,
       export: await exportToolWorkflowForTenant(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {

--- a/src/api/v1/oauth-google.controller.ts
+++ b/src/api/v1/oauth-google.controller.ts
@@ -6,6 +6,7 @@ import { doc, errors, htmlResponse } from "@/api/lib/openapi";
 import basePrisma from "@/api/lib/prisma";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, NotFoundError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import {
@@ -51,7 +52,6 @@ import { vaultRefWhere } from "@/modules/vault/service";
 
 const idParams = t.Object({
   id: t.String({
-    pattern: "^\\d+$",
     description: "Vault entry id (BigInt serialized as a decimal string).",
   }),
 });
@@ -100,7 +100,7 @@ export const oauthGoogleVaultController = new Elysia({
     "/:id/oauth/google/authorize",
     async ({ tenantContext, params, body }) => {
       const ctx = ctxOrThrow(tenantContext);
-      const id = BigInt(params.id);
+      const id = requireDbId(params.id);
       const cred = await loadGoogleCredential(ctx, id);
       const scopes = validateScopes((body as { scopes: string[] }).scopes);
       const codeVerifier = generateCodeVerifier();
@@ -145,7 +145,7 @@ export const oauthGoogleVaultController = new Elysia({
     "/:id/oauth/google/status",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      const cred = await loadGoogleCredential(ctx, BigInt(params.id));
+      const cred = await loadGoogleCredential(ctx, requireDbId(params.id));
       return { instance: instanceIdentity, ...projectStatus(cred) };
     },
     {
@@ -155,7 +155,7 @@ export const oauthGoogleVaultController = new Elysia({
         "Returns the connection state of a google_oauth vault entry; never returns tokens or the client secret.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Disconnect: best-effort revoke the refresh token, then drop the tokens (keep clientId/secret).
@@ -163,7 +163,7 @@ export const oauthGoogleVaultController = new Elysia({
     "/:id/oauth/google/disconnect",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      const id = BigInt(params.id);
+      const id = requireDbId(params.id);
       const cred = await loadGoogleCredential(ctx, id);
       if (cred.refreshToken) await revokeGoogleToken(cred.refreshToken);
       const stripped: GoogleOAuthCredential = {
@@ -185,7 +185,7 @@ export const oauthGoogleVaultController = new Elysia({
         "Best-effort revokes the refresh token and drops the stored tokens for a google_oauth vault entry, keeping the client id and secret.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   );
 

--- a/src/api/v1/oauth-mcp.controller.ts
+++ b/src/api/v1/oauth-mcp.controller.ts
@@ -6,6 +6,7 @@ import { doc, errors, htmlResponse } from "@/api/lib/openapi";
 import basePrisma from "@/api/lib/prisma";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, NotFoundError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import {
@@ -61,7 +62,6 @@ import { vaultRefWhere } from "@/modules/vault/service";
 
 const idParams = t.Object({
   id: t.String({
-    pattern: "^\\d+$",
     description: "Vault entry id (BigInt serialized as a decimal string).",
   }),
 });
@@ -126,7 +126,7 @@ export const oauthMcpVaultController = new Elysia({
     "/:id/oauth/mcp/authorize",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      const id = BigInt(params.id);
+      const id = requireDbId(params.id);
       const { cred, baseUrl } = await loadMcpCredential(ctx, id);
       if (!baseUrl) {
         throw new NotFoundError(
@@ -215,7 +215,7 @@ export const oauthMcpVaultController = new Elysia({
         "Discovers the MCP server OAuth configuration, registers a client via DCR if needed, and builds the authorization URL and signed state to start the consent flow for an mcp_oauth vault entry.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404, 422, 502),
+      response: errors(400, 401, 403, 404, 502),
     },
   )
   // Connection status (never returns tokens or the client secret).
@@ -223,7 +223,7 @@ export const oauthMcpVaultController = new Elysia({
     "/:id/oauth/mcp/status",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      const { cred } = await loadMcpCredential(ctx, BigInt(params.id));
+      const { cred } = await loadMcpCredential(ctx, requireDbId(params.id));
       return { instance: instanceIdentity, ...projectMcpStatus(cred) };
     },
     {
@@ -233,7 +233,7 @@ export const oauthMcpVaultController = new Elysia({
         "Returns the connection state of an mcp_oauth vault entry; never returns tokens or the client secret.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Disconnect: drop the tokens but keep the discovered config + registered client so a reconnect
@@ -242,7 +242,7 @@ export const oauthMcpVaultController = new Elysia({
     "/:id/oauth/mcp/disconnect",
     async ({ tenantContext, params }) => {
       const ctx = ctxOrThrow(tenantContext);
-      const id = BigInt(params.id);
+      const id = requireDbId(params.id);
       const { cred } = await loadMcpCredential(ctx, id);
       const stripped: McpOAuthCredential = {
         resource: cred.resource,
@@ -269,7 +269,7 @@ export const oauthMcpVaultController = new Elysia({
         "Drops the stored tokens for an mcp_oauth vault entry, keeping the discovered OAuth config and registered client.",
       ),
       params: idParams,
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   );
 

--- a/src/api/v1/tools.controller.ts
+++ b/src/api/v1/tools.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -184,7 +185,7 @@ export const toolsController = new Elysia({
       instance: instanceIdentity,
       tool: await getToolDefinition(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -207,7 +208,7 @@ export const toolsController = new Elysia({
       instance: instanceIdentity,
       references: await toolReferences(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -249,7 +250,7 @@ export const toolsController = new Elysia({
       instance: instanceIdentity,
       tool: await updateToolDefinition(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body as ToolDefinitionUpdate,
       ),
     }),
@@ -271,7 +272,10 @@ export const toolsController = new Elysia({
   .delete(
     "/:id",
     async ({ tenantContext, params }) => {
-      await deleteToolDefinition(ctxOrThrow(tenantContext), BigInt(params.id));
+      await deleteToolDefinition(
+        ctxOrThrow(tenantContext),
+        requireDbId(params.id),
+      );
       return { instance: instanceIdentity, success: true };
     },
     {

--- a/src/api/v1/v1.controller.ts
+++ b/src/api/v1/v1.controller.ts
@@ -10,6 +10,7 @@ import {
 } from "@/api/lib/query-filters";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
+import { requireDbId } from "@/lib/db-id";
 import { AppError, ForbiddenError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -97,7 +98,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params }) => {
       const tenant = await getTenant(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       return { instance: instanceIdentity, tenant };
     },
@@ -120,7 +121,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params, body }) => {
       const tenant = await updateTenant(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body as TenantUpdate,
       );
       return { instance: instanceIdentity, tenant };
@@ -155,7 +156,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params, body }) => {
       const ctx = ctxOrThrow(tenantContext);
       const b = body as { confirmName: string; password: string };
-      const id = BigInt(params.id);
+      const id = requireDbId(params.id);
       const tenant = await getTenant(ctx, id);
       if (b.confirmName.trim() !== tenant.name) {
         throw new AppError(
@@ -321,7 +322,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
       instance: instanceIdentity,
       conversation: await getConversationDetail(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -351,7 +352,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
         instance: instanceIdentity,
         ...(await getConversationMessages(
           ctxOrThrow(tenantContext),
-          BigInt(params.id),
+          requireDbId(params.id),
           {},
           undefined,
           before,
@@ -392,7 +393,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params, query, set }) => {
       const blob = await getConversationMedia(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         query.url,
       );
       if (!blob) {
@@ -435,7 +436,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params, body }) => {
       await replyToConversation(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body.content,
         body.private ?? false,
       );
@@ -477,7 +478,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params, body }) => {
       await handoffConversation(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body.assigneeId ?? null,
       );
       return { instance: instanceIdentity, success: true };
@@ -513,7 +514,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params }) => {
       const outcome = await returnConversationToAgent(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       // The call succeeded either way — the conversation is pending and the mirror is correct. The
       // outcome says whether the unassign happened, because "taken-over" means a human claimed it
@@ -543,7 +544,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params }) => {
       const { outcome } = await reengageConversation(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       return { instance: instanceIdentity, outcome };
     },
@@ -570,7 +571,7 @@ export const v1Controller = new Elysia({ prefix: "/v1" })
     async ({ tenantContext, params, body }) => {
       await setConversationStatus(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body.status,
       );
       return { instance: instanceIdentity, success: true };

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import { doc, errors } from "@/api/lib/openapi";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
+import { requireDbId } from "@/lib/db-id";
 import { ForbiddenError, TenantTargetRequiredError } from "@/lib/errors";
 import { instanceIdentity } from "@/lib/instance";
 import type { TenantContext } from "@/lib/tenancy";
@@ -49,7 +50,6 @@ function ctxOrThrow(ctx: TenantContext | null): TenantContext {
 
 const idParams = t.Object({
   id: t.String({
-    pattern: "^\\d+$",
     description: "Vault entry id (BigInt serialized as a decimal string).",
   }),
 });
@@ -139,7 +139,7 @@ export const vaultController = new Elysia({
         baseUrl?: string | null;
         paramName?: string;
       };
-      const entryId = BigInt(params.id);
+      const entryId = requireDbId(params.id);
       const id = await updateVaultEntry(ctxOrThrow(tenantContext), entryId, b);
       return {
         instance: instanceIdentity,
@@ -190,7 +190,7 @@ export const vaultController = new Elysia({
       instance: instanceIdentity,
       references: await vaultReferences(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {
@@ -200,7 +200,7 @@ export const vaultController = new Elysia({
         "Returns where a vault entry is referenced across the tenant's configuration.",
       ),
       params: idParams,
-      response: errors(401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   )
   // Test-on-save: probe a typed value (pre-save) or a stored credential by id. Stateless for the
@@ -255,7 +255,7 @@ export const vaultController = new Elysia({
     "/:id/test",
     async ({ tenantContext, params, body }) => {
       const b = (body ?? {}) as { baseURL?: string | null };
-      const ref = formatVaultRef(BigInt(params.id));
+      const ref = formatVaultRef(requireDbId(params.id));
       const result = await testStoredVaultEntry(
         ctxOrThrow(tenantContext),
         ref,
@@ -286,7 +286,7 @@ export const vaultController = new Elysia({
   .delete(
     "/:id",
     async ({ tenantContext, params }) => {
-      await deleteVaultEntry(ctxOrThrow(tenantContext), BigInt(params.id));
+      await deleteVaultEntry(ctxOrThrow(tenantContext), requireDbId(params.id));
       return { instance: instanceIdentity, success: true };
     },
     {
@@ -296,6 +296,6 @@ export const vaultController = new Elysia({
         "Permanently removes a tenant secret by id.",
       ),
       params: idParams,
-      response: errors(401, 403, 404, 422),
+      response: errors(400, 401, 403, 404),
     },
   );

--- a/src/api/v1/webhooks.controller.ts
+++ b/src/api/v1/webhooks.controller.ts
@@ -154,7 +154,7 @@ export const webhooksController = new Elysia({
       instance: instanceIdentity,
       subscription: await updateWebhookSubscription(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
         body as WebhookSubscriptionUpdate,
       ),
     }),
@@ -209,7 +209,7 @@ export const webhooksController = new Elysia({
     async ({ tenantContext, params }) => {
       await deleteWebhookSubscription(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       );
       return { instance: instanceIdentity, success: true };
     },
@@ -236,7 +236,7 @@ export const webhooksController = new Elysia({
       instance: instanceIdentity,
       result: await sendWebhookTest(
         ctxOrThrow(tenantContext),
-        BigInt(params.id),
+        requireDbId(params.id),
       ),
     }),
     {

--- a/src/lib/tenancy/index.ts
+++ b/src/lib/tenancy/index.ts
@@ -40,27 +40,51 @@ export function authorize(
 // NOTE: pure request-context resolution (unit-tested without Elysia). X-Tenant-Id is a
 // control-plane header: honored ONLY for SUPER_ADMIN (who has no home tenant and selects
 // a target per request). For everyone else it is forgeable and ignored — a mismatching
-// value is flagged as an anomaly to log, never silently accepted. A malformed selector
-// for a super admin yields a null target (→ TenantTargetRequiredError at use, i.e. 400).
+// value is flagged as an anomaly to log, never silently accepted.
+//
+// A malformed selector is REPORTED rather than folded into "no target", and the boundary refuses it
+// (api/middlewares/tenancy.ts). Folding was this function's old behaviour and the reason to change
+// it is that "absent" and "malformed" do not mean the same thing to the routes downstream: measured
+// with `X-Tenant-Id: abc`, `GET /v1/agents` answered 400, `GET /v1/vault/:id/oauth/google/status`
+// answered 403, and `GET /v1/metrics/costs` answered 200 with `{ status: "disabled" }`. A caller who
+// mistyped a selector got three different answers and, on the last one, a successful-looking body
+// for a request that named no tenant at all. Issue #371.
 export function resolveRequestTenantContext(
   user: { id: bigint; tenantId: bigint | null; role: UserRole } | null,
   headerTenantId: string | undefined,
-): { context: TenantContext | null; anomaly: boolean } {
+): {
+  context: TenantContext | null;
+  anomaly: boolean;
+  malformedSelector?: string;
+} {
   if (!user) return { context: null, anomaly: false };
 
   if (user.role === "SUPER_ADMIN") {
     // NOTE: `parseDbId`, not `BigInt` in a try. The catch only saw the spellings BigInt THROWS on,
-    // so the comment above was true of `abc` and false of the rest: `0x7`, `+7` and ` 7 ` all
-    // selected tenant 7 under a spelling no column has, and a selector past 2^63-1 parsed here and
-    // was refused by Postgres when the lookup bound it, answering 500 where this says 400. Same
-    // rule as the route ids in src/api, one surface further out. Issue #371.
+    // so `0x7`, `+7` and ` 7 ` all selected tenant 7 under a spelling no column has, and a selector
+    // past 2^63-1 parsed here and was refused by Postgres when the lookup bound it. Same rule as the
+    // route ids in src/api, one surface further out.
+    //
+    // Truthiness, not `!== undefined`: the console OMITS the header when nothing is selected
+    // (src/client/lib/api.ts), so an empty value never reaches here from it, and an empty string is
+    // the one spelling of "no selector" that a hand-written caller can send.
     const target = headerTenantId ? parseDbId(headerTenantId) : null;
+    if (headerTenantId && target === null) {
+      return {
+        context: { tenantId: null, userId: user.id, role: user.role },
+        anomaly: false,
+        malformedSelector: headerTenantId,
+      };
+    }
     return {
       context: { tenantId: target, userId: user.id, role: user.role },
       anomaly: false,
     };
   }
 
+  // NOTE: no malformed report for anyone else. The header is not honored for them at all, so its
+  // SHAPE decides nothing, and refusing on it would turn a forgeable value nobody reads into a way
+  // to fail another principal's request.
   const anomaly =
     headerTenantId !== undefined &&
     headerTenantId !== String(user.tenantId ?? "");

--- a/src/lib/tenancy/index.ts
+++ b/src/lib/tenancy/index.ts
@@ -22,6 +22,8 @@ export {
   runScopedOn,
 } from "./multi-tenant";
 
+import { parseDbId } from "@/lib/db-id";
+
 // NOTE: fail-closed cross-tenant gate. SUPER_ADMIN may target any tenant (the actual
 // data access still goes through asSuperAdmin, which is audited). Everyone else may only
 // touch their own tenant; a mismatch or missing target is Forbidden.
@@ -47,14 +49,12 @@ export function resolveRequestTenantContext(
   if (!user) return { context: null, anomaly: false };
 
   if (user.role === "SUPER_ADMIN") {
-    let target: bigint | null = null;
-    if (headerTenantId) {
-      try {
-        target = BigInt(headerTenantId);
-      } catch {
-        target = null;
-      }
-    }
+    // NOTE: `parseDbId`, not `BigInt` in a try. The catch only saw the spellings BigInt THROWS on,
+    // so the comment above was true of `abc` and false of the rest: `0x7`, `+7` and ` 7 ` all
+    // selected tenant 7 under a spelling no column has, and a selector past 2^63-1 parsed here and
+    // was refused by Postgres when the lookup bound it, answering 500 where this says 400. Same
+    // rule as the route ids in src/api, one surface further out. Issue #371.
+    const target = headerTenantId ? parseDbId(headerTenantId) : null;
     return {
       context: { tenantId: target, userId: user.id, role: user.role },
       anomaly: false,

--- a/tests/api/lib/schema-refusal-declared.test.ts
+++ b/tests/api/lib/schema-refusal-declared.test.ts
@@ -150,6 +150,17 @@ export function bodyViolation(s: Schema): { path: string[]; bad: unknown } {
     const type = sub?.type;
     if (type === "string") return { path: [key], bad: 42 };
     if (type !== undefined) return { path: [key], bad: "zzz" };
+    // NOTE: a UNION is permissive for the junk `violation` looks for, which is a STRING outside the
+    // members, and still refuses a type no member declares. `POST /v1/vault/:id/test` is the case
+    // that pays for this line: its only body property is `string | null`, so it takes any string and
+    // answers 422 for a number. That 422 was measurable before only through the route's PATH
+    // pattern, and went dark when the pattern moved into the handler (issue #371).
+    const members = (sub?.anyOf ?? []) as Schema[];
+    const takesANumber = members.some(
+      (m) =>
+        m?.type === undefined || m.type === "number" || m.type === "integer",
+    );
+    if (members.length > 0 && !takesANumber) return { path: [key], bad: 42 };
   }
   return { path: [], bad: undefined };
 }

--- a/tests/api/route-id-spelling.test.ts
+++ b/tests/api/route-id-spelling.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { Glob } from "bun";
+
+// The spelling this API is not allowed to write again.
+//
+// `src/lib/db-id.ts` has named `BigInt(params.id)` as the one to avoid since it was written, and the
+// count when this fence was added was ONE HUNDRED sites across eighteen controllers. A rule stated in
+// a header is a rule the next route inherits only if its author reads that header; this file is the
+// half that does not depend on their reading it.
+//
+// It is a source sweep and not a request sweep on purpose. The behaviour is covered over the real
+// route table in tests/api/v1/route-id-refusal.test.ts, and that file can only reach routes it can
+// call: a POST whose body is required, or a route added tomorrow, is invisible to it. What a route
+// WROTE is visible here the moment it is written. Issue #371.
+const OFFENDING = /BigInt\(\s*params\./;
+
+const sources = async (): Promise<string[]> => {
+  const glob = new Glob("**/*.ts");
+  const out: string[] = [];
+  for await (const file of glob.scan({ cwd: "src/api" })) out.push(file);
+  return out.sort();
+};
+
+describe("a route parameter is parsed, not cast", () => {
+  test("no controller casts a path parameter with BigInt", async () => {
+    const offenders: string[] = [];
+    for (const file of await sources()) {
+      const text = await Bun.file(`src/api/${file}`).text();
+      text.split("\n").forEach((line, i) => {
+        if (OFFENDING.test(line)) offenders.push(`src/api/${file}:${i + 1}`);
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  // The sweep above is worth nothing if it reads no files, and a wrong cwd or a moved directory is
+  // exactly how that happens silently.
+  test("the sweep reads the controllers", async () => {
+    const files = await sources();
+    expect(files.length).toBeGreaterThanOrEqual(30);
+    expect(files).toContain("v1/agents.controller.ts");
+  });
+
+  // The control: the pattern above has to actually match the spelling it forbids, or the sweep is
+  // green because it matches nothing.
+  test("the pattern matches the spelling it forbids", () => {
+    expect(OFFENDING.test("        BigInt(params.id),")).toBe(true);
+    expect(OFFENDING.test("BigInt( params.mediaId )")).toBe(true);
+    expect(OFFENDING.test("requireDbId(params.id)")).toBe(false);
+    expect(OFFENDING.test("BigInt(query.tenantId)")).toBe(false);
+  });
+});

--- a/tests/api/v1/route-id-refusal.test.ts
+++ b/tests/api/v1/route-id-refusal.test.ts
@@ -202,6 +202,47 @@ describe("the refusal a malformed path id produces", () => {
     expect(await res.json()).toEqual({ error: "Não é um id válido" });
   });
 
+  // The tenant selector is an id in a HEADER, and it used to be folded into "no target" when it was
+  // not one. These three routes read a null target differently: measured before this, `abc` answered
+  // 400 here, 403 on the vault route, and 200 with `{ status: "disabled" }` on the metrics route,
+  // which is a successful-looking body for a request that named no tenant. Refused at the boundary,
+  // all three answer the same thing.
+  test("a malformed tenant selector is refused, not treated as no selector", async () => {
+    const paths = [
+      "/api/v1/agents",
+      "/api/v1/metrics/costs",
+      "/api/v1/vault/1/oauth/google/status",
+    ];
+    const answers: string[] = [];
+    for (const path of paths) {
+      const res = await app.handle(
+        new BunRequest(`http://localhost${path}`, {
+          headers: {
+            cookie: `fazerai_auth_token=${token}`,
+            "X-Tenant-Id": "0x7",
+          },
+        }),
+      );
+      answers.push(`${res.status} ${JSON.stringify(await res.json())}`);
+    }
+    expect(answers).toEqual([
+      '400 {"error":"Not a valid X-Tenant-Id"}',
+      '400 {"error":"Not a valid X-Tenant-Id"}',
+      '400 {"error":"Not a valid X-Tenant-Id"}',
+    ]);
+  });
+
+  // The control: omitting the selector is not malformed, and each route still answers it its own
+  // way. This is what stops the refusal above from being read as "the header became required".
+  test("omitting the selector is still not a refusal", async () => {
+    const res = await app.handle(
+      new BunRequest("http://localhost/api/v1/metrics/costs", {
+        headers: { cookie: `fazerai_auth_token=${token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
   // The other half of "a path segment is not an id", on the one route that COMPARED one. The guard
   // that stops an admin from locking themselves out read `user.id.toString() === params.id`, and
   // `parseDbId` accepts leading zeros, so `001` addressed the caller's own row while failing that

--- a/tests/api/v1/route-id-refusal.test.ts
+++ b/tests/api/v1/route-id-refusal.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { authPlugin } from "@/api/lib/auth";
+import {
+  mockFindUnique,
+  mockUser,
+  setupPrismaMock,
+} from "@/tests/utils/prisma-mock";
+
+// What a route answers when the id in its PATH is not one.
+//
+// Driven over the real app, and swept over the real route table rather than over a hand-written list
+// of paths: the defect was one rule spelled a hundred times, so a test that names the routes it
+// checks would have gone stale the same way the rule did. `app.routes` carries the params schema
+// Elysia resolved, which is what says whether a path segment is an id at all.
+//
+// Measured on this app before the sweep, over the 57 GET/DELETE routes carrying one: 46 answered
+// 500, 12 answered 422, one answered 200, and five already answered 400. The 500 is the one the
+// issue reports — `BigInt` is arbitrary precision, so an id past 2^63-1 parses in the handler and is
+// refused by POSTGRES when the query binds it. Issue #371.
+//
+// The suite has no database in the general case and does not need one here: every assertion is about
+// a refusal that happens BEFORE any query, and the run without a database is what makes "reached the
+// database at all" visible as a 500.
+
+const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
+setupPrismaMock();
+const app = (await import("@/app")).default;
+
+const fleetUser = { ...mockUser, tenantId: null, role: "SUPER_ADMIN" as const };
+mockFindUnique.mockImplementation(() => Promise.resolve(fleetUser));
+const tokenApp = new Elysia()
+  .use(authPlugin)
+  .post("/mint", async ({ setAuthCookie }) => ({
+    token: await setAuthCookie(fleetUser),
+  }));
+const { token } = (await (
+  await tokenApp.handle(
+    new Request("http://localhost/mint", { method: "POST" }),
+  )
+).json()) as { token: string };
+
+// A path segment that addresses a row. Every OTHER `:param` in this app is opaque — a route token, a
+// thread key shaped `tenant:playground:agent:uuid`, an OAuth client_id, a jti, an asset kind. Listed
+// by what they ARE rather than derived from the name, because `clientId` and `agentId` are the same
+// shape of name and only one of them is a row id.
+const DB_ID_PARAMS = new Set(["id", "agentId", "mediaId"]);
+
+// The label the refusal names, per route parameter. `requireDbId`'s default is the parameter's own
+// name; two routes name the domain id instead, because the path spells it `:id` and the value is a
+// delivery.
+const LABEL: Record<string, string> = {
+  "GET /api/v1/webhooks/deliveries/:id": "deliveryId",
+};
+
+// Cases where a DIFFERENT value is refused before the id is read, so they say nothing about it.
+// Asserted as an exact set below: a route that stops refusing the id has to show up here rather than
+// quietly leave the sweep.
+const ANSWERED_BEFORE_THE_ID: Record<string, string> = {
+  "DELETE /api/admin/users/:id [id]": "the body requires the caller's password",
+  "DELETE /api/v1/tenants/:id [id]": "the body requires confirmName",
+  "DELETE /api/v1/agents/:id [id]": "the body requires confirmName",
+  "GET /api/v1/agents/:id/playground/media/:mediaId [id]":
+    "this route ignores the agent id and scopes the lookup by tenant",
+};
+
+interface RouteEntry {
+  method: string;
+  path: string;
+  hooks?: { params?: { properties?: Record<string, unknown> } };
+}
+
+interface Probe {
+  key: string;
+  method: string;
+  path: string;
+  param: string;
+  label: string;
+}
+
+const probes: Probe[] = [];
+for (const route of app.routes as unknown as RouteEntry[]) {
+  if (route.method !== "GET" && route.method !== "DELETE") continue;
+  const properties = route.hooks?.params?.properties ?? {};
+  for (const param of Object.keys(properties)) {
+    if (!DB_ID_PARAMS.has(param)) continue;
+    const key = `${route.method} ${route.path} [${param}]`;
+    if (key in ANSWERED_BEFORE_THE_ID) continue;
+    probes.push({
+      key,
+      method: route.method,
+      path: route.path,
+      param,
+      label: LABEL[`${route.method} ${route.path}`] ?? param,
+    });
+  }
+}
+
+// Every spelling `BigInt` accepts and a bigint column does not, plus the one it accepts and the
+// column cannot hold. The last row is the issue: it is not a `SyntaxError`, so the branch in
+// src/app.ts that answers the others never sees it.
+const MALFORMED = [
+  "abc",
+  "0x7",
+  "+7",
+  " 7 ",
+  "1e3",
+  "7.0",
+  "9223372036854775808",
+];
+
+// The spelling every route is swept with. The out-of-range one, because it is the row the issue
+// reports and the only one no route refused: the others were already answered 400, badly.
+const OUT_OF_RANGE = "9223372036854775808";
+
+// One route per family, for the spelling table below. Sweeping every route with every spelling costs
+// 350 requests against a limiter whose budget is ONE BUCKET for the whole process (600/min, shared
+// with every other file in the same worker), and a 429 in the middle of a sweep is a green test that
+// stopped testing. The spellings themselves are a decision table on `parseDbId`
+// (tests/lib/db-id.test.ts); what these three add is that a ROUTE reaches it.
+const BY_FAMILY = [
+  // never carried a shape constraint: the 400 came from the BigInt branch in src/app.ts
+  "GET /api/v1/agents/:id [id]",
+  // carried `pattern: "^[0-9]+$"` in its params schema, and answered 422 before the auth guard
+  "GET /api/v1/vault/:id/references [id]",
+  // the parameter is not named `id`, so the refusal has to name the one it refused
+  "GET /api/v1/chatwoot/labels/:agentId [agentId]",
+];
+
+const call = async (
+  probe: Probe,
+  raw: string,
+): Promise<{ status: number; body: Record<string, unknown>; text: string }> => {
+  const path = probe.path.replace(/:([A-Za-z]+)/g, (_m, name: string) => {
+    if (name === probe.param) return encodeURIComponent(raw);
+    return DB_ID_PARAMS.has(name) ? "1" : "zzz";
+  });
+  const query = path.includes("/media")
+    ? "?url=https%3A%2F%2Fexample.com%2Fa.png"
+    : "";
+  const res = await app.handle(
+    new BunRequest(`http://localhost${path}${query}`, {
+      method: probe.method,
+      headers: {
+        cookie: `fazerai_auth_token=${token}`,
+        "X-Tenant-Id": "1",
+        "content-type": "application/json",
+      },
+      body: probe.method === "DELETE" ? "{}" : undefined,
+    }),
+  );
+  // The limiter's budget is ONE bucket for the whole process and every request here resolves to the
+  // same key, so a file that ran earlier in this worker has already spent some of it. A 429 in the
+  // middle of a sweep is not a result about the route, and it must not read as one.
+  if (res.status === 429) {
+    throw new Error(
+      `${probe.key}: the shared rate-limit budget ran out mid-sweep; this file is spending too many requests`,
+    );
+  }
+  const text = await res.text();
+  let body: Record<string, unknown> = {};
+  try {
+    body = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    body = {};
+  }
+  return { status: res.status, body, text };
+};
+
+describe("a path id that is not one", () => {
+  // A filter that stops matching would empty the sweep and leave every assertion below vacuous, so
+  // the count is the first thing asserted. The number is the floor the route table was at when this
+  // was written, not a ceiling: adding routes must not need this file edited.
+  test("the sweep still covers the route table", () => {
+    expect(probes.length).toBeGreaterThanOrEqual(49);
+  });
+
+  test("an id past 2^63-1 is refused by every route, not by Postgres", async () => {
+    const wrong: string[] = [];
+    for (const probe of probes) {
+      const { status, body } = await call(probe, OUT_OF_RANGE);
+      if (status !== 400 || body.error !== `Not a valid ${probe.label}`) {
+        wrong.push(`${probe.key} -> ${status} ${JSON.stringify(body)}`);
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  test("every malformed spelling is refused, in the app's own vocabulary", async () => {
+    const wrong: string[] = [];
+    for (const key of BY_FAMILY) {
+      const probe = probes.find((p) => p.key === key);
+      if (!probe) throw new Error(`${key} left the route table`);
+      for (const raw of MALFORMED) {
+        const { status, body } = await call(probe, raw);
+        const expected = `Not a valid ${probe.label}`;
+        if (status !== 400 || body.error !== expected) {
+          wrong.push(
+            `${probe.key} ${JSON.stringify(raw)} -> ${status} ${JSON.stringify(body)}`,
+          );
+        }
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  // The half the 400 above cannot show. `Invalid ID format` was plain text, so `apiErrorMessage`
+  // (src/client/lib/apiError.ts) read no `error` key and fell back to its generic transport sentence:
+  // the console could not surface what the server had already named.
+  test("the refusal is JSON, and localized", async () => {
+    const probe = probes.find((p) => p.path === "/api/v1/agents/:id");
+    if (!probe) throw new Error("the agents route left the table");
+    const path = "/api/v1/agents/abc";
+    const res = await app.handle(
+      new BunRequest(`http://localhost${path}`, {
+        headers: {
+          cookie: `fazerai_auth_token=${token}`,
+          "X-Tenant-Id": "1",
+          "accept-language": "pt-BR",
+        },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toEqual({ error: "Não é um id válido" });
+  });
+
+  // The refusal is a status, and a status a route can return is part of its published contract: the
+  // Eden types the console is built against and the committed openapi.json both come from these
+  // `response:` maps (issue #314 pays for the same rule on 422). This covers every method, including
+  // the POSTs and PATCHes the request sweep above cannot reach.
+  test("every route with an id in its path declares the 400 it can answer", () => {
+    const undeclared: string[] = [];
+    for (const route of app.routes as unknown as RouteEntry[]) {
+      const properties = route.hooks?.params?.properties ?? {};
+      if (!Object.keys(properties).some((name) => DB_ID_PARAMS.has(name)))
+        continue;
+      const declared = (
+        route as unknown as { hooks?: { response?: Record<string, unknown> } }
+      ).hooks?.response;
+      if (!declared || !("400" in declared)) {
+        undeclared.push(`${route.method} ${route.path}`);
+      }
+    }
+    expect(undeclared).toEqual([]);
+  });
+
+  // The other half of "a path segment is not an id", on the one route that COMPARED one. The guard
+  // that stops an admin from locking themselves out read `user.id.toString() === params.id`, and
+  // `parseDbId` accepts leading zeros, so `001` addressed the caller's own row while failing that
+  // string equality. Nothing covered this guard at all before, in either spelling.
+  test("the self-demotion guard reads the id, not the segment", async () => {
+    const demote = async (segment: string) =>
+      app.handle(
+        new BunRequest(`http://localhost/api/admin/users/${segment}/role`, {
+          method: "PATCH",
+          headers: {
+            cookie: `fazerai_auth_token=${token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ role: "AGENT" }),
+        }),
+      );
+
+    // The control: the plain spelling of the caller's own id has always been caught.
+    const plain = await demote(String(fleetUser.id));
+    expect(plain.status).toBe(403);
+
+    const padded = await demote(`00${fleetUser.id}`);
+    expect(padded.status).toBe(403);
+    expect(await padded.json()).toEqual({ error: "Cannot demote yourself" });
+  });
+
+  // The excluded set is data, and data rots. Each entry is checked to still be excluded FOR THE
+  // REASON given: it answers something, and that something is not the id refusal.
+  test("every excluded case is still answered by something else", async () => {
+    const stale: string[] = [];
+    for (const [key, reason] of Object.entries(ANSWERED_BEFORE_THE_ID)) {
+      const [method, path, bracket] = key.split(" ");
+      const param = (bracket ?? "").replace(/[[\]]/g, "");
+      if (!method || !path || !param) throw new Error(`unreadable key: ${key}`);
+      const { status, body } = await call(
+        { key, method, path, param, label: param },
+        "abc",
+      );
+      if (status === 400 && body.error === `Not a valid ${param}`) {
+        stale.push(`${key} now refuses the id (${reason})`);
+      }
+    }
+    expect(stale).toEqual([]);
+  });
+});

--- a/tests/api/v1/route-id-refusal.test.ts
+++ b/tests/api/v1/route-id-refusal.test.ts
@@ -7,21 +7,23 @@ import {
   setupPrismaMock,
 } from "@/tests/utils/prisma-mock";
 
-// What a route answers when the id in its PATH is not one.
+// What a route does with an id in its path that is not one.
 //
-// Driven over the real app, and swept over the real route table rather than over a hand-written list
-// of paths: the defect was one rule spelled a hundred times, so a test that names the routes it
-// checks would have gone stale the same way the rule did. `app.routes` carries the params schema
-// Elysia resolved, which is what says whether a path segment is an id at all.
+// The defect was one rule spelled a hundred times, so the coverage here is over the REAL route table
+// rather than over a hand-written list of paths: `app.routes` carries both the params schema Elysia
+// resolved and the handler it registered, which is what says whether a path segment is an id and
+// whether the handler parsed it. Measured before the sweep, over the 57 GET/DELETE routes carrying
+// one: 46 answered 500, 12 answered 422, one answered 200, and five already answered 400. The 500 is
+// the one the issue reports, because `BigInt` is arbitrary precision, so an id past 2^63-1 parses in
+// the handler and is refused by POSTGRES when the query binds it. Issue #371.
 //
-// Measured on this app before the sweep, over the 57 GET/DELETE routes carrying one: 46 answered
-// 500, 12 answered 422, one answered 200, and five already answered 400. The 500 is the one the
-// issue reports — `BigInt` is arbitrary precision, so an id past 2^63-1 parses in the handler and is
-// refused by POSTGRES when the query binds it. Issue #371.
-//
-// The suite has no database in the general case and does not need one here: every assertion is about
-// a refusal that happens BEFORE any query, and the run without a database is what makes "reached the
-// database at all" visible as a 500.
+// The two structural tests below send no requests, and that is deliberate rather than convenient.
+// The limiter's budget is ONE bucket for the whole process (600/min, `peer ?? "unknown"` under
+// `app.handle`, so every request in every file in the worker shares it), and how many files share a
+// process depends on the runner's core count. A per-route request sweep cost about 77 of that budget
+// and passed on this machine while answering 429 on CI, where it also starved 24 tests in other
+// files that had nothing to do with it. So the ROUTES are covered by reading the table, and the
+// requests below are spent only on the wire contract, which reading cannot show.
 
 const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
   .BunRequest;
@@ -42,61 +44,107 @@ const { token } = (await (
   )
 ).json()) as { token: string };
 
-// A path segment that addresses a row. Every OTHER `:param` in this app is opaque — a route token, a
+// A path segment that addresses a row. Every OTHER `:param` in this app is opaque: a route token, a
 // thread key shaped `tenant:playground:agent:uuid`, an OAuth client_id, a jti, an asset kind. Listed
 // by what they ARE rather than derived from the name, because `clientId` and `agentId` are the same
 // shape of name and only one of them is a row id.
 const DB_ID_PARAMS = new Set(["id", "agentId", "mediaId"]);
 
-// The label the refusal names, per route parameter. `requireDbId`'s default is the parameter's own
-// name; two routes name the domain id instead, because the path spells it `:id` and the value is a
-// delivery.
-const LABEL: Record<string, string> = {
-  "GET /api/v1/webhooks/deliveries/:id": "deliveryId",
-};
-
-// Cases where a DIFFERENT value is refused before the id is read, so they say nothing about it.
-// Asserted as an exact set below: a route that stops refusing the id has to show up here rather than
-// quietly leave the sweep.
-const ANSWERED_BEFORE_THE_ID: Record<string, string> = {
-  "DELETE /api/admin/users/:id [id]": "the body requires the caller's password",
-  "DELETE /api/v1/tenants/:id [id]": "the body requires confirmName",
-  "DELETE /api/v1/agents/:id [id]": "the body requires confirmName",
+// A route parameter no handler reads. Held as an exact set so that a handler which STOPS parsing one
+// has to be written down here rather than quietly leaving the coverage.
+const NOT_READ_BY_ITS_HANDLER: Record<string, string> = {
   "GET /api/v1/agents/:id/playground/media/:mediaId [id]":
-    "this route ignores the agent id and scopes the lookup by tenant",
+    "the blob is looked up by media id and scoped by tenant; the agent id in the path is decoration",
 };
 
 interface RouteEntry {
   method: string;
   path: string;
-  hooks?: { params?: { properties?: Record<string, unknown> } };
+  handler?: unknown;
+  hooks?: {
+    params?: { properties?: Record<string, unknown> };
+    response?: Record<string, unknown>;
+  };
 }
 
-interface Probe {
+interface IdParam {
   key: string;
-  method: string;
-  path: string;
+  route: RouteEntry;
   param: string;
-  label: string;
 }
 
-const probes: Probe[] = [];
+const idParams: IdParam[] = [];
 for (const route of app.routes as unknown as RouteEntry[]) {
-  if (route.method !== "GET" && route.method !== "DELETE") continue;
-  const properties = route.hooks?.params?.properties ?? {};
-  for (const param of Object.keys(properties)) {
+  for (const param of Object.keys(route.hooks?.params?.properties ?? {})) {
     if (!DB_ID_PARAMS.has(param)) continue;
-    const key = `${route.method} ${route.path} [${param}]`;
-    if (key in ANSWERED_BEFORE_THE_ID) continue;
-    probes.push({
-      key,
-      method: route.method,
-      path: route.path,
+    idParams.push({
+      key: `${route.method} ${route.path} [${param}]`,
+      route,
       param,
-      label: LABEL[`${route.method} ${route.path}`] ?? param,
     });
   }
 }
+
+const handlerSource = (route: RouteEntry): string =>
+  typeof route.handler === "function" ? String(route.handler) : "";
+
+describe("every route that takes an id in its path parses it", () => {
+  // A filter that stops matching would empty both structural tests and leave them vacuously green,
+  // so the count is asserted first. A floor, not a ceiling: adding routes must not need this edited.
+  test("the route table still carries the id parameters", () => {
+    expect(idParams.length).toBeGreaterThanOrEqual(100);
+    expect(idParams.map((p) => p.key)).toContain("GET /api/v1/agents/:id [id]");
+  });
+
+  test("each one is parsed by the handler that receives it", () => {
+    const unparsed = idParams
+      .filter(({ key }) => !(key in NOT_READ_BY_ITS_HANDLER))
+      .filter(
+        ({ route, param }) =>
+          !handlerSource(route).includes(`requireDbId(params.${param}`),
+      )
+      .map(({ key }) => key);
+    expect(unparsed).toEqual([]);
+  });
+
+  // The control for the test above: it reads TRANSPILED source, so a build that renamed the import
+  // would make it match nothing and pass. This fails in that case instead.
+  test("the handler source is readable, and the match is not vacuous", () => {
+    const agents = idParams.find(
+      (p) => p.key === "GET /api/v1/agents/:id [id]",
+    );
+    if (!agents) throw new Error("the agents route left the table");
+    const source = handlerSource(agents.route);
+    expect(source).toContain("requireDbId(params.id");
+    expect(source).not.toContain("BigInt(params.id");
+    const parsed = idParams.filter(({ route, param }) =>
+      handlerSource(route).includes(`requireDbId(params.${param}`),
+    );
+    expect(parsed.length).toBeGreaterThanOrEqual(100);
+  });
+
+  // The exclusions are data, and data rots.
+  test("a parameter listed as unread is still unread", () => {
+    const stale = Object.keys(NOT_READ_BY_ITS_HANDLER).filter((key) => {
+      const entry = idParams.find((p) => p.key === key);
+      if (!entry) return true;
+      return handlerSource(entry.route).includes(
+        `requireDbId(params.${entry.param}`,
+      );
+    });
+    expect(stale).toEqual([]);
+  });
+
+  // The refusal is a status, and a status a route can return is part of its published contract: the
+  // Eden types the console is built against and the committed openapi.json both come from these
+  // `response:` maps (issue #314 pays for the same rule on 422).
+  test("every one of those routes declares the 400 it can answer", () => {
+    const undeclared = idParams
+      .filter(({ route }) => !("400" in (route.hooks?.response ?? {})))
+      .map(({ key }) => key);
+    expect(undeclared).toEqual([]);
+  });
+});
 
 // Every spelling `BigInt` accepts and a bigint column does not, plus the one it accepts and the
 // column cannot hold. The last row is the issue: it is not a `SyntaxError`, so the branch in
@@ -111,140 +159,47 @@ const MALFORMED = [
   "9223372036854775808",
 ];
 
-// The spelling every route is swept with. The out-of-range one, because it is the row the issue
-// reports and the only one no route refused: the others were already answered 400, badly.
-const OUT_OF_RANGE = "9223372036854775808";
-
-// One route per family, for the spelling table below. Sweeping every route with every spelling costs
-// 350 requests against a limiter whose budget is ONE BUCKET for the whole process (600/min, shared
-// with every other file in the same worker), and a 429 in the middle of a sweep is a green test that
-// stopped testing. The spellings themselves are a decision table on `parseDbId`
-// (tests/lib/db-id.test.ts); what these three add is that a ROUTE reaches it.
-const BY_FAMILY = [
-  // never carried a shape constraint: the 400 came from the BigInt branch in src/app.ts
-  "GET /api/v1/agents/:id [id]",
-  // carried `pattern: "^[0-9]+$"` in its params schema, and answered 422 before the auth guard
-  "GET /api/v1/vault/:id/references [id]",
-  // the parameter is not named `id`, so the refusal has to name the one it refused
-  "GET /api/v1/chatwoot/labels/:agentId [agentId]",
-];
-
-const call = async (
-  probe: Probe,
-  raw: string,
-): Promise<{ status: number; body: Record<string, unknown>; text: string }> => {
-  const path = probe.path.replace(/:([A-Za-z]+)/g, (_m, name: string) => {
-    if (name === probe.param) return encodeURIComponent(raw);
-    return DB_ID_PARAMS.has(name) ? "1" : "zzz";
-  });
-  const query = path.includes("/media")
-    ? "?url=https%3A%2F%2Fexample.com%2Fa.png"
-    : "";
-  const res = await app.handle(
-    new BunRequest(`http://localhost${path}${query}`, {
-      method: probe.method,
+const get = (path: string, lang = "en"): Promise<Response> =>
+  app.handle(
+    new BunRequest(`http://localhost${path}`, {
       headers: {
         cookie: `fazerai_auth_token=${token}`,
         "X-Tenant-Id": "1",
-        "content-type": "application/json",
+        "accept-language": lang,
       },
-      body: probe.method === "DELETE" ? "{}" : undefined,
     }),
   );
-  // The limiter's budget is ONE bucket for the whole process and every request here resolves to the
-  // same key, so a file that ran earlier in this worker has already spent some of it. A 429 in the
-  // middle of a sweep is not a result about the route, and it must not read as one.
-  if (res.status === 429) {
-    throw new Error(
-      `${probe.key}: the shared rate-limit budget ran out mid-sweep; this file is spending too many requests`,
-    );
-  }
-  const text = await res.text();
-  let body: Record<string, unknown> = {};
-  try {
-    body = JSON.parse(text) as Record<string, unknown>;
-  } catch {
-    body = {};
-  }
-  return { status: res.status, body, text };
-};
 
-describe("a path id that is not one", () => {
-  // A filter that stops matching would empty the sweep and leave every assertion below vacuous, so
-  // the count is the first thing asserted. The number is the floor the route table was at when this
-  // was written, not a ceiling: adding routes must not need this file edited.
-  test("the sweep still covers the route table", () => {
-    expect(probes.length).toBeGreaterThanOrEqual(49);
-  });
-
-  test("an id past 2^63-1 is refused by every route, not by Postgres", async () => {
+describe("the refusal a malformed path id produces", () => {
+  test("every spelling is answered 400, naming the parameter", async () => {
     const wrong: string[] = [];
-    for (const probe of probes) {
-      const { status, body } = await call(probe, OUT_OF_RANGE);
-      if (status !== 400 || body.error !== `Not a valid ${probe.label}`) {
-        wrong.push(`${probe.key} -> ${status} ${JSON.stringify(body)}`);
+    for (const raw of MALFORMED) {
+      const res = await get(`/api/v1/agents/${encodeURIComponent(raw)}`);
+      const body = (await res.json()) as Record<string, unknown>;
+      if (res.status !== 400 || body.error !== "Not a valid id") {
+        wrong.push(
+          `${JSON.stringify(raw)} -> ${res.status} ${JSON.stringify(body)}`,
+        );
       }
     }
     expect(wrong).toEqual([]);
   });
 
-  test("every malformed spelling is refused, in the app's own vocabulary", async () => {
-    const wrong: string[] = [];
-    for (const key of BY_FAMILY) {
-      const probe = probes.find((p) => p.key === key);
-      if (!probe) throw new Error(`${key} left the route table`);
-      for (const raw of MALFORMED) {
-        const { status, body } = await call(probe, raw);
-        const expected = `Not a valid ${probe.label}`;
-        if (status !== 400 || body.error !== expected) {
-          wrong.push(
-            `${probe.key} ${JSON.stringify(raw)} -> ${status} ${JSON.stringify(body)}`,
-          );
-        }
-      }
-    }
-    expect(wrong).toEqual([]);
+  // The refusal names the parameter it refused, which on this route is not `id`.
+  test("a parameter that is not called id is named by its own name", async () => {
+    const res = await get("/api/v1/chatwoot/labels/abc");
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Not a valid agentId" });
   });
 
-  // The half the 400 above cannot show. `Invalid ID format` was plain text, so `apiErrorMessage`
-  // (src/client/lib/apiError.ts) read no `error` key and fell back to its generic transport sentence:
-  // the console could not surface what the server had already named.
-  test("the refusal is JSON, and localized", async () => {
-    const probe = probes.find((p) => p.path === "/api/v1/agents/:id");
-    if (!probe) throw new Error("the agents route left the table");
-    const path = "/api/v1/agents/abc";
-    const res = await app.handle(
-      new BunRequest(`http://localhost${path}`, {
-        headers: {
-          cookie: `fazerai_auth_token=${token}`,
-          "X-Tenant-Id": "1",
-          "accept-language": "pt-BR",
-        },
-      }),
-    );
+  // The half the status cannot show. `Invalid ID format` was plain text, so `apiErrorMessage`
+  // (src/client/lib/apiError.ts) read no `error` key and fell back to its generic transport
+  // sentence: the console could not surface what the server had already named.
+  test("it is JSON, and localized", async () => {
+    const res = await get("/api/v1/agents/abc", "pt-BR");
     expect(res.status).toBe(400);
     expect(res.headers.get("content-type")).toContain("application/json");
     expect(await res.json()).toEqual({ error: "Não é um id válido" });
-  });
-
-  // The refusal is a status, and a status a route can return is part of its published contract: the
-  // Eden types the console is built against and the committed openapi.json both come from these
-  // `response:` maps (issue #314 pays for the same rule on 422). This covers every method, including
-  // the POSTs and PATCHes the request sweep above cannot reach.
-  test("every route with an id in its path declares the 400 it can answer", () => {
-    const undeclared: string[] = [];
-    for (const route of app.routes as unknown as RouteEntry[]) {
-      const properties = route.hooks?.params?.properties ?? {};
-      if (!Object.keys(properties).some((name) => DB_ID_PARAMS.has(name)))
-        continue;
-      const declared = (
-        route as unknown as { hooks?: { response?: Record<string, unknown> } }
-      ).hooks?.response;
-      if (!declared || !("400" in declared)) {
-        undeclared.push(`${route.method} ${route.path}`);
-      }
-    }
-    expect(undeclared).toEqual([]);
   });
 
   // The other half of "a path segment is not an id", on the one route that COMPARED one. The guard
@@ -252,7 +207,7 @@ describe("a path id that is not one", () => {
   // `parseDbId` accepts leading zeros, so `001` addressed the caller's own row while failing that
   // string equality. Nothing covered this guard at all before, in either spelling.
   test("the self-demotion guard reads the id, not the segment", async () => {
-    const demote = async (segment: string) =>
+    const demote = (segment: string) =>
       app.handle(
         new BunRequest(`http://localhost/api/admin/users/${segment}/role`, {
           method: "PATCH",
@@ -265,30 +220,10 @@ describe("a path id that is not one", () => {
       );
 
     // The control: the plain spelling of the caller's own id has always been caught.
-    const plain = await demote(String(fleetUser.id));
-    expect(plain.status).toBe(403);
+    expect((await demote(String(fleetUser.id))).status).toBe(403);
 
     const padded = await demote(`00${fleetUser.id}`);
     expect(padded.status).toBe(403);
     expect(await padded.json()).toEqual({ error: "Cannot demote yourself" });
-  });
-
-  // The excluded set is data, and data rots. Each entry is checked to still be excluded FOR THE
-  // REASON given: it answers something, and that something is not the id refusal.
-  test("every excluded case is still answered by something else", async () => {
-    const stale: string[] = [];
-    for (const [key, reason] of Object.entries(ANSWERED_BEFORE_THE_ID)) {
-      const [method, path, bracket] = key.split(" ");
-      const param = (bracket ?? "").replace(/[[\]]/g, "");
-      if (!method || !path || !param) throw new Error(`unreadable key: ${key}`);
-      const { status, body } = await call(
-        { key, method, path, param, label: param },
-        "abc",
-      );
-      if (status === 400 && body.error === `Not a valid ${param}`) {
-        stale.push(`${key} now refuses the id (${reason})`);
-      }
-    }
-    expect(stale).toEqual([]);
   });
 });

--- a/tests/lib/tenancy.test.ts
+++ b/tests/lib/tenancy.test.ts
@@ -76,7 +76,7 @@ describe("resolveRequestTenantContext", () => {
   // the spellings BigInt THROWS on: every row here used to come back as a target. The first four
   // selected tenant 7 under a spelling no column has, and the last two parsed to a value the column
   // cannot hold, which Postgres refuses at bind time with a 500 on a path documented as 400.
-  test("a selector BigInt would accept and a column would not is still no target", () => {
+  test("a selector BigInt would accept and a column would not is reported malformed", () => {
     for (const header of [
       "0x7",
       "+7",
@@ -84,17 +84,53 @@ describe("resolveRequestTenantContext", () => {
       "0b111",
       "9223372036854775808",
       "99999999999999999999",
+      "not-a-number",
     ]) {
-      const { context } = resolveRequestTenantContext(superAdmin, header);
+      const { context, malformedSelector } = resolveRequestTenantContext(
+        superAdmin,
+        header,
+      );
       expect(context?.tenantId).toBeNull();
+      // Reported, not folded into "no selector at all": the routes downstream answer those two
+      // differently, and one of them answers 200.
+      expect(malformedSelector).toBe(header);
     }
   });
 
-  // The control for the row above: the same digits, unpadded, still select.
+  // The control for the row above: the same digits, unpadded, still select and report nothing.
   test("a plain decimal selector still selects", () => {
-    expect(resolveRequestTenantContext(superAdmin, "7").context?.tenantId).toBe(
-      7n,
+    const { context, malformedSelector } = resolveRequestTenantContext(
+      superAdmin,
+      "7",
     );
+    expect(context?.tenantId).toBe(7n);
+    expect(malformedSelector).toBeUndefined();
+  });
+
+  // Absent and empty are the same thing and neither is malformed: the console omits the header when
+  // nothing is selected (src/client/lib/api.ts), so refusing an empty value would refuse a request
+  // that named no tenant, which every route already answers on its own terms.
+  test("an absent or empty selector is not malformed", () => {
+    for (const header of [undefined, ""]) {
+      const { context, malformedSelector } = resolveRequestTenantContext(
+        superAdmin,
+        header,
+      );
+      expect(context?.tenantId).toBeNull();
+      expect(malformedSelector).toBeUndefined();
+    }
+  });
+
+  // The header decides nothing for anyone but a SUPER_ADMIN, so its shape decides nothing either.
+  // Refusing on it would let a forgeable value nobody reads fail another principal's request.
+  test("a malformed selector from a non-super-admin is ignored, not refused", () => {
+    const { context, malformedSelector, anomaly } = resolveRequestTenantContext(
+      tenantAdmin,
+      "0x7",
+    );
+    expect(context?.tenantId).toBe(3n);
+    expect(malformedSelector).toBeUndefined();
+    expect(anomaly).toBe(true);
   });
 
   test("tenant admin keeps own tenant and flags a forged header as anomaly", () => {

--- a/tests/lib/tenancy.test.ts
+++ b/tests/lib/tenancy.test.ts
@@ -72,6 +72,31 @@ describe("resolveRequestTenantContext", () => {
     expect(context?.tenantId).toBeNull();
   });
 
+  // The half the test above did not reach. The old parse was `BigInt` in a try, so it refused only
+  // the spellings BigInt THROWS on: every row here used to come back as a target. The first four
+  // selected tenant 7 under a spelling no column has, and the last two parsed to a value the column
+  // cannot hold, which Postgres refuses at bind time with a 500 on a path documented as 400.
+  test("a selector BigInt would accept and a column would not is still no target", () => {
+    for (const header of [
+      "0x7",
+      "+7",
+      " 7 ",
+      "0b111",
+      "9223372036854775808",
+      "99999999999999999999",
+    ]) {
+      const { context } = resolveRequestTenantContext(superAdmin, header);
+      expect(context?.tenantId).toBeNull();
+    }
+  });
+
+  // The control for the row above: the same digits, unpadded, still select.
+  test("a plain decimal selector still selects", () => {
+    expect(resolveRequestTenantContext(superAdmin, "7").context?.tenantId).toBe(
+      7n,
+    );
+  });
+
   test("tenant admin keeps own tenant and flags a forged header as anomaly", () => {
     const ok = resolveRequestTenantContext(tenantAdmin, "3");
     expect(ok.context?.tenantId).toBe(3n);


### PR DESCRIPTION
`src/lib/db-id.ts` has named `BigInt(params.id)` as the spelling to avoid since it was written, and
100 routes across 18 controllers still wrote it. `BigInt` is arbitrary precision and lenient, and
both halves bite: it accepts spellings no column has, and it accepts values no column can hold.

Measured over the real route table, on the 57 GET/DELETE routes carrying a database id in their
path, one parameter at a time:

| the caller sends | routes | answer |
| --- | --- | --- |
| `9223372036854775808` | 46 | **500**, raised by Postgres when the query bound it |
| `9223372036854775808` | 1 | **200** |
| `9223372036854775808` | 5 | 400, already correct |
| `abc` | 44 | 400, as plain text with no `error` key |
| `abc` | 12 | 422, from a `pattern` on the params schema |

The aliases are the part the issue's table understates. `0x7`, `+7` and ` 7 ` all reach the handler
as `7n`, so `DELETE /api/admin/invitations/0x7` addresses invitation 7 under a spelling the column
does not have, and anything keyed on the raw path segment sees four ids where there is one.

The plain-text 400 has a second cost: `apiErrorMessage` (`src/client/lib/apiError.ts`) reads
`value.error` and answers null for everything else, which is its "transport failure, show the
generic sentence" branch. So the console could not surface a refusal the server had already made.

## What changed

Every route parses with `requireDbId`, which is what `webhooks.controller.ts` and the documents
controllers already did: one refusal, 400, JSON, localized, naming the parameter it refused.

The same rule reaches one surface further out, the `X-Tenant-Id` selector, whose `BigInt` in a `try`
saw only the spellings BigInt throws on, so `0x7` selected tenant 7 and a selector past 2^63-1 became
a 500. It is now refused **at the boundary** rather than folded into "no target", because those two
do not mean the same thing downstream: measured with `X-Tenant-Id: abc`, `GET /v1/agents` answered
400, `GET /v1/vault/:id/oauth/google/status` answered 403, and `GET /v1/metrics/costs` answered
**200** with `{ status: "disabled" }`, a successful-looking body for a request that named no tenant.
All three now answer `400 {"error":"Not a valid X-Tenant-Id"}`. An absent or empty selector is
unchanged and is not a refusal (the console omits the header when nothing is selected), and the
header still decides nothing for a non-super-admin, so its shape is not refused for them either.

Two routes carried a private spelling of the rule and now answer like the rest:

- `GET /:id/playground/media/:mediaId` caught the `SyntaxError` and answered **404**, telling the
  caller their id was fine and the row was gone.
- `PATCH /admin/users/:id/role` compared `user.id.toString() === params.id`. `parseDbId` accepts
  leading zeros, so `001` addressed the caller's own row while failing that string equality, and the
  guard that stops an admin from locking themselves out was bypassed. Nothing covered that guard in
  either spelling before.

The 19 params schemas that carried `pattern: "^[0-9]+$"` lose it. It is not a guard being removed:
`requireDbId` refuses a strict superset of what the pattern refuses (the pattern accepts every
19-digit value, including the ones past 2^63-1, which is how `DELETE /v1/mcp/admin/approvals/:id`
still answered 500 with the pattern in place). What it bought was a second answer to one mistake,
and it ran before the auth gate: measured, `/api/v1/vault/abc/references` answered 422
unauthenticated while `/api/v1/agents/abc` answered 401.

Bookkeeping that follows from it, both caught by the existing #314 fence rather than by hand: 13
routes stop being able to answer 422 and stop declaring it, and 5 routes that could always answer
400 now declare it (`DELETE /admin/users/:id` never did).

## Why not the shape the issue prefers

The issue's first choice is a db-id format in the params schema, refusing before the handler runs.
Both ways of writing it were built and measured against the real app, alongside today's spelling:

| | handler receives | rate-limit cost | status |
| --- | --- | --- | --- |
| `BigInt(params.id)` today | `string` | 1 | 400 plain text, or 500 |
| `t.Transform` that throws | `bigint` | **0** | 400 |
| `format` carrying the range | `string` | 1 | 422 |
| `requireDbId` in the handler | `bigint` | 1 | 400 |

The transform is the shape the issue describes, and it is the one that cannot be taken. It throws
before the handler, so it never reaches the limiter's counting hook, and the `AppError` handler
registered ahead of the limiters answers it first: the refusal is free. That is the hole
`tests/api/middlewares/rateLimitMetering.test.ts` exists to pin, measured here at cost 0 against 1
for every other answer.

The format is chargeable but cannot express the range without a direct dependency on
`@sinclair/typebox`, which is an undeclared transitive peer of Elysia, and it moves the answer to
422 on 98 routes. #381 answers the identical question on the query side with 400, so 400 is what
this side answers too.

## What of the report does not hold

**The branch in `src/app.ts` cannot go yet.** The issue says it goes "once nothing depends on it",
and after this something still does: ids taken from a **body** are still cast, in
`knowledge.controller.ts` (`BigInt(body.knowledgeBaseId)`), `admin.controller.ts`
(`BigInt(body.tenantId)`), `experiments.controller.ts` and `chatwoot-admin.controller.ts`
(`BigInt(b.agentId)`). Deleting the branch here would turn those 400s into 500s. Path ids are this
PR, query filters were #381, and the body is the third surface; it needs an issue of its own.

## Validation scope

**Proved over the real route table, without sending a request.**
`tests/api/v1/route-id-refusal.test.ts` reads `app.routes`, which carries both the params schema
Elysia resolved and the handler it registered: all **106** id parameters, across every method, are
asserted to be parsed by the handler that receives them, and each of those routes is asserted to
declare the 400 it can answer. One parameter is held as an asserted exclusion (`:id` on the playground
media route, which the handler genuinely ignores), and the exclusion is itself re-checked. The match
reads transpiled source, so a control asserts it is not vacuous.

**Proved over the wire, on eleven requests.** Every malformed spelling on one route; a route whose
parameter is not called `id`, so the sentence has to name the right one; the body being JSON and
localized; and the self-demotion guard in both spellings. Plus a source fence
(`tests/api/route-id-spelling.test.ts`) that stays red while `BigInt(params.` survives anywhere under
`src/api`, with a positive control on the pattern itself, and a decision table on the tenant selector.

Eleven mutations were applied one at a time and every one was caught: reverting a single site in four
different controllers (including the two parameters not called `id`), reverting the self-demotion
comparison, killing the range check in `parseDbId`, killing its digits check, reverting the tenant
header, removing one declared 400, dropping the boundary refusal, and never reporting a selector as
malformed.

**Why the coverage is structural rather than a request sweep, measured.** The first version of this
file swept every GET/DELETE route over HTTP. It cost about 77 requests, passed locally, and answered
**429** on CI, where it also starved 24 tests in other files that had nothing to do with it. The
limiter's budget is one bucket for the whole process (600/min; under `app.handle` the key resolves to
`peer ?? "unknown"`, so every request in every file in the worker shares it), and how many files share
a process depends on the runner's core count. Reading the table covers more routes, every method
instead of two, and costs nothing. What it cannot show is the wire contract, which is what the eleven
requests are spent on.

**Unmeasured, and pre-existing.** That CI run also says the `tests/api` group's headroom against that
one bucket is thin: 24 failures in files this PR does not touch. This PR stops adding to it and does
not fix it.

**Unchanged, and worth naming.** `parseDbId` still accepts leading zeros, so `007` addresses row 7.
That is why the self-demotion guard now compares parsed ids instead of the segment. Narrowing
`parseDbId` itself would change a function the vault refs, the MCP writes and #381's query filters
all lean on, and nothing measured here asks for it.

**No live validation.** Nothing on this path talks to a vendor.

Fixes #371
