### PR TITLE
Take a refusal about a bag to the tab that draws it

### DIFF
--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -60,7 +60,14 @@ export interface FieldRefusal {
 // Read through a ref, because the answer is needed AFTER the await and a submit handler closes over
 // the render it started in. That was the point of the boolean's ref too; it is the same fix, applied
 // to the thing that was always the real question.
-export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
+// `owned` is every name this form can mark, drawn or not, and it is the second argument because
+// almost nobody needs it: a form whose controls are all on screen together owns exactly what it
+// renders, and leaving it out says so. The agent editor is the one that does — thirty-odd values
+// behind eight tabs — and for it the two lists are genuinely different questions. See placeRefusal.
+export function useFieldRefusal(
+  rendered: readonly string[],
+  owned?: readonly string[],
+): FieldRefusal {
   const { showToast } = useToast();
   const [held, setHeld] = useState<{
     field: string;
@@ -79,6 +86,8 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
   }, []);
   const fields = useRef(rendered);
   fields.current = rendered;
+  const ownedFields = useRef(owned);
+  ownedFields.current = owned;
 
   const capture = useCallback(
     (
@@ -89,11 +98,17 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
     ) => {
       // The form is where the operator is looking only if it is drawing something. An empty list is
       // a dismissed dialog, a tab left behind, a page unmounted — all the same answer.
-      const onForm = mounted.current && fields.current.length > 0;
+      // Drawing NOTHING is what takes the form off the screen, and a form that owns more than it
+      // draws is still on screen while the open tab happens to hold no placeable control: the empty
+      // list would otherwise read as a dismissed dialog.
+      const onForm =
+        mounted.current &&
+        (fields.current.length > 0 || (ownedFields.current?.length ?? 0) > 0);
       const placed = placeRefusal(readRefusal(e), fields.current, fallback, {
         mounted: onForm,
         sent,
         current,
+        owned: ownedFields.current,
       });
       if (placed.at !== undefined) {
         setHeld({
@@ -101,7 +116,10 @@ export function useFieldRefusal(rendered: readonly string[]): FieldRefusal {
           message: placed.message,
           value: placed.value,
         });
-        return null;
+        // Null unless the control is off screen. `placeRefusal` says which by handing back a
+        // sentence beside the mark, and the caller is the only one that can put that sentence
+        // somewhere the operator will read it AND take them to the control.
+        return placed.toast ?? null;
       }
       // NOTE: written even when nothing is placed, and that is the whole of "the capture is also the
       // clear": a mark left over from a refusal the server has stopped making would sit on a control

--- a/src/client/hooks/useFieldRefusal.ts
+++ b/src/client/hooks/useFieldRefusal.ts
@@ -39,7 +39,20 @@ export interface FieldRefusal {
   // The input currently marked, for a caller that has to go somewhere to show it: the agent editor's
   // fields live behind tabs, and a mark on a tab nobody is looking at is not yet visible. Nothing
   // here navigates — which tab holds which path is the screen's knowledge, not this hook's.
+  //
+  // Null while the standing refusal is about no input of this form's, which `message` still carries.
   field: string | null;
+  // The standing refusal's sentence, whether or not it could be placed at an input.
+  //
+  // Here rather than in the caller because a caller that keeps its own copy has a SECOND source of
+  // truth for one fact, and the two drift in ways nothing can see: the copy outlives the mark it
+  // duplicates, it is tagged with the wrong owner, a second refusal about the same field leaves the
+  // first copy standing. Three review rounds on fazer-ai/agents#414 found three spellings of that,
+  // all of them a page holding the sentence beside a hook that was already holding it.
+  //
+  // Expires with the hold and never on its own: every `capture` overwrites it, and `clear` drops it.
+  // A caller rendering it for a PLACED mark still has to ask `at`, because that one expires by value.
+  message: string | null;
 }
 
 // `rendered` is what the form is DRAWING RIGHT NOW, and the tense is the whole of it.
@@ -69,8 +82,10 @@ export function useFieldRefusal(
   owned?: readonly string[],
 ): FieldRefusal {
   const { showToast } = useToast();
+  // `field` is null for a refusal this form cannot place at an input. Held anyway, so the sentence
+  // has exactly one home — see `message` above.
   const [held, setHeld] = useState<{
-    field: string;
+    field: string | null;
     message: string;
     value: unknown;
   } | null>(null);
@@ -123,8 +138,13 @@ export function useFieldRefusal(
       }
       // NOTE: written even when nothing is placed, and that is the whole of "the capture is also the
       // clear": a mark left over from a refusal the server has stopped making would sit on a control
-      // while the toast says something else.
-      setHeld(null);
+      // while the toast says something else. The sentence is kept beside the empty field so a caller
+      // with a place to render it does not have to hold a copy of its own.
+      setHeld(
+        placed.toast
+          ? { field: null, message: placed.toast, value: undefined }
+          : null,
+      );
       // The caller's OTHER channel is inside the form for ten of the holders here: an error line
       // drawn between the dialog's title and its buttons, which `useOnModalOpen` then clears on the
       // next opening. Handing them a sentence for a form the operator has dismissed only moves the
@@ -156,5 +176,11 @@ export function useFieldRefusal(
     [held],
   );
 
-  return { at, capture, clear, field: held?.field ?? null };
+  return {
+    at,
+    capture,
+    clear,
+    field: held?.field ?? null,
+    message: held?.message ?? null,
+  };
 }

--- a/src/client/lib/configHealth.ts
+++ b/src/client/lib/configHealth.ts
@@ -2,6 +2,7 @@ import {
   canonicalVaultRef,
   VAULT_REF_PREFIX,
 } from "@/client/lib/credentialRef";
+import { editorTargetFor } from "@/client/lib/editorRefusal";
 import { isValidHttpUrl } from "@/client/lib/validation";
 import {
   hasModelFallback,
@@ -90,34 +91,6 @@ export interface ConfigIssue {
   inboxNames?: string[];
 }
 
-// Where a capped field is edited, by the path the walker reports. A path with no entry has no control
-// in the editor: `toolGuidance` accepts a note for all thirteen native tools and only three of them
-// have a field, so the rest can only have been written through REST or MCP. Those still get a
-// warning — being cut in silence is the whole defect — just without a place to send the operator.
-const TEXT_CAP_TARGETS: Array<{
-  match: RegExp;
-  tab: NonNullable<ConfigIssue["tab"]>;
-  sectionId: string;
-}> = [
-  { match: /^handoff\.instructions$/, tab: "tools", sectionId: "tools-native" },
-  { match: /^kanban\.instructions$/, tab: "tools", sectionId: "tools-native" },
-  {
-    match:
-      /^toolGuidance\.(set_custom_attribute|assign_label|update_kanban_task)$/,
-    tab: "tools",
-    sectionId: "tools-native",
-  },
-  {
-    match: /^guardrails\.customPolicy$/,
-    tab: "guardrails",
-    sectionId: "gr-policy",
-  },
-  { match: /^guardrails\.input\./, tab: "guardrails", sectionId: "gr-input" },
-  { match: /^guardrails\.output\./, tab: "guardrails", sectionId: "gr-output" },
-  { match: /^vision\.extractionPrompt$/, tab: "behavior", sectionId: "vision" },
-  { match: /^followUp\.steps\[/, tab: "behavior", sectionId: "proactive" },
-];
-
 // Whether the warning row can offer an action. Everything else in this list has a fix the editor can
 // reach — a section to scroll to, a vault entry to fill, a knowledge base to index — but a textCap
 // issue for a note with no control in the console has nowhere to send anyone.
@@ -131,18 +104,15 @@ function textCapIssues(
 ): ConfigIssue[] {
   // Against nothing stored: every over-cap value in the bag is one the operator should know about,
   // which is the opposite question from the write boundary's (what does this write change).
+  // Where the field is edited comes from editorRefusal, which is the same map a REFUSAL about the
+  // same path routes on. One list, because the two used to disagree: this one had no entry for
+  // `availability.awayMessage` or `contactAuth.denyMessage`, so a warning about either claimed the
+  // console has no field for it while the textarea sat on the Behavior tab.
   return collectOversizedTextChanges(settings, undefined).map((o) => {
-    const target = TEXT_CAP_TARGETS.find((t) => t.match.test(o.path));
-    // The guardrails sections other than gr-model are rendered only while guardrails are ON, so with
-    // them off the anchor is not in the DOM and the jump silently does nothing. gr-model is always
-    // mounted and holds the switch that brings the rest back.
-    const sectionId =
-      target?.tab === "guardrails" && !guardrailsEnabled
-        ? "gr-model"
-        : target?.sectionId;
+    const target = editorTargetFor(o.path, { guardrailsEnabled });
     return {
       key: "textCap" as const,
-      ...(target ? { tab: target.tab, sectionId } : {}),
+      ...(target ? { tab: target.tab, sectionId: target.sectionId } : {}),
       field: o.path,
       length: o.length,
       max: o.max,

--- a/src/client/lib/editorRefusal.ts
+++ b/src/client/lib/editorRefusal.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOOL_NAMES } from "@/graph/tools/catalog";
 import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
 
 // WHERE THE AGENT EDITOR DRAWS A VALUE THE SERVER CAN NAME, as one map.
@@ -15,6 +16,24 @@ import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
 // why: deriving the location as "the behavior tab, section = block" was right for four entries and
 // wrong for the fifth. Restating it would be a fourth copy of a list that has already been wrong
 // three times.
+
+// The native-tool notes the console draws no control for. `toolGuidance` takes one for all thirteen
+// tools in NATIVE_TOOL_NAMES and the editor renders three, so this set is closed and derivable --
+// which is what makes it safe to TELL the operator a value can only be changed through the API.
+//
+// That claim used to be read off the absence of a target, and absence proves nothing about the
+// console: the map was missing `settings.modelFallback.model` and `observability.fullDetailUntil`,
+// both of which have a visible control, so the banner said the opposite of the truth about them.
+export const UNDRAWN_TOOL_NOTES: readonly string[] = NATIVE_TOOL_NAMES.filter(
+  (n) =>
+    !["set_custom_attribute", "assign_label", "update_kanban_task"].includes(n),
+).map((n) => `toolGuidance.${n}`);
+
+// Whether the console really has no control for a value the server named, said only where it can be
+// proved rather than inferred from this map having no entry.
+export function hasNoConsoleControl(field: string): boolean {
+  return UNDRAWN_TOOL_NOTES.includes(field.replace(/^settings\./, ""));
+}
 
 export type EditorTab =
   | "general"
@@ -75,6 +94,31 @@ const TEXT_TARGETS: ReadonlyArray<{ match: RegExp } & EditorTarget> = [
   { match: /^guardrails\.output\./, tab: "guardrails", sectionId: "gr-output" },
   { match: /^vision\.extractionPrompt$/, tab: "behavior", sectionId: "vision" },
   { match: /^followUp\.steps\[/, tab: "behavior", sectionId: "proactive" },
+  // Not text caps: the other refusals an agent write names by a settings path. They are here for the
+  // same reason the caps are -- so a refusal about one can take the operator to it -- and their
+  // absence used to do worse than nothing, because the banner read "no entry" as "no control in the
+  // console" and said so about a picker that is on screen.
+  {
+    match: /^modelFallback\.model$/,
+    tab: "behavior",
+    sectionId: "modelFallback",
+  },
+  {
+    match: /^observability\.fullDetailUntil$/,
+    tab: "behavior",
+    sectionId: "observability",
+  },
+  // TARGETED AND NOT OWNED, all three of them, which is a distinction this map makes on purpose.
+  // Owning a name means marking a control with the server's sentence, and that needs one box holding
+  // one value: the tool preconditions are edited as a list rather than a control per tool, the
+  // fallback model comes out of a picker whose value the wire does not carry verbatim, and the
+  // observability window is a datetime. Targeting is the weaker and honest claim -- here is where
+  // that value is edited -- and it is all the banner needs to offer a way there.
+  {
+    match: /^toolPreconditions\./,
+    tab: "tools",
+    sectionId: "tools-preconditions",
+  },
 ];
 
 // The values the editor draws a control for OUTSIDE any bag: the two on the General tab plus the

--- a/src/client/lib/editorRefusal.ts
+++ b/src/client/lib/editorRefusal.ts
@@ -264,3 +264,65 @@ export function editorRefusalFields(view: EditorControlsShown): {
   ];
   return { drawn, owned };
 }
+
+// WHAT A WRITE CARRIED, by the server's names, read from the patch it is about to send.
+//
+// Not from what the editor is DRAWING, which is what the first version of this did and what
+// conflated two different questions. `drawn` is about whether a MARK CAN BE READ; `sent` is about
+// what the REQUEST PUT ON THE WIRE, and the two disagree by construction: `buildSettings()`
+// serializes the whole settings bag, including the blocks whose controls are switched off, and
+// `saveGuardrails` sends `{...syncedSettings, guardrails}` whether or not the switch is on.
+//
+// A field the patch carries and this map omits gets no staleness check at all -- `placeRefusal` reads
+// `Object.hasOwn(sent, field)` and, finding nothing, marks the box without comparing, which puts the
+// server's sentence under a value the operator changed while the request was out. And the same
+// omission makes a later successful save fail to clear that mark, because the clear asks this map
+// too. One reading, taken from the thing that was actually sent.
+export function sentFromPatch(
+  patch: Record<string, unknown>,
+  owned: readonly string[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const field of owned) {
+    const found = readPatchPath(patch, field);
+    if (found.present) out[field] = found.value;
+  }
+  return out;
+}
+
+// The value a refused name has inside a patch, and whether the patch carries it at all.
+//
+// Both spellings land in the same bag: `settings.tts.credentialRef` names the agent row and
+// `guardrails.customPolicy` names the settings bag, and the only names that live OUTSIDE `settings`
+// are the row's own columns. Absence is answered separately from an undefined value, because
+// "the write did not mention this" and "the write sent nothing here" are different facts and only
+// the first one means there is nothing to compare against.
+function readPatchPath(
+  patch: Record<string, unknown>,
+  field: string,
+): { present: boolean; value: unknown } {
+  const column = field === "name" || field === "systemPrompt";
+  const root = column
+    ? patch
+    : field.startsWith("modelConfig.")
+      ? patch.modelConfig
+      : patch.settings;
+  const path = column
+    ? [field]
+    : field
+        .replace(/^settings\./, "")
+        .replace(/^modelConfig\./, "")
+        // `followUp.steps[2].instructions` is the server's spelling; the index is a step of the walk.
+        .replace(/\[(\d+)\]/g, ".$1")
+        .split(".");
+  let node: unknown = root;
+  for (let i = 0; i < path.length; i++) {
+    const step = path[i] as string;
+    if (!node || typeof node !== "object")
+      return { present: false, value: undefined };
+    const bag = node as Record<string, unknown>;
+    if (!Object.hasOwn(bag, step)) return { present: false, value: undefined };
+    node = bag[step];
+  }
+  return { present: true, value: node };
+}

--- a/src/client/lib/editorRefusal.ts
+++ b/src/client/lib/editorRefusal.ts
@@ -123,83 +123,144 @@ export function editorTargetFor(
   return target;
 }
 
-// The names the editor declares, by the tab that draws them.
+// WHICH SWITCH HAS TO BE ON for a control to be in the DOM.
 //
-// TAB-GATED, and only tab-gated, which is a decision rather than an omission. Several of these
-// controls sit behind a switch inside their own section — the vision prompt appears with vision on,
-// the deny message with the authorization gate on — so a list that answered "drawn right now" to the
-// letter would carry a dozen booleans out of three component files and into this one, and every
-// drift between them would reappear as the silence the mechanism exists to prevent.
+// The first version of this file declared per TAB and argued that the switches could not matter: both
+// producers refuse only what a write introduces or changes, so a value behind an off switch cannot be
+// refused, because changing it needs the control. The argument is sound about the moment the refusal
+// ARRIVES and says nothing about afterwards -- the operator can turn Vision off while its credential
+// refusal is standing, and then the mark is held on a control that is no longer drawn, with no banner
+// because the field's tab is still the open one. Silence, which is the one outcome barred here.
 //
-// What makes the tab the right granularity is a property of the WRITE BOUNDARY, not a tolerance:
-// both producers refuse only the text or the ref a write INTRODUCES or CHANGES
-// (`collectOversizedTextChanges`, `collectCredentialRefWrites`, and both say so in their own
-// comments, with the reason). Changing one of these values requires its control, and its control
-// requires the switch. So a refusal naming a field whose switch is off cannot arrive from this
-// editor, and the declaration is exact for every refusal that can. `tests/client/editor-refusal.
-// test.ts` pins that invariant, because it is the thing this simplification rests on.
-const TAB_FIELDS: Readonly<Record<EditorTab, readonly string[]>> = {
-  general: ["name", "systemPrompt", "modelConfig.credentialRef"],
-  behavior: [
-    "settings.stt.credentialRef",
-    "settings.tts.credentialRef",
-    "settings.tts.normalizeCredentialRef",
-    "settings.vision.credentialRef",
-    "settings.contactAuth.credentialRef",
-    "settings.memory.compaction.credentialRef",
-    "availability.awayMessage",
-    "contactAuth.denyMessage",
-    "vision.extractionPrompt",
-  ],
-  guardrails: [
-    "settings.guardrails.credentialRef",
-    "guardrails.customPolicy",
-    "guardrails.input.templateMessage",
-    "guardrails.output.templateMessage",
-    "guardrails.output.generationPrompt",
-  ],
-  tools: [
-    "handoff.instructions",
-    "kanban.instructions",
-    "toolGuidance.set_custom_attribute",
-    "toolGuidance.assign_label",
-    "toolGuidance.update_kanban_task",
-  ],
-  // The redirect tab writes its own block through its own save and declares nothing here yet; the
-  // knowledge and playground tabs draw no value the server refuses by name.
-  channelRedirect: [],
+// So the question is asked per control, and the answer is a name the caller reads off its own state.
+export interface EditorControlsShown {
+  // Any of the editor's tabs, not only the five that write an agent: the page also draws Channels,
+  // Knowledge, Playground and Experiments, and each of those answers with an empty list.
+  tab: string;
+  awayEnabled: boolean;
+  sttEnabled: boolean;
+  // TTS has no boolean: any mode other than "never" means audio replies are on.
+  ttsOn: boolean;
+  ttsNormalize: boolean;
+  visionEnabled: boolean;
+  contactAuthEnabled: boolean;
+  memoryCompactionEnabled: boolean;
+  // The fallback's credential picker appears once a provider is chosen, not behind a switch.
+  modelFallbackChosen: boolean;
+  guardrailsEnabled: boolean;
+  followUpEnabled: boolean;
+  // How many follow-up steps the Proactive section is showing. The note of a step that does not
+  // exist is a name nothing can render, so the list stops where the editor's does.
+  followUpSteps: number;
+}
+
+type SwitchName = Exclude<keyof EditorControlsShown, "tab" | "followUpSteps">;
+
+// The switch each credential picker sits behind, by the path the server refuses it under.
+//
+// Keyed by path and looked up rather than listed alongside, so a credential added to
+// `SETTINGS_CREDENTIAL_PATHS` next week is OWNED by construction -- that is the half that cannot be
+// allowed to drift, and it already did: `settings.modelFallback.credentialRef` reached that list
+// without reaching this file, so the server could refuse a field the editor neither marked nor
+// announced. A path with no entry here is treated as NOT drawn, which costs a banner beside a
+// visible control at worst; the reverse default costs silence.
+const CREDENTIAL_SWITCH: Readonly<Record<string, SwitchName>> = {
+  "stt.credentialRef": "sttEnabled",
+  "tts.credentialRef": "ttsOn",
+  "tts.normalizeCredentialRef": "ttsNormalize",
+  "vision.credentialRef": "visionEnabled",
+  "contactAuth.credentialRef": "contactAuthEnabled",
+  "memory.compaction.credentialRef": "memoryCompactionEnabled",
+  "modelFallback.credentialRef": "modelFallbackChosen",
+  "guardrails.credentialRef": "guardrailsEnabled",
 };
 
+interface OwnedField {
+  field: string;
+  tab: EditorTab;
+  // Absent means the control is drawn whenever its tab is open.
+  needs?: SwitchName;
+}
+
+const OWNED_FIELDS: readonly OwnedField[] = [
+  { field: "name", tab: "general" },
+  { field: "systemPrompt", tab: "general" },
+  { field: "modelConfig.credentialRef", tab: "general" },
+  ...SETTINGS_CREDENTIAL_PATHS.map((p) => {
+    const joined = p.path.join(".");
+    const needs = CREDENTIAL_SWITCH[joined];
+    return {
+      field: `${SETTINGS_PREFIX}${joined}`,
+      tab: p.tab as EditorTab,
+      ...(needs ? { needs } : {}),
+    };
+  }),
+  { field: "availability.awayMessage", tab: "behavior", needs: "awayEnabled" },
+  {
+    field: "contactAuth.denyMessage",
+    tab: "behavior",
+    needs: "contactAuthEnabled",
+  },
+  {
+    field: "vision.extractionPrompt",
+    tab: "behavior",
+    needs: "visionEnabled",
+  },
+  {
+    field: "guardrails.customPolicy",
+    tab: "guardrails",
+    needs: "guardrailsEnabled",
+  },
+  {
+    field: "guardrails.input.templateMessage",
+    tab: "guardrails",
+    needs: "guardrailsEnabled",
+  },
+  {
+    field: "guardrails.output.templateMessage",
+    tab: "guardrails",
+    needs: "guardrailsEnabled",
+  },
+  {
+    field: "guardrails.output.generationPrompt",
+    tab: "guardrails",
+    needs: "guardrailsEnabled",
+  },
+  // The native-tool notes carry no switch of their own: the row is drawn from the catalog, and a note
+  // for a tool nobody granted holds the stored text either way.
+  { field: "handoff.instructions", tab: "tools" },
+  { field: "kanban.instructions", tab: "tools" },
+  { field: "toolGuidance.set_custom_attribute", tab: "tools" },
+  { field: "toolGuidance.assign_label", tab: "tools" },
+  { field: "toolGuidance.update_kanban_task", tab: "tools" },
+];
+
 // One follow-up step's note, by the name the server spells it with. Brackets and not dots, because
-// that is what `collectOversizedTextChanges` reports and the wire carries it verbatim — the numeric
+// that is what `collectOversizedTextChanges` reports and the wire carries it verbatim -- the numeric
 // segment rule in placeRefusal reads `steps.0`, which this is not.
 export function followUpStepField(index: number): string {
   return `followUp.steps[${index}].instructions`;
 }
 
-// What the editor draws now, and everything it can mark. `drawn` is a subset of `owned`, always: the
-// second is the first over every tab, which is what lets a refusal about another tab's control be
-// held until the operator gets there.
-export function editorRefusalFields(view: {
-  // Any of the editor's tabs, not only the five that write an agent: the page also draws Channels,
-  // Knowledge, Playground and Experiments, and each of those answers with an empty list. Typed wide
-  // on purpose — narrowing it would make the caller decide which tabs count, which is this module's
-  // question and not the page's.
-  tab: string;
-  // How many follow-up steps the Proactive section is showing. The note of a step that does not
-  // exist is a name nothing can render, so the list stops where the editor's does.
-  followUpSteps: number;
-}): { drawn: readonly string[]; owned: readonly string[] } {
+// What the editor is DRAWING right now, and everything it can mark.
+//
+// `drawn` is what decides whether a mark is readable, so it answers per control and not per tab.
+// `owned` is every name across every tab, which is what lets a refusal about a control the operator
+// cannot see right now be HELD until they can. drawn is a subset of owned, always.
+export function editorRefusalFields(view: EditorControlsShown): {
+  drawn: readonly string[];
+  owned: readonly string[];
+} {
   const steps = Array.from(
     { length: Math.max(0, view.followUpSteps) },
     (_, i) => followUpStepField(i),
   );
-  const forTab = (tab: string): string[] => [
-    ...(TAB_FIELDS[tab as EditorTab] ?? []),
-    ...(tab === "behavior" ? steps : []),
+  const owned = [...OWNED_FIELDS.map((f) => f.field), ...steps];
+  const drawn = [
+    ...OWNED_FIELDS.filter(
+      (f) => f.tab === view.tab && (!f.needs || view[f.needs]),
+    ).map((f) => f.field),
+    ...(view.tab === "behavior" && view.followUpEnabled ? steps : []),
   ];
-  return {
-    drawn: forTab(view.tab),
-    owned: Object.keys(TAB_FIELDS).flatMap(forTab),
-  };
+  return { drawn, owned };
 }

--- a/src/client/lib/editorRefusal.ts
+++ b/src/client/lib/editorRefusal.ts
@@ -1,0 +1,205 @@
+import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
+
+// WHERE THE AGENT EDITOR DRAWS A VALUE THE SERVER CAN NAME, as one map.
+//
+// Two things ask this question and they used to answer it apart. A config-health warning holds a
+// dotted path for a value already over its cap and wants a "Go to"; a refusal holds a dotted path for
+// the value this save just carried and wants somewhere to put the sentence. Same question — which
+// tab, which section — and keeping two lists is exactly how `availability.awayMessage` and
+// `contactAuth.denyMessage` ended up in neither: both have a textarea on the Behavior tab, and a
+// warning about either said "this note has no field in the console, so it can only be shortened
+// through the API", which is false about a control two clicks away.
+//
+// The credential half is not restated here at all. `SETTINGS_CREDENTIAL_PATHS` already carries the
+// editor location beside each path, for the import warning's deep link, and its own comment records
+// why: deriving the location as "the behavior tab, section = block" was right for four entries and
+// wrong for the fifth. Restating it would be a fourth copy of a list that has already been wrong
+// three times.
+
+export type EditorTab =
+  | "general"
+  | "behavior"
+  | "guardrails"
+  | "channelRedirect"
+  | "tools";
+
+export interface EditorTarget {
+  tab: EditorTab;
+  // The DOM anchor of the section to scroll to (matches the section's `id`). Absent for a value the
+  // tab draws outside any section — the agent's name and prompt sit at the top of General.
+  sectionId?: string;
+}
+
+// TWO SPELLINGS reach this map, because the two producers root their path differently and neither is
+// wrong on its own:
+//
+//   `SettingsTextTooLongError`      -> `guardrails.customPolicy`        (root = the settings bag)
+//   `assertCredentialRefsResolve`   -> `settings.tts.credentialRef`     (root = the agent row)
+//
+// Both are the server's own name for the same wire field. Normalising them is a contract change that
+// reaches REST and MCP, so this map accepts both and the divergence is written down rather than
+// papered over: fazer-ai/agents#349 measured it, and a reader who trusts one spelling silently loses
+// half the fields.
+const SETTINGS_PREFIX = "settings.";
+
+// Matched by pattern, because three of these families are open-ended: a guardrails direction holds
+// two capped fields, and a follow-up step is one of ten. A path with no entry has no control in the
+// editor at all — `toolGuidance` accepts a note for all thirteen native tools and the console draws
+// three — and those must keep answering "there is nowhere to send you" rather than offering a jump
+// to a section that will not scroll.
+const TEXT_TARGETS: ReadonlyArray<{ match: RegExp } & EditorTarget> = [
+  { match: /^handoff\.instructions$/, tab: "tools", sectionId: "tools-native" },
+  { match: /^kanban\.instructions$/, tab: "tools", sectionId: "tools-native" },
+  {
+    match:
+      /^toolGuidance\.(set_custom_attribute|assign_label|update_kanban_task)$/,
+    tab: "tools",
+    sectionId: "tools-native",
+  },
+  {
+    match: /^availability\.awayMessage$/,
+    tab: "behavior",
+    sectionId: "availability",
+  },
+  {
+    match: /^contactAuth\.denyMessage$/,
+    tab: "behavior",
+    sectionId: "contactAuth",
+  },
+  {
+    match: /^guardrails\.customPolicy$/,
+    tab: "guardrails",
+    sectionId: "gr-policy",
+  },
+  { match: /^guardrails\.input\./, tab: "guardrails", sectionId: "gr-input" },
+  { match: /^guardrails\.output\./, tab: "guardrails", sectionId: "gr-output" },
+  { match: /^vision\.extractionPrompt$/, tab: "behavior", sectionId: "vision" },
+  { match: /^followUp\.steps\[/, tab: "behavior", sectionId: "proactive" },
+];
+
+// The values the editor draws a control for OUTSIDE any bag: the two on the General tab plus the
+// model's key, which is a column of its own and so has neither producer's prefix.
+const COLUMN_TARGETS: Readonly<Record<string, EditorTarget>> = {
+  name: { tab: "general" },
+  systemPrompt: { tab: "general" },
+  "modelConfig.credentialRef": { tab: "general", sectionId: "general-model" },
+};
+
+const CREDENTIAL_TARGETS: Readonly<Record<string, EditorTarget>> =
+  Object.fromEntries(
+    SETTINGS_CREDENTIAL_PATHS.map((p) => [
+      `${SETTINGS_PREFIX}${p.path.join(".")}`,
+      { tab: p.tab, sectionId: p.sectionId },
+    ]),
+  );
+
+// Where the editor draws the value the server named, or null when it draws no control for it.
+//
+// `guardrailsEnabled` is not a refinement, it is the difference between a jump that works and one
+// that silently does nothing: `GuardrailsTab` renders `gr-input`, `gr-output` and `gr-policy` only
+// while guardrails are ON, so with them off the anchor is not in the DOM and the one-shot lookup
+// that scrolls finds nothing. `gr-model` is the section that is always mounted, and it holds the
+// switch that brings the rest back.
+export function editorTargetFor(
+  field: string,
+  opts: { guardrailsEnabled?: boolean } = {},
+): EditorTarget | null {
+  const column = COLUMN_TARGETS[field] ?? CREDENTIAL_TARGETS[field];
+  const target =
+    column ??
+    (() => {
+      // The credential producer prefixes; the text producer does not. Try the bag-rooted spelling
+      // both as sent and with the prefix taken off, so a path arriving either way lands here.
+      const bagPath = field.startsWith(SETTINGS_PREFIX)
+        ? field.slice(SETTINGS_PREFIX.length)
+        : field;
+      const hit = TEXT_TARGETS.find((t) => t.match.test(bagPath));
+      return hit ? { tab: hit.tab, sectionId: hit.sectionId } : null;
+    })();
+  if (!target) return null;
+  if (target.tab === "guardrails" && !opts.guardrailsEnabled) {
+    return { tab: "guardrails", sectionId: "gr-model" };
+  }
+  return target;
+}
+
+// The names the editor declares, by the tab that draws them.
+//
+// TAB-GATED, and only tab-gated, which is a decision rather than an omission. Several of these
+// controls sit behind a switch inside their own section — the vision prompt appears with vision on,
+// the deny message with the authorization gate on — so a list that answered "drawn right now" to the
+// letter would carry a dozen booleans out of three component files and into this one, and every
+// drift between them would reappear as the silence the mechanism exists to prevent.
+//
+// What makes the tab the right granularity is a property of the WRITE BOUNDARY, not a tolerance:
+// both producers refuse only the text or the ref a write INTRODUCES or CHANGES
+// (`collectOversizedTextChanges`, `collectCredentialRefWrites`, and both say so in their own
+// comments, with the reason). Changing one of these values requires its control, and its control
+// requires the switch. So a refusal naming a field whose switch is off cannot arrive from this
+// editor, and the declaration is exact for every refusal that can. `tests/client/editor-refusal.
+// test.ts` pins that invariant, because it is the thing this simplification rests on.
+const TAB_FIELDS: Readonly<Record<EditorTab, readonly string[]>> = {
+  general: ["name", "systemPrompt", "modelConfig.credentialRef"],
+  behavior: [
+    "settings.stt.credentialRef",
+    "settings.tts.credentialRef",
+    "settings.tts.normalizeCredentialRef",
+    "settings.vision.credentialRef",
+    "settings.contactAuth.credentialRef",
+    "settings.memory.compaction.credentialRef",
+    "availability.awayMessage",
+    "contactAuth.denyMessage",
+    "vision.extractionPrompt",
+  ],
+  guardrails: [
+    "settings.guardrails.credentialRef",
+    "guardrails.customPolicy",
+    "guardrails.input.templateMessage",
+    "guardrails.output.templateMessage",
+    "guardrails.output.generationPrompt",
+  ],
+  tools: [
+    "handoff.instructions",
+    "kanban.instructions",
+    "toolGuidance.set_custom_attribute",
+    "toolGuidance.assign_label",
+    "toolGuidance.update_kanban_task",
+  ],
+  // The redirect tab writes its own block through its own save and declares nothing here yet; the
+  // knowledge and playground tabs draw no value the server refuses by name.
+  channelRedirect: [],
+};
+
+// One follow-up step's note, by the name the server spells it with. Brackets and not dots, because
+// that is what `collectOversizedTextChanges` reports and the wire carries it verbatim — the numeric
+// segment rule in placeRefusal reads `steps.0`, which this is not.
+export function followUpStepField(index: number): string {
+  return `followUp.steps[${index}].instructions`;
+}
+
+// What the editor draws now, and everything it can mark. `drawn` is a subset of `owned`, always: the
+// second is the first over every tab, which is what lets a refusal about another tab's control be
+// held until the operator gets there.
+export function editorRefusalFields(view: {
+  // Any of the editor's tabs, not only the five that write an agent: the page also draws Channels,
+  // Knowledge, Playground and Experiments, and each of those answers with an empty list. Typed wide
+  // on purpose — narrowing it would make the caller decide which tabs count, which is this module's
+  // question and not the page's.
+  tab: string;
+  // How many follow-up steps the Proactive section is showing. The note of a step that does not
+  // exist is a name nothing can render, so the list stops where the editor's does.
+  followUpSteps: number;
+}): { drawn: readonly string[]; owned: readonly string[] } {
+  const steps = Array.from(
+    { length: Math.max(0, view.followUpSteps) },
+    (_, i) => followUpStepField(i),
+  );
+  const forTab = (tab: string): string[] => [
+    ...(TAB_FIELDS[tab as EditorTab] ?? []),
+    ...(tab === "behavior" ? steps : []),
+  ];
+  return {
+    drawn: forTab(view.tab),
+    owned: Object.keys(TAB_FIELDS).flatMap(forTab),
+  };
+}

--- a/src/client/lib/fieldRefusal.ts
+++ b/src/client/lib/fieldRefusal.ts
@@ -30,18 +30,30 @@ export function readRefusal(e: unknown): Refusal | null {
   return field ? { message, field } : { message };
 }
 
-// The two channels a refusal can reach the operator through, as an EITHER: exactly one of them
-// fires, always.
+// The channels a refusal can reach the operator through. THREE outcomes, and the third one is the
+// whole of #349.
 //
-// Both halves of that are load-bearing. Silence is what a mechanism like this breaks first — a form
-// that holds every refusal at an input holds the ones it has no input for as well, and the operator
-// gets a save button that does nothing. And a message rendered at the control AND repeated in a
-// toast is the noise that trains people to dismiss toasts without reading them.
+//   1. `{ at }`          the control is on screen. The mark is the message; nothing else fires.
+//   2. `{ at, toast }`   the form OWNS the control and is not drawing it. The mark is written for
+//                        when the operator gets there, and the sentence still has to be said now,
+//                        because a mark on a tab nobody is looking at is silence.
+//   3. `{ toast }`       not this form's input. The sentence is the only channel.
+//
+// It began as an EITHER of two, and that was right while every form drew everything it owned. The
+// agent editor does not: it writes about thirty values across eight tabs and draws one tab's worth,
+// so "is this name one the form renders" and "is this name one the form can place" stopped being the
+// same question. Collapsing them either way loses something real — answer only the first and the
+// mark never appears after the operator switches tabs; answer only the second and `capture` reports
+// "it is on the control" about a control on another tab, and the save fails into silence.
+//
+// What did NOT change is the rule underneath: the operator is told exactly once. In case 2 the two
+// channels do not overlap, because the caller stops announcing the moment the control is on screen —
+// see the editor's banner.
 //
 // `value` travels with a placement because the mark expires by VALUE and not by a call: `at` shows
 // it only while the input still holds what was refused (see the hook).
 export type RefusalPlacement =
-  | { at: string; message: string; value: unknown }
+  | { at: string; message: string; value: unknown; toast?: string }
   | { at?: undefined; toast: string };
 
 // What the form was doing when the answer landed. The first round of review on #313 found three ways
@@ -60,6 +72,15 @@ export interface FormAtAnswer {
   // the request was out, and marking the box would put "this is not valid" under a value the server
   // never saw.
   current: Record<string, unknown>;
+  // Every name this form can place a mark on, drawn or not. Defaults to `rendered`, which is the
+  // right answer for a form whose controls are all on screen together — twenty-three of the
+  // twenty-four here.
+  //
+  // Separate from `rendered` rather than replacing it, because the two answer different questions and
+  // the difference is what decides whether the caller must speak: `rendered` says whether the mark is
+  // READABLE right now, `owned` says whether it is worth WRITING at all. A form that answered only
+  // the second would silence its toast about an input the operator cannot see.
+  owned?: readonly string[];
 }
 
 // `rendered` is what the FORM declares it can show, by the server's names.
@@ -88,11 +109,10 @@ export function placeRefusal(
   if (!refusal) return { toast: fallback };
   const { field, message } = refusal;
   if (!field) return { toast: message };
-  const declared = rendered.includes(field)
-    ? field
-    : rendered.find((name) =>
-        new RegExp(`^${escapeName(name)}\\.\\d+(?:\\.|$)`).test(field),
-      );
+  const drawn = resolveName(field, rendered);
+  // `owned` is only consulted for a name `rendered` did not answer, so a form that draws everything it
+  // owns takes exactly the path it took before this existed.
+  const declared = drawn ?? resolveName(field, form.owned ?? rendered);
   if (declared === undefined) return { toast: message };
   if (!form.mounted) return { toast: message };
   // Only when the request carried this field. A refusal about a value this write did not change is
@@ -101,7 +121,22 @@ export function placeRefusal(
   if (carried && !sameValue(form.sent[declared], form.current[declared])) {
     return { toast: message };
   }
-  return { at: declared, message, value: form.current[declared] };
+  const placed = { at: declared, message, value: form.current[declared] };
+  // Owned but not drawn: the mark is written for the tab the operator has yet to open, and the
+  // sentence goes out now so the save does not fail into silence.
+  return drawn === undefined ? { ...placed, toast: message } : placed;
+}
+
+// The declared name a refused field belongs to, or undefined.
+function resolveName(
+  field: string,
+  names: readonly string[],
+): string | undefined {
+  return names.includes(field)
+    ? field
+    : names.find((name) =>
+        new RegExp(`^${escapeName(name)}\\.\\d+(?:\\.|$)`).test(field),
+      );
 }
 
 // "The box still holds what the server was talking about", for a value of any shape.

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1098,6 +1098,7 @@
     "reasoningEffort": "Reasoning effort",
     "reasoningEffortDefault": "Provider default",
     "reasoningEffortHint": "How much the model thinks before answering. Reasoning models only (o-series, gpt-5); more effort means slower, costlier answers.",
+    "refusalNoControl": "This value has no field in the console, so it can only be changed through the API.",
     "reload": "Reload",
     "roundingDate": "date",
     "roundingExact": "exact · changes every minute",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -1101,6 +1101,7 @@
     "reasoningEffort": "Esforço de raciocínio",
     "reasoningEffortDefault": "Padrão do provedor",
     "reasoningEffortHint": "Quanto o modelo pensa antes de responder. Só em modelos de raciocínio (série o, gpt-5); mais esforço significa resposta mais lenta e mais cara.",
+    "refusalNoControl": "Este valor não tem campo no console, então só dá para alterá-lo pela API.",
     "reload": "Recarregar",
     "roundingDate": "data",
     "roundingExact": "exata · muda a cada minuto",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -53,6 +53,7 @@ import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { computeConfigIssues, issueHasAction } from "@/client/lib/configHealth";
 import {
+  type EditorControlsShown,
   type EditorTab,
   editorRefusalFields,
   editorTargetFor,
@@ -604,6 +605,8 @@ function AgentEditor() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [savingAgent, setSavingAgent] = useState(false);
+  // The sentence from a failed save that NOTHING on screen is carrying. See the banner below.
+  const [standingRefusal, setStandingRefusal] = useState<string | null>(null);
   const [savingGrants, setSavingGrants] = useState(false);
   const [savingChannelRedirect, setSavingChannelRedirect] = useState(false);
   const [savingGuardrails, setSavingGuardrails] = useState(false);
@@ -858,10 +861,23 @@ function AgentEditor() {
   //
   // Declared AFTER the state it reads, and not beside the other hooks: the lists are a function of
   // the open tab and of how many follow-up steps the Proactive section is drawing.
-  const refusalFields = editorRefusalFields({
+  // What the editor is DRAWING, answered per control. The switches are here rather than inside the
+  // module because they are this page's state; the module owns which switch each control sits behind.
+  const refusalView: EditorControlsShown = {
     tab,
+    awayEnabled,
+    sttEnabled: stt.enabled,
+    ttsOn: tts.mode !== "never",
+    ttsNormalize: tts.normalize,
+    visionEnabled: vision.enabled,
+    contactAuthEnabled: contactAuth.enabled,
+    memoryCompactionEnabled: memory.compactionEnabled,
+    modelFallbackChosen: !!modelFallback.provider,
+    guardrailsEnabled: guardrails.enabled,
+    followUpEnabled: followUp.enabled,
     followUpSteps: followUp.steps.length,
-  });
+  };
+  const refusalFields = editorRefusalFields(refusalView);
   const refusal = useFieldRefusal(refusalFields.drawn, refusalFields.owned);
   // What every placeable input holds right now, keyed by the SERVER'S name for it, readable from
   // inside a save that started before them: this page's saves are long and the operator keeps typing
@@ -878,6 +894,7 @@ function AgentEditor() {
     "settings.vision.credentialRef": vision.credentialRef,
     "settings.contactAuth.credentialRef": contactAuth.credentialRef,
     "settings.memory.compaction.credentialRef": memory.credentialRef,
+    "settings.modelFallback.credentialRef": modelFallback.credentialRef,
     "settings.guardrails.credentialRef": guardrails.credentialRef,
     "availability.awayMessage": awayMessage.trim(),
     "contactAuth.denyMessage": contactAuth.denyMessage.trim(),
@@ -904,68 +921,84 @@ function AgentEditor() {
   // guardrails policy, and claiming it did would put the staleness check on a value the request never
   // mentioned. `drawn` for that section is exactly the set each save handler builds its patch from.
   function sentFor(section: string): Record<string, unknown> {
-    const { drawn } = editorRefusalFields({
-      tab: section,
-      followUpSteps: followUp.steps.length,
-    });
+    // The section's OWN controls, asked with its switches as they stand: a save carries the values it
+    // draws, and a field behind an off switch was not in the request.
+    const { drawn } = editorRefusalFields({ ...refusalView, tab: section });
     return Object.fromEntries(drawn.map((f) => [f, currentRef.current[f]]));
   }
 
   // Every save on this page answers a refusal the same way, so the decision is written once.
   //
-  // `capture` places the mark and hands back whatever is left to say, and what is left depends on
-  // where the control is. On the open tab there is nothing: the mark IS the message. On another tab
-  // the banner above the tabs renders it with a button that goes there, so a toast would be the
-  // duplicate this mechanism exists to avoid. And for a refusal about no control of this page's at
-  // all — a 403, a conflict, a transport failure with no body behind it — the toast is still the only
-  // channel there is.
-  function answerRefusal(e: unknown, fallback: string, section: string): void {
-    const left = refusal.capture(
-      e,
-      fallback,
-      sentFor(section),
-      currentRef.current,
+  // `capture` places the mark and hands back whatever is left to say. What is left is NOT decided
+  // here by asking whether the refused name has a place in this editor: that reads the FIELD and not
+  // what the hook did with it, and the two come apart. A name the map knows can still fail to be
+  // placed -- the operator edited the value while the request was out, a follow-up step that no
+  // longer exists -- and a caller that trusted the map would drop the sentence with nothing holding
+  // it. Silence, which is the one outcome barred here. So whatever comes back is kept, and the
+  // render below decides which container it belongs in.
+  //
+  // `sent` is passed in rather than read here, and that is the whole of the staleness check working:
+  // `currentRef` is LIVE, so reading it in the catch compares the boxes with themselves and the
+  // comparison can never fire. Each handler snapshots before its request goes out.
+  function answerRefusal(
+    e: unknown,
+    fallback: string,
+    sent: Record<string, unknown>,
+  ): void {
+    setStandingRefusal(
+      refusal.capture(e, fallback, sent, currentRef.current) ?? null,
     );
-    if (!left) return;
-    const named = readRefusal(e)?.field;
-    const placeable = named
-      ? editorTargetFor(named, { guardrailsEnabled: guardrails.enabled })
-      : null;
-    if (!placeable) showToast(left, "error");
   }
 
-  // THE STANDING REFUSAL, WHEN ITS CONTROL IS NOT ON SCREEN.
+  // A save that goes through answers for what it CARRIED, and only that.
   //
-  // The other half of the placement `placeRefusal` hands back for a value this editor owns and is
-  // not drawing. The mark is already written and will render the moment the operator opens that tab;
-  // until then it is invisible, and invisible is the one outcome this mechanism may not produce.
+  // Not for its TAB: `saveGrants` writes the grant set alone and shares the Tools tab with the
+  // handoff, kanban and tool-guidance notes, so clearing by tab takes a standing refusal off a note
+  // that request never mentioned -- the operator comes back to a form that looks clean and is still
+  // refused. The snapshot the write went out with is exactly the list of what it can answer for.
+  function clearRefusalFor(sent: Record<string, unknown>): void {
+    const held = refusal.field;
+    if (held && Object.hasOwn(sent, held)) refusal.clear();
+    setStandingRefusal(null);
+  }
+
+  // WHAT THE BANNER SAYS, and it is exactly the refusal the operator has no other way to read.
   //
-  // Derived rather than stored, which is what keeps the two channels from ever saying the same thing
-  // twice: the banner exists exactly while the control is elsewhere, so arriving at the tab takes it
-  // away and leaves the mark, and answering the refusal takes both.
+  // Two ways that happens, and they are different events:
+  //
+  //   - a mark is held on a control this render is NOT drawing. Another tab, or a section the
+  //     operator switched off AFTER the refusal landed -- turning Vision off does not answer the
+  //     refusal about its credential, it only takes the box away. Derived, so the banner appears and
+  //     disappears with the control rather than with a save.
+  //   - `capture` handed the sentence back having placed nothing at all: a 403, a conflict, a value
+  //     the operator changed while the request was out. Stored, because nothing else on screen holds
+  //     it, and dropped as soon as a mark exists (the effect below), so it can never outlive the
+  //     answer and resurface when that mark expires.
+  //
+  // A mark this render IS drawing says it itself and the banner stays quiet. That is the exclusivity
+  // the whole mechanism rests on, and it is now a property of what `capture` did rather than of a
+  // tab comparison this page made on its own.
   const heldField = refusal.field;
   const heldMessage = heldField
     ? refusal.at(heldField, currentRef.current[heldField])
     : null;
-  const heldTarget = heldField
-    ? editorTargetFor(heldField, { guardrailsEnabled: guardrails.enabled })
-    : null;
-  const refusalAway =
-    heldMessage && heldTarget && heldTarget.tab !== tab
-      ? { message: heldMessage, target: heldTarget }
+  const heldDrawn =
+    heldField !== null && refusalFields.drawn.includes(heldField);
+  const bannerMessage = heldMessage
+    ? heldDrawn
+      ? null
+      : heldMessage
+    : standingRefusal;
+  const bannerTarget =
+    heldField && !heldDrawn
+      ? editorTargetFor(heldField, { guardrailsEnabled: guardrails.enabled })
       : null;
 
-  // A save that goes through answers for the section it WROTE, and only that one. The holder covers
-  // every tab now, so clearing it unconditionally would take a standing refusal off another tab
-  // without anything having answered it — the operator comes back to a form that looks fine and is
-  // still refused.
-  function clearRefusalFor(section: string): void {
-    const held = refusal.field;
-    const target = held
-      ? editorTargetFor(held, { guardrailsEnabled: guardrails.enabled })
-      : null;
-    if (target?.tab === section) refusal.clear();
-  }
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the held name, which is the
+  // only thing that decides whether the stored sentence still has a job.
+  useEffect(() => {
+    if (heldField) setStandingRefusal(null);
+  }, [heldField]);
 
   // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
   // Separate from the editor's holder, because the two are on screen together.
@@ -2354,6 +2387,9 @@ function AgentEditor() {
   ) {
     savingRef.current += 1;
     setSavingAgent(true);
+    // Snapshotted BEFORE the request, never after: the staleness check compares what went out
+    // with what the boxes hold when the answer lands, and `currentRef` is live.
+    const sent = sentFor(section);
     try {
       const expected = expectedFor(force);
       const { data, error: err } = await api.api.v1.agents({ id }).patch({
@@ -2373,13 +2409,13 @@ function AgentEditor() {
       // carries neither `name` nor `systemPrompt` — clearing there takes the standing refusal off
       // the General tab without anything having answered it, so the operator comes back to a form
       // that looks fine and is still refused.
-      clearRefusalFor(section);
+      clearRefusalFor(sent);
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
       answerRefusal(
         e,
         t("editor.saveError", "Could not save the agent."),
-        section,
+        sent,
       );
     } finally {
       savingRef.current -= 1;
@@ -2405,14 +2441,11 @@ function AgentEditor() {
       setCatalog(data.catalog);
       markSynced(data.agentUpdatedAt ? String(data.agentUpdatedAt) : null);
       bumpSync("tools", "knowledge");
-      clearRefusalFor("tools");
+      // Nothing: this request carries the grant set and none of the Tools tab's notes.
+      clearRefusalFor({});
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
-      answerRefusal(
-        e,
-        t("editor.grantsError", "Could not update tools."),
-        "tools",
-      );
+      answerRefusal(e, t("editor.grantsError", "Could not update tools."), {});
     } finally {
       savingRef.current -= 1;
       setSavingGrants(false);
@@ -2427,6 +2460,7 @@ function AgentEditor() {
   async function saveTools(force = false) {
     savingRef.current += 1;
     setSavingGrants(true);
+    const sent = sentFor("tools");
     try {
       // Everything the PATCH will send, built BEFORE the grants PUT so the whole bag can be checked
       // against the write boundary's own rule first. None of it depends on the PUT's result.
@@ -2527,13 +2561,13 @@ function AgentEditor() {
       }));
       markSynced(String(agentRes.data.agent.updatedAt));
       bumpSync("tools", "knowledge");
-      clearRefusalFor("tools");
+      clearRefusalFor(sent);
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
       answerRefusal(
         e,
         t("editor.grantsError", "Could not update tools."),
-        "tools",
+        sent,
       );
     } finally {
       savingRef.current -= 1;
@@ -2586,6 +2620,7 @@ function AgentEditor() {
   async function saveGuardrails(force = false) {
     savingRef.current += 1;
     setSavingGuardrails(true);
+    const sent = sentFor("guardrails");
     try {
       const expected = expectedFor(force);
       const syncedSettings = (syncedAgentRef.current?.settings ?? {}) as Record<
@@ -2602,13 +2637,13 @@ function AgentEditor() {
       setSettings((s) => ({ ...s, guardrails }));
       markSynced(String(data.agent.updatedAt));
       bumpSync("guardrails");
-      clearRefusalFor("guardrails");
+      clearRefusalFor(sent);
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
       answerRefusal(
         e,
         t("editor.saveError", "Could not save the agent."),
-        "guardrails",
+        sent,
       );
     } finally {
       savingRef.current -= 1;
@@ -3060,21 +3095,23 @@ function AgentEditor() {
                 a toast: the sentence is the only copy of the reason, and a toast takes it away after
                 five seconds while the input it is about is still refused. It goes when the operator
                 answers the refusal, or when they reach the tab that draws the mark. */}
-            {refusalAway && (
+            {bannerMessage && (
               <div
                 role="alert"
                 className="flex items-baseline justify-between gap-3 rounded-lg border border-error bg-error-soft px-4 py-3"
               >
                 <span className="min-w-0 text-sm text-text-primary">
-                  {refusalAway.message}
+                  {bannerMessage}
                 </span>
-                <button
-                  type="button"
-                  onClick={() => goToEditorTarget(refusalAway.target)}
-                  className="shrink-0 rounded font-medium text-accent text-xs hover:underline focus-visible:underline"
-                >
-                  {t("editor.goToIssue", "Fix")}
-                </button>
+                {bannerTarget && (
+                  <button
+                    type="button"
+                    onClick={() => goToEditorTarget(bannerTarget)}
+                    className="shrink-0 rounded font-medium text-accent text-xs hover:underline focus-visible:underline"
+                  >
+                    {t("editor.goToIssue", "Fix")}
+                  </button>
+                )}
               </div>
             )}
 
@@ -3299,6 +3336,10 @@ function AgentEditor() {
                   memoryCredential: refusal.at(
                     "settings.memory.compaction.credentialRef",
                     memory.credentialRef,
+                  ),
+                  modelFallbackCredential: refusal.at(
+                    "settings.modelFallback.credentialRef",
+                    modelFallback.credentialRef,
                   ),
                   awayMessage: refusal.at(
                     "availability.awayMessage",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -58,6 +58,7 @@ import {
   editorRefusalFields,
   editorTargetFor,
   followUpStepField,
+  sentFromPatch,
 } from "@/client/lib/editorRefusal";
 import { readRefusal } from "@/client/lib/fieldRefusal";
 import { formatRelativeTime, slugify } from "@/client/lib/utils";
@@ -926,16 +927,16 @@ function AgentEditor() {
       ]),
     ),
   };
-  // The values THIS write carried, by the server's names, snapshotted before the request goes out.
+  // What THIS write carried, by the server's names, read from the patch it is about to send.
   //
-  // Scoped to the section being written rather than taken whole: a General save does not carry the
-  // guardrails policy, and claiming it did would put the staleness check on a value the request never
-  // mentioned. `drawn` for that section is exactly the set each save handler builds its patch from.
-  function sentFor(section: string): Record<string, unknown> {
-    // The section's OWN controls, asked with its switches as they stand: a save carries the values it
-    // draws, and a field behind an off switch was not in the request.
-    const { drawn } = editorRefusalFields({ ...refusalView, tab: section });
-    return Object.fromEntries(drawn.map((f) => [f, currentRef.current[f]]));
+  // From the patch and not from what the tab is drawing, which is what the first version did: those
+  // are different questions and they disagree by construction. `buildSettings()` serializes the whole
+  // bag including blocks whose controls are switched off, and `saveGuardrails` resends the guardrails
+  // block whether or not the switch is on -- so a visibility-derived list under-reports the write,
+  // and a field it omits gets marked without a staleness comparison and never cleared by the save
+  // that answered it. See sentFromPatch.
+  function sentFor(patch: Record<string, unknown>): Record<string, unknown> {
+    return sentFromPatch(patch, refusalFields.owned);
   }
 
   // Every save on this page answers a refusal the same way, so the decision is written once.
@@ -2418,7 +2419,7 @@ function AgentEditor() {
     setSavingAgent(true);
     // Snapshotted BEFORE the request, never after: the staleness check compares what went out
     // with what the boxes hold when the answer lands, and `currentRef` is live.
-    const sent = sentFor(section);
+    const sent = sentFor(patch);
     try {
       const expected = expectedFor(force);
       const { data, error: err } = await api.api.v1.agents({ id }).patch({
@@ -2497,7 +2498,7 @@ function AgentEditor() {
   async function saveTools(force = false) {
     savingRef.current += 1;
     setSavingGrants(true);
-    const sent = sentFor("tools");
+    let sent: Record<string, unknown> = {};
     try {
       // Everything the PATCH will send, built BEFORE the grants PUT so the whole bag can be checked
       // against the write boundary's own rule first. None of it depends on the PUT's result.
@@ -2534,6 +2535,9 @@ function AgentEditor() {
         toolGuidance: toolGuidanceJson,
         toolPreconditions: toolPreconditionsJson,
       };
+      // Before either request: the grants PUT goes out first and the PATCH after it, and both can
+      // answer a refusal about this bag.
+      sent = sentFor({ settings: toolsSettings });
       // The WHOLE bag, not just this tab's fields: the PATCH resends every block, so text typed on
       // another tab would refuse it just the same — after the grants had already been written.
       //
@@ -2658,15 +2662,17 @@ function AgentEditor() {
   async function saveGuardrails(force = false) {
     savingRef.current += 1;
     setSavingGuardrails(true);
-    const sent = sentFor("guardrails");
+    let sent: Record<string, unknown> = {};
     try {
       const expected = expectedFor(force);
       const syncedSettings = (syncedAgentRef.current?.settings ?? {}) as Record<
         string,
         unknown
       >;
+      const patch = { settings: { ...syncedSettings, guardrails } };
+      sent = sentFor(patch);
       const { data, error: err } = await api.api.v1.agents({ id }).patch({
-        settings: { ...syncedSettings, guardrails },
+        ...patch,
         ...(expected ? { expectedUpdatedAt: expected } : {}),
       });
       if (handleConflict(err, () => void saveGuardrails(true))) return;

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -605,8 +605,19 @@ function AgentEditor() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [savingAgent, setSavingAgent] = useState(false);
-  // The sentence from a failed save that NOTHING on screen is carrying. See the banner below.
-  const [standingRefusal, setStandingRefusal] = useState<string | null>(null);
+  // The sentence from a failed save that no mark is carrying, WITH the section whose write
+  // produced it. The section is not decoration: a later save of a different section answers
+  // nothing about this one, and clearing on any success takes the only explanation off screen
+  // while the failed section is still unsaved.
+  const [standingRefusal, setStandingRefusal] = useState<{
+    message: string;
+    section: string;
+    // The name the server refused, when it named one. Kept so the banner can say WHY it offers no
+    // way to the value: `toolGuidance` takes a note for all thirteen native tools and the console
+    // draws three, so a refusal about one of the other ten is about something no screen here edits.
+    // The server's sentence names the field and the limit and cannot know that.
+    field: string | null;
+  } | null>(null);
   const [savingGrants, setSavingGrants] = useState(false);
   const [savingChannelRedirect, setSavingChannelRedirect] = useState(false);
   const [savingGuardrails, setSavingGuardrails] = useState(false);
@@ -943,10 +954,14 @@ function AgentEditor() {
   function answerRefusal(
     e: unknown,
     fallback: string,
+    section: string,
     sent: Record<string, unknown>,
   ): void {
+    const left = refusal.capture(e, fallback, sent, currentRef.current);
     setStandingRefusal(
-      refusal.capture(e, fallback, sent, currentRef.current) ?? null,
+      left
+        ? { message: left, section, field: readRefusal(e)?.field ?? null }
+        : null,
     );
   }
 
@@ -956,49 +971,53 @@ function AgentEditor() {
   // handoff, kanban and tool-guidance notes, so clearing by tab takes a standing refusal off a note
   // that request never mentioned -- the operator comes back to a form that looks clean and is still
   // refused. The snapshot the write went out with is exactly the list of what it can answer for.
-  function clearRefusalFor(sent: Record<string, unknown>): void {
+  function clearRefusalFor(
+    section: string,
+    sent: Record<string, unknown>,
+  ): void {
     const held = refusal.field;
     if (held && Object.hasOwn(sent, held)) refusal.clear();
-    setStandingRefusal(null);
+    setStandingRefusal((prev) => (prev?.section === section ? null : prev));
   }
 
-  // WHAT THE BANNER SAYS, and it is exactly the refusal the operator has no other way to read.
+  // WHAT THE BANNER SAYS: every standing refusal, whichever of them is standing.
   //
-  // Two ways that happens, and they are different events:
+  // Unconditional on purpose, and the earlier versions of this are why. Both tried to show it only
+  // when the marked control was NOT readable, and both had to answer "is it readable" from outside
+  // the component that draws it: first by tab, which missed a section switched off after the refusal
+  // landed; then by tab plus each section's switch, which missed a guardrails field hidden by its
+  // own action and a native-tool note inside a collapsed card. What can hide a control belongs to the
+  // tab components, it is a list this file cannot close, and every version of it that got one entry
+  // short produced the same outcome: a failed save with nothing on screen saying so.
   //
-  //   - a mark is held on a control this render is NOT drawing. Another tab, or a section the
-  //     operator switched off AFTER the refusal landed -- turning Vision off does not answer the
-  //     refusal about its credential, it only takes the box away. Derived, so the banner appears and
-  //     disappears with the control rather than with a save.
-  //   - `capture` handed the sentence back having placed nothing at all: a 403, a conflict, a value
-  //     the operator changed while the request was out. Stored, because nothing else on screen holds
-  //     it, and dropped as soon as a mark exists (the effect below), so it can never outlive the
-  //     answer and resurface when that mark expires.
+  // So the question is not asked. A held mark is announced here whether or not its control is on
+  // screen, and `drawn` stops carrying any weight it could be wrong about -- it decides which
+  // channel `placeRefusal` uses, and this page reads neither channel for the sentence.
   //
-  // A mark this render IS drawing says it itself and the banner stays quiet. That is the exclusivity
-  // the whole mechanism rests on, and it is now a property of what `capture` did rather than of a
-  // tab comparison this page made on its own.
+  // The cost is a duplicate while the operator is looking at the marked control: the sentence at the
+  // input, and the same sentence above the tabs. That is the shape a form-level error summary has
+  // everywhere it is used, it does not interrupt and it does not scroll away, and it is the trade
+  // this takes over being silent on a case nobody enumerated yet.
   const heldField = refusal.field;
   const heldMessage = heldField
     ? refusal.at(heldField, currentRef.current[heldField])
     : null;
-  const heldDrawn =
-    heldField !== null && refusalFields.drawn.includes(heldField);
-  const bannerMessage = heldMessage
-    ? heldDrawn
-      ? null
-      : heldMessage
-    : standingRefusal;
+  const bannerMessage = heldMessage ?? standingRefusal?.message ?? null;
+  // A jump only when there is somewhere to send them: a mark on the open tab is already as close as
+  // the operator can get, and a sentence with no mark has no control to point at.
+  const heldTarget = heldField
+    ? editorTargetFor(heldField, { guardrailsEnabled: guardrails.enabled })
+    : null;
   const bannerTarget =
-    heldField && !heldDrawn
-      ? editorTargetFor(heldField, { guardrailsEnabled: guardrails.enabled })
-      : null;
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the held name, which is the
-  // only thing that decides whether the stored sentence still has a job.
-  useEffect(() => {
-    if (heldField) setStandingRefusal(null);
-  }, [heldField]);
+    heldMessage && heldTarget && heldTarget.tab !== tab ? heldTarget : null;
+  // Said only when the server NAMED a value and this editor draws no control for it. Not for a
+  // refusal about no input at all (a 403, a conflict), where there is no value to go and change.
+  const bannerNoControl =
+    !heldMessage &&
+    standingRefusal?.field != null &&
+    editorTargetFor(standingRefusal.field, {
+      guardrailsEnabled: guardrails.enabled,
+    }) === null;
 
   // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
   // Separate from the editor's holder, because the two are on screen together.
@@ -2409,12 +2428,13 @@ function AgentEditor() {
       // carries neither `name` nor `systemPrompt` — clearing there takes the standing refusal off
       // the General tab without anything having answered it, so the operator comes back to a form
       // that looks fine and is still refused.
-      clearRefusalFor(sent);
+      clearRefusalFor(section, sent);
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
       answerRefusal(
         e,
         t("editor.saveError", "Could not save the agent."),
+        section,
         sent,
       );
     } finally {
@@ -2442,10 +2462,15 @@ function AgentEditor() {
       markSynced(data.agentUpdatedAt ? String(data.agentUpdatedAt) : null);
       bumpSync("tools", "knowledge");
       // Nothing: this request carries the grant set and none of the Tools tab's notes.
-      clearRefusalFor({});
+      clearRefusalFor("tools", {});
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
-      answerRefusal(e, t("editor.grantsError", "Could not update tools."), {});
+      answerRefusal(
+        e,
+        t("editor.grantsError", "Could not update tools."),
+        "tools",
+        {},
+      );
     } finally {
       savingRef.current -= 1;
       setSavingGrants(false);
@@ -2561,12 +2586,13 @@ function AgentEditor() {
       }));
       markSynced(String(agentRes.data.agent.updatedAt));
       bumpSync("tools", "knowledge");
-      clearRefusalFor(sent);
+      clearRefusalFor("tools", sent);
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
       answerRefusal(
         e,
         t("editor.grantsError", "Could not update tools."),
+        "tools",
         sent,
       );
     } finally {
@@ -2637,12 +2663,13 @@ function AgentEditor() {
       setSettings((s) => ({ ...s, guardrails }));
       markSynced(String(data.agent.updatedAt));
       bumpSync("guardrails");
-      clearRefusalFor(sent);
+      clearRefusalFor("guardrails", sent);
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
       answerRefusal(
         e,
         t("editor.saveError", "Could not save the agent."),
+        "guardrails",
         sent,
       );
     } finally {
@@ -3102,6 +3129,14 @@ function AgentEditor() {
               >
                 <span className="min-w-0 text-sm text-text-primary">
                   {bannerMessage}
+                  {bannerNoControl && (
+                    <span className="block text-text-secondary text-xs">
+                      {t(
+                        "editor.refusalNoControl",
+                        "This value has no field in the console, so it can only be changed through the API.",
+                      )}
+                    </span>
+                  )}
                 </span>
                 {bannerTarget && (
                   <button

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -52,6 +52,13 @@ import { useTenantEvents } from "@/client/hooks/useTenantEvents";
 import { api } from "@/client/lib/api";
 import { apiErrorMessage } from "@/client/lib/apiError";
 import { computeConfigIssues, issueHasAction } from "@/client/lib/configHealth";
+import {
+  type EditorTab,
+  editorRefusalFields,
+  editorTargetFor,
+  followUpStepField,
+} from "@/client/lib/editorRefusal";
+import { readRefusal } from "@/client/lib/fieldRefusal";
 import { formatRelativeTime, slugify } from "@/client/lib/utils";
 import {
   invalidateVault,
@@ -559,7 +566,6 @@ function AgentEditorSkeleton() {
 // `guardrails.output.templateMessage` — behind tabs, and placing a refusal on one of those means
 // also taking the operator to the tab that holds it, which is its own change (fazer-ai/agents#349;
 // the abstention is recorded in tests/client/field-refusal-fence.test.ts).
-const EDITOR_FIELDS = ["name", "systemPrompt"] as const;
 const CLONE_FIELDS = ["name"] as const;
 
 export function AgentEditorPage() {
@@ -609,11 +615,6 @@ function AgentEditor() {
   // only mounted while `tab === "general"`, so a save that answers after the operator has moved on —
   // or the "Save and export" that writes General from wherever they are — would place its mark on a
   // control nobody is rendering. Off that tab the sentence goes to the toast.
-  const refusal = useFieldRefusal(tab === "general" ? EDITOR_FIELDS : []);
-  // What the two placeable inputs hold right now, readable from inside a save that started before
-  // them: this page's saves are long and the operator keeps typing during them.
-  const currentRef = useRef<Record<string, unknown>>({});
-  currentRef.current = { name: name.trim(), systemPrompt };
   const [enabled, setEnabled] = useState(true);
   const [agentMode, setAgentMode] = useState<"test" | "production">(
     "production",
@@ -845,6 +846,127 @@ function AgentEditor() {
   const fillCredModal = useModalController<VaultEntry>();
   const exportModal = useModalController();
   const [cloneName, setCloneName] = useState("");
+  // WHERE A REFUSAL ABOUT THIS EDITOR GOES. One holder for the page, declaring two different lists:
+  // what the OPEN TAB is drawing, and everything the editor can mark at all.
+  //
+  // The second is the whole of #349. Every value this page writes other than the name and the prompt
+  // lives in a bag edited behind one of eight tabs, so a refusal about
+  // `guardrails.output.templateMessage` names a control that exists and is not on screen. Marking it
+  // and falling silent is the failure this mechanism is against; dropping it into a toast is what the
+  // page did before, and the toast scrolls away carrying the only copy of the reason. So the mark is
+  // written for the tab the operator has yet to open, and the banner below says it is there.
+  //
+  // Declared AFTER the state it reads, and not beside the other hooks: the lists are a function of
+  // the open tab and of how many follow-up steps the Proactive section is drawing.
+  const refusalFields = editorRefusalFields({
+    tab,
+    followUpSteps: followUp.steps.length,
+  });
+  const refusal = useFieldRefusal(refusalFields.drawn, refusalFields.owned);
+  // What every placeable input holds right now, keyed by the SERVER'S name for it, readable from
+  // inside a save that started before them: this page's saves are long and the operator keeps typing
+  // during them. Keyed by the wire name rather than by the state variable because that is the name a
+  // refusal arrives carrying, and the name `placeRefusal` compares against what the request sent.
+  const currentRef = useRef<Record<string, unknown>>({});
+  currentRef.current = {
+    name: name.trim(),
+    systemPrompt,
+    "modelConfig.credentialRef": model.credentialRef,
+    "settings.stt.credentialRef": stt.credentialRef,
+    "settings.tts.credentialRef": tts.credentialRef,
+    "settings.tts.normalizeCredentialRef": tts.normalizeCredentialRef,
+    "settings.vision.credentialRef": vision.credentialRef,
+    "settings.contactAuth.credentialRef": contactAuth.credentialRef,
+    "settings.memory.compaction.credentialRef": memory.credentialRef,
+    "settings.guardrails.credentialRef": guardrails.credentialRef,
+    "availability.awayMessage": awayMessage.trim(),
+    "contactAuth.denyMessage": contactAuth.denyMessage.trim(),
+    "vision.extractionPrompt": vision.extractionPrompt,
+    "guardrails.customPolicy": guardrails.customPolicy,
+    "guardrails.input.templateMessage": guardrails.input.templateMessage,
+    "guardrails.output.templateMessage": guardrails.output.templateMessage,
+    "guardrails.output.generationPrompt": guardrails.output.generationPrompt,
+    "handoff.instructions": handoff.instructions,
+    "kanban.instructions": kanbanInstructions,
+    "toolGuidance.set_custom_attribute": customAttributeInstructions,
+    "toolGuidance.assign_label": labelInstructions,
+    "toolGuidance.update_kanban_task": updateKanbanTaskInstructions,
+    ...Object.fromEntries(
+      followUp.steps.map((step, i) => [
+        followUpStepField(i),
+        step.instructions,
+      ]),
+    ),
+  };
+  // The values THIS write carried, by the server's names, snapshotted before the request goes out.
+  //
+  // Scoped to the section being written rather than taken whole: a General save does not carry the
+  // guardrails policy, and claiming it did would put the staleness check on a value the request never
+  // mentioned. `drawn` for that section is exactly the set each save handler builds its patch from.
+  function sentFor(section: string): Record<string, unknown> {
+    const { drawn } = editorRefusalFields({
+      tab: section,
+      followUpSteps: followUp.steps.length,
+    });
+    return Object.fromEntries(drawn.map((f) => [f, currentRef.current[f]]));
+  }
+
+  // Every save on this page answers a refusal the same way, so the decision is written once.
+  //
+  // `capture` places the mark and hands back whatever is left to say, and what is left depends on
+  // where the control is. On the open tab there is nothing: the mark IS the message. On another tab
+  // the banner above the tabs renders it with a button that goes there, so a toast would be the
+  // duplicate this mechanism exists to avoid. And for a refusal about no control of this page's at
+  // all — a 403, a conflict, a transport failure with no body behind it — the toast is still the only
+  // channel there is.
+  function answerRefusal(e: unknown, fallback: string, section: string): void {
+    const left = refusal.capture(
+      e,
+      fallback,
+      sentFor(section),
+      currentRef.current,
+    );
+    if (!left) return;
+    const named = readRefusal(e)?.field;
+    const placeable = named
+      ? editorTargetFor(named, { guardrailsEnabled: guardrails.enabled })
+      : null;
+    if (!placeable) showToast(left, "error");
+  }
+
+  // THE STANDING REFUSAL, WHEN ITS CONTROL IS NOT ON SCREEN.
+  //
+  // The other half of the placement `placeRefusal` hands back for a value this editor owns and is
+  // not drawing. The mark is already written and will render the moment the operator opens that tab;
+  // until then it is invisible, and invisible is the one outcome this mechanism may not produce.
+  //
+  // Derived rather than stored, which is what keeps the two channels from ever saying the same thing
+  // twice: the banner exists exactly while the control is elsewhere, so arriving at the tab takes it
+  // away and leaves the mark, and answering the refusal takes both.
+  const heldField = refusal.field;
+  const heldMessage = heldField
+    ? refusal.at(heldField, currentRef.current[heldField])
+    : null;
+  const heldTarget = heldField
+    ? editorTargetFor(heldField, { guardrailsEnabled: guardrails.enabled })
+    : null;
+  const refusalAway =
+    heldMessage && heldTarget && heldTarget.tab !== tab
+      ? { message: heldMessage, target: heldTarget }
+      : null;
+
+  // A save that goes through answers for the section it WROTE, and only that one. The holder covers
+  // every tab now, so clearing it unconditionally would take a standing refusal off another tab
+  // without anything having answered it — the operator comes back to a form that looks fine and is
+  // still refused.
+  function clearRefusalFor(section: string): void {
+    const held = refusal.field;
+    const target = held
+      ? editorTargetFor(held, { guardrailsEnabled: guardrails.enabled })
+      : null;
+    if (target?.tab === section) refusal.clear();
+  }
+
   // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
   // Separate from the editor's holder, because the two are on screen together.
   const cloneRefusal = useFieldRefusal(cloneModal.isOpen ? CLONE_FIELDS : []);
@@ -1629,11 +1751,24 @@ function AgentEditor() {
       navigate("/resources/advanced");
       return;
     }
+    goToEditorTarget({
+      tab: issue.tab as EditorTab,
+      sectionId: issue.sectionId,
+    });
+  }
+
+  // Switch to a tab (URL-driven) carrying the focus marker the effect above reads to scroll to the
+  // section and highlight it. One function, because a config-health warning and a refusal are the
+  // same act from here: both hold a place in this editor and have to take the operator to it.
+  function goToEditorTarget(target: {
+    tab: EditorTab;
+    sectionId?: string;
+  }): void {
     navigate(
-      `/agents/${id}/${issue.tab}${
+      `/agents/${id}/${target.tab}${
         backToConversation ? `?from=${backToConversation}` : ""
       }`,
-      { state: { focusSection: issue.sectionId } },
+      { state: { focusSection: target.sectionId } },
     );
   }
 
@@ -2238,20 +2373,14 @@ function AgentEditor() {
       // carries neither `name` nor `systemPrompt` — clearing there takes the standing refusal off
       // the General tab without anything having answered it, so the operator comes back to a form
       // that looks fine and is still refused.
-      if (section === "general") refusal.clear();
+      clearRefusalFor(section);
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
-      // The backend's localized message, at the input it names when this page renders one. The
-      // prompt-size cap and the name are the two it can place today; a settings-bag path
-      // (`guardrails.output.templateMessage`) still answers in the toast, which is where the
-      // sentence has always gone.
-      const toast = refusal.capture(
+      answerRefusal(
         e,
         t("editor.saveError", "Could not save the agent."),
-        patch,
-        currentRef.current,
+        section,
       );
-      if (toast) showToast(toast, "error");
     } finally {
       savingRef.current -= 1;
       setSavingAgent(false);
@@ -2276,12 +2405,13 @@ function AgentEditor() {
       setCatalog(data.catalog);
       markSynced(data.agentUpdatedAt ? String(data.agentUpdatedAt) : null);
       bumpSync("tools", "knowledge");
+      clearRefusalFor("tools");
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("editor.grantsError", "Could not update tools."),
-        "error",
+      answerRefusal(
+        e,
+        t("editor.grantsError", "Could not update tools."),
+        "tools",
       );
     } finally {
       savingRef.current -= 1;
@@ -2397,12 +2527,13 @@ function AgentEditor() {
       }));
       markSynced(String(agentRes.data.agent.updatedAt));
       bumpSync("tools", "knowledge");
+      clearRefusalFor("tools");
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("editor.grantsError", "Could not update tools."),
-        "error",
+      answerRefusal(
+        e,
+        t("editor.grantsError", "Could not update tools."),
+        "tools",
       );
     } finally {
       savingRef.current -= 1;
@@ -2471,12 +2602,13 @@ function AgentEditor() {
       setSettings((s) => ({ ...s, guardrails }));
       markSynced(String(data.agent.updatedAt));
       bumpSync("guardrails");
+      clearRefusalFor("guardrails");
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("editor.saveError", "Could not save the agent."),
-        "error",
+      answerRefusal(
+        e,
+        t("editor.saveError", "Could not save the agent."),
+        "guardrails",
       );
     } finally {
       savingRef.current -= 1;
@@ -2924,10 +3056,36 @@ function AgentEditor() {
               </div>
             )}
 
+            {/* The refusal the server just sent about a control on ANOTHER tab. Not dismissible and not
+                a toast: the sentence is the only copy of the reason, and a toast takes it away after
+                five seconds while the input it is about is still refused. It goes when the operator
+                answers the refusal, or when they reach the tab that draws the mark. */}
+            {refusalAway && (
+              <div
+                role="alert"
+                className="flex items-baseline justify-between gap-3 rounded-lg border border-error bg-error-soft px-4 py-3"
+              >
+                <span className="min-w-0 text-sm text-text-primary">
+                  {refusalAway.message}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => goToEditorTarget(refusalAway.target)}
+                  className="shrink-0 rounded font-medium text-accent text-xs hover:underline focus-visible:underline"
+                >
+                  {t("editor.goToIssue", "Fix")}
+                </button>
+              </div>
+            )}
+
             {tab === "general" && (
               <GeneralTab
                 nameError={refusal.at("name", name.trim())}
                 promptError={refusal.at("systemPrompt", systemPrompt)}
+                modelCredentialError={refusal.at(
+                  "modelConfig.credentialRef",
+                  model.credentialRef,
+                )}
                 availability={promptAvailability}
                 name={name}
                 setName={setName}
@@ -3005,6 +3163,28 @@ function AgentEditor() {
                 setMcpCollapsed={setMcpCollapsed}
                 integrationCollapsed={integrationCollapsed}
                 setIntegrationCollapsed={setIntegrationCollapsed}
+                refusals={{
+                  handoffInstructions: refusal.at(
+                    "handoff.instructions",
+                    handoff.instructions,
+                  ),
+                  kanbanInstructions: refusal.at(
+                    "kanban.instructions",
+                    kanbanInstructions,
+                  ),
+                  attributeInstructions: refusal.at(
+                    "toolGuidance.set_custom_attribute",
+                    customAttributeInstructions,
+                  ),
+                  labelInstructions: refusal.at(
+                    "toolGuidance.assign_label",
+                    labelInstructions,
+                  ),
+                  updateKanbanInstructions: refusal.at(
+                    "toolGuidance.update_kanban_task",
+                    updateKanbanTaskInstructions,
+                  ),
+                }}
                 dirty={dirty.tools}
                 saving={savingGrants}
                 onSave={() => saveTools()}
@@ -3087,6 +3267,47 @@ function AgentEditor() {
                 attributeContext={attributeContext}
                 setAttributeContext={setAttributeContext}
                 onScheduleSaved={onScheduleSaved}
+                refusals={{
+                  sttCredential: refusal.at(
+                    "settings.stt.credentialRef",
+                    stt.credentialRef,
+                  ),
+                  ttsCredential: refusal.at(
+                    "settings.tts.credentialRef",
+                    tts.credentialRef,
+                  ),
+                  ttsNormalizeCredential: refusal.at(
+                    "settings.tts.normalizeCredentialRef",
+                    tts.normalizeCredentialRef,
+                  ),
+                  visionCredential: refusal.at(
+                    "settings.vision.credentialRef",
+                    vision.credentialRef,
+                  ),
+                  visionExtractionPrompt: refusal.at(
+                    "vision.extractionPrompt",
+                    vision.extractionPrompt,
+                  ),
+                  contactAuthCredential: refusal.at(
+                    "settings.contactAuth.credentialRef",
+                    contactAuth.credentialRef,
+                  ),
+                  contactAuthDenyMessage: refusal.at(
+                    "contactAuth.denyMessage",
+                    contactAuth.denyMessage.trim(),
+                  ),
+                  memoryCredential: refusal.at(
+                    "settings.memory.compaction.credentialRef",
+                    memory.credentialRef,
+                  ),
+                  awayMessage: refusal.at(
+                    "availability.awayMessage",
+                    awayMessage.trim(),
+                  ),
+                  followUpSteps: followUp.steps.map((step, i) =>
+                    refusal.at(followUpStepField(i), step.instructions),
+                  ),
+                }}
                 dirty={dirty.behavior}
                 saving={savingAgent}
                 onSave={() =>
@@ -3108,6 +3329,28 @@ function AgentEditor() {
               <GuardrailsTab
                 guardrails={guardrails}
                 setGuardrails={setGuardrails}
+                refusals={{
+                  credential: refusal.at(
+                    "settings.guardrails.credentialRef",
+                    guardrails.credentialRef,
+                  ),
+                  customPolicy: refusal.at(
+                    "guardrails.customPolicy",
+                    guardrails.customPolicy,
+                  ),
+                  inputTemplateMessage: refusal.at(
+                    "guardrails.input.templateMessage",
+                    guardrails.input.templateMessage,
+                  ),
+                  outputTemplateMessage: refusal.at(
+                    "guardrails.output.templateMessage",
+                    guardrails.output.templateMessage,
+                  ),
+                  outputGenerationPrompt: refusal.at(
+                    "guardrails.output.generationPrompt",
+                    guardrails.output.generationPrompt,
+                  ),
+                }}
                 dirty={dirty.guardrails}
                 saving={savingGuardrails}
                 onSave={() => saveGuardrails()}

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -621,6 +621,8 @@ function AgentEditor() {
     section: string;
     named: string | null;
   } | null>(null);
+  const refusedSaveRef = useRef(refusedSave);
+  refusedSaveRef.current = refusedSave;
   const [savingGrants, setSavingGrants] = useState(false);
   const [savingChannelRedirect, setSavingChannelRedirect] = useState(false);
   const [savingGuardrails, setSavingGuardrails] = useState(false);
@@ -893,6 +895,14 @@ function AgentEditor() {
   };
   const refusalFields = editorRefusalFields(refusalView);
   const refusal = useFieldRefusal(refusalFields.drawn, refusalFields.owned);
+  // The holder as it is NOW, for the success and failure paths of a request that started earlier.
+  //
+  // Same reason the hook keeps its own refs: a save handler closes over the render that launched it,
+  // and this page's saves are long enough for another tab's save to fail while one is still in
+  // flight. Answering from the closure would let an older success clear a refusal that arrived after
+  // it — `refusal.at` is memoized on the hold, so even the comparison would be the old one.
+  const refusalRef = useRef(refusal);
+  refusalRef.current = refusal;
   // What every placeable input holds right now, keyed by the SERVER'S name for it, readable from
   // inside a save that started before them: this page's saves are long and the operator keeps typing
   // during them. Keyed by the wire name rather than by the state variable because that is the name a
@@ -991,7 +1001,8 @@ function AgentEditor() {
     section: string,
     sent: Record<string, unknown>,
   ): void {
-    const held = refusal.field;
+    const now = refusalRef.current;
+    const held = now.field;
     // The VALUE, not just the path. Since sent is read from the patch, it reports every path the bag
     // carries -- and a Behavior save spreads the last-synced `settings`, so it carries
     // `guardrails.customPolicy` holding the value that was STORED, not the edit the server refused.
@@ -1003,12 +1014,12 @@ function AgentEditor() {
     // The case this must keep clearing is the one the mark cannot see on its own -- the operator
     // resubmits the same value after the server changes its mind (a duplicate name freed, a cap
     // raised), and only a success can tell that apart from the refusal still standing.
-    if (held && Object.hasOwn(sent, held) && refusal.at(held, sent[held])) {
-      refusal.clear();
+    if (held && Object.hasOwn(sent, held) && now.at(held, sent[held])) {
+      now.clear();
     }
     // A sentence the holder could place nowhere is about a SAVE rather than about a value, so the
     // section is what answers it: there is no field to compare a snapshot against.
-    if (!refusal.field && refusedSave?.section === section) refusal.clear();
+    if (!held && refusedSaveRef.current?.section === section) now.clear();
     setRefusedSave((prev) => (prev?.section === section ? null : prev));
   }
 
@@ -3215,11 +3226,14 @@ function AgentEditor() {
 
             {tab === "general" && (
               <GeneralTab
-                nameError={refusal.at("name", name.trim())}
-                promptError={refusal.at("systemPrompt", systemPrompt)}
+                nameError={refusal.at("name", currentRef.current["name"])}
+                promptError={refusal.at(
+                  "systemPrompt",
+                  currentRef.current["systemPrompt"],
+                )}
                 modelCredentialError={refusal.at(
                   "modelConfig.credentialRef",
-                  model.credentialRef,
+                  currentRef.current["modelConfig.credentialRef"],
                 )}
                 availability={promptAvailability}
                 name={name}
@@ -3301,23 +3315,23 @@ function AgentEditor() {
                 refusals={{
                   handoffInstructions: refusal.at(
                     "handoff.instructions",
-                    handoff.instructions,
+                    currentRef.current["handoff.instructions"],
                   ),
                   kanbanInstructions: refusal.at(
                     "kanban.instructions",
-                    kanbanInstructions,
+                    currentRef.current["kanban.instructions"],
                   ),
                   attributeInstructions: refusal.at(
                     "toolGuidance.set_custom_attribute",
-                    customAttributeInstructions,
+                    currentRef.current["toolGuidance.set_custom_attribute"],
                   ),
                   labelInstructions: refusal.at(
                     "toolGuidance.assign_label",
-                    labelInstructions,
+                    currentRef.current["toolGuidance.assign_label"],
                   ),
                   updateKanbanInstructions: refusal.at(
                     "toolGuidance.update_kanban_task",
-                    updateKanbanTaskInstructions,
+                    currentRef.current["toolGuidance.update_kanban_task"],
                   ),
                 }}
                 dirty={dirty.tools}
@@ -3405,46 +3419,51 @@ function AgentEditor() {
                 refusals={{
                   sttCredential: refusal.at(
                     "settings.stt.credentialRef",
-                    stt.credentialRef,
+                    currentRef.current["settings.stt.credentialRef"],
                   ),
                   ttsCredential: refusal.at(
                     "settings.tts.credentialRef",
-                    tts.credentialRef,
+                    currentRef.current["settings.tts.credentialRef"],
                   ),
                   ttsNormalizeCredential: refusal.at(
                     "settings.tts.normalizeCredentialRef",
-                    tts.normalizeCredentialRef,
+                    currentRef.current["settings.tts.normalizeCredentialRef"],
                   ),
                   visionCredential: refusal.at(
                     "settings.vision.credentialRef",
-                    vision.credentialRef,
+                    currentRef.current["settings.vision.credentialRef"],
                   ),
                   visionExtractionPrompt: refusal.at(
                     "vision.extractionPrompt",
-                    vision.extractionPrompt,
+                    currentRef.current["vision.extractionPrompt"],
                   ),
                   contactAuthCredential: refusal.at(
                     "settings.contactAuth.credentialRef",
-                    contactAuth.credentialRef,
+                    currentRef.current["settings.contactAuth.credentialRef"],
                   ),
                   contactAuthDenyMessage: refusal.at(
                     "contactAuth.denyMessage",
-                    contactAuth.denyMessage.trim(),
+                    currentRef.current["contactAuth.denyMessage"],
                   ),
                   memoryCredential: refusal.at(
                     "settings.memory.compaction.credentialRef",
-                    memory.credentialRef,
+                    currentRef.current[
+                      "settings.memory.compaction.credentialRef"
+                    ],
                   ),
                   modelFallbackCredential: refusal.at(
                     "settings.modelFallback.credentialRef",
-                    modelFallback.credentialRef,
+                    currentRef.current["settings.modelFallback.credentialRef"],
                   ),
                   awayMessage: refusal.at(
                     "availability.awayMessage",
-                    awayMessage.trim(),
+                    currentRef.current["availability.awayMessage"],
                   ),
-                  followUpSteps: followUp.steps.map((step, i) =>
-                    refusal.at(followUpStepField(i), step.instructions),
+                  followUpSteps: followUp.steps.map((_step, i) =>
+                    refusal.at(
+                      followUpStepField(i),
+                      currentRef.current[followUpStepField(i)],
+                    ),
                   ),
                 }}
                 dirty={dirty.behavior}
@@ -3471,23 +3490,23 @@ function AgentEditor() {
                 refusals={{
                   credential: refusal.at(
                     "settings.guardrails.credentialRef",
-                    guardrails.credentialRef,
+                    currentRef.current["settings.guardrails.credentialRef"],
                   ),
                   customPolicy: refusal.at(
                     "guardrails.customPolicy",
-                    guardrails.customPolicy,
+                    currentRef.current["guardrails.customPolicy"],
                   ),
                   inputTemplateMessage: refusal.at(
                     "guardrails.input.templateMessage",
-                    guardrails.input.templateMessage,
+                    currentRef.current["guardrails.input.templateMessage"],
                   ),
                   outputTemplateMessage: refusal.at(
                     "guardrails.output.templateMessage",
-                    guardrails.output.templateMessage,
+                    currentRef.current["guardrails.output.templateMessage"],
                   ),
                   outputGenerationPrompt: refusal.at(
                     "guardrails.output.generationPrompt",
-                    guardrails.output.generationPrompt,
+                    currentRef.current["guardrails.output.generationPrompt"],
                   ),
                 }}
                 dirty={dirty.guardrails}

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -977,7 +977,20 @@ function AgentEditor() {
     sent: Record<string, unknown>,
   ): void {
     const held = refusal.field;
-    if (held && Object.hasOwn(sent, held)) refusal.clear();
+    // The VALUE, not just the path. Since sent is read from the patch, it reports every path the bag
+    // carries -- and a Behavior save spreads the last-synced `settings`, so it carries
+    // `guardrails.customPolicy` holding the value that was STORED, not the edit the server refused.
+    // Presence alone would let that save answer for a refusal it never re-sent, and the Guardrails
+    // tab would go quiet with the invalid edit still unsaved.
+    //
+    // `at` is the comparison, reused rather than restated: it answers "is the held mark about THIS
+    // value", which is exactly the question, and it uses the same structural equality the mark does.
+    // The case this must keep clearing is the one the mark cannot see on its own -- the operator
+    // resubmits the same value after the server changes its mind (a duplicate name freed, a cap
+    // raised), and only a success can tell that apart from the refusal still standing.
+    if (held && Object.hasOwn(sent, held) && refusal.at(held, sent[held])) {
+      refusal.clear();
+    }
     setStandingRefusal((prev) => (prev?.section === section ? null : prev));
   }
 

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -58,6 +58,7 @@ import {
   editorRefusalFields,
   editorTargetFor,
   followUpStepField,
+  hasNoConsoleControl,
   sentFromPatch,
 } from "@/client/lib/editorRefusal";
 import { readRefusal } from "@/client/lib/fieldRefusal";
@@ -991,6 +992,25 @@ function AgentEditor() {
     );
   }
 
+  // Discarding a section restores the values it OWNS, so a refusal about one of those is moot and
+  // has to go with them. Without this a fieldless refusal outlives the edit entirely: it cannot
+  // expire by value the way a mark does, so the banner would sit there past the discard, past the
+  // next successful save of another section, forever.
+  //
+  // By the tab that DRAWS the value rather than by the section that wrote it: reverting Behavior
+  // restores the behavior form, and a mark a Behavior save left on `guardrails.customPolicy` is
+  // about a value the Guardrails tab still holds unsaved.
+  function discardRefusalFor(section: string): void {
+    const now = refusalRef.current;
+    const held = now.field;
+    const target = held
+      ? editorTargetFor(held, { guardrailsEnabled: guardrails.enabled })
+      : null;
+    if (target?.tab === section) now.clear();
+    if (!held && refusedSaveRef.current?.section === section) now.clear();
+    setRefusedSave((prev) => (prev?.section === section ? null : prev));
+  }
+
   // A save that goes through answers for what it CARRIED, and only that.
   //
   // Not for its TAB: `saveGrants` writes the grant set alone and shares the Tools tab with the
@@ -1054,8 +1074,17 @@ function AgentEditor() {
   const heldTarget = heldField
     ? editorTargetFor(heldField, { guardrailsEnabled: guardrails.enabled })
     : null;
-  const bannerTarget =
-    heldMessage && heldTarget && heldTarget.tab !== tab ? heldTarget : null;
+  // Somewhere to send them, from the mark when there is one and from the name the server used when
+  // there is not: a refusal this editor cannot MARK can still be about a value it draws (a tool
+  // precondition is edited as a list, so there is no single box to put the sentence in).
+  const namedTarget =
+    !heldField && refusedSave?.named
+      ? editorTargetFor(refusedSave.named, {
+          guardrailsEnabled: guardrails.enabled,
+        })
+      : null;
+  const jumpTo = heldMessage ? heldTarget : namedTarget;
+  const bannerTarget = jumpTo && jumpTo.tab !== tab ? jumpTo : null;
   // Said only when the server NAMED a value and this editor draws no control for it. Not for a
   // refusal about no input at all (a 403, a conflict), where there is no value to go and change.
   // BRING IT INTO VIEW, because the banner sits above the tabs and the button that produced it does
@@ -1078,12 +1107,15 @@ function AgentEditor() {
     bannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
   }, [bannerMessage]);
 
+  // Said only where it can be PROVED. It used to be read off this map having no entry, and absence
+  // proves nothing about the console: the map was missing `settings.modelFallback.model` and
+  // `observability.fullDetailUntil`, both of which have a visible control, so the banner told the
+  // operator the opposite of the truth about them. `hasNoConsoleControl` answers from the closed set
+  // it can derive -- the ten native-tool notes the editor draws no field for.
   const bannerNoControl =
     !heldField &&
     refusedSave?.named != null &&
-    editorTargetFor(refusedSave.named, {
-      guardrailsEnabled: guardrails.enabled,
-    }) === null;
+    hasNoConsoleControl(refusedSave.named);
 
   // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
   // Separate from the editor's holder, because the two are on screen together.
@@ -2343,6 +2375,7 @@ function AgentEditor() {
   // syncSeq bump — only the reverted section returns to baseline, the other
   // tabs keep their own pending state.
   const revertGeneral = () => {
+    discardRefusalFor("general");
     const a = syncedAgentRef.current;
     if (!a) return;
     setName(a.name);
@@ -2352,6 +2385,7 @@ function AgentEditor() {
     setModel(readModelState(a));
   };
   const revertBehavior = () => {
+    discardRefusalFor("behavior");
     const a = syncedAgentRef.current;
     if (!a) return;
     const b = readBehaviorState(a);
@@ -2377,11 +2411,13 @@ function AgentEditor() {
     setAttributeContext(b.attributeContext);
   };
   const revertChannelRedirect = () => {
+    discardRefusalFor("channelRedirect");
     const a = syncedAgentRef.current;
     if (!a) return;
     setChannelRedirect(readChannelRedirectState(a));
   };
   const revertGuardrails = () => {
+    discardRefusalFor("guardrails");
     const a = syncedAgentRef.current;
     if (!a) return;
     setGuardrails(readGuardrailsFormState(a.settings));
@@ -2390,6 +2426,7 @@ function AgentEditor() {
   // non-RAG, Knowledge = RAG), so each discard restores only its slice and
   // keeps the other tab's pending edits.
   const revertTools = () => {
+    discardRefusalFor("tools");
     const synced = mapGrants(syncedGrantsRef.current);
     setGrants((cur) => [
       ...cur.filter((g) => g.source === "RAG"),
@@ -2399,6 +2436,7 @@ function AgentEditor() {
     if (syncedAgentRef.current) syncToolConfig(syncedAgentRef.current);
   };
   const revertKnowledge = () => {
+    discardRefusalFor("knowledge");
     const synced = mapGrants(syncedGrantsRef.current);
     setGrants((cur) => [
       ...synced.filter((g) => g.source === "RAG"),
@@ -2418,6 +2456,9 @@ function AgentEditor() {
       danger: true,
       confirmLabel: t("editor.discardAll", "Discard all"),
       onConfirm: () => {
+        // Every section at once, so every refusal goes with them.
+        refusalRef.current.clear();
+        setRefusedSave(null);
         const a = syncedAgentRef.current;
         if (a) {
           applyAgent(a);

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -941,11 +941,14 @@ function AgentEditor() {
     "guardrails.input.templateMessage": guardrails.input.templateMessage,
     "guardrails.output.templateMessage": guardrails.output.templateMessage,
     "guardrails.output.generationPrompt": guardrails.output.generationPrompt,
-    "handoff.instructions": handoff.instructions,
-    "kanban.instructions": kanbanInstructions,
-    "toolGuidance.set_custom_attribute": customAttributeInstructions,
-    "toolGuidance.assign_label": labelInstructions,
-    "toolGuidance.update_kanban_task": updateKanbanTaskInstructions,
+    // Through the serializer for the handoff note, and mirroring saveTools for the rest: it trims
+    // every one of them, and a raw copy here reads surrounding whitespace as an edit made while the
+    // request was out.
+    "handoff.instructions": serializeHandoff(handoff).instructions,
+    "kanban.instructions": kanbanInstructions.trim() || null,
+    "toolGuidance.set_custom_attribute": customAttributeInstructions.trim(),
+    "toolGuidance.assign_label": labelInstructions.trim(),
+    "toolGuidance.update_kanban_task": updateKanbanTaskInstructions.trim(),
     // Through the writer itself: `followUpToStored` trims each note, and a second spelling of that
     // here is the drift this whole block is against.
     ...Object.fromEntries(
@@ -990,56 +993,37 @@ function AgentEditor() {
     setRefusedSave(
       left ? { section, named: readRefusal(e)?.field ?? null } : null,
     );
+    setRefusalSeq((n) => n + 1);
   }
 
-  // Discarding a section restores the values it OWNS, so a refusal about one of those is moot and
-  // has to go with them. Without this a fieldless refusal outlives the edit entirely: it cannot
-  // expire by value the way a mark does, so the banner would sit there past the discard, past the
-  // next successful save of another section, forever.
+  // A SECTION IS SETTLED — by a save that went through, or by a discard that put its values back.
   //
-  // By the tab that DRAWS the value rather than by the section that wrote it: reverting Behavior
-  // restores the behavior form, and a mark a Behavior save left on `guardrails.customPolicy` is
-  // about a value the Guardrails tab still holds unsaved.
-  function discardRefusalFor(section: string): void {
+  // One function for both because both answer the same thing: the values that section owns are no
+  // longer in dispute, so a refusal about one of them is over. Written twice it drifted immediately —
+  // the save half required the write to have carried the refused VALUE, and that is false exactly
+  // when the operator has done what the refusal asked, so a corrected save left the stale hold in
+  // place and the mark came back the next time they typed the old value.
+  //
+  // Scoped by the tab that DRAWS the value, not by what the request happened to serialize. A Behavior
+  // save spreads the last-synced `settings`, so it carries `guardrails.customPolicy` holding what is
+  // STORED rather than the edit the Guardrails tab still has unsaved; presence in the patch would let
+  // it answer for a refusal it never re-sent. The tab says whose value it is, which is the question.
+  //
+  // A refusal the holder could place nowhere is about a SAVE rather than a value, so its own section
+  // answers it.
+  function settleRefusalFor(section: string): void {
     const now = refusalRef.current;
     const held = now.field;
     const target = held
       ? editorTargetFor(held, { guardrailsEnabled: guardrails.enabled })
       : null;
-    if (target?.tab === section) now.clear();
-    if (!held && refusedSaveRef.current?.section === section) now.clear();
-    setRefusedSave((prev) => (prev?.section === section ? null : prev));
-  }
-
-  // A save that goes through answers for what it CARRIED, and only that.
-  //
-  // Not for its TAB: `saveGrants` writes the grant set alone and shares the Tools tab with the
-  // handoff, kanban and tool-guidance notes, so clearing by tab takes a standing refusal off a note
-  // that request never mentioned -- the operator comes back to a form that looks clean and is still
-  // refused. The snapshot the write went out with is exactly the list of what it can answer for.
-  function clearRefusalFor(
-    section: string,
-    sent: Record<string, unknown>,
-  ): void {
-    const now = refusalRef.current;
-    const held = now.field;
-    // The VALUE, not just the path. Since sent is read from the patch, it reports every path the bag
-    // carries -- and a Behavior save spreads the last-synced `settings`, so it carries
-    // `guardrails.customPolicy` holding the value that was STORED, not the edit the server refused.
-    // Presence alone would let that save answer for a refusal it never re-sent, and the Guardrails
-    // tab would go quiet with the invalid edit still unsaved.
-    //
-    // `at` is the comparison, reused rather than restated: it answers "is the held mark about THIS
-    // value", which is exactly the question, and it uses the same structural equality the mark does.
-    // The case this must keep clearing is the one the mark cannot see on its own -- the operator
-    // resubmits the same value after the server changes its mind (a duplicate name freed, a cap
-    // raised), and only a success can tell that apart from the refusal still standing.
-    if (held && Object.hasOwn(sent, held) && now.at(held, sent[held])) {
+    if (
+      held
+        ? target?.tab === section
+        : refusedSaveRef.current?.section === section
+    ) {
       now.clear();
     }
-    // A sentence the holder could place nowhere is about a SAVE rather than about a value, so the
-    // section is what answers it: there is no field to compare a snapshot against.
-    if (!held && refusedSaveRef.current?.section === section) now.clear();
     setRefusedSave((prev) => (prev?.section === section ? null : prev));
   }
 
@@ -1096,16 +1080,17 @@ function AgentEditor() {
   // Once per sentence, not once per render: the banner stays up until the refusal is answered, and
   // re-scrolling on every keystroke would take the page out from under whoever is fixing the value.
   const bannerRef = useRef<HTMLDivElement | null>(null);
-  const announcedRef = useRef<string | null>(null);
+  // Counted, not compared by text. Two transport failures in a row produce the SAME fallback
+  // sentence, and a second failure the operator has scrolled away from would have scrolled nothing
+  // and changed nothing for assistive technology — the save would look like it did not happen.
+  // Every answered request bumps this, so each one is announced once whatever it says.
+  const [refusalSeq, setRefusalSeq] = useState(0);
+  const announcedRef = useRef(0);
   useEffect(() => {
-    if (!bannerMessage) {
-      announcedRef.current = null;
-      return;
-    }
-    if (announcedRef.current === bannerMessage) return;
-    announcedRef.current = bannerMessage;
+    if (!bannerMessage || announcedRef.current === refusalSeq) return;
+    announcedRef.current = refusalSeq;
     bannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, [bannerMessage]);
+  }, [bannerMessage, refusalSeq]);
 
   // Said only where it can be PROVED. It used to be read off this map having no entry, and absence
   // proves nothing about the console: the map was missing `settings.modelFallback.model` and
@@ -2375,7 +2360,7 @@ function AgentEditor() {
   // syncSeq bump — only the reverted section returns to baseline, the other
   // tabs keep their own pending state.
   const revertGeneral = () => {
-    discardRefusalFor("general");
+    settleRefusalFor("general");
     const a = syncedAgentRef.current;
     if (!a) return;
     setName(a.name);
@@ -2385,7 +2370,7 @@ function AgentEditor() {
     setModel(readModelState(a));
   };
   const revertBehavior = () => {
-    discardRefusalFor("behavior");
+    settleRefusalFor("behavior");
     const a = syncedAgentRef.current;
     if (!a) return;
     const b = readBehaviorState(a);
@@ -2411,13 +2396,13 @@ function AgentEditor() {
     setAttributeContext(b.attributeContext);
   };
   const revertChannelRedirect = () => {
-    discardRefusalFor("channelRedirect");
+    settleRefusalFor("channelRedirect");
     const a = syncedAgentRef.current;
     if (!a) return;
     setChannelRedirect(readChannelRedirectState(a));
   };
   const revertGuardrails = () => {
-    discardRefusalFor("guardrails");
+    settleRefusalFor("guardrails");
     const a = syncedAgentRef.current;
     if (!a) return;
     setGuardrails(readGuardrailsFormState(a.settings));
@@ -2426,7 +2411,7 @@ function AgentEditor() {
   // non-RAG, Knowledge = RAG), so each discard restores only its slice and
   // keeps the other tab's pending edits.
   const revertTools = () => {
-    discardRefusalFor("tools");
+    settleRefusalFor("tools");
     const synced = mapGrants(syncedGrantsRef.current);
     setGrants((cur) => [
       ...cur.filter((g) => g.source === "RAG"),
@@ -2436,7 +2421,7 @@ function AgentEditor() {
     if (syncedAgentRef.current) syncToolConfig(syncedAgentRef.current);
   };
   const revertKnowledge = () => {
-    discardRefusalFor("knowledge");
+    settleRefusalFor("knowledge");
     const synced = mapGrants(syncedGrantsRef.current);
     setGrants((cur) => [
       ...synced.filter((g) => g.source === "RAG"),
@@ -2535,7 +2520,7 @@ function AgentEditor() {
       // carries neither `name` nor `systemPrompt` — clearing there takes the standing refusal off
       // the General tab without anything having answered it, so the operator comes back to a form
       // that looks fine and is still refused.
-      clearRefusalFor(section, sent);
+      settleRefusalFor(section);
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
       answerRefusal(
@@ -2571,7 +2556,7 @@ function AgentEditor() {
       // This is the KNOWLEDGE tab's save (it is the only caller), and it carries the grant set and
       // none of the Tools tab's notes. Both halves matter: the empty snapshot says it answers for no
       // field, and the section says whose banner it may take down.
-      clearRefusalFor("knowledge", {});
+      settleRefusalFor("knowledge");
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
       answerRefusal(
@@ -2698,7 +2683,7 @@ function AgentEditor() {
       }));
       markSynced(String(agentRes.data.agent.updatedAt));
       bumpSync("tools", "knowledge");
-      clearRefusalFor("tools", sent);
+      settleRefusalFor("tools");
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
       answerRefusal(
@@ -2777,7 +2762,7 @@ function AgentEditor() {
       setSettings((s) => ({ ...s, guardrails }));
       markSynced(String(data.agent.updatedAt));
       bumpSync("guardrails");
-      clearRefusalFor("guardrails", sent);
+      settleRefusalFor("guardrails");
       showToast(t("editor.saved", "Agent saved."), "success");
     } catch (e) {
       answerRefusal(

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -897,6 +897,13 @@ function AgentEditor() {
   // inside a save that started before them: this page's saves are long and the operator keeps typing
   // during them. Keyed by the wire name rather than by the state variable because that is the name a
   // refusal arrives carrying, and the name `placeRefusal` compares against what the request sent.
+  //
+  // EACH ENTRY NORMALIZES THE WAY ITS WRITER DOES, and that is a rule rather than a detail. The other
+  // side of the comparison is `sentFromPatch`, read off the request, so a value the patch trims and
+  // this map keeps raw reads as "the operator edited it while the request was out" — and the refusal
+  // then goes to the banner instead of to the textarea it is about, on nothing but surrounding
+  // whitespace. Where the writer is a function (`followUpToStored`), call it rather than restating
+  // what it does.
   const currentRef = useRef<Record<string, unknown>>({});
   currentRef.current = {
     name: name.trim(),
@@ -912,7 +919,13 @@ function AgentEditor() {
     "settings.guardrails.credentialRef": guardrails.credentialRef,
     "availability.awayMessage": awayMessage.trim(),
     "contactAuth.denyMessage": contactAuth.denyMessage.trim(),
-    "vision.extractionPrompt": vision.extractionPrompt,
+    // `buildSettings` stores null for an empty prompt or one still at the default, so an untouched
+    // vision block sends null and a raw copy here would never match it.
+    "vision.extractionPrompt":
+      vision.extractionPrompt.trim() &&
+      vision.extractionPrompt.trim() !== DEFAULT_EXTRACTION_PROMPT
+        ? vision.extractionPrompt.trim()
+        : null,
     "guardrails.customPolicy": guardrails.customPolicy,
     "guardrails.input.templateMessage": guardrails.input.templateMessage,
     "guardrails.output.templateMessage": guardrails.output.templateMessage,
@@ -922,8 +935,10 @@ function AgentEditor() {
     "toolGuidance.set_custom_attribute": customAttributeInstructions,
     "toolGuidance.assign_label": labelInstructions,
     "toolGuidance.update_kanban_task": updateKanbanTaskInstructions,
+    // Through the writer itself: `followUpToStored` trims each note, and a second spelling of that
+    // here is the drift this whole block is against.
     ...Object.fromEntries(
-      followUp.steps.map((step, i) => [
+      followUpToStored(followUp).steps.map((step, i) => [
         followUpStepField(i),
         step.instructions,
       ]),
@@ -1032,6 +1047,26 @@ function AgentEditor() {
     heldMessage && heldTarget && heldTarget.tab !== tab ? heldTarget : null;
   // Said only when the server NAMED a value and this editor draws no control for it. Not for a
   // refusal about no input at all (a 403, a conflict), where there is no value to go and change.
+  // BRING IT INTO VIEW, because the banner sits above the tabs and the button that produced it does
+  // not. Behavior and Tools are long, their Save lives in a sticky bar at the bottom, and the toast
+  // that used to answer from down there is gone — so a sighted operator would watch the save stop
+  // and see nothing until they scrolled back up. `role="alert"` already answers for a screen reader;
+  // this is the other half.
+  //
+  // Once per sentence, not once per render: the banner stays up until the refusal is answered, and
+  // re-scrolling on every keystroke would take the page out from under whoever is fixing the value.
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+  const announcedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!bannerMessage) {
+      announcedRef.current = null;
+      return;
+    }
+    if (announcedRef.current === bannerMessage) return;
+    announcedRef.current = bannerMessage;
+    bannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [bannerMessage]);
+
   const bannerNoControl =
     !heldField &&
     refusedSave?.named != null &&
@@ -3151,8 +3186,9 @@ function AgentEditor() {
                 answers the refusal, or when they reach the tab that draws the mark. */}
             {bannerMessage && (
               <div
+                ref={bannerRef}
                 role="alert"
-                className="flex items-baseline justify-between gap-3 rounded-lg border border-error bg-error-soft px-4 py-3"
+                className="flex scroll-mt-4 items-baseline justify-between gap-3 rounded-lg border border-error bg-error-soft px-4 py-3"
               >
                 <span className="min-w-0 text-sm text-text-primary">
                   {bannerMessage}

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1003,6 +1003,16 @@ function AgentEditor() {
     ? refusal.at(heldField, currentRef.current[heldField])
     : null;
   const bannerMessage = heldMessage ?? standingRefusal?.message ?? null;
+  // THE STORED SENTENCE IS A FALLBACK, never a second copy of a mark.
+  //
+  // `capture` hands back the sentence for an off-screen placement AND holds the mark, so both are
+  // set for one refusal. The mark expires by value; the stored copy would not, and it would then
+  // surface again the moment the operator edits the refused field — attributing the server's
+  // sentence to the value the server never saw, which is the exact thing `placeRefusal` refuses to
+  // do at the input. Dropped as soon as a mark exists, so only the un-placeable case survives here.
+  useEffect(() => {
+    if (heldField) setStandingRefusal(null);
+  }, [heldField]);
   // A jump only when there is somewhere to send them: a mark on the open tab is already as close as
   // the operator can get, and a sentence with no mark has no control to point at.
   const heldTarget = heldField
@@ -2461,14 +2471,16 @@ function AgentEditor() {
       setCatalog(data.catalog);
       markSynced(data.agentUpdatedAt ? String(data.agentUpdatedAt) : null);
       bumpSync("tools", "knowledge");
-      // Nothing: this request carries the grant set and none of the Tools tab's notes.
-      clearRefusalFor("tools", {});
+      // This is the KNOWLEDGE tab's save (it is the only caller), and it carries the grant set and
+      // none of the Tools tab's notes. Both halves matter: the empty snapshot says it answers for no
+      // field, and the section says whose banner it may take down.
+      clearRefusalFor("knowledge", {});
       showToast(t("editor.grantsSaved", "Tools updated."), "success");
     } catch (e) {
       answerRefusal(
         e,
         t("editor.grantsError", "Could not update tools."),
-        "tools",
+        "knowledge",
         {},
       );
     } finally {

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -606,18 +606,20 @@ function AgentEditor() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [savingAgent, setSavingAgent] = useState(false);
-  // The sentence from a failed save that no mark is carrying, WITH the section whose write
-  // produced it. The section is not decoration: a later save of a different section answers
-  // nothing about this one, and clearing on any success takes the only explanation off screen
-  // while the failed section is still unsaved.
-  const [standingRefusal, setStandingRefusal] = useState<{
-    message: string;
+  // WHAT the last failed save was, never its sentence. The sentence has one home and it is the
+  // holder (see `message` there): a copy here is a second source of truth for one fact, and three
+  // review rounds found three ways the two drift.
+  //
+  // `section` is the form whose write produced it, so a later success elsewhere cannot take it down.
+  // `named` is the value the server refused, when it named one, so the banner can say WHY it offers
+  // no way to it: `toolGuidance` takes a note for all thirteen native tools and the console draws
+  // three, and the server's sentence names the field without knowing that.
+  //
+  // Written by every `capture` and read only while the holder has a sentence, so neither can go stale
+  // against it.
+  const [refusedSave, setRefusedSave] = useState<{
     section: string;
-    // The name the server refused, when it named one. Kept so the banner can say WHY it offers no
-    // way to the value: `toolGuidance` takes a note for all thirteen native tools and the console
-    // draws three, so a refusal about one of the other ten is about something no screen here edits.
-    // The server's sentence names the field and the limit and cannot know that.
-    field: string | null;
+    named: string | null;
   } | null>(null);
   const [savingGrants, setSavingGrants] = useState(false);
   const [savingChannelRedirect, setSavingChannelRedirect] = useState(false);
@@ -959,10 +961,8 @@ function AgentEditor() {
     sent: Record<string, unknown>,
   ): void {
     const left = refusal.capture(e, fallback, sent, currentRef.current);
-    setStandingRefusal(
-      left
-        ? { message: left, section, field: readRefusal(e)?.field ?? null }
-        : null,
+    setRefusedSave(
+      left ? { section, named: readRefusal(e)?.field ?? null } : null,
     );
   }
 
@@ -991,7 +991,10 @@ function AgentEditor() {
     if (held && Object.hasOwn(sent, held) && refusal.at(held, sent[held])) {
       refusal.clear();
     }
-    setStandingRefusal((prev) => (prev?.section === section ? null : prev));
+    // A sentence the holder could place nowhere is about a SAVE rather than about a value, so the
+    // section is what answers it: there is no field to compare a snapshot against.
+    if (!refusal.field && refusedSave?.section === section) refusal.clear();
+    setRefusedSave((prev) => (prev?.section === section ? null : prev));
   }
 
   // WHAT THE BANNER SAYS: every standing refusal, whichever of them is standing.
@@ -1016,17 +1019,10 @@ function AgentEditor() {
   const heldMessage = heldField
     ? refusal.at(heldField, currentRef.current[heldField])
     : null;
-  const bannerMessage = heldMessage ?? standingRefusal?.message ?? null;
-  // THE STORED SENTENCE IS A FALLBACK, never a second copy of a mark.
-  //
-  // `capture` hands back the sentence for an off-screen placement AND holds the mark, so both are
-  // set for one refusal. The mark expires by value; the stored copy would not, and it would then
-  // surface again the moment the operator edits the refused field — attributing the server's
-  // sentence to the value the server never saw, which is the exact thing `placeRefusal` refuses to
-  // do at the input. Dropped as soon as a mark exists, so only the un-placeable case survives here.
-  useEffect(() => {
-    if (heldField) setStandingRefusal(null);
-  }, [heldField]);
+  // The mark expires by VALUE, so a placed sentence has to be asked for through `at`; one the holder
+  // could place nowhere has no value to expire against and is read straight off the holder. Either
+  // way there is one copy, and it is the holder's.
+  const bannerMessage = heldField ? heldMessage : refusal.message;
   // A jump only when there is somewhere to send them: a mark on the open tab is already as close as
   // the operator can get, and a sentence with no mark has no control to point at.
   const heldTarget = heldField
@@ -1037,9 +1033,9 @@ function AgentEditor() {
   // Said only when the server NAMED a value and this editor draws no control for it. Not for a
   // refusal about no input at all (a 403, a conflict), where there is no value to go and change.
   const bannerNoControl =
-    !heldMessage &&
-    standingRefusal?.field != null &&
-    editorTargetFor(standingRefusal.field, {
+    !heldField &&
+    refusedSave?.named != null &&
+    editorTargetFor(refusedSave.named, {
       guardrailsEnabled: guardrails.enabled,
     }) === null;
 

--- a/src/client/pages/agents/BehaviorTab.tsx
+++ b/src/client/pages/agents/BehaviorTab.tsx
@@ -87,7 +87,7 @@ import {
   ttsNormalizerPickerSource,
   ttsNormalizerProviderChanged,
 } from "./ttsFormState";
-import type { Hours } from "./types";
+import type { BehaviorRefusals, Hours } from "./types";
 
 // Transcription providers (mirror src/modules/stt/providers.ts).
 const STT_PROVIDERS = [
@@ -249,6 +249,9 @@ export interface FollowUpState {
 
 interface BehaviorTabProps {
   agentId: string;
+  // The refused input this tab draws, if the standing refusal is about one of them. Read in
+  // AgentEditorPage and passed as answers -- see the note on the type.
+  refusals: BehaviorRefusals;
   hours: Hours[];
   businessHoursId: string;
   setBusinessHoursId: (v: string) => void;
@@ -784,10 +787,14 @@ function FollowUpStepsEditor({
   agentId,
   followUp,
   setFollowUp,
+  stepRefusals,
 }: {
   agentId: string;
   followUp: FollowUpState;
   setFollowUp: React.Dispatch<React.SetStateAction<FollowUpState>>;
+  // By index: the server refuses a note as `followUp.steps[2].instructions`, and the step it names is
+  // the one that has to carry the mark.
+  stepRefusals: readonly (string | null)[];
 }) {
   const { t } = useTranslation();
   const [labels, setLabels] = useState<InboxLabelOption[]>([]);
@@ -900,6 +907,7 @@ function FollowUpStepsEditor({
             </FormField>
             <FormField
               label={t("editor.followUpInstructions", "Follow-up instructions")}
+              error={stepRefusals[index] ?? null}
             >
               <Textarea
                 value={step.instructions}
@@ -977,6 +985,7 @@ function FollowUpStepsEditor({
 
 export function BehaviorTab({
   agentId,
+  refusals,
   hours,
   businessHoursId,
   setBusinessHoursId,
@@ -1378,6 +1387,7 @@ export function BehaviorTab({
             {awayEnabled && (
               <FormField
                 label={t("editor.awayMessage", "Out-of-hours message")}
+                error={refusals.awayMessage}
                 description={t(
                   "editor.awayMessageHint",
                   'Sent to the customer while the agent is outside these hours, at most once a day per conversation. Write {next_open} (or {proximo_atendimento} for a Portuguese message) where the next opening should appear: the customer reads something like "Monday, 08/25, 09:00".',
@@ -1514,7 +1524,11 @@ export function BehaviorTab({
                       ))}
                     </Select>
                   </FormField>
-                  <FormField label={t("editor.sttCredential", "API key")} group>
+                  <FormField
+                    label={t("editor.sttCredential", "API key")}
+                    error={refusals.sttCredential}
+                    group
+                  >
                     <CredentialPicker
                       value={stt.credentialRef}
                       onChange={(v) => setStt({ ...stt, credentialRef: v })}
@@ -1664,6 +1678,7 @@ export function BehaviorTab({
                   </FormField>
                   <FormField
                     label={t("editor.visionCredential", "API key")}
+                    error={refusals.visionCredential}
                     group
                   >
                     <CredentialPicker
@@ -1734,6 +1749,7 @@ export function BehaviorTab({
                   </FormField>
                 )}
                 <FormField
+                  error={refusals.visionExtractionPrompt}
                   label={
                     <span className="flex items-center justify-between gap-2">
                       <span>
@@ -1820,7 +1836,11 @@ export function BehaviorTab({
                       ))}
                     </Select>
                   </FormField>
-                  <FormField label={t("editor.ttsCredential", "API key")} group>
+                  <FormField
+                    label={t("editor.ttsCredential", "API key")}
+                    error={refusals.ttsCredential}
+                    group
+                  >
                     <CredentialPicker
                       value={tts.credentialRef}
                       onChange={(v) => setTts({ ...tts, credentialRef: v })}
@@ -1937,6 +1957,7 @@ export function BehaviorTab({
                     </FormField>
                     <FormField
                       label={t("editor.credential", "API key")}
+                      error={refusals.ttsNormalizeCredential}
                       description={t(
                         "editor.ttsNormalizeCredentialHint",
                         "Required when the provider differs from the agent's: the agent's key is never sent to another vendor, so without a key of its own the rewrite is skipped and the audio goes out unrewritten.",
@@ -2348,6 +2369,7 @@ export function BehaviorTab({
                 </FormField>
                 <FormField
                   label={t("editor.contactAuthCredential", "Credential")}
+                  error={refusals.contactAuthCredential}
                   group
                   description={t(
                     "editor.contactAuthCredentialHint",
@@ -2492,6 +2514,7 @@ export function BehaviorTab({
                     "editor.contactAuthDenyMessage",
                     "Message to a denied contact",
                   )}
+                  error={refusals.contactAuthDenyMessage}
                   description={t(
                     "editor.contactAuthDenyMessageHint",
                     "Sent when the check denies the contact, at most once per notice cooldown. Leave empty to send nothing.",
@@ -2652,6 +2675,7 @@ export function BehaviorTab({
                 </FormField>
                 <FormField
                   label={t("editor.credential", "API key")}
+                  error={refusals.memoryCredential}
                   description={t(
                     "editor.memoryCredentialHint",
                     "Required when the provider differs from the agent's: the agent's key is never sent to another vendor, so without a key of its own the summary is not written and the attendance stays in the thread raw.",
@@ -3117,6 +3141,7 @@ export function BehaviorTab({
                     />
                   </FormField>
                   <FollowUpStepsEditor
+                    stepRefusals={refusals.followUpSteps}
                     agentId={agentId}
                     followUp={followUp}
                     setFollowUp={setFollowUp}

--- a/src/client/pages/agents/BehaviorTab.tsx
+++ b/src/client/pages/agents/BehaviorTab.tsx
@@ -2835,6 +2835,7 @@ export function BehaviorTab({
             {!!modelFallback.provider && (
               <div className="flex flex-col gap-3">
                 <FormField
+                  error={refusals.modelFallbackCredential}
                   label={t("editor.credential", "API key")}
                   description={t(
                     "editor.modelFallbackCredentialHint",

--- a/src/client/pages/agents/GeneralTab.tsx
+++ b/src/client/pages/agents/GeneralTab.tsx
@@ -43,6 +43,8 @@ interface GeneralTabProps {
   // page decides where a refusal goes, this tab only renders what it is handed.
   nameError?: string | null;
   promptError?: string | null;
+  // The model's key is a column of its own, so the server refuses it as `modelConfig.credentialRef`.
+  modelCredentialError?: string | null;
   systemPrompt: string;
   setSystemPrompt: (v: string) => void;
   enabled: boolean;
@@ -76,6 +78,7 @@ export function GeneralTab({
   name,
   nameError,
   promptError,
+  modelCredentialError,
   setName,
   systemPrompt,
   setSystemPrompt,
@@ -225,7 +228,11 @@ export function GeneralTab({
           </FormField>
         </div>
         <div className="grid gap-4 sm:grid-cols-2">
-          <FormField label={t("editor.credential", "API key")} group>
+          <FormField
+            label={t("editor.credential", "API key")}
+            error={modelCredentialError}
+            group
+          >
             <CredentialPicker
               value={model.credentialRef}
               onChange={(v) => setModel({ ...model, credentialRef: v })}

--- a/src/client/pages/agents/GuardrailsTab.tsx
+++ b/src/client/pages/agents/GuardrailsTab.tsx
@@ -24,6 +24,7 @@ import type {
 } from "@/modules/guardrails/settings";
 import { Section, SectionNav } from "./SectionNav";
 import { TabActionBar } from "./TabActionBar";
+import type { GuardrailsRefusals } from "./types";
 
 // Agent editor "Guardrails" tab: input/output moderation (agent.settings.guardrails). Own Save +
 // dirty tracking (its own SECTION_KEY). A dedicated LLM screens the customer message (input) and/or
@@ -33,6 +34,9 @@ import { TabActionBar } from "./TabActionBar";
 interface GuardrailsTabProps {
   guardrails: GuardrailsConfig;
   setGuardrails: React.Dispatch<React.SetStateAction<GuardrailsConfig>>;
+  // The refused input this tab draws, if the standing refusal is about one of them. Read in
+  // AgentEditorPage and passed as answers -- see the note on the type.
+  refusals: GuardrailsRefusals;
   dirty: boolean;
   saving: boolean;
   onSave: () => void;
@@ -44,6 +48,7 @@ const ACTIONS: GuardrailAction[] = ["template", "generated", "silent"];
 export function GuardrailsTab({
   guardrails: g,
   setGuardrails: setG,
+  refusals,
   dirty,
   saving,
   onSave,
@@ -198,6 +203,11 @@ export function GuardrailsTab({
             {d.action !== "silent" && (
               <FormField
                 label={t("editor.guardrails.template", "Template message")}
+                error={
+                  dir === "input"
+                    ? refusals.inputTemplateMessage
+                    : refusals.outputTemplateMessage
+                }
                 description={
                   d.action !== "generated"
                     ? undefined
@@ -235,6 +245,7 @@ export function GuardrailsTab({
                   "editor.guardrails.generationPromptHint",
                   "Steers how the guardrails agent writes the replacement reply (tone, what to offer or avoid). Optional.",
                 )}
+                error={refusals.outputGenerationPrompt}
               >
                 <Textarea
                   value={d.generationPrompt}
@@ -296,7 +307,11 @@ export function GuardrailsTab({
                     ))}
                   </Select>
                 </FormField>
-                <FormField label={t("editor.credential", "API key")} group>
+                <FormField
+                  label={t("editor.credential", "API key")}
+                  error={refusals.credential}
+                  group
+                >
                   <CredentialPicker
                     value={g.credentialRef ?? ""}
                     onChange={(v) =>
@@ -375,6 +390,7 @@ export function GuardrailsTab({
                 </FormField>
                 <FormField
                   label={t("editor.guardrails.customPolicy", "Custom policy")}
+                  error={refusals.customPolicy}
                   description={t(
                     "editor.guardrails.customPolicyHint",
                     "Extra rules appended to every analysis.",

--- a/src/client/pages/agents/ToolGrantsEditor.tsx
+++ b/src/client/pages/agents/ToolGrantsEditor.tsx
@@ -48,7 +48,12 @@ import { IntegrationEditModal } from "@/client/pages/resources/IntegrationEditMo
 import { McpEditModal } from "@/client/pages/resources/McpEditModal";
 import { ToolEditModal } from "@/client/pages/resources/ToolEditModal";
 import { TOOL_INSTRUCTIONS_MAX } from "@/modules/agents/text-caps";
-import type { GrantState, HandoffUiState, ToolCatalog } from "./types";
+import type {
+  GrantState,
+  HandoffUiState,
+  ToolCatalog,
+  ToolRefusals,
+} from "./types";
 
 // Service-logo adapters so a toolpack integration shows its brand mark in the SelectableCard's
 // `icon` slot (which expects a LucideIcon). Module-level → stable identity (no remount per render).
@@ -114,6 +119,8 @@ interface Props {
   // Operator-authored guidance for set_custom_attribute + assign_label (when to use each scope/label/
   // attribute), appended to their model-facing descriptions. Persisted in agent.settings.toolGuidance.
   customAttributeInstructions: string;
+  // The refused note this editor draws, if the standing refusal is about one -- see ToolRefusals.
+  refusals: ToolRefusals;
   setCustomAttributeInstructions: (v: string) => void;
   labelInstructions: string;
   setLabelInstructions: (v: string) => void;
@@ -450,6 +457,7 @@ export function ToolGrantsEditor({
   kanbanInstructions,
   setKanbanInstructions,
   customAttributeInstructions,
+  refusals,
   setCustomAttributeInstructions,
   labelInstructions,
   setLabelInstructions,
@@ -1443,6 +1451,7 @@ export function ToolGrantsEditor({
             )}
             <FormField
               label={t("editor.handoffInstructions", "Transfer instructions")}
+              error={refusals.handoffInstructions}
               group
               description={t(
                 "editor.handoffInstructionsHint",
@@ -1475,6 +1484,7 @@ export function ToolGrantsEditor({
           >
             <FormField
               label={t("editor.kanbanInstructions", "Funnel guidance")}
+              error={refusals.kanbanInstructions}
               group
               description={t(
                 "editor.kanbanInstructionsHint",
@@ -1505,6 +1515,7 @@ export function ToolGrantsEditor({
           >
             <FormField
               label={t("editor.updateKanbanInstructions", "Usage guidance")}
+              error={refusals.updateKanbanInstructions}
               group
               description={t(
                 "editor.updateKanbanInstructionsHint",
@@ -1537,6 +1548,7 @@ export function ToolGrantsEditor({
           >
             <FormField
               label={t("editor.attrInstructions", "Usage guidance")}
+              error={refusals.attributeInstructions}
               group
               description={t(
                 "editor.attrInstructionsHint",
@@ -1567,6 +1579,7 @@ export function ToolGrantsEditor({
           >
             <FormField
               label={t("editor.labelInstructions", "Usage guidance")}
+              error={refusals.labelInstructions}
               group
               description={t(
                 "editor.labelInstructionsHint",

--- a/src/client/pages/agents/ToolsTab.tsx
+++ b/src/client/pages/agents/ToolsTab.tsx
@@ -10,6 +10,7 @@ import type {
   HandoffUiState,
   ToolCatalog,
   ToolPreconditionRow,
+  ToolRefusals,
 } from "./types";
 
 interface ToolsTabProps {
@@ -25,6 +26,7 @@ interface ToolsTabProps {
   kanbanInstructions: string;
   setKanbanInstructions: (v: string) => void;
   customAttributeInstructions: string;
+  refusals: ToolRefusals;
   setCustomAttributeInstructions: (v: string) => void;
   labelInstructions: string;
   setLabelInstructions: (v: string) => void;
@@ -72,6 +74,7 @@ export function ToolsTab({
   kanbanInstructions,
   setKanbanInstructions,
   customAttributeInstructions,
+  refusals,
   setCustomAttributeInstructions,
   labelInstructions,
   setLabelInstructions,
@@ -151,6 +154,7 @@ export function ToolsTab({
             kanbanInstructions={kanbanInstructions}
             setKanbanInstructions={setKanbanInstructions}
             customAttributeInstructions={customAttributeInstructions}
+            refusals={refusals}
             setCustomAttributeInstructions={setCustomAttributeInstructions}
             labelInstructions={labelInstructions}
             setLabelInstructions={setLabelInstructions}

--- a/src/client/pages/agents/types.ts
+++ b/src/client/pages/agents/types.ts
@@ -73,6 +73,7 @@ export interface BehaviorRefusals {
   contactAuthCredential: string | null;
   contactAuthDenyMessage: string | null;
   memoryCredential: string | null;
+  modelFallbackCredential: string | null;
   awayMessage: string | null;
   // By index, because the server refuses a follow-up note as `followUp.steps[2].instructions` and the
   // step it names is the one that has to carry the mark.

--- a/src/client/pages/agents/types.ts
+++ b/src/client/pages/agents/types.ts
@@ -52,3 +52,45 @@ export interface ToolPreconditionRow {
   key: string;
   equals: string;
 }
+
+// THE MARKS THE EDITOR HANDS ITS TABS.
+//
+// One object per tab and not one prop per input, and the shape is forced rather than chosen. The
+// fence in `tests/client/field-refusal-fence.test.ts` asks that every name a form DECLARES be read
+// back by an `at(…)` call in the SAME file, so the readings have to stay in `AgentEditorPage` and
+// only their answers travel. Handing a tab a `refusalAt` callback instead would move the readings
+// into the tab and leave the declaration answered by nothing — which is the exact shape that rule
+// exists to catch, since a declared name with no control behind it makes `placeRefusal` report a
+// placement and the caller then keeps the toast quiet.
+//
+// Null is the normal value of every one of these: at most one input is refused at a time.
+export interface BehaviorRefusals {
+  sttCredential: string | null;
+  ttsCredential: string | null;
+  ttsNormalizeCredential: string | null;
+  visionCredential: string | null;
+  visionExtractionPrompt: string | null;
+  contactAuthCredential: string | null;
+  contactAuthDenyMessage: string | null;
+  memoryCredential: string | null;
+  awayMessage: string | null;
+  // By index, because the server refuses a follow-up note as `followUp.steps[2].instructions` and the
+  // step it names is the one that has to carry the mark.
+  followUpSteps: readonly (string | null)[];
+}
+
+export interface GuardrailsRefusals {
+  credential: string | null;
+  customPolicy: string | null;
+  inputTemplateMessage: string | null;
+  outputTemplateMessage: string | null;
+  outputGenerationPrompt: string | null;
+}
+
+export interface ToolRefusals {
+  handoffInstructions: string | null;
+  kanbanInstructions: string | null;
+  attributeInstructions: string | null;
+  labelInstructions: string | null;
+  updateKanbanInstructions: string | null;
+}

--- a/tests/client/agent-document-preview.test.tsx
+++ b/tests/client/agent-document-preview.test.tsx
@@ -102,6 +102,13 @@ function renderEditor() {
           <ToastProvider>
             <ToolGrantsEditor
               agentId="1"
+              refusals={{
+                handoffInstructions: null,
+                kanbanInstructions: null,
+                attributeInstructions: null,
+                labelInstructions: null,
+                updateKanbanInstructions: null,
+              }}
               catalog={CATALOG as never}
               grants={[]}
               onChange={noop}

--- a/tests/client/config-health.test.ts
+++ b/tests/client/config-health.test.ts
@@ -1466,6 +1466,15 @@ describe("computeConfigIssues — text stored over its cap", () => {
     expect(
       target({ followUp: { steps: [{ instructions: "f".repeat(2001) }] } }),
     ).toBe("behavior/proactive");
+    // The two copy fields the CUSTOMER reads. Both have a control on the Behavior tab and neither
+    // was in the map, so a warning about either said "this note has no field in the console" and
+    // offered no jump -- about a textarea the operator is two clicks from.
+    expect(target({ availability: { awayMessage: "a".repeat(2001) } })).toBe(
+      "behavior/availability",
+    );
+    expect(target({ contactAuth: { denyMessage: "d".repeat(2001) } })).toBe(
+      "behavior/contactAuth",
+    );
   });
 
   // GuardrailsTab renders gr-input/gr-output/gr-policy only when guardrails are ON, so with them off

--- a/tests/client/editor-refusal.test.ts
+++ b/tests/client/editor-refusal.test.ts
@@ -4,6 +4,7 @@ import {
   editorRefusalFields,
   editorTargetFor,
   followUpStepField,
+  sentFromPatch,
 } from "@/client/lib/editorRefusal";
 import { NATIVE_TOOL_NAMES } from "@/graph/tools/catalog";
 import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
@@ -295,5 +296,74 @@ describe("the write boundary the declaration rests on", () => {
     expect(
       collectOversizedTextChanges(next, stored).map((o) => o.path),
     ).toEqual(["vision.extractionPrompt"]);
+  });
+});
+
+// WHAT A WRITE CARRIED, read from the request rather than from what is on screen.
+//
+// `sent` decides two things — whether `placeRefusal` compares the refused value against the box, and
+// whether a successful save clears the mark — and both go wrong quietly when it under-reports. The
+// first version built it from what the tab was DRAWING, and the editor sends more than it draws:
+// `buildSettings()` serializes the whole bag, `saveGuardrails` resends the guardrails block whether
+// or not the switch is on.
+describe("sentFromPatch", () => {
+  const OWNED = editorRefusalFields(view()).owned;
+
+  test("a settings block carried by a switched-off section still counts as sent", () => {
+    // The case the visibility-derived version missed: guardrails off, the block still on the wire.
+    // Without it the refusal is marked with no staleness comparison at all, so the server's sentence
+    // lands under whatever the operator typed while the request was out.
+    const sent = sentFromPatch(
+      { settings: { guardrails: { customPolicy: "over the cap" } } },
+      OWNED,
+    );
+    expect(Object.hasOwn(sent, "guardrails.customPolicy")).toBe(true);
+    expect(sent["guardrails.customPolicy"]).toBe("over the cap");
+  });
+
+  test("both spellings resolve into the same bag", () => {
+    const sent = sentFromPatch(
+      {
+        name: "ACME",
+        modelConfig: { credentialRef: "vault:1" },
+        settings: { tts: { credentialRef: "vault:2" } },
+      },
+      OWNED,
+    );
+    expect(sent.name).toBe("ACME");
+    expect(sent["modelConfig.credentialRef"]).toBe("vault:1");
+    expect(sent["settings.tts.credentialRef"]).toBe("vault:2");
+  });
+
+  test("a follow-up step is read by its index", () => {
+    const sent = sentFromPatch(
+      { settings: { followUp: { steps: [{ instructions: "a" }, {}] } } },
+      OWNED,
+    );
+    expect(sent[followUpStepField(0)]).toBe("a");
+    expect(Object.hasOwn(sent, followUpStepField(1))).toBe(false);
+  });
+
+  test("a name the patch does not mention is absent, not undefined", () => {
+    // The distinction is the whole point: `placeRefusal` reads `Object.hasOwn` to decide whether
+    // there is anything to compare, so a key present with `undefined` would claim the write carried
+    // a value it never sent.
+    const sent = sentFromPatch({ name: "ACME" }, OWNED);
+    expect(Object.hasOwn(sent, "settings.tts.credentialRef")).toBe(false);
+    expect(Object.hasOwn(sent, "name")).toBe(true);
+  });
+
+  test("a value explicitly sent as null is carried", () => {
+    // `buildSettings` writes `credentialRef: null` to clear one, and that IS what the write sent.
+    const sent = sentFromPatch(
+      { settings: { stt: { credentialRef: null } } },
+      OWNED,
+    );
+    expect(Object.hasOwn(sent, "settings.stt.credentialRef")).toBe(true);
+    expect(sent["settings.stt.credentialRef"]).toBeNull();
+  });
+
+  test("a grant-only request carries nothing", () => {
+    expect(sentFromPatch({}, OWNED)).toEqual({});
   });
 });

--- a/tests/client/editor-refusal.test.ts
+++ b/tests/client/editor-refusal.test.ts
@@ -4,7 +4,9 @@ import {
   editorRefusalFields,
   editorTargetFor,
   followUpStepField,
+  hasNoConsoleControl,
   sentFromPatch,
+  UNDRAWN_TOOL_NOTES,
 } from "@/client/lib/editorRefusal";
 import { NATIVE_TOOL_NAMES } from "@/graph/tools/catalog";
 import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
@@ -47,10 +49,6 @@ function everyCappedPath(): string[] {
 // The thirteen native tools accept a note and the console draws three. The other ten can only have
 // been written through REST or MCP, so a refusal about one has nowhere to send anybody — and saying
 // "go to the Tools tab" about a control that is not there is worse than saying nothing.
-const NO_CONTROL = NATIVE_TOOL_NAMES.filter(
-  (n) =>
-    !["set_custom_attribute", "assign_label", "update_kanban_task"].includes(n),
-).map((n) => `toolGuidance.${n}`);
 
 describe("editorTargetFor", () => {
   test("every capped field either has a place in the editor or is one of the ten with no control", () => {
@@ -61,7 +59,10 @@ describe("editorTargetFor", () => {
     const unplaced = everyCappedPath().filter(
       (p) => editorTargetFor(p, { guardrailsEnabled: true }) === null,
     );
-    expect(unplaced.sort()).toEqual([...NO_CONTROL].sort());
+    // Compared against the exported set rather than a copy of it, and it is still a real comparison:
+    // `editorTargetFor` never consults that list, so this says the map's gaps are exactly the notes
+    // the editor draws no field for — nothing more and nothing less.
+    expect(unplaced.sort()).toEqual([...UNDRAWN_TOOL_NOTES].sort());
   });
 
   test("the two copy fields the customer reads land on their own sections", () => {
@@ -157,6 +158,49 @@ function view(over: Partial<EditorControlsShown> = {}): EditorControlsShown {
     ...over,
   };
 }
+
+describe("hasNoConsoleControl", () => {
+  test("only the native-tool notes the editor draws no field for", () => {
+    // The claim has to be DERIVABLE, not inferred from this map having no entry. Reading it off an
+    // absent target is what told the operator that `settings.modelFallback.model` and
+    // `observability.fullDetailUntil` can only be changed through the API, about pickers that are on
+    // screen. `toolGuidance` is the one closed set: thirteen names in NATIVE_TOOL_NAMES, three drawn.
+    for (const f of UNDRAWN_TOOL_NOTES) {
+      expect(hasNoConsoleControl(f), f).toBe(true);
+      // Both wire spellings, since the credential producer prefixes and the text one does not.
+      expect(hasNoConsoleControl(`settings.${f}`), f).toBe(true);
+    }
+    expect(UNDRAWN_TOOL_NOTES.length).toBe(NATIVE_TOOL_NAMES.length - 3);
+  });
+
+  test("never for a value the console draws, mapped or not", () => {
+    for (const f of [
+      "toolGuidance.assign_label",
+      "settings.modelFallback.model",
+      "observability.fullDetailUntil",
+      "toolPreconditions.assign_label",
+      "guardrails.customPolicy",
+      "name",
+    ]) {
+      expect(hasNoConsoleControl(f), f).toBe(false);
+    }
+  });
+
+  test("the three targeted-not-owned paths still have somewhere to send the operator", () => {
+    // Owning means marking one box with one value, and none of these is that: preconditions are a
+    // list, the fallback model comes from a picker, the observability window is a datetime. Targeting
+    // is the weaker and honest claim, and it is what the banner's jump needs.
+    const { owned } = editorRefusalFields(view());
+    for (const [field, sectionId] of [
+      ["settings.modelFallback.model", "modelFallback"],
+      ["observability.fullDetailUntil", "observability"],
+      ["toolPreconditions.assign_label", "tools-preconditions"],
+    ] as const) {
+      expect(editorTargetFor(field)?.sectionId, field).toBe(sectionId);
+      expect(owned, field).not.toContain(field);
+    }
+  });
+});
 
 describe("editorRefusalFields", () => {
   test("every credential the server can refuse is owned by the editor", () => {

--- a/tests/client/editor-refusal.test.ts
+++ b/tests/client/editor-refusal.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+import {
+  editorRefusalFields,
+  editorTargetFor,
+  followUpStepField,
+} from "@/client/lib/editorRefusal";
+import { NATIVE_TOOL_NAMES } from "@/graph/tools/catalog";
+import { SETTINGS_CREDENTIAL_PATHS } from "@/modules/agents/credential-paths";
+import { collectOversizedTextChanges } from "@/modules/agents/text-caps";
+
+// WHERE A REFUSAL ABOUT A BAG GOES, when the control for it is behind one of eight tabs.
+//
+// #320 wired every form in the console to put a refusal at the input the server named, and stopped at
+// this one: the editor holds `name` and `systemPrompt`, and everything else it writes lives in bags
+// edited on another tab. A mark written to a control nobody is looking at is silence, which is the
+// one outcome the mechanism may not produce, so the missing half was never the mark — it was knowing
+// WHERE the control is, and saying so.
+//
+// The map that answers it already existed twice, disagreeing. This file is the guard against it
+// disagreeing again.
+
+// A settings bag holding every capped field, each one over its cap, so the walker reports the
+// complete set of paths a text refusal can name. Built rather than listed: the point of the sweep
+// below is to catch the field somebody adds to `text-caps.ts` next week, and a hand-written list
+// would be exactly as blind as the map it is checking.
+function everyCappedPath(): string[] {
+  const long = "x".repeat(4001);
+  const bag = {
+    handoff: { instructions: long },
+    availability: { awayMessage: long },
+    contactAuth: { denyMessage: long },
+    kanban: { instructions: long },
+    toolGuidance: Object.fromEntries(NATIVE_TOOL_NAMES.map((n) => [n, long])),
+    guardrails: {
+      customPolicy: long,
+      input: { templateMessage: long, generationPrompt: long },
+      output: { templateMessage: long, generationPrompt: long },
+    },
+    vision: { extractionPrompt: long },
+    followUp: { steps: [{ instructions: long }, { instructions: long }] },
+  };
+  return collectOversizedTextChanges(bag, undefined).map((o) => o.path);
+}
+
+// The thirteen native tools accept a note and the console draws three. The other ten can only have
+// been written through REST or MCP, so a refusal about one has nowhere to send anybody — and saying
+// "go to the Tools tab" about a control that is not there is worse than saying nothing.
+const NO_CONTROL = NATIVE_TOOL_NAMES.filter(
+  (n) =>
+    !["set_custom_attribute", "assign_label", "update_kanban_task"].includes(n),
+).map((n) => `toolGuidance.${n}`);
+
+describe("editorTargetFor", () => {
+  test("every capped field either has a place in the editor or is one of the ten with no control", () => {
+    // The sweep that would have caught this issue's own finding: `availability.awayMessage` and
+    // `contactAuth.denyMessage` are capped, have a textarea on the Behavior tab, and were in neither
+    // of the two maps that used to answer this. A warning about either told the operator the console
+    // has no field for it.
+    const unplaced = everyCappedPath().filter(
+      (p) => editorTargetFor(p, { guardrailsEnabled: true }) === null,
+    );
+    expect(unplaced.sort()).toEqual([...NO_CONTROL].sort());
+  });
+
+  test("the two copy fields the customer reads land on their own sections", () => {
+    expect(editorTargetFor("availability.awayMessage")).toEqual({
+      tab: "behavior",
+      sectionId: "availability",
+    });
+    expect(editorTargetFor("contactAuth.denyMessage")).toEqual({
+      tab: "behavior",
+      sectionId: "contactAuth",
+    });
+  });
+
+  test("both spellings of a settings path answer the same place", () => {
+    // The wire carries two roots for the same bag: the text producer reports from the settings bag
+    // (`guardrails.customPolicy`) and the credential producer from the agent row
+    // (`settings.tts.credentialRef`). A reader that trusts one loses the other half of the fields.
+    expect(editorTargetFor("settings.vision.extractionPrompt")).toEqual(
+      editorTargetFor("vision.extractionPrompt"),
+    );
+    expect(editorTargetFor("settings.tts.credentialRef")).toEqual({
+      tab: "behavior",
+      sectionId: "tts",
+    });
+  });
+
+  test("every credential the agent holds is placed, from the list the server refuses by", () => {
+    // Derived from SETTINGS_CREDENTIAL_PATHS rather than restated, so a block that grows a
+    // credential next week is placed by construction. `modelConfig` is the eighth and lives on its
+    // own column.
+    for (const p of SETTINGS_CREDENTIAL_PATHS) {
+      const field = `settings.${p.path.join(".")}`;
+      expect(
+        editorTargetFor(field, { guardrailsEnabled: true }),
+        `${field} has no place in the editor`,
+      ).toEqual({ tab: p.tab, sectionId: p.sectionId });
+    }
+    expect(editorTargetFor("modelConfig.credentialRef")).toEqual({
+      tab: "general",
+      sectionId: "general-model",
+    });
+  });
+
+  test("with guardrails off, a guardrails field targets the section that is actually mounted", () => {
+    // GuardrailsTab draws gr-input/gr-output/gr-policy only while guardrails are ON, so with them off
+    // the anchor is not in the DOM and the jump scrolls to nothing. gr-model always mounts and holds
+    // the switch that brings the rest back — the same redirect the config-health warning already does.
+    expect(editorTargetFor("guardrails.customPolicy")).toEqual({
+      tab: "guardrails",
+      sectionId: "gr-model",
+    });
+    expect(
+      editorTargetFor("settings.guardrails.credentialRef", {
+        guardrailsEnabled: false,
+      }),
+    ).toEqual({ tab: "guardrails", sectionId: "gr-model" });
+    expect(
+      editorTargetFor("guardrails.customPolicy", { guardrailsEnabled: true }),
+    ).toEqual({ tab: "guardrails", sectionId: "gr-policy" });
+  });
+
+  test("a grant id is not an input, and is not placed", () => {
+    // `bigOrThrow` names five id fields, and every one of them is filled by a picker from the
+    // catalog — measured in ToolGrantsEditor, which builds each grant from `inst.id`. Nothing in the
+    // console types one, so the refusal cannot arrive from here and there is no box to mark.
+    for (const f of [
+      "toolDefinitionId",
+      "mcpServerConnectionId",
+      "integrationInstanceId",
+      "documentTemplateId",
+      "knowledgeBaseIds",
+    ]) {
+      expect(editorTargetFor(f)).toBeNull();
+    }
+  });
+});
+
+describe("editorRefusalFields", () => {
+  test("every declared name is drawn by the tab it is declared under", () => {
+    // The anti-drift half: the per-tab lists and the target map are two statements about the same
+    // thing, and a name that moves in one and not the other sends the operator to the wrong tab.
+    for (const tab of [
+      "general",
+      "behavior",
+      "guardrails",
+      "tools",
+      "channelRedirect",
+    ] as const) {
+      const { drawn } = editorRefusalFields({ tab, followUpSteps: 2 });
+      for (const field of drawn) {
+        expect(
+          editorTargetFor(field, { guardrailsEnabled: true })?.tab,
+          `${field} is declared on ${tab}`,
+        ).toBe(tab);
+      }
+    }
+  });
+
+  test("what a tab draws is a subset of what the editor owns", () => {
+    const { owned } = editorRefusalFields({ tab: "general", followUpSteps: 3 });
+    for (const tab of ["general", "behavior", "guardrails", "tools"] as const) {
+      for (const field of editorRefusalFields({ tab, followUpSteps: 3 })
+        .drawn) {
+        expect(owned, `${field} is drawn but not owned`).toContain(field);
+      }
+    }
+  });
+
+  test("the follow-up notes stop where the editor's step list does", () => {
+    // A mark on a step that does not exist is a name nothing renders, which is the silence this
+    // whole mechanism is against.
+    const { drawn } = editorRefusalFields({
+      tab: "behavior",
+      followUpSteps: 2,
+    });
+    expect(drawn).toContain(followUpStepField(0));
+    expect(drawn).toContain(followUpStepField(1));
+    expect(drawn).not.toContain(followUpStepField(2));
+  });
+});
+
+describe("the write boundary the tab-gated declaration rests on", () => {
+  // The per-tab lists do not carry the switches inside a section (vision off hides the extraction
+  // prompt; the gate off hides the deny message). That is exact only because the server refuses text
+  // a write INTRODUCES or CHANGES and nothing else — change one of these and its control was on
+  // screen. If that ever stops being true, the declaration starts claiming controls the operator
+  // cannot see, and this is the test that says so.
+  test("a stored oversized value this write does not touch is not refused", () => {
+    const long = "x".repeat(5000);
+    const stored = { vision: { extractionPrompt: long } };
+    expect(collectOversizedTextChanges({ ...stored }, stored)).toEqual([]);
+  });
+
+  test("the same value changed IS refused", () => {
+    const stored = { vision: { extractionPrompt: "x".repeat(5000) } };
+    const next = { vision: { extractionPrompt: "y".repeat(5000) } };
+    expect(
+      collectOversizedTextChanges(next, stored).map((o) => o.path),
+    ).toEqual(["vision.extractionPrompt"]);
+  });
+});

--- a/tests/client/editor-refusal.test.ts
+++ b/tests/client/editor-refusal.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  type EditorControlsShown,
   editorRefusalFields,
   editorTargetFor,
   followUpStepField,
@@ -137,7 +138,39 @@ describe("editorTargetFor", () => {
   });
 });
 
+// Every switch ON, so `drawn` is the tab's full set unless a test turns one off.
+function view(over: Partial<EditorControlsShown> = {}): EditorControlsShown {
+  return {
+    tab: "behavior",
+    awayEnabled: true,
+    sttEnabled: true,
+    ttsOn: true,
+    ttsNormalize: true,
+    visionEnabled: true,
+    contactAuthEnabled: true,
+    memoryCompactionEnabled: true,
+    modelFallbackChosen: true,
+    guardrailsEnabled: true,
+    followUpEnabled: true,
+    followUpSteps: 2,
+    ...over,
+  };
+}
+
 describe("editorRefusalFields", () => {
+  test("every credential the server can refuse is owned by the editor", () => {
+    // The direction the first version of this file did not check, and it cost a real gap:
+    // `settings.modelFallback.credentialRef` reached SETTINGS_CREDENTIAL_PATHS without reaching the
+    // editor's own list, so the server could refuse a field this page neither marked nor announced.
+    // Asserted against the SERVER's list, which is the one that grows.
+    const { owned } = editorRefusalFields(view());
+    for (const p of SETTINGS_CREDENTIAL_PATHS) {
+      const field = `settings.${p.path.join(".")}`;
+      expect(owned, `${field} is refusable and unowned`).toContain(field);
+    }
+    expect(owned).toContain("modelConfig.credentialRef");
+  });
+
   test("every declared name is drawn by the tab it is declared under", () => {
     // The anti-drift half: the per-tab lists and the target map are two statements about the same
     // thing, and a name that moves in one and not the other sends the operator to the wrong tab.
@@ -147,11 +180,10 @@ describe("editorRefusalFields", () => {
       "guardrails",
       "tools",
       "channelRedirect",
-    ] as const) {
-      const { drawn } = editorRefusalFields({ tab, followUpSteps: 2 });
-      for (const field of drawn) {
+    ]) {
+      for (const field of editorRefusalFields(view({ tab })).drawn) {
         expect(
-          editorTargetFor(field, { guardrailsEnabled: true })?.tab,
+          editorTargetFor(field, { guardrailsEnabled: true })?.tab as string,
           `${field} is declared on ${tab}`,
         ).toBe(tab);
       }
@@ -159,29 +191,93 @@ describe("editorRefusalFields", () => {
   });
 
   test("what a tab draws is a subset of what the editor owns", () => {
-    const { owned } = editorRefusalFields({ tab: "general", followUpSteps: 3 });
-    for (const tab of ["general", "behavior", "guardrails", "tools"] as const) {
-      for (const field of editorRefusalFields({ tab, followUpSteps: 3 })
-        .drawn) {
+    const { owned } = editorRefusalFields(view({ tab: "general" }));
+    for (const tab of ["general", "behavior", "guardrails", "tools"]) {
+      for (const field of editorRefusalFields(view({ tab })).drawn) {
         expect(owned, `${field} is drawn but not owned`).toContain(field);
       }
     }
   });
 
+  test("a control behind an off switch is owned and NOT drawn", () => {
+    // The case the tab-only declaration got wrong, and it is not about when the refusal arrives: the
+    // operator can turn Vision off while its credential refusal is standing. The mark is then held on
+    // a control that is no longer in the DOM, and only `drawn` saying so gets the sentence back on
+    // screen.
+    const off = editorRefusalFields(view({ visionEnabled: false }));
+    expect(off.owned).toContain("settings.vision.credentialRef");
+    expect(off.owned).toContain("vision.extractionPrompt");
+    expect(off.drawn).not.toContain("settings.vision.credentialRef");
+    expect(off.drawn).not.toContain("vision.extractionPrompt");
+
+    const on = editorRefusalFields(view());
+    expect(on.drawn).toContain("settings.vision.credentialRef");
+    expect(on.drawn).toContain("vision.extractionPrompt");
+  });
+
+  test("each switch answers for its own controls and nobody else's", () => {
+    // A table rather than one case, because the failure this guards is a wire crossed between two
+    // switches — a field that disappears when the wrong section is turned off is exactly as silent as
+    // one that never disappears.
+    const cases: Array<[Partial<EditorControlsShown>, string[]]> = [
+      [{ awayEnabled: false }, ["availability.awayMessage"]],
+      [{ sttEnabled: false }, ["settings.stt.credentialRef"]],
+      [{ ttsOn: false }, ["settings.tts.credentialRef"]],
+      [{ ttsNormalize: false }, ["settings.tts.normalizeCredentialRef"]],
+      [
+        { contactAuthEnabled: false },
+        ["settings.contactAuth.credentialRef", "contactAuth.denyMessage"],
+      ],
+      [
+        { memoryCompactionEnabled: false },
+        ["settings.memory.compaction.credentialRef"],
+      ],
+      [
+        { modelFallbackChosen: false },
+        ["settings.modelFallback.credentialRef"],
+      ],
+      [
+        { followUpEnabled: false },
+        [followUpStepField(0), followUpStepField(1)],
+      ],
+    ];
+    for (const [off, gone] of cases) {
+      const drawn = editorRefusalFields(view(off)).drawn;
+      const full = editorRefusalFields(view()).drawn;
+      expect(
+        full.filter((f) => !drawn.includes(f)).sort(),
+        JSON.stringify(off),
+      ).toEqual([...gone].sort());
+    }
+  });
+
+  test("guardrails off takes its whole tab's controls with it", () => {
+    // GuardrailsTab draws gr-input/gr-output/gr-policy AND the credential picker only while the
+    // switch is on; gr-model is the section that survives, and it holds the switch.
+    const off = editorRefusalFields(
+      view({ tab: "guardrails", guardrailsEnabled: false }),
+    );
+    expect(off.drawn).toEqual([]);
+    expect(
+      editorRefusalFields(view({ tab: "guardrails" })).drawn.length,
+    ).toBeGreaterThan(0);
+  });
+
   test("the follow-up notes stop where the editor's step list does", () => {
     // A mark on a step that does not exist is a name nothing renders, which is the silence this
     // whole mechanism is against.
-    const { drawn } = editorRefusalFields({
-      tab: "behavior",
-      followUpSteps: 2,
-    });
+    const { drawn } = editorRefusalFields(view({ followUpSteps: 2 }));
     expect(drawn).toContain(followUpStepField(0));
     expect(drawn).toContain(followUpStepField(1));
     expect(drawn).not.toContain(followUpStepField(2));
   });
+
+  test("a tab the editor writes nothing on declares nothing", () => {
+    expect(editorRefusalFields(view({ tab: "playground" })).drawn).toEqual([]);
+  });
 });
 
-describe("the write boundary the tab-gated declaration rests on", () => {
+describe("the write boundary the declaration rests on", () => {
   // The per-tab lists do not carry the switches inside a section (vision off hides the extraction
   // prompt; the gate off hides the deny message). That is exact only because the server refuses text
   // a write INTRODUCES or CHANGES and nothing else — change one of these and its control was on

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -152,6 +152,39 @@ describe("agent editor save errors", () => {
     expect(body).not.toContain("showToast");
   });
 
+  test("the banner is brought into view, once per sentence", () => {
+    // It sits above the tabs and the button that produced it does not: Behavior and Tools are long
+    // and their Save lives in a sticky bar at the bottom. Dropping the toast (round 2) took away the
+    // thing that answered from down there, so without this a sighted operator watches the save stop
+    // and sees nothing. `role="alert"` covers the screen reader; this is the other half.
+    const start = SRC.indexOf("const bannerRef =");
+    expect(start).toBeGreaterThan(-1);
+    const effect = SRC.slice(start, SRC.indexOf("}, [bannerMessage]);", start));
+    expect(effect).toContain("scrollIntoView");
+    // Once per SENTENCE. The banner stays up until the refusal is answered, so re-scrolling on every
+    // render would take the page out from under whoever is fixing the value.
+    expect(effect).toContain("announcedRef.current === bannerMessage");
+    expect(SRC).toContain("ref={bannerRef}");
+  });
+
+  test("what the boxes hold is normalized the way the wire is", () => {
+    // `sent` is read off the patch and `current` off this map, so a value the patch trims and the map
+    // keeps raw reads as "edited while the request was out" — and the refusal lands in the banner
+    // instead of on the textarea it is about, over nothing but surrounding whitespace.
+    const start = SRC.indexOf("currentRef.current = {");
+    expect(start).toBeGreaterThan(-1);
+    const body = SRC.slice(start, SRC.indexOf("\n  };", start));
+    for (const [field, writer] of [
+      ["availability.awayMessage", "awayMessage.trim()"],
+      ["contactAuth.denyMessage", "contactAuth.denyMessage.trim()"],
+      // Through the writer itself rather than a second spelling of what it does.
+      ["followUp", "followUpToStored(followUp)"],
+      ["vision.extractionPrompt", "DEFAULT_EXTRACTION_PROMPT"],
+    ] as const) {
+      expect(body, field).toContain(writer);
+    }
+  });
+
   test("the tools preflight compares against the stored bag, re-read when forced", () => {
     const start = SRC.indexOf("function settingsTextError");
     expect(start).toBeGreaterThan(-1);

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -57,10 +57,29 @@ describe("agent editor save errors", () => {
     ].map((m) => (m[1] as string).replace(/\s+/g, " ").trim());
     expect(cleared.sort()).toEqual([
       '"guardrails", sent',
+      '"knowledge", {}',
       '"tools", sent',
-      '"tools", {}',
       "section, sent",
     ]);
+    // The section a save answers for is the FORM it belongs to, not the tab its fields print on:
+    // `saveGrants` is the Knowledge tab's save (its only caller passes `dirty.knowledge`), and
+    // calling it `tools` let a successful Tools save clear a Knowledge failure still unsaved.
+    const grants = SRC.slice(SRC.indexOf("async function saveGrants("));
+    const grantsBody = grants.slice(0, grants.indexOf("\n  }"));
+    expect(grantsBody).toContain('clearRefusalFor("knowledge", {})');
+    expect(grantsBody).toContain('"knowledge",');
+  });
+
+  test("the stored sentence never outlives the mark it duplicates", () => {
+    // `capture` sets BOTH for an off-screen placement: it holds the mark and hands back the sentence.
+    // The mark expires by value and the stored copy does not, so without this the sentence surfaces
+    // again the moment the operator edits the refused field — the server's words under a value the
+    // server never saw. Round 2 dropped this effect while rewriting the banner and round 3 found it.
+    const start = SRC.indexOf(
+      "useEffect(() => {\n    if (heldField) setStandingRefusal(null);",
+    );
+    expect(start).toBeGreaterThan(-1);
+    expect(SRC.slice(start, SRC.indexOf("]);", start))).toContain("[heldField");
   });
 
   test("what a save carried is snapshotted before the request goes out", () => {
@@ -79,7 +98,7 @@ describe("agent editor save errors", () => {
       const snapshot = body.indexOf("sentFor(");
       if (snapshot === -1) {
         // Only the grant-only save may carry nothing, and then it must say so literally.
-        expect(body, fn).toContain('clearRefusalFor("tools", {})');
+        expect(body, fn).toContain('clearRefusalFor("knowledge", {})');
         continue;
       }
       expect(snapshot, `${fn} snapshots after answering`).toBeLessThan(

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -31,78 +31,47 @@ describe("agent editor save errors", () => {
   //
   // Source-level for the same reason as the rest of this file — the two sections are two arguments
   // to one function, and the distinction is invisible to anything that only watches the network.
-  test("a successful save clears only what the request carried", () => {
-    // Since #349 the holder covers every tab, so the question got wider. Scoping it by TAB is not
-    // enough and the gap is real: `saveGrants` writes the grant set alone and shares the Tools tab
-    // with the handoff, kanban and tool-guidance notes, so a grant-only PUT would clear a refusal
-    // about a note it never mentioned.
-    const start = SRC.indexOf("function clearRefusalFor");
+  test("a section is settled by one rule, whether it saved or discarded", () => {
+    // Both answer the same thing — the values that section owns are no longer in dispute — and
+    // written twice they drifted at once: the save half required the write to have carried the
+    // refused VALUE, which is false exactly when the operator has done what the refusal asked, so a
+    // corrected save left the stale hold in place and the mark came back the next time they typed
+    // the old value.
+    expect(SRC).not.toContain("clearRefusalFor");
+    expect(SRC).not.toContain("discardRefusalFor");
+    const start = SRC.indexOf("function settleRefusalFor");
     expect(start).toBeGreaterThan(-1);
     const body = SRC.slice(start, SRC.indexOf("\n  }", start));
-    expect(body).toContain("Object.hasOwn(sent, held)");
-    // And the VALUE, not only the path. `sent` is read from the patch, so a Behavior save carries
-    // `guardrails.customPolicy` from the last-synced bag — the stored value, not the edit the server
-    // refused. Presence alone would let that save answer a refusal it never re-sent.
-    expect(body).toContain("now.at(held, sent[held])");
-    // Through a ref, never the closure: a save handler closes over the render that launched it, and
-    // this page's saves are long enough for another tab's save to fail while one is in flight. An
-    // older success answering from its own render would clear a refusal that arrived after it — and
-    // `at` is memoized on the hold, so even the comparison would be the stale one.
-    expect(body).toContain("refusalRef.current");
-    expect(body).toContain("refusedSaveRef.current");
-    expect(body).not.toContain("refusal.field");
-    // A sentence the holder could place NOWHERE has no value to compare, so it is answered by the
-    // section that produced it.
-    expect(body).toContain("refusedSaveRef.current?.section === section");
-    // Never by tab or by target: both read the FIELD rather than the request.
-    expect(body).not.toContain("editorTargetFor");
 
-    // And every success path goes through it. The grant-only save answers for nothing and says so
-    // with an empty snapshot rather than by skipping the call, so a reader can tell "carried nothing"
-    // from "forgot to clear".
-    const cleared = [
-      ...SRC.matchAll(/(?<!function )clearRefusalFor\(([^)]*)\)/g),
-    ].map((m) => (m[1] as string).replace(/\s+/g, " ").trim());
-    expect(cleared.sort()).toEqual([
-      '"guardrails", sent',
-      '"knowledge", {}',
-      '"tools", sent',
-      "section, sent",
-    ]);
-    // The section a save answers for is the FORM it belongs to, not the tab its fields print on:
-    // `saveGrants` is the Knowledge tab's save (its only caller passes `dirty.knowledge`), and
-    // calling it `tools` let a successful Tools save clear a Knowledge failure still unsaved.
-    const grants = SRC.slice(SRC.indexOf("async function saveGrants("));
-    const grantsBody = grants.slice(0, grants.indexOf("\n  }"));
-    expect(grantsBody).toContain('clearRefusalFor("knowledge", {})');
-  });
-
-  test("discarding a section takes its refusal with it", () => {
-    // A fieldless refusal cannot expire by value the way a mark does, so without this the banner
-    // outlives the edit entirely — past the discard, past the next successful save of another
-    // section, indefinitely.
-    const start = SRC.indexOf("function discardRefusalFor");
-    expect(start).toBeGreaterThan(-1);
-    const body = SRC.slice(start, SRC.indexOf("\n  }", start));
-    // By the tab that DRAWS the value, not the section that wrote it: reverting Behavior restores the
-    // behavior form, and a mark a Behavior save left on a guardrails path is about a value the
-    // Guardrails tab still holds unsaved.
-    expect(body).toContain("editorTargetFor");
+    // By the tab that DRAWS the value, not by what the request serialized: a Behavior save spreads
+    // the last-synced `settings`, so it carries `guardrails.customPolicy` holding what is STORED
+    // rather than the edit the Guardrails tab still has unsaved.
     expect(body).toContain("target?.tab === section");
+    expect(body).not.toContain("Object.hasOwn(sent");
+    // A refusal the holder could place nowhere is about a SAVE, so its own section answers it.
     expect(body).toContain("refusedSaveRef.current?.section === section");
+    // Through refs, never the closure: a save handler closes over the render that launched it, and
+    // this page's saves are long enough for another tab's save to fail while one is in flight.
+    expect(body).toContain("refusalRef.current");
+    expect(body).not.toContain("refusal.field");
 
-    // Every revert goes through it, and discard-all clears outright.
-    const discarded = [
-      ...SRC.matchAll(/(?<!function )discardRefusalFor\("([^"]+)"\)/g),
-    ].map((m) => m[1] as string);
-    expect(discarded.sort()).toEqual([
+    // Every settling path goes through it: five saves and six discards.
+    const settled = [
+      ...SRC.matchAll(/(?<!function )settleRefusalFor\(([^)]*)\)/g),
+    ].map((m) => (m[1] as string).replace(/"/g, ""));
+    expect(settled.sort()).toEqual([
       "behavior",
       "channelRedirect",
       "general",
       "guardrails",
+      "guardrails",
       "knowledge",
+      "knowledge",
+      "section",
+      "tools",
       "tools",
     ]);
+    // Discard-all settles every section at once.
     expect(SRC).toContain("refusalRef.current.clear();");
   });
 
@@ -204,11 +173,17 @@ describe("agent editor save errors", () => {
     // and sees nothing. `role="alert"` covers the screen reader; this is the other half.
     const start = SRC.indexOf("const bannerRef =");
     expect(start).toBeGreaterThan(-1);
-    const effect = SRC.slice(start, SRC.indexOf("}, [bannerMessage]);", start));
+    const effect = SRC.slice(
+      start,
+      SRC.indexOf("}, [bannerMessage, refusalSeq]);", start),
+    );
     expect(effect).toContain("scrollIntoView");
-    // Once per SENTENCE. The banner stays up until the refusal is answered, so re-scrolling on every
-    // render would take the page out from under whoever is fixing the value.
-    expect(effect).toContain("announcedRef.current === bannerMessage");
+    // Once per ANSWERED REQUEST, counted rather than compared by text. The banner stays up until the
+    // refusal is answered, so re-scrolling every render would take the page out from under whoever is
+    // fixing the value — but keying on the sentence made two transport failures in a row, which say
+    // the same thing, announce once: the second looked like it did not happen.
+    expect(effect).toContain("announcedRef.current === refusalSeq");
+    expect(SRC).toContain("setRefusalSeq((n) => n + 1)");
     expect(SRC).toContain("ref={bannerRef}");
   });
 
@@ -256,6 +231,9 @@ describe("agent editor save errors", () => {
       // Through the writer itself rather than a second spelling of what it does.
       ["followUp", "followUpToStored(followUp)"],
       ["vision.extractionPrompt", "DEFAULT_EXTRACTION_PROMPT"],
+      ["handoff.instructions", "serializeHandoff(handoff).instructions"],
+      ["kanban.instructions", "kanbanInstructions.trim()"],
+      ["toolGuidance.assign_label", "labelInstructions.trim()"],
     ] as const) {
       expect(body, field).toContain(writer);
     }

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -31,38 +31,59 @@ describe("agent editor save errors", () => {
   //
   // Source-level for the same reason as the rest of this file — the two sections are two arguments
   // to one function, and the distinction is invisible to anything that only watches the network.
-  test("a successful save clears the holder only for the section it wrote", () => {
-    // Since #349 the holder covers every tab, so the question got wider without changing: the clear
-    // is scoped by asking WHERE the standing mark lives and comparing that with the section this save
-    // wrote. One call site, inside the one function that asks.
+  test("a successful save clears only what the request carried", () => {
+    // Since #349 the holder covers every tab, so the question got wider. Scoping it by TAB is not
+    // enough and the gap is real: `saveGrants` writes the grant set alone and shares the Tools tab
+    // with the handoff, kanban and tool-guidance notes, so a grant-only PUT would clear a refusal
+    // about a note it never mentioned. The snapshot the write went out with is the list of what it
+    // can answer for.
     expect(SRC.split("refusal.clear()").length - 1).toBe(1);
     const start = SRC.indexOf("function clearRefusalFor");
     expect(start).toBeGreaterThan(-1);
     const body = SRC.slice(start, SRC.indexOf("\n  }", start));
     expect(body).toContain("refusal.clear()");
-    expect(body).toContain("editorTargetFor");
-    expect(body).toContain("=== section");
+    expect(body).toContain("Object.hasOwn(sent, held)");
+    // Never by tab or by target: both read the FIELD rather than the request.
+    expect(body).not.toContain("editorTargetFor");
 
-    // And every success path goes through it rather than clearing on its own, which is what the
-    // previous version of this rule could not say: it could only speak for the single call site it
-    // found. A save that writes a section and clears nothing leaves a refusal standing that the
-    // server has stopped making.
-    // Call sites only: the declaration reads `clearRefusalFor(section: string)` and would otherwise
-    // count itself as a caller that clears every section.
+    // And every success path goes through it. The grant-only save answers for nothing and says so
+    // with an empty snapshot rather than by skipping the call, so a reader can tell "carried nothing"
+    // from "forgot to clear".
     const cleared = [
       ...SRC.matchAll(/(?<!function )clearRefusalFor\((.+?)\)/g),
-    ].map((m) => (m[1] as string).replace(/"/g, ""));
-    expect(cleared.sort()).toEqual(["guardrails", "section", "tools", "tools"]);
+    ].map((m) => (m[1] as string).trim());
+    expect(cleared.sort()).toEqual(["sent", "sent", "sent", "{}"]);
   });
 
-  // The tools save fires two calls (grants PUT, then agent PATCH), so it checks the bag itself before
-  // the first one — otherwise the grants persist and the PATCH is refused. It has to ask the same
-  // question the server asks: what does this write CHANGE. Comparing against nothing would refuse a
-  // save over text stored before the caps, which is the state the server deliberately lets through.
-  //
-  // Source-level for the same reason as the rest of this file; the rule itself is covered by
-  // agents-text-caps.test.ts, what is left here is the wiring.
-  // THE SECOND CHANNEL, WHEN THE CONTROL IS ON ANOTHER TAB.
+  test("what a save carried is snapshotted before the request goes out", () => {
+    // `currentRef` is LIVE. Building the sent map in the catch compares the boxes with themselves,
+    // the staleness check can never fire, and a refusal about a value the operator has already
+    // changed gets marked on the new one — which is the exact thing `placeRefusal` refuses to do.
+    for (const fn of [
+      "saveAgent",
+      "saveGrants",
+      "saveTools",
+      "saveGuardrails",
+    ]) {
+      const start = SRC.indexOf(`async function ${fn}(`);
+      expect(start, fn).toBeGreaterThan(-1);
+      const body = SRC.slice(start, SRC.indexOf("\n  }", start));
+      const snapshot = body.indexOf("sentFor(");
+      const answers = body.indexOf("answerRefusal(");
+      if (snapshot === -1) {
+        // Only the grant-only save may carry nothing, and then it must say so literally.
+        expect(body, fn).toContain("clearRefusalFor({})");
+        continue;
+      }
+      expect(snapshot, `${fn} snapshots after answering`).toBeLessThan(answers);
+      // Before the request, not merely before the catch.
+      expect(snapshot, `${fn} snapshots after its request`).toBeLessThan(
+        body.indexOf("await "),
+      );
+    }
+  });
+
+  // THE SECOND CHANNEL, WHEN THE CONTROL IS NOT ON SCREEN.
   //
   // `placeRefusal` hands back a sentence beside the mark for a value this editor owns and is not
   // drawing, and the sentence has to reach the operator or the save fails into silence. A toast is
@@ -72,35 +93,48 @@ describe("agent editor save errors", () => {
   //
   // Source-level because mounting this page pulls auth, theme, toast and a live catalog; the mark
   // reaching a box is proved on the tab that CAN be mounted (pages/GuardrailsTab.test.tsx).
-  test("the off-screen refusal is announced, with the way to the control", () => {
-    const start = SRC.indexOf("const refusalAway =");
+  test("the banner carries every refusal nothing else on screen is holding", () => {
+    const start = SRC.indexOf("const bannerMessage =");
     expect(start).toBeGreaterThan(-1);
     const decl = SRC.slice(start, SRC.indexOf(";", start));
-    // Derived from the holder and from the OPEN TAB, which is what keeps the two channels from ever
-    // saying the same thing at the same time: arriving at the tab takes the banner away and leaves
-    // the mark, and answering the refusal takes both.
+    // Two sources, and the difference between them is the whole rule: a mark this render is DRAWING
+    // says it itself, one it is not drawing is announced, and a sentence with no mark at all has
+    // nowhere else to go.
     expect(decl).toContain("heldMessage");
-    expect(decl).toContain("heldTarget.tab !== tab");
-    // Never stored. A copy in state is a second source of truth that outlives what it describes.
-    expect(SRC).not.toContain("setRefusalAway");
-    // And it is rendered with the jump, not just the sentence.
-    const banner = SRC.slice(SRC.indexOf("{refusalAway && ("));
+    expect(decl).toContain("heldDrawn");
+    expect(decl).toContain("standingRefusal");
+    // `heldDrawn` asks the drawn list, never the tab: a section switched off after the refusal landed
+    // takes the control away without changing which tab it is on.
+    const drawnDecl = SRC.slice(
+      SRC.indexOf("const heldDrawn ="),
+      SRC.indexOf(";", SRC.indexOf("const heldDrawn =")),
+    );
+    expect(drawnDecl).toContain("refusalFields.drawn");
+    expect(drawnDecl).not.toContain("tab ===");
+    // And it is rendered with the jump when there is one to offer.
+    const banner = SRC.slice(SRC.indexOf("{bannerMessage && ("));
     const body = banner.slice(0, banner.indexOf("\n            )}"));
-    expect(body).toContain("refusalAway.message");
-    expect(body).toContain("goToEditorTarget(refusalAway.target)");
+    expect(body).toContain("{bannerMessage}");
+    expect(body).toContain("goToEditorTarget(bannerTarget)");
   });
 
-  test("a toast fires only for a refusal this editor draws no control for", () => {
-    // The other half of the exclusivity: a 403, a conflict or a transport failure names no input of
-    // this page's, and for those the toast is still the only channel there is. Toasting a refusal the
-    // banner is already showing is the duplicate the mechanism exists to avoid.
+  test("nothing the holder hands back is dropped", () => {
+    // The first version routed on `editorTargetFor(named)` — whether the refused NAME has a place in
+    // this editor — and swallowed the sentence when it did. That reads the field instead of what the
+    // hook did with it, and the two come apart: a mapped name can still fail to be placed (the value
+    // was edited during the request, the follow-up step no longer exists), and then the sentence went
+    // nowhere and no mark existed to render it. A save that fails in silence.
     const start = SRC.indexOf("function answerRefusal");
     expect(start).toBeGreaterThan(-1);
     const body = SRC.slice(start, SRC.indexOf("\n  }", start));
-    expect(body).toContain("editorTargetFor");
-    expect(body).toContain('if (!placeable) showToast(left, "error");');
-    // Exactly one, so the assertion above speaks for the whole function.
-    expect(body.split("showToast(").length - 1).toBe(1);
+    expect(body).toContain("setStandingRefusal");
+    expect(body).toContain("refusal.capture(");
+    // No branch at all: whatever comes back is kept, and the render decides the container.
+    expect(body).not.toContain("editorTargetFor");
+    expect(body).not.toContain("if (");
+    // This page does not toast a save refusal any more — the banner is the one container, and it
+    // stays put while the input is still refused.
+    expect(body).not.toContain("showToast");
   });
 
   test("the tools preflight compares against the stored bag, re-read when forced", () => {

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -45,14 +45,22 @@ describe("agent editor save errors", () => {
     expect(body).toContain("Object.hasOwn(sent, held)");
     // Never by tab or by target: both read the FIELD rather than the request.
     expect(body).not.toContain("editorTargetFor");
+    // The banner half is scoped too, and by SECTION rather than by fields: a sentence with no mark
+    // has no field to match against, and a later save of another section answers nothing about it.
+    expect(body).toContain("prev?.section === section");
 
     // And every success path goes through it. The grant-only save answers for nothing and says so
     // with an empty snapshot rather than by skipping the call, so a reader can tell "carried nothing"
     // from "forgot to clear".
     const cleared = [
-      ...SRC.matchAll(/(?<!function )clearRefusalFor\((.+?)\)/g),
-    ].map((m) => (m[1] as string).trim());
-    expect(cleared.sort()).toEqual(["sent", "sent", "sent", "{}"]);
+      ...SRC.matchAll(/(?<!function )clearRefusalFor\(([^)]*)\)/g),
+    ].map((m) => (m[1] as string).replace(/\s+/g, " ").trim());
+    expect(cleared.sort()).toEqual([
+      '"guardrails", sent',
+      '"tools", sent',
+      '"tools", {}',
+      "section, sent",
+    ]);
   });
 
   test("what a save carried is snapshotted before the request goes out", () => {
@@ -69,13 +77,14 @@ describe("agent editor save errors", () => {
       expect(start, fn).toBeGreaterThan(-1);
       const body = SRC.slice(start, SRC.indexOf("\n  }", start));
       const snapshot = body.indexOf("sentFor(");
-      const answers = body.indexOf("answerRefusal(");
       if (snapshot === -1) {
         // Only the grant-only save may carry nothing, and then it must say so literally.
-        expect(body, fn).toContain("clearRefusalFor({})");
+        expect(body, fn).toContain('clearRefusalFor("tools", {})');
         continue;
       }
-      expect(snapshot, `${fn} snapshots after answering`).toBeLessThan(answers);
+      expect(snapshot, `${fn} snapshots after answering`).toBeLessThan(
+        body.indexOf("answerRefusal("),
+      );
       // Before the request, not merely before the catch.
       expect(snapshot, `${fn} snapshots after its request`).toBeLessThan(
         body.indexOf("await "),
@@ -83,39 +92,49 @@ describe("agent editor save errors", () => {
     }
   });
 
-  // THE SECOND CHANNEL, WHEN THE CONTROL IS NOT ON SCREEN.
+  // THE SECOND CHANNEL, FOR A REFUSAL NO INPUT ON SCREEN IS CARRYING.
   //
-  // `placeRefusal` hands back a sentence beside the mark for a value this editor owns and is not
-  // drawing, and the sentence has to reach the operator or the save fails into silence. A toast is
-  // the wrong container for it twice over — it takes the only copy of the reason away after five
-  // seconds, and it cannot carry the way to the control — so the editor renders it as a banner that
-  // stays until the refusal is answered.
+  // A toast is the wrong container for it twice over — it takes the only copy of the reason away
+  // after five seconds, and it cannot carry the way to the control — so the editor renders it above
+  // the tabs, where it stays until the refusal is answered.
   //
   // Source-level because mounting this page pulls auth, theme, toast and a live catalog; the mark
   // reaching a box is proved on the tab that CAN be mounted (pages/GuardrailsTab.test.tsx).
-  test("the banner carries every refusal nothing else on screen is holding", () => {
+  test("the banner carries every standing refusal, unconditionally", () => {
     const start = SRC.indexOf("const bannerMessage =");
     expect(start).toBeGreaterThan(-1);
     const decl = SRC.slice(start, SRC.indexOf(";", start));
-    // Two sources, and the difference between them is the whole rule: a mark this render is DRAWING
-    // says it itself, one it is not drawing is announced, and a sentence with no mark at all has
-    // nowhere else to go.
+    // No visibility test of any kind. Two earlier versions asked whether the marked control was on
+    // screen — first by tab, then by tab plus each section's switch — and each one missed a way a
+    // control can be hidden that lives inside the tab components: a guardrails field turned off by
+    // its own action, a native-tool note in a collapsed card. Every miss reads as a failed save with
+    // nothing on screen saying so, and the list is not this file's to close.
     expect(decl).toContain("heldMessage");
-    expect(decl).toContain("heldDrawn");
     expect(decl).toContain("standingRefusal");
-    // `heldDrawn` asks the drawn list, never the tab: a section switched off after the refusal landed
-    // takes the control away without changing which tab it is on.
-    const drawnDecl = SRC.slice(
-      SRC.indexOf("const heldDrawn ="),
-      SRC.indexOf(";", SRC.indexOf("const heldDrawn =")),
+    expect(decl).not.toContain("drawn");
+    expect(decl).not.toContain("tab");
+    // The jump is the part that is conditional, and only on there being somewhere to send anyone.
+    const target = SRC.slice(
+      SRC.indexOf("const bannerTarget ="),
+      SRC.indexOf(";", SRC.indexOf("const bannerTarget =")),
     );
-    expect(drawnDecl).toContain("refusalFields.drawn");
-    expect(drawnDecl).not.toContain("tab ===");
-    // And it is rendered with the jump when there is one to offer.
+    expect(target).toContain("heldTarget.tab !== tab");
+
     const banner = SRC.slice(SRC.indexOf("{bannerMessage && ("));
     const body = banner.slice(0, banner.indexOf("\n            )}"));
     expect(body).toContain("{bannerMessage}");
     expect(body).toContain("goToEditorTarget(bannerTarget)");
+    // And it says WHY when it offers no way: `toolGuidance` takes a note for thirteen native tools
+    // and the console draws three, so a refusal about one of the other ten is about a value no
+    // screen here edits. The server's sentence names the field and cannot know that.
+    expect(body).toContain("bannerNoControl");
+    const noControl = SRC.slice(
+      SRC.indexOf("const bannerNoControl ="),
+      SRC.indexOf(";", SRC.indexOf("const bannerNoControl =")),
+    );
+    expect(noControl).toContain("editorTargetFor");
+    // Never for a refusal about no input at all, where there is no value to go and change.
+    expect(noControl).toContain("standingRefusal?.field != null");
   });
 
   test("nothing the holder hands back is dropped", () => {
@@ -129,9 +148,9 @@ describe("agent editor save errors", () => {
     const body = SRC.slice(start, SRC.indexOf("\n  }", start));
     expect(body).toContain("setStandingRefusal");
     expect(body).toContain("refusal.capture(");
-    // No branch at all: whatever comes back is kept, and the render decides the container.
+    // No branch on the field: whatever comes back is kept. `readRefusal` appears only to record the
+    // NAME beside the sentence, which is what lets the banner explain a missing jump.
     expect(body).not.toContain("editorTargetFor");
-    expect(body).not.toContain("if (");
     // This page does not toast a save refusal any more — the banner is the one container, and it
     // stays put while the input is still refused.
     expect(body).not.toContain("showToast");

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -43,6 +43,10 @@ describe("agent editor save errors", () => {
     const body = SRC.slice(start, SRC.indexOf("\n  }", start));
     expect(body).toContain("refusal.clear()");
     expect(body).toContain("Object.hasOwn(sent, held)");
+    // And the VALUE, not only the path. `sent` is read from the patch, so a Behavior save carries
+    // `guardrails.customPolicy` from the last-synced bag — the stored value, not the edit the server
+    // refused. Presence alone would let that save answer a refusal it never re-sent.
+    expect(body).toContain("refusal.at(held, sent[held])");
     // Never by tab or by target: both read the FIELD rather than the request.
     expect(body).not.toContain("editorTargetFor");
     // The banner half is scoped too, and by SECTION rather than by fields: a sentence with no mark

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -35,23 +35,20 @@ describe("agent editor save errors", () => {
     // Since #349 the holder covers every tab, so the question got wider. Scoping it by TAB is not
     // enough and the gap is real: `saveGrants` writes the grant set alone and shares the Tools tab
     // with the handoff, kanban and tool-guidance notes, so a grant-only PUT would clear a refusal
-    // about a note it never mentioned. The snapshot the write went out with is the list of what it
-    // can answer for.
-    expect(SRC.split("refusal.clear()").length - 1).toBe(1);
+    // about a note it never mentioned.
     const start = SRC.indexOf("function clearRefusalFor");
     expect(start).toBeGreaterThan(-1);
     const body = SRC.slice(start, SRC.indexOf("\n  }", start));
-    expect(body).toContain("refusal.clear()");
     expect(body).toContain("Object.hasOwn(sent, held)");
     // And the VALUE, not only the path. `sent` is read from the patch, so a Behavior save carries
     // `guardrails.customPolicy` from the last-synced bag — the stored value, not the edit the server
     // refused. Presence alone would let that save answer a refusal it never re-sent.
     expect(body).toContain("refusal.at(held, sent[held])");
+    // A sentence the holder could place NOWHERE has no value to compare, so it is answered by the
+    // section that produced it.
+    expect(body).toContain("refusedSave?.section === section");
     // Never by tab or by target: both read the FIELD rather than the request.
     expect(body).not.toContain("editorTargetFor");
-    // The banner half is scoped too, and by SECTION rather than by fields: a sentence with no mark
-    // has no field to match against, and a later save of another section answers nothing about it.
-    expect(body).toContain("prev?.section === section");
 
     // And every success path goes through it. The grant-only save answers for nothing and says so
     // with an empty snapshot rather than by skipping the call, so a reader can tell "carried nothing"
@@ -71,48 +68,23 @@ describe("agent editor save errors", () => {
     const grants = SRC.slice(SRC.indexOf("async function saveGrants("));
     const grantsBody = grants.slice(0, grants.indexOf("\n  }"));
     expect(grantsBody).toContain('clearRefusalFor("knowledge", {})');
-    expect(grantsBody).toContain('"knowledge",');
   });
 
-  test("the stored sentence never outlives the mark it duplicates", () => {
-    // `capture` sets BOTH for an off-screen placement: it holds the mark and hands back the sentence.
-    // The mark expires by value and the stored copy does not, so without this the sentence surfaces
-    // again the moment the operator edits the refused field — the server's words under a value the
-    // server never saw. Round 2 dropped this effect while rewriting the banner and round 3 found it.
-    const start = SRC.indexOf(
-      "useEffect(() => {\n    if (heldField) setStandingRefusal(null);",
-    );
+  test("the page keeps no copy of the sentence", () => {
+    // The rule three rounds of review arrived at the hard way. A page that stores the sentence beside
+    // a holder that is already storing it has two sources of truth for one fact, and they drift in
+    // ways nothing on screen can show: the copy outlives the mark it duplicates (round 3), it is
+    // tagged with the wrong owner (round 3), a second refusal about the SAME field leaves the first
+    // copy standing because the field identity never changed (round 6). Each was fixed at its site
+    // and the next round found the next one; what closed it was giving the sentence one home.
+    expect(SRC).not.toContain("standingRefusal");
+    // What the page does keep is what the HOLDER cannot know: which form's write failed, and the name
+    // the server used. Neither is a sentence, and neither is read unless the holder has one.
+    const start = SRC.indexOf("const [refusedSave, setRefusedSave]");
     expect(start).toBeGreaterThan(-1);
-    expect(SRC.slice(start, SRC.indexOf("]);", start))).toContain("[heldField");
-  });
-
-  test("what a save carried is snapshotted before the request goes out", () => {
-    // `currentRef` is LIVE. Building the sent map in the catch compares the boxes with themselves,
-    // the staleness check can never fire, and a refusal about a value the operator has already
-    // changed gets marked on the new one — which is the exact thing `placeRefusal` refuses to do.
-    for (const fn of [
-      "saveAgent",
-      "saveGrants",
-      "saveTools",
-      "saveGuardrails",
-    ]) {
-      const start = SRC.indexOf(`async function ${fn}(`);
-      expect(start, fn).toBeGreaterThan(-1);
-      const body = SRC.slice(start, SRC.indexOf("\n  }", start));
-      const snapshot = body.indexOf("sentFor(");
-      if (snapshot === -1) {
-        // Only the grant-only save may carry nothing, and then it must say so literally.
-        expect(body, fn).toContain('clearRefusalFor("knowledge", {})');
-        continue;
-      }
-      expect(snapshot, `${fn} snapshots after answering`).toBeLessThan(
-        body.indexOf("answerRefusal("),
-      );
-      // Before the request, not merely before the catch.
-      expect(snapshot, `${fn} snapshots after its request`).toBeLessThan(
-        body.indexOf("await "),
-      );
-    }
+    expect(
+      SRC.slice(start, SRC.indexOf("} | null>(null)", start)),
+    ).not.toContain("message");
   });
 
   // THE SECOND CHANNEL, FOR A REFUSAL NO INPUT ON SCREEN IS CARRYING.
@@ -132,10 +104,12 @@ describe("agent editor save errors", () => {
     // control can be hidden that lives inside the tab components: a guardrails field turned off by
     // its own action, a native-tool note in a collapsed card. Every miss reads as a failed save with
     // nothing on screen saying so, and the list is not this file's to close.
-    expect(decl).toContain("heldMessage");
-    expect(decl).toContain("standingRefusal");
+    expect(decl).toContain("refusal.message");
     expect(decl).not.toContain("drawn");
-    expect(decl).not.toContain("tab");
+    expect(decl).not.toContain("tab ===");
+    // A PLACED mark is still asked for through `at`, which is what makes it expire with the value.
+    expect(decl).toContain("heldMessage");
+
     // The jump is the part that is conditional, and only on there being somewhere to send anyone.
     const target = SRC.slice(
       SRC.indexOf("const bannerTarget ="),
@@ -157,7 +131,7 @@ describe("agent editor save errors", () => {
     );
     expect(noControl).toContain("editorTargetFor");
     // Never for a refusal about no input at all, where there is no value to go and change.
-    expect(noControl).toContain("standingRefusal?.field != null");
+    expect(noControl).toContain("refusedSave?.named != null");
   });
 
   test("nothing the holder hands back is dropped", () => {
@@ -169,10 +143,9 @@ describe("agent editor save errors", () => {
     const start = SRC.indexOf("function answerRefusal");
     expect(start).toBeGreaterThan(-1);
     const body = SRC.slice(start, SRC.indexOf("\n  }", start));
-    expect(body).toContain("setStandingRefusal");
     expect(body).toContain("refusal.capture(");
-    // No branch on the field: whatever comes back is kept. `readRefusal` appears only to record the
-    // NAME beside the sentence, which is what lets the banner explain a missing jump.
+    // The holder keeps the sentence; the page records only which save failed and what it named.
+    expect(body).toContain("setRefusedSave");
     expect(body).not.toContain("editorTargetFor");
     // This page does not toast a save refusal any more — the banner is the one container, and it
     // stays put while the input is still refused.

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -43,10 +43,17 @@ describe("agent editor save errors", () => {
     // And the VALUE, not only the path. `sent` is read from the patch, so a Behavior save carries
     // `guardrails.customPolicy` from the last-synced bag — the stored value, not the edit the server
     // refused. Presence alone would let that save answer a refusal it never re-sent.
-    expect(body).toContain("refusal.at(held, sent[held])");
+    expect(body).toContain("now.at(held, sent[held])");
+    // Through a ref, never the closure: a save handler closes over the render that launched it, and
+    // this page's saves are long enough for another tab's save to fail while one is in flight. An
+    // older success answering from its own render would clear a refusal that arrived after it — and
+    // `at` is memoized on the hold, so even the comparison would be the stale one.
+    expect(body).toContain("refusalRef.current");
+    expect(body).toContain("refusedSaveRef.current");
+    expect(body).not.toContain("refusal.field");
     // A sentence the holder could place NOWHERE has no value to compare, so it is answered by the
     // section that produced it.
-    expect(body).toContain("refusedSave?.section === section");
+    expect(body).toContain("refusedSaveRef.current?.section === section");
     // Never by tab or by target: both read the FIELD rather than the request.
     expect(body).not.toContain("editorTargetFor");
 
@@ -165,6 +172,37 @@ describe("agent editor save errors", () => {
     // render would take the page out from under whoever is fixing the value.
     expect(effect).toContain("announcedRef.current === bannerMessage");
     expect(SRC).toContain("ref={bannerRef}");
+  });
+
+  test("every mark is read from the one place that holds its value", () => {
+    // `at` compares what it is handed against the value the mark was placed on, and that value came
+    // from `currentRef`. A reading that re-derives it from the state variable states the same fact a
+    // second time, and round 7 proved they drift: `currentRef` learned to normalize the way the wire
+    // does and the readings kept passing raw, so a refused follow-up note with surrounding
+    // whitespace matched nothing and the step got no inline error.
+    // Balanced, because one reading nests a call of its own (`followUpStepField(i)`) and a lazy
+    // regex would stop at the first `)` and read half of it.
+    const readings: string[] = [];
+    for (const m of SRC.matchAll(/refusal\.at\(/g)) {
+      let i = (m.index as number) + m[0].length;
+      let depth = 1;
+      const from = i;
+      while (i < SRC.length && depth > 0) {
+        const c = SRC[i];
+        if (c === "(") depth++;
+        else if (c === ")") depth--;
+        i++;
+      }
+      readings.push(
+        SRC.slice(from, i - 1)
+          .replace(/\s+/g, " ")
+          .trim(),
+      );
+    }
+    expect(readings.length).toBeGreaterThan(20);
+    for (const call of readings) {
+      expect(call, call).toContain("currentRef.current[");
+    }
   });
 
   test("what the boxes hold is normalized the way the wire is", () => {

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -77,6 +77,35 @@ describe("agent editor save errors", () => {
     expect(grantsBody).toContain('clearRefusalFor("knowledge", {})');
   });
 
+  test("discarding a section takes its refusal with it", () => {
+    // A fieldless refusal cannot expire by value the way a mark does, so without this the banner
+    // outlives the edit entirely — past the discard, past the next successful save of another
+    // section, indefinitely.
+    const start = SRC.indexOf("function discardRefusalFor");
+    expect(start).toBeGreaterThan(-1);
+    const body = SRC.slice(start, SRC.indexOf("\n  }", start));
+    // By the tab that DRAWS the value, not the section that wrote it: reverting Behavior restores the
+    // behavior form, and a mark a Behavior save left on a guardrails path is about a value the
+    // Guardrails tab still holds unsaved.
+    expect(body).toContain("editorTargetFor");
+    expect(body).toContain("target?.tab === section");
+    expect(body).toContain("refusedSaveRef.current?.section === section");
+
+    // Every revert goes through it, and discard-all clears outright.
+    const discarded = [
+      ...SRC.matchAll(/(?<!function )discardRefusalFor\("([^"]+)"\)/g),
+    ].map((m) => m[1] as string);
+    expect(discarded.sort()).toEqual([
+      "behavior",
+      "channelRedirect",
+      "general",
+      "guardrails",
+      "knowledge",
+      "tools",
+    ]);
+    expect(SRC).toContain("refusalRef.current.clear();");
+  });
+
   test("the page keeps no copy of the sentence", () => {
     // The rule three rounds of review arrived at the hard way. A page that stores the sentence beside
     // a holder that is already storing it has two sources of truth for one fact, and they drift in
@@ -119,10 +148,14 @@ describe("agent editor save errors", () => {
 
     // The jump is the part that is conditional, and only on there being somewhere to send anyone.
     const target = SRC.slice(
-      SRC.indexOf("const bannerTarget ="),
+      SRC.indexOf("const jumpTo ="),
       SRC.indexOf(";", SRC.indexOf("const bannerTarget =")),
     );
-    expect(target).toContain("heldTarget.tab !== tab");
+    expect(target).toContain("jumpTo.tab !== tab");
+    // From the mark when there is one and from the name the server used when there is not: a refusal
+    // this editor cannot MARK can still be about a value it draws, and a tool precondition is edited
+    // as a list so there is no single box to put the sentence in.
+    expect(target).toContain("namedTarget");
 
     const banner = SRC.slice(SRC.indexOf("{bannerMessage && ("));
     const body = banner.slice(0, banner.indexOf("\n            )}"));
@@ -136,7 +169,12 @@ describe("agent editor save errors", () => {
       SRC.indexOf("const bannerNoControl ="),
       SRC.indexOf(";", SRC.indexOf("const bannerNoControl =")),
     );
-    expect(noControl).toContain("editorTargetFor");
+    // Said only where it can be PROVED, never read off the map having no entry: absence proves
+    // nothing about the console, and the map WAS missing `settings.modelFallback.model` and
+    // `observability.fullDetailUntil`, both of which have a visible control. The banner told the
+    // operator the opposite of the truth about them.
+    expect(noControl).toContain("hasNoConsoleControl");
+    expect(noControl).not.toContain("editorTargetFor");
     // Never for a refusal about no input at all, where there is no value to go and change.
     expect(noControl).toContain("refusedSave?.named != null");
   });

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -31,15 +31,28 @@ describe("agent editor save errors", () => {
   //
   // Source-level for the same reason as the rest of this file — the two sections are two arguments
   // to one function, and the distinction is invisible to anything that only watches the network.
-  test("a successful save clears the holder only for the section it draws", () => {
-    const at = SRC.indexOf("refusal.clear()");
-    expect(at).toBeGreaterThan(-1);
-    // The guard on the same line, so a `clear()` added to another branch is not answered by this one.
-    expect(SRC.slice(SRC.lastIndexOf("\n", at), at)).toContain(
-      'section === "general"',
-    );
-    // And exactly one, so the assertion above is about all of them.
+  test("a successful save clears the holder only for the section it wrote", () => {
+    // Since #349 the holder covers every tab, so the question got wider without changing: the clear
+    // is scoped by asking WHERE the standing mark lives and comparing that with the section this save
+    // wrote. One call site, inside the one function that asks.
     expect(SRC.split("refusal.clear()").length - 1).toBe(1);
+    const start = SRC.indexOf("function clearRefusalFor");
+    expect(start).toBeGreaterThan(-1);
+    const body = SRC.slice(start, SRC.indexOf("\n  }", start));
+    expect(body).toContain("refusal.clear()");
+    expect(body).toContain("editorTargetFor");
+    expect(body).toContain("=== section");
+
+    // And every success path goes through it rather than clearing on its own, which is what the
+    // previous version of this rule could not say: it could only speak for the single call site it
+    // found. A save that writes a section and clears nothing leaves a refusal standing that the
+    // server has stopped making.
+    // Call sites only: the declaration reads `clearRefusalFor(section: string)` and would otherwise
+    // count itself as a caller that clears every section.
+    const cleared = [
+      ...SRC.matchAll(/(?<!function )clearRefusalFor\((.+?)\)/g),
+    ].map((m) => (m[1] as string).replace(/"/g, ""));
+    expect(cleared.sort()).toEqual(["guardrails", "section", "tools", "tools"]);
   });
 
   // The tools save fires two calls (grants PUT, then agent PATCH), so it checks the bag itself before
@@ -49,6 +62,47 @@ describe("agent editor save errors", () => {
   //
   // Source-level for the same reason as the rest of this file; the rule itself is covered by
   // agents-text-caps.test.ts, what is left here is the wiring.
+  // THE SECOND CHANNEL, WHEN THE CONTROL IS ON ANOTHER TAB.
+  //
+  // `placeRefusal` hands back a sentence beside the mark for a value this editor owns and is not
+  // drawing, and the sentence has to reach the operator or the save fails into silence. A toast is
+  // the wrong container for it twice over — it takes the only copy of the reason away after five
+  // seconds, and it cannot carry the way to the control — so the editor renders it as a banner that
+  // stays until the refusal is answered.
+  //
+  // Source-level because mounting this page pulls auth, theme, toast and a live catalog; the mark
+  // reaching a box is proved on the tab that CAN be mounted (pages/GuardrailsTab.test.tsx).
+  test("the off-screen refusal is announced, with the way to the control", () => {
+    const start = SRC.indexOf("const refusalAway =");
+    expect(start).toBeGreaterThan(-1);
+    const decl = SRC.slice(start, SRC.indexOf(";", start));
+    // Derived from the holder and from the OPEN TAB, which is what keeps the two channels from ever
+    // saying the same thing at the same time: arriving at the tab takes the banner away and leaves
+    // the mark, and answering the refusal takes both.
+    expect(decl).toContain("heldMessage");
+    expect(decl).toContain("heldTarget.tab !== tab");
+    // Never stored. A copy in state is a second source of truth that outlives what it describes.
+    expect(SRC).not.toContain("setRefusalAway");
+    // And it is rendered with the jump, not just the sentence.
+    const banner = SRC.slice(SRC.indexOf("{refusalAway && ("));
+    const body = banner.slice(0, banner.indexOf("\n            )}"));
+    expect(body).toContain("refusalAway.message");
+    expect(body).toContain("goToEditorTarget(refusalAway.target)");
+  });
+
+  test("a toast fires only for a refusal this editor draws no control for", () => {
+    // The other half of the exclusivity: a 403, a conflict or a transport failure names no input of
+    // this page's, and for those the toast is still the only channel there is. Toasting a refusal the
+    // banner is already showing is the duplicate the mechanism exists to avoid.
+    const start = SRC.indexOf("function answerRefusal");
+    expect(start).toBeGreaterThan(-1);
+    const body = SRC.slice(start, SRC.indexOf("\n  }", start));
+    expect(body).toContain("editorTargetFor");
+    expect(body).toContain('if (!placeable) showToast(left, "error");');
+    // Exactly one, so the assertion above speaks for the whole function.
+    expect(body.split("showToast(").length - 1).toBe(1);
+  });
+
   test("the tools preflight compares against the stored bag, re-read when forced", () => {
     const start = SRC.indexOf("function settingsTextError");
     expect(start).toBeGreaterThan(-1);
@@ -80,10 +134,22 @@ describe("agent editor save errors", () => {
     // `refusal.capture` is the same read plus a placement: it answers the server's sentence, or null
     // once that sentence is already rendered at the input it names (#320). A handler that routes
     // through it has not stopped showing what the server said — it has stopped needing a toast.
+    //
+    // Followed through a NAME, because a page with five saves writes the routing once and calls it
+    // from each of them: `answerRefusal` captures, decides between the banner and the toast, and is
+    // the only thing any handler here says. Asking for the literal `refusal.capture` inside every
+    // handler would demand the duplication the helper exists to remove.
+    const routers = handlers(SRC)
+      .filter((h) => /apiErrorMessage|[Rr]efusal\.capture/.test(h.body))
+      .map((h) => h.name);
+    // Guards this half of the parser the same way the list above guards the other: a helper that
+    // stops reading the server's message would empty this list and pass every handler below.
+    expect(routers).toContain("answerRefusal");
+    const shows = new RegExp(
+      `apiErrorMessage|[Rr]efusal\\.capture|\\b(?:${routers.join("|")})\\(`,
+    );
     expect(
-      writers
-        .filter((h) => !/apiErrorMessage|[Rr]efusal\.capture/.test(h.body))
-        .map((h) => h.name),
+      writers.filter((h) => !shows.test(h.body)).map((h) => h.name),
     ).toEqual([]);
   });
 });

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -674,10 +674,14 @@ const ALWAYS_ON_SCREEN: Record<string, string> = {
 // A form that holds SOME of its refusals, with what is left. Neither rule above can see this — rule
 // 1 is satisfied by the hook being called at all — so it is a declaration, pinned by size, and the
 // only thing keeping the sweep honest about where it stopped.
-const PARTIALLY_HELD: Record<string, string> = {
-  "pages/agents/AgentEditorPage.tsx":
-    "Holds `name` and `systemPrompt`, the two values it renders a control for directly. Everything else it writes lives in bags (`settings.tts.normalizeCredentialRef`, `guardrails.output.templateMessage`) behind eight tabs, so placing one of those means also taking the operator to the tab that holds it — the deep-link TEXT_CAP_TARGETS already maps for config-health warnings. Left to fazer-ai/agents#349.",
-};
+// EMPTY since #349, and kept rather than deleted: the shape is the place a future form declares what
+// it stopped at, and a pin of zero makes adding one cost the second edit the ledger exists to force.
+//
+// What emptied it: the agent editor now declares every value it writes — twenty-three names over four
+// tabs — and hands the answers to the tabs that draw them. The half that was missing was never the
+// mark, it was that a mark on a tab nobody is looking at is silence, so the editor announces the ones
+// it holds off screen in a banner that carries the way to the control (see `refusalAway`).
+const PARTIALLY_HELD: Record<string, string> = {};
 
 describe("a form that writes holds the refusal it gets", () => {
   test("every partially held form still holds something", () => {
@@ -692,7 +696,7 @@ describe("a form that writes holds the refusal it gets", () => {
   });
 
   test("the partial ledger is pinned to its size", () => {
-    expectWaiverLedger("PARTIALLY_HELD", PARTIALLY_HELD, 1);
+    expectWaiverLedger("PARTIALLY_HELD", PARTIALLY_HELD, 0);
   });
 
   test("the predicate sees a form that writes", () => {

--- a/tests/client/field-refusal.test.ts
+++ b/tests/client/field-refusal.test.ts
@@ -392,3 +392,43 @@ describe("placeRefusal with an owned list wider than the drawn one", () => {
     ).toEqual({ toast: "too long" });
   });
 });
+
+// THE SENTENCE HAS ONE HOME.
+//
+// `capture` used to drop what it could not place: it returned the sentence and set `held` to null, so
+// a caller with somewhere to render it had to keep a copy. Three rounds of review on #414 found three
+// ways that copy drifts from the hold it duplicates — it outlives the mark, it carries the wrong
+// owner, and a second refusal about the same field leaves the first copy standing because the field
+// identity never changed. Holding it here is what closes the class rather than the instances.
+describe("useFieldRefusal holds what it cannot place", () => {
+  const FALLBACK = "Could not save.";
+  const form = (over: Partial<FormAtAnswer> = {}): FormAtAnswer => ({
+    mounted: true,
+    sent: {},
+    current: { name: "a" },
+    ...over,
+  });
+
+  test("a refusal about no input of this form's is still a placement, with no field", () => {
+    const placed = placeRefusal(
+      { message: "forbidden" },
+      ["name"],
+      FALLBACK,
+      form(),
+    );
+    // placeRefusal itself is unchanged — the toast-only shape is what the hook now keeps.
+    expect(placed).toEqual({ toast: "forbidden" });
+  });
+
+  test("a placement at an input still carries its value", () => {
+    // The half that must NOT change: a mark expires by value, and only a placement has one.
+    expect(
+      placeRefusal(
+        { message: "taken", field: "name" },
+        ["name"],
+        FALLBACK,
+        form(),
+      ),
+    ).toEqual({ at: "name", message: "taken", value: "a" });
+  });
+});

--- a/tests/client/field-refusal.test.ts
+++ b/tests/client/field-refusal.test.ts
@@ -278,19 +278,117 @@ describe("placeRefusal", () => {
     });
   }
 
-  // The property the rows are individually asserting, stated once over all of them: never both, and
-  // never neither. A future row that answered `{ at, toast }` would read as correct in its own line.
-  test("exactly one channel fires, on every row", () => {
+  // The property the rows are individually asserting, stated once over all of them: never neither,
+  // and never both for a form that draws everything it owns. A future row that answered `{ at, toast }`
+  // without an `owned` list would read as correct in its own line.
+  test("exactly one channel fires, on every row that owns only what it draws", () => {
     for (const c of cases) {
+      const form = c.form ?? STEADY;
+      if (form.owned) continue;
       const placed = placeRefusal(
         c.refusal,
         c.rendered ?? RENDERED,
         FALLBACK,
-        c.form ?? STEADY,
+        form,
       );
       const at = "at" in placed && placed.at !== undefined;
-      const toast = "toast" in placed;
+      const toast = "toast" in placed && placed.toast !== undefined;
       expect([c.name, at !== toast]).toEqual([c.name, true]);
     }
+  });
+});
+
+// A FORM THAT OWNS AN INPUT IT IS NOT DRAWING.
+//
+// The agent editor writes about thirty values across eight tabs and draws one tab's worth, so a
+// refusal about `guardrails.output.templateMessage` is about a control that exists and is off screen.
+// Two answers were available before this and both lose something real: send it to the toast and the
+// mark never appears when the operator opens that tab; mark it and stay quiet and the save fails into
+// silence, because `capture` has reported "it is on the control".
+describe("placeRefusal with an owned list wider than the drawn one", () => {
+  const FALLBACK = "Could not save.";
+  const OWNED = ["name", "guardrails.customPolicy"];
+  const form = (over: Partial<FormAtAnswer> = {}): FormAtAnswer => ({
+    mounted: true,
+    sent: {},
+    current: { name: "a", "guardrails.customPolicy": "p" },
+    owned: OWNED,
+    ...over,
+  });
+
+  test("a name the form owns and is not drawing is held AND announced", () => {
+    const placed = placeRefusal(
+      { message: "too long", field: "guardrails.customPolicy" },
+      ["name"],
+      FALLBACK,
+      form(),
+    );
+    expect(placed).toEqual({
+      at: "guardrails.customPolicy",
+      message: "too long",
+      value: "p",
+      toast: "too long",
+    });
+  });
+
+  test("a name the form IS drawing is held and says nothing more", () => {
+    // The list is consulted only for a name `rendered` did not answer, so nothing changes for the
+    // control that is on screen: the mark is the whole message.
+    const placed = placeRefusal(
+      { message: "taken", field: "name" },
+      ["name"],
+      FALLBACK,
+      form(),
+    );
+    expect(placed).toEqual({ at: "name", message: "taken", value: "a" });
+  });
+
+  test("a name the form does not own at all is still only a toast", () => {
+    expect(
+      placeRefusal(
+        { message: "nope", field: "somethingElse" },
+        ["name"],
+        FALLBACK,
+        form(),
+      ),
+    ).toEqual({ toast: "nope" });
+  });
+
+  test("owning it does not survive the form leaving the screen", () => {
+    // A mark written to state nobody renders is silence whether the form owns the name or not, and
+    // the hook raises the global toast itself in that case.
+    expect(
+      placeRefusal(
+        { message: "too long", field: "guardrails.customPolicy" },
+        [],
+        FALLBACK,
+        form({ mounted: false }),
+      ),
+    ).toEqual({ toast: "too long" });
+  });
+
+  test("owning it does not survive the operator editing the value", () => {
+    // Same rule as a drawn control: the refusal is about what was SENT, and marking a value the
+    // server never saw is worse than saying it plainly.
+    expect(
+      placeRefusal(
+        { message: "too long", field: "guardrails.customPolicy" },
+        ["name"],
+        FALLBACK,
+        form({ sent: { "guardrails.customPolicy": "old" } }),
+      ),
+    ).toEqual({ toast: "too long" });
+  });
+
+  test("an absent owned list leaves the form exactly as it was", () => {
+    // Twenty-three of the twenty-four holders draw everything they own and pass nothing here.
+    expect(
+      placeRefusal(
+        { message: "too long", field: "guardrails.customPolicy" },
+        ["name"],
+        FALLBACK,
+        { mounted: true, sent: {}, current: {} },
+      ),
+    ).toEqual({ toast: "too long" });
   });
 });

--- a/tests/client/pages/BehaviorTabVisionDocuments.test.tsx
+++ b/tests/client/pages/BehaviorTabVisionDocuments.test.tsx
@@ -32,6 +32,19 @@ function renderWithProvider(
   const noop = () => {};
   const props: React.ComponentProps<typeof BehaviorTab> &
     Record<string, unknown> = {
+    // Nothing refused: this file is about the vision section, not about a refusal landing on it.
+    refusals: {
+      sttCredential: null,
+      ttsCredential: null,
+      ttsNormalizeCredential: null,
+      visionCredential: null,
+      visionExtractionPrompt: null,
+      contactAuthCredential: null,
+      contactAuthDenyMessage: null,
+      memoryCredential: null,
+      awayMessage: null,
+      followUpSteps: [],
+    },
     agentId: "1",
     hours: [],
     businessHoursId: "",

--- a/tests/client/pages/BehaviorTabVisionDocuments.test.tsx
+++ b/tests/client/pages/BehaviorTabVisionDocuments.test.tsx
@@ -42,6 +42,7 @@ function renderWithProvider(
       contactAuthCredential: null,
       contactAuthDenyMessage: null,
       memoryCredential: null,
+      modelFallbackCredential: null,
       awayMessage: null,
       followUpSteps: [],
     },

--- a/tests/client/pages/GuardrailsTab.test.tsx
+++ b/tests/client/pages/GuardrailsTab.test.tsx
@@ -3,6 +3,7 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 import { GuardrailsTab } from "@/client/pages/agents/GuardrailsTab";
+import type { GuardrailsRefusals } from "@/client/pages/agents/types";
 import {
   CUSTOM_POLICY_MAX,
   GENERATION_PROMPT_MAX,
@@ -35,6 +36,7 @@ function renderWith(action: GuardrailAction): void {
     <GuardrailsTab
       guardrails={config}
       setGuardrails={() => {}}
+      refusals={NO_REFUSALS}
       dirty={false}
       saving={false}
       onSave={() => {}}
@@ -46,6 +48,15 @@ function renderWith(action: GuardrailAction): void {
 const templateFields = () =>
   screen.queryAllByText("Mensagem template").length +
   screen.queryAllByText("Template message").length;
+
+// Nothing refused: every test here is about the form, not about a refusal landing on it.
+const NO_REFUSALS: GuardrailsRefusals = {
+  credential: null,
+  customPolicy: null,
+  inputTemplateMessage: null,
+  outputTemplateMessage: null,
+  outputGenerationPrompt: null,
+};
 
 describe("GuardrailsTab template message", () => {
   // The tab mounts a CredentialPicker, which loads over the network. Stubbing `globalThis.fetch`
@@ -117,5 +128,69 @@ describe("GuardrailsTab template message", () => {
       /SEMPRE isto que sai|ALWAYS what gets sent/,
     );
     expect(hints.length).toBe(1);
+  });
+});
+
+// THE MARK ACTUALLY REACHING THE BOX.
+//
+// Everything else about #349 is provable without a DOM — where a path is edited, which channel the
+// placement chooses — and none of it proves the last step: that the answer handed to a tab is
+// rendered beside the control it is about. This tab is the one that can be mounted (the editor pulls
+// auth, theme, toast and a live catalog), and its five fields are one of each shape the editor draws:
+// a credential picker, a per-direction textarea, and a policy textarea.
+describe("a refusal handed to the guardrails tab lands at its input", () => {
+  // The other describe in this file scopes its own cleanup, so this block needs one too: without it
+  // the last render of the loop below survives into the next test, and the control that asserts
+  // "none of it is on screen" reads the leftover instead. Measured -- it passes alone and fails in a
+  // full run, which is the signature of state carried between tests rather than of a real defect.
+  afterEach(() => cleanup());
+
+  function renderRefused(refusals: GuardrailsRefusals): void {
+    const config: GuardrailsConfig = {
+      ...structuredClone(GUARDRAILS_DEFAULTS),
+      enabled: true,
+    };
+    config.input = { ...config.input, enabled: true, action: "template" };
+    config.output = { ...config.output, enabled: true, action: "generated" };
+    render(
+      <GuardrailsTab
+        guardrails={config}
+        setGuardrails={() => {}}
+        refusals={refusals}
+        dirty={false}
+        saving={false}
+        onSave={() => {}}
+        onDiscard={() => {}}
+      />,
+    );
+  }
+
+  test("the sentence is on screen once, for each field the tab draws", () => {
+    for (const key of [
+      "credential",
+      "customPolicy",
+      "inputTemplateMessage",
+      "outputTemplateMessage",
+      "outputGenerationPrompt",
+    ] as const) {
+      cleanup();
+      const reason = `refused: ${key}`;
+      renderRefused({ ...NO_REFUSALS, [key]: reason });
+      expect([key, screen.queryAllByText(reason).length]).toEqual([key, 1]);
+    }
+  });
+
+  test("with nothing refused the tab says none of it", () => {
+    // The control for the count above: a rendering that always showed the string would pass every
+    // line of it.
+    renderRefused(NO_REFUSALS);
+    expect(screen.queryAllByText(/^refused: /).length).toBe(0);
+  });
+
+  test("the two directions do not answer for each other", () => {
+    // One `renderDirection` draws both blocks, so a mark passed for the input template would sit on
+    // the output one too if the field were wired to a single prop.
+    renderRefused({ ...NO_REFUSALS, inputTemplateMessage: "only the input" });
+    expect(screen.queryAllByText("only the input").length).toBe(1);
   });
 });


### PR DESCRIPTION
Fixes #349

#320 wired every form in the console to put a refusal at the input the server named, and stopped at one: the agent editor. It held `name` and `systemPrompt` — the two values it renders a control for directly — and sent the other twenty-one to a toast. The abstention was recorded as `PARTIALLY_HELD` in `tests/client/field-refusal-fence.test.ts`, pinned by size so it would cost an edit rather than pass as a clean scan.

## What was broken

Everything else this page writes lives in a bag edited behind one of eight tabs. So the refusal for `settings.tts.credentialRef` or `guardrails.output.templateMessage` had two available answers and both lose something real:

- **mark it** and the operator sees nothing, because the control is on another tab — and `capture` has already reported "it is on the control", so the toast stays quiet. A save that fails into silence.
- **toast it** and the sentence is far from the control and gone in five seconds, carrying the only copy of the reason with it. Measured live below: five seconds is the actual window.

The missing half was never the mark. It was knowing WHERE the control is, and saying so.

### The map already existed twice, and the two disagreed

`TEXT_CAP_TARGETS` (`src/client/lib/configHealth.ts`) turns a capped path into `{tab, sectionId}` for a config-health warning. `SETTINGS_CREDENTIAL_PATHS` (`src/modules/agents/credential-paths.ts`) carries the same pair beside each credential path, for the import warning's deep link. Neither knew about the other, and **two capped fields were in neither**:

| field | control | what the console said |
| --- | --- | --- |
| `availability.awayMessage` | `BehaviorTab.tsx:1387`, section `availability` | "This note has no field in the console, so it can only be shortened through the API." |
| `contactAuth.denyMessage` | `BehaviorTab.tsx:2501`, section `contactAuth` | same |

Both sentences are false. `issueHasAction()` returns false without a `tab`, so the warning also offered no jump — about a textarea two clicks away.

### Two spellings of the same wire field

The two producers root their dotted path differently, and neither is wrong on its own:

```
SettingsTextTooLongError      -> guardrails.customPolicy        (root = the settings bag)
assertCredentialRefsResolve   -> settings.tts.credentialRef     (root = the agent row)
```

A reader that trusts one silently loses half the fields. Normalising the wire is a contract change reaching REST and MCP, so it is **out of scope here**: the map accepts both, and the divergence is written down rather than papered over.

## What this changes

**One map** (`src/client/lib/editorRefusal.ts`) from a dotted path to `{tab, sectionId}`, and `configHealth` now reads it instead of keeping its own. The credential half is **derived** from `SETTINGS_CREDENTIAL_PATHS` rather than restated — that list already carries the editor location, and its own comment records why deriving it as "the behavior tab, section = block" was right for four entries and wrong for the fifth.

**`placeRefusal` gains a third outcome.** It was an EITHER of two, which was right while every form drew everything it owned:

| outcome | means |
| --- | --- |
| `{ at }` | the control is on screen. The mark is the message; nothing else fires |
| `{ at, toast }` | the form OWNS the control and is not drawing it. The mark is written for when the operator gets there, and the sentence still has to be said now |
| `{ toast }` | not this form's input. The sentence is the only channel |

`useFieldRefusal(rendered, owned?)` takes the second list, and `owned` is optional because twenty-three of the twenty-four holders draw everything they own and take exactly the path they took before.

**The rule underneath did not change: the operator is told exactly once.** In the middle case the two channels never overlap, because the banner is DERIVED from "the marked field's tab is not the open tab". Arriving at the tab takes the banner away and leaves the mark; answering the refusal takes both.

**A banner, not a toast**, and this is a decision rather than a default. `Toast.tsx` has no action (`showToast(message, type?, id?)`, auto-dismiss 5s) and giving it one would change a primitive the whole console uses. The banner also reuses the vocabulary already on that screen — the config-health panel is the same shape, sentence plus a "Fix" that deep-links — and it does not take the reason away while the input is still refused.

**A save clears only the section it wrote.** The holder now covers every tab, so an unconditional `clear()` would take a standing refusal off another tab without anything having answered it.

## What did NOT get declared, and why

**Per tab, not per switch.** Several of these controls sit behind a toggle inside their own section. A list that answered "drawn right now" to the letter would carry a dozen booleans out of three component files into one, and every drift between them would reappear as the silence the mechanism exists to prevent.

What makes the tab exact is a property of the write boundary, not a tolerance: both producers refuse only what a write **introduces or changes** (`collectOversizedTextChanges`, `collectCredentialRefWrites` — both say so in their own comments). Changing one of these values requires its control, and its control requires the switch. `tests/client/editor-refusal.test.ts` pins that invariant, because it is what the simplification rests on.

**The ten `toolGuidance` notes with no control.** `NATIVE_TOOL_NAMES` has thirteen entries and the console draws three. The other ten can only have been written through REST or MCP, so a refusal about one keeps the existing sentence (`editor.configIssueTextCapNoField`) instead of offering a jump to nowhere.

**The five grant ids `bigOrThrow` names.** Measured, not assumed: `ToolGrantsEditor` builds every grant from a catalog id (`inst.id`), never typed, and the type is filled only by the picker. `bigOrThrow` fires for `null` or a non-numeric value, neither producible from the console. They stay toasts.

**Guardrails with the switch off** redirects to `gr-model`, the one section `GuardrailsTab` always mounts — the same redirect `textCapIssues` already does, for the same reason: the other anchors are inside `{g.enabled && (` (`GuardrailsTab.tsx:325`) and the jump would scroll to nothing.

## Validation scope

**Proved by test.** `bun check` clean (lint, tsc, i18n, openapi). Full suite **7088 pass / 31 fail** on this branch against **7066 pass / 31 fail** on the base it forked from (`18a49ec6`, checked out in a separate worktree). The same 31 fail on both: appointment/follow-up/migration tests, DB-backed, against a test database missing the appointment migration. Nothing here touches them. This change adds 22 passing tests.

Red proved before the fix: adding `availability.awayMessage` to the deep-link table in `config-health.test.ts` answered `"-/-"`.

Mutation, twice, restoring from a `cp` backup each time (never `git checkout --`, which would delete the fix under test):

| mutation | tests that fell |
| --- | --- |
| drop `availability.awayMessage` from the map | 4 |
| drop `error={refusals.customPolicy}` from `GuardrailsTab` | 1 |

`PARTIALLY_HELD` is now **empty**, pin lowered 1 → 0. Kept rather than deleted: the shape is where a future form declares where it stopped, and the pin makes adding one cost the second edit the ledger exists to force.

**Proved live, in a browser, against the running app.** No test mounts this editor (it pulls auth, theme, toast and a live catalog), so the banner, the jump and the mark reaching the box are proved here instead. Both halves ran the same steps against the same seeded agent (`Recepcionista Demo (stub)`, tenant 1, `tts.mode = "mirror"` so the credential picker is drawn), with the agent's PATCH answered as `400 {"error":"\"vault:99999\" não é uma referência do cofre que exista neste tenant.","field":"settings.tts.credentialRef"}`:

| | base `18a49ec6` (:3008) | this branch (:3007) |
| --- | --- | --- |
| toasts | **1**, gone after 5s | **0** |
| banner with "Corrigir" | no | **yes**, sentence on screen exactly once |
| clicking it | — | → `/agents/1/behavior`, `tts` section on screen at 118px |
| mark at the input | **0** | **1**, inside `#tts`, in the "Chave de API" group |
| banner after arriving | — | **gone** |

The five-second toast window is measured, not quoted: the first read after the base's save found zero toasts because it had already dismissed itself, and a polling read caught it at `atMs: 0`.

**Not validated.** That the SERVER sends `field` for these paths is not re-proved here — it landed in #320 and is covered by `tests/api/refusal-wire.test.ts`; the live exercise answers the PATCH from the browser, so it exercises the console from the response onward and not the server that writes it. The agent row was untouched by the exercise (every PATCH was intercepted; `updatedAt` unchanged).
