### PR TITLE
A test run answers about this tree, or it refuses to start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,11 @@ DB_POOL_MAX=30
 # - TEST_MIGRATION_DATABASE_URL: superuser connection for the suite's setup/teardown. tests/setup.ts
 #   redirects MIGRATION_DATABASE_URL to this at preload (guarding the name ends in `_test`), so the
 #   Prisma CLI keeps using the dev MIGRATION_DATABASE_URL while tests hit the test DB.
+# The database NAME here is a BASE, not the target: both the suite and `bun db:test:setup` append
+# this checkout's identity to it, so two clones or worktrees on one machine never share a database.
+# They used to, and `prisma migrate deploy` only ever ADDS — a migration applied from one branch
+# stayed applied under the next, and the suite reported failures about code nobody had touched
+# (tests/db-name.ts, issue #417). The setup command prints the derived name it provisioned.
 TEST_APP_DATABASE_URL=postgres://fazerai_app:fazerai_app_pw@localhost:${POSTGRES_PORT}/fazerai_agents_test
 TEST_MIGRATION_DATABASE_URL=postgres://postgres:postgres@localhost:${POSTGRES_PORT}/fazerai_agents_test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ The three operational **skills** (`.claude/skills/agents-{onboarding,operation,d
 | `bun prisma:migrate`               | Run database migrations                                                                  |
 | `bun db:bootstrap`                 | Provision the NON-superuser runtime role + schema grants (run after any reset)           |
 | `bun db:reset`                     | Reset the database AND re-provision runtime-role grants (never bare `migrate reset`)     |
-| `bun db:test:setup`                | Provision/migrate the isolated test database                                             |
+| `bun db:test:setup`                | Provision/migrate this checkout's test database (name derived per checkout; reprovisions it when another branch left a migration behind) |
 | `bun prisma:generate`              | Generate Prisma client                                                                   |
 | `bun i18n:extract`                 | Extract translation keys (also part of `bun check`)                                      |
 | `bun set-admin <email> [password]` | Promote a user to admin (creates the user if it doesn't exist; optionally sets password) |

--- a/scripts/test-db-setup.ts
+++ b/scripts/test-db-setup.ts
@@ -2,8 +2,8 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { Client } from "pg";
-import { foreignMigrations } from "@/tests/db-gate";
-import { testDbNameFor, withDbName } from "@/tests/db-name";
+import { appliedMigrations, foreignMigrations } from "@/tests/db-gate";
+import { checkoutRootFrom, testDbNameFor, withDbName } from "@/tests/db-name";
 
 // Provisions (idempotently) the DEDICATED test database the integration suite runs against, so
 // tests never touch the dev DB. The suite does destructive, unscoped ops (e.g. `DELETE FROM
@@ -14,7 +14,7 @@ import { testDbNameFor, withDbName } from "@/tests/db-name";
 // Steps: CREATE DATABASE (if missing) → db-bootstrap (extension, role grants, langgraph schema) →
 // prisma migrate deploy. Safe to re-run.
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = checkoutRootFrom(import.meta.url, "..");
 
 function substitutePort(url: string): string {
   // biome-ignore lint/suspicious/noTemplateCurlyInString: matching the literal ${POSTGRES_PORT} placeholder from .env, not a JS template.
@@ -142,14 +142,15 @@ async function foreignOf(url: string): Promise<string[]> {
   const client = new Client({ connectionString: url });
   await client.connect();
   try {
-    const { rows } = await client.query<{ migration_name: string }>(
-      `SELECT migration_name FROM _prisma_migrations
+    const { rows } = await client.query<{
+      migration_name: string;
+      finished_at: Date | null;
+      rolled_back_at: Date | null;
+    }>(
+      `SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations
        WHERE to_regclass('_prisma_migrations') IS NOT NULL`,
     );
-    return foreignMigrations(
-      rows.map((r) => r.migration_name),
-      localMigrations(),
-    );
+    return foreignMigrations(appliedMigrations(rows), localMigrations());
   } catch {
     return [];
   } finally {

--- a/scripts/test-db-setup.ts
+++ b/scripts/test-db-setup.ts
@@ -2,7 +2,7 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { Client } from "pg";
-import { appliedMigrations, foreignMigrations } from "@/tests/db-gate";
+import { reprovisionReasons } from "@/tests/db-gate";
 import { checkoutRootFrom, testDbNameFor, withDbName } from "@/tests/db-name";
 
 // Provisions (idempotently) the DEDICATED test database the integration suite runs against, so
@@ -81,12 +81,12 @@ async function main() {
     // something is still connected, Postgres refusing is the right answer, not killing a suite that
     // is mid-run.
     if (rowCount !== 0) {
-      const foreign = await foreignOf(targetSuUrl);
-      if (foreign.length > 0) {
+      const reasons = await reprovisionOf(targetSuUrl);
+      if (reasons.length > 0) {
         console.log(
-          `test-db-setup: "${dbName}" carries ${foreign.length} migration(s) this tree does not have, so it is being reprovisioned:`,
+          `test-db-setup: "${dbName}" cannot be deployed onto (${reasons.length} reason(s)), so it is being reprovisioned:`,
         );
-        for (const m of foreign) console.log(`  ${m}`);
+        for (const m of reasons) console.log(`  ${m}`);
         await maint.query(`DROP DATABASE "${dbName}"`);
         await maint.query(`CREATE DATABASE "${dbName}"`);
         console.log(`test-db-setup: recreated database "${dbName}"`);
@@ -137,8 +137,8 @@ function localMigrations(): string[] {
 }
 
 // `_prisma_migrations` may not exist at all (a database created and never migrated), and that is a
-// state and not an error: nothing is foreign in it.
-async function foreignOf(url: string): Promise<string[]> {
+// state and not an error: there is nothing to undo in it, only migrations to apply.
+async function reprovisionOf(url: string): Promise<string[]> {
   const client = new Client({ connectionString: url });
   await client.connect();
   try {
@@ -150,7 +150,7 @@ async function foreignOf(url: string): Promise<string[]> {
       `SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations
        WHERE to_regclass('_prisma_migrations') IS NOT NULL`,
     );
-    return foreignMigrations(appliedMigrations(rows), localMigrations());
+    return reprovisionReasons(rows, localMigrations());
   } catch {
     return [];
   } finally {

--- a/scripts/test-db-setup.ts
+++ b/scripts/test-db-setup.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env bun
-import { readdirSync } from "node:fs";
-import { join } from "node:path";
 import { Client } from "pg";
-import { reprovisionReasons } from "@/tests/db-gate";
+import {
+  localMigrations,
+  type MigrationRow,
+  reprovisionReasons,
+} from "@/tests/db-gate";
 import { checkoutRootFrom, testDbNameFor, withDbName } from "@/tests/db-name";
 
 // Provisions (idempotently) the DEDICATED test database the integration suite runs against, so
@@ -74,12 +76,21 @@ async function main() {
       "SELECT 1 FROM pg_database WHERE datname = $1",
       [dbName],
     );
-    // A database carrying a migration this tree has never heard of cannot be REPAIRED by deploying:
-    // the row is already in `_prisma_migrations`, so nothing is pending and whatever that migration
-    // dropped stays dropped. Reprovisioning is the only way back, and it costs nothing here because
-    // the database holds test fixtures and nothing else. The DROP is deliberately not FORCEd: if
-    // something is still connected, Postgres refusing is the right answer, not killing a suite that
-    // is mid-run.
+    // A database in one of the states `reprovisionReasons` names cannot be REPAIRED by deploying,
+    // so it is dropped and rebuilt, which costs nothing because it holds test fixtures and nothing
+    // else.
+    //
+    // The connections are closed first, and that reverses a decision made earlier in this change on
+    // the reasoning that Postgres refusing is safer than killing a suite mid-run. What refuted it
+    // was measuring the refusal: `database "…" is being accessed by other users`, exit 1, with the
+    // holder being ONE backend in `state=idle` whose last statement was `ROLLBACK` — a pool
+    // connection leaked by a test process that had already exited. That is the ordinary case, not
+    // the concurrent-run case, so the refusal fires where there is nothing to protect and hands the
+    // reader a Postgres error naming no way out.
+    //
+    // What makes closing them defensible is the OTHER half of this change: the database is derived
+    // per checkout, so the only thing that can be connected is this checkout's own work, and the
+    // person typing this command owns it. `datname` fences the termination to this database alone.
     if (rowCount !== 0) {
       const reasons = await reprovisionOf(targetSuUrl);
       if (reasons.length > 0) {
@@ -87,6 +98,16 @@ async function main() {
           `test-db-setup: "${dbName}" cannot be deployed onto (${reasons.length} reason(s)), so it is being reprovisioned:`,
         );
         for (const m of reasons) console.log(`  ${m}`);
+        const { rows: closed } = await maint.query(
+          `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()`,
+          [dbName],
+        );
+        if (closed.length > 0) {
+          console.log(
+            `test-db-setup: closed ${closed.length} connection(s) still open on it`,
+          );
+        }
         await maint.query(`DROP DATABASE "${dbName}"`);
         await maint.query(`CREATE DATABASE "${dbName}"`);
         console.log(`test-db-setup: recreated database "${dbName}"`);
@@ -127,30 +148,17 @@ async function main() {
   console.log(`test-db-setup: "${dbName}" ready`);
 }
 
-// The migrations this tree carries, read the same way tests/setup.ts reads them at preload.
-function localMigrations(): string[] {
-  return readdirSync(join(ROOT, "prisma", "migrations"), {
-    withFileTypes: true,
-  })
-    .filter((e) => e.isDirectory())
-    .map((e) => e.name);
-}
-
 // `_prisma_migrations` may not exist at all (a database created and never migrated), and that is a
 // state and not an error: there is nothing to undo in it, only migrations to apply.
 async function reprovisionOf(url: string): Promise<string[]> {
   const client = new Client({ connectionString: url });
   await client.connect();
   try {
-    const { rows } = await client.query<{
-      migration_name: string;
-      finished_at: Date | null;
-      rolled_back_at: Date | null;
-    }>(
-      `SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations
+    const { rows } = await client.query<MigrationRow>(
+      `SELECT migration_name, checksum, finished_at, rolled_back_at FROM _prisma_migrations
        WHERE to_regclass('_prisma_migrations') IS NOT NULL`,
     );
-    return reprovisionReasons(rows, localMigrations());
+    return reprovisionReasons(rows, localMigrations(ROOT));
   } catch {
     return [];
   } finally {

--- a/scripts/test-db-setup.ts
+++ b/scripts/test-db-setup.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import { Client } from "pg";
+import { foreignMigrations } from "@/tests/db-gate";
+import { testDbNameFor, withDbName } from "@/tests/db-name";
 
 // Provisions (idempotently) the DEDICATED test database the integration suite runs against, so
 // tests never touch the dev DB. The suite does destructive, unscoped ops (e.g. `DELETE FROM
@@ -9,6 +13,8 @@ import { Client } from "pg";
 // Reads TEST_APP_DATABASE_URL (app role) and TEST_MIGRATION_DATABASE_URL (superuser) from the env.
 // Steps: CREATE DATABASE (if missing) → db-bootstrap (extension, role grants, langgraph schema) →
 // prisma migrate deploy. Safe to re-run.
+
+const ROOT = new URL("..", import.meta.url).pathname;
 
 function substitutePort(url: string): string {
   // biome-ignore lint/suspicious/noTemplateCurlyInString: matching the literal ${POSTGRES_PORT} placeholder from .env, not a JS template.
@@ -38,28 +44,59 @@ async function main() {
   const appUrl = substitutePort(appUrlRaw);
   const suUrl = substitutePort(suUrlRaw);
 
-  const dbName = dbNameOf(suUrl);
-  // Guard: this script (and the suite) must only ever run against a *_test database.
-  if (!dbName.endsWith("_test") || dbName !== dbNameOf(appUrl)) {
+  const declared = dbNameOf(suUrl);
+  // Guard: this script (and the suite) must only ever run against a *_test database. It reads the
+  // DECLARED name, before the derivation below, because it is a statement about what the developer
+  // pointed at.
+  if (!declared.endsWith("_test") || declared !== dbNameOf(appUrl)) {
     throw new Error(
-      `refusing to provision: test DB name must end in "_test" and match across both URLs (su="${dbName}", app="${dbNameOf(appUrl)}")`,
+      `refusing to provision: test DB name must end in "_test" and match across both URLs (su="${declared}", app="${dbNameOf(appUrl)}")`,
     );
   }
 
+  // The `.env` name is the base; the target is per checkout, by the same derivation tests/setup.ts
+  // applies at preload. Deriving it in both places rather than asking each checkout to edit its
+  // `.env` is what makes the isolation impossible to forget — see tests/db-name.ts (issue #417).
+  const dbName = testDbNameFor(declared, ROOT);
+  if (dbName !== declared) {
+    console.log(
+      `test-db-setup: this checkout's database is "${dbName}" (base "${declared}")`,
+    );
+  }
+  const targetSuUrl = withDbName(suUrl, dbName);
+  const targetAppUrl = withDbName(appUrl, dbName);
+
   // 1. CREATE DATABASE if missing (via the postgres maintenance DB).
-  const maint = new Client({ connectionString: maintenanceUrl(suUrl) });
+  const maint = new Client({ connectionString: maintenanceUrl(targetSuUrl) });
   await maint.connect();
   try {
     const { rowCount } = await maint.query(
       "SELECT 1 FROM pg_database WHERE datname = $1",
       [dbName],
     );
-    if (rowCount === 0) {
+    // A database carrying a migration this tree has never heard of cannot be REPAIRED by deploying:
+    // the row is already in `_prisma_migrations`, so nothing is pending and whatever that migration
+    // dropped stays dropped. Reprovisioning is the only way back, and it costs nothing here because
+    // the database holds test fixtures and nothing else. The DROP is deliberately not FORCEd: if
+    // something is still connected, Postgres refusing is the right answer, not killing a suite that
+    // is mid-run.
+    if (rowCount !== 0) {
+      const foreign = await foreignOf(targetSuUrl);
+      if (foreign.length > 0) {
+        console.log(
+          `test-db-setup: "${dbName}" carries ${foreign.length} migration(s) this tree does not have, so it is being reprovisioned:`,
+        );
+        for (const m of foreign) console.log(`  ${m}`);
+        await maint.query(`DROP DATABASE "${dbName}"`);
+        await maint.query(`CREATE DATABASE "${dbName}"`);
+        console.log(`test-db-setup: recreated database "${dbName}"`);
+      } else {
+        console.log(`test-db-setup: database "${dbName}" already exists`);
+      }
+    } else if (rowCount === 0) {
       // dbName is validated (*_test) and comes from our own env, not external input.
       await maint.query(`CREATE DATABASE "${dbName}"`);
       console.log(`test-db-setup: created database "${dbName}"`);
-    } else {
-      console.log(`test-db-setup: database "${dbName}" already exists`);
     }
   } finally {
     await maint.end();
@@ -70,8 +107,8 @@ async function main() {
   // MIGRATION_DATABASE_URL; prisma migrate (prisma.config.ts) connects via MIGRATION_DATABASE_URL.
   const childEnv = {
     ...process.env,
-    DATABASE_URL: appUrl,
-    MIGRATION_DATABASE_URL: suUrl,
+    DATABASE_URL: targetAppUrl,
+    MIGRATION_DATABASE_URL: targetSuUrl,
   };
   for (const cmd of [
     ["bun", "scripts/db-bootstrap.ts"],
@@ -88,6 +125,36 @@ async function main() {
     }
   }
   console.log(`test-db-setup: "${dbName}" ready`);
+}
+
+// The migrations this tree carries, read the same way tests/setup.ts reads them at preload.
+function localMigrations(): string[] {
+  return readdirSync(join(ROOT, "prisma", "migrations"), {
+    withFileTypes: true,
+  })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+}
+
+// `_prisma_migrations` may not exist at all (a database created and never migrated), and that is a
+// state and not an error: nothing is foreign in it.
+async function foreignOf(url: string): Promise<string[]> {
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  try {
+    const { rows } = await client.query<{ migration_name: string }>(
+      `SELECT migration_name FROM _prisma_migrations
+       WHERE to_regclass('_prisma_migrations') IS NOT NULL`,
+    );
+    return foreignMigrations(
+      rows.map((r) => r.migration_name),
+      localMigrations(),
+    );
+  } catch {
+    return [];
+  } finally {
+    await client.end();
+  }
 }
 
 main().catch((err) => {

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -19,6 +19,10 @@
 // late, and against a number nobody reads; refusing to start names what is missing while the reader
 // is still looking at the command they typed.
 
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
 export const DB_GATE_OPT_OUT = "ALLOW_NO_DB";
 
 // Every line here has to be runnable FROM THE STATE THAT PRINTED IT, as one paste. `bun run
@@ -170,9 +174,12 @@ export function withDeadline<T>(
 // FAILED migration, and the one part of its answer worth keeping.
 export type MigrationRow = {
   migration_name: string;
+  checksum: string;
   finished_at: Date | null;
   rolled_back_at: Date | null;
 };
+
+export type LocalMigration = { name: string; checksum: string };
 
 export function appliedMigrations(rows: MigrationRow[]): string[] {
   return rows
@@ -229,16 +236,44 @@ export function pendingMigrations(
 // what the second review round found: a caller handed the filtered names cannot see the rows that
 // were filtered out, and a caller that has to remember to pass them separately is a caller that
 // will not.
+// The same NAME, different SQL. A migration edited after it was applied, or a directory name two
+// branches both reached for, leaves the two name sets identical while the schema is whichever SQL
+// ran — so every comparison above is satisfied and the run proceeds against the wrong tables.
+// `_prisma_migrations.checksum` is a plain SHA-256 of the migration.sql bytes, in hex; verified
+// against three real rows of this repo's own ledger rather than assumed, because a checksum
+// comparison against the wrong algorithm reports every migration as changed.
+export function changedMigrations(
+  rows: MigrationRow[],
+  local: LocalMigration[],
+): string[] {
+  const onDisk = new Map(local.map((m) => [m.name, m.checksum]));
+  return rows
+    .filter((r) => {
+      const here = onDisk.get(r.migration_name);
+      // Absent from disk is FOREIGN, which is a different answer and already has one.
+      return here !== undefined && here !== r.checksum;
+    })
+    .map((r) => r.migration_name)
+    .sort();
+}
+
 export function schemaOutOfStep(
   dbName: string,
   rows: MigrationRow[],
-  local: string[],
+  local: LocalMigration[],
 ): string | null {
+  const names = local.map((m) => m.name);
   const applied = appliedMigrations(rows);
   const failed = failedMigrations(rows);
-  const foreign = foreignMigrations(applied, local);
-  const pending = pendingMigrations(applied, local);
-  if (foreign.length === 0 && pending.length === 0 && failed.length === 0) {
+  const foreign = foreignMigrations(applied, names);
+  const pending = pendingMigrations(applied, names);
+  const changed = changedMigrations(rows, local);
+  if (
+    foreign.length === 0 &&
+    pending.length === 0 &&
+    failed.length === 0 &&
+    changed.length === 0
+  ) {
     return null;
   }
   const lines = [
@@ -262,6 +297,12 @@ export function schemaOutOfStep(
       ...failed.map((m) => `    ${m}`),
     );
   }
+  if (changed.length > 0) {
+    lines.push(
+      `  applied from different SQL than the file now holds:`,
+      ...changed.map((m) => `    ${m}`),
+    );
+  }
   // One command for both directions, and it has to REPROVISION rather than deploy: a foreign
   // migration is already recorded in `_prisma_migrations`, so nothing is pending and a plain
   // `migrate deploy` is a no-op that leaves the schema exactly as wrong as it found it.
@@ -278,11 +319,16 @@ const RESYNC = "bun run db:test:setup";
 // because it holds test fixtures and nothing else.
 export function reprovisionReasons(
   rows: MigrationRow[],
-  local: string[],
+  local: LocalMigration[],
 ): string[] {
+  const names = local.map((m) => m.name);
   const applied = appliedMigrations(rows);
   const reasons: string[] = [];
-  for (const m of foreignMigrations(applied, local)) {
+  for (const m of changedMigrations(rows, local)) {
+    // Applied from SQL the file no longer holds. Deploying skips it entirely: it is recorded.
+    reasons.push(`${m} (applied from different SQL than the file now holds)`);
+  }
+  for (const m of foreignMigrations(applied, names)) {
     // Already recorded, so nothing is pending and whatever it dropped stays dropped.
     reasons.push(`${m} (applied here, absent from this tree)`);
   }
@@ -290,8 +336,25 @@ export function reprovisionReasons(
     // `migrate deploy` refuses the whole database with P3009 while this row stands.
     reasons.push(`${m} (recorded but never finished)`);
   }
-  for (const m of outOfOrderPending(applied, local)) {
+  for (const m of outOfOrderPending(applied, names)) {
     reasons.push(`${m} (would be applied after a migration that sorts later)`);
   }
   return reasons;
+}
+
+// THE ONE FUNCTION HERE THAT TOUCHES A DISK, and it lives beside the decisions rather than in each
+// caller because both of them ask the same question and a second copy is a second answer. It reads
+// the tree, never the database, so nothing above it stops being provable with fixtures.
+export function localMigrations(root: string): LocalMigration[] {
+  const dir = join(root, "prisma", "migrations");
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => ({
+      name: e.name,
+      // Prisma's own checksum: SHA-256 of the migration.sql bytes, hex. A directory without one is
+      // not a migration Prisma would apply, and hashing nothing keeps it from matching anything.
+      checksum: createHash("sha256")
+        .update(readFileSync(join(dir, e.name, "migration.sql")))
+        .digest("hex"),
+    }));
 }

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -266,21 +266,30 @@ export function changedMigrations(
 // exactly as a fresh build would have run them. A freshly provisioned database of this repo was
 // measured at 56 migrations and 0 disagreements, which is what makes this a signal rather than a
 // second way to refuse every run.
+// ONE comparator for both the sort and the comparison, and it is code-point order because that is
+// what Prisma applies in — it sorts the directory names as bytes. Using `localeCompare` for the
+// tie-break and `<` for the inversion was two different orders: measured, they disagree on
+// `20260101000000-b` vs `20260101000000_a`, on `a-b` vs `a_b`, on `A_x` vs `a_x` and on `m-1` vs
+// `m_1`, so a tie sorted one way is reported as an inversion by the other — refusing a correct
+// database, recreating it, and refusing it again. The same trap the ordering of exposed names hit
+// in #412, one layer down.
+function byName(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export function appliedOutOfOrder(rows: MigrationRow[]): string[] {
   const finished = rows
     .filter((r) => r.finished_at !== null && r.rolled_back_at === null)
     .sort((a, b) => {
       const at = (a.finished_at as Date).getTime();
       const bt = (b.finished_at as Date).getTime();
-      return at === bt
-        ? a.migration_name.localeCompare(b.migration_name)
-        : at - bt;
+      return at === bt ? byName(a.migration_name, b.migration_name) : at - bt;
     });
   const out: string[] = [];
   for (let i = 1; i < finished.length; i++) {
     const prev = finished[i - 1] as MigrationRow;
     const cur = finished[i] as MigrationRow;
-    if (cur.migration_name < prev.migration_name) {
+    if (byName(cur.migration_name, prev.migration_name) < 0) {
       out.push(`${cur.migration_name} (ran after ${prev.migration_name})`);
     }
   }

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -168,16 +168,45 @@ export function withDeadline<T>(
 // database left partially migrated reads as matching this tree and the suite runs against a schema
 // nobody finished writing. This is the distinction `prisma migrate status` draws when it reports a
 // FAILED migration, and the one part of its answer worth keeping.
-export function appliedMigrations(
-  rows: {
-    migration_name: string;
-    finished_at: Date | null;
-    rolled_back_at: Date | null;
-  }[],
-): string[] {
+export type MigrationRow = {
+  migration_name: string;
+  finished_at: Date | null;
+  rolled_back_at: Date | null;
+};
+
+export function appliedMigrations(rows: MigrationRow[]): string[] {
   return rows
     .filter((r) => r.finished_at !== null && r.rolled_back_at === null)
     .map((r) => r.migration_name);
+}
+
+// The rows `appliedMigrations` drops, which are not nothing: an apply that died half-way leaves the
+// row with `finished_at` still null, and `prisma migrate deploy` then refuses the whole database
+// with P3009 rather than continuing. Dropping them from the applied set and stopping there is how
+// the FIRST version of this check came to call such a database up to date — measured, with a
+// half-applied foreign row planted in a real ledger: 57 rows, 56 counted, `foreignMigrations`
+// empty, verdict "up to date". So they are named separately rather than merely excluded.
+export function failedMigrations(rows: MigrationRow[]): string[] {
+  return rows
+    .filter((r) => r.finished_at === null || r.rolled_back_at !== null)
+    .map((r) => r.migration_name)
+    .sort();
+}
+
+// A migration this tree has not applied yet whose NAME sorts before one it already applied. Prisma
+// applies pending migrations in filename order and nothing else, so deploying this one now runs it
+// AFTER the newer one — an order no fresh database would ever produce, and it is decided by the
+// filename rather than by when anybody wrote it. Not hypothetical in this repo: three migrations
+// share the timestamp `20260827000000` and are told apart by their suffixes alone, so which of two
+// branches sorts first has nothing to do with which was written first.
+export function outOfOrderPending(
+  applied: string[],
+  local: string[],
+): string[] {
+  const pending = pendingMigrations(applied, local);
+  const newest = [...applied].sort().pop();
+  if (newest === undefined) return [];
+  return pending.filter((p) => p < newest);
 }
 
 export function foreignMigrations(
@@ -196,14 +225,22 @@ export function pendingMigrations(
   return local.filter((m) => !done.has(m)).sort();
 }
 
+// Takes the LEDGER, not an applied set someone already filtered. The difference is the whole of
+// what the second review round found: a caller handed the filtered names cannot see the rows that
+// were filtered out, and a caller that has to remember to pass them separately is a caller that
+// will not.
 export function schemaOutOfStep(
   dbName: string,
-  applied: string[],
+  rows: MigrationRow[],
   local: string[],
 ): string | null {
+  const applied = appliedMigrations(rows);
+  const failed = failedMigrations(rows);
   const foreign = foreignMigrations(applied, local);
   const pending = pendingMigrations(applied, local);
-  if (foreign.length === 0 && pending.length === 0) return null;
+  if (foreign.length === 0 && pending.length === 0 && failed.length === 0) {
+    return null;
+  }
   const lines = [
     `the test database "${dbName}" does not match this tree, so failures below would be about its schema and not about the code.`,
   ];
@@ -219,6 +256,12 @@ export function schemaOutOfStep(
       ...pending.map((m) => `    ${m}`),
     );
   }
+  if (failed.length > 0) {
+    lines.push(
+      `  recorded but never finished, or resolved as rolled back:`,
+      ...failed.map((m) => `    ${m}`),
+    );
+  }
   // One command for both directions, and it has to REPROVISION rather than deploy: a foreign
   // migration is already recorded in `_prisma_migrations`, so nothing is pending and a plain
   // `migrate deploy` is a no-op that leaves the schema exactly as wrong as it found it.
@@ -227,3 +270,28 @@ export function schemaOutOfStep(
 }
 
 const RESYNC = "bun run db:test:setup";
+
+// WHY THE COMMAND ABOVE HAS TO REPROVISION AND NOT DEPLOY, per state. Deploying is only ever the
+// right repair for a database that is simply BEHIND this tree, in this tree's own order. Every
+// other state below is one `prisma migrate deploy` either cannot fix or fixes into a schema a fresh
+// database would not have, so the answer is to throw the database away — which costs nothing,
+// because it holds test fixtures and nothing else.
+export function reprovisionReasons(
+  rows: MigrationRow[],
+  local: string[],
+): string[] {
+  const applied = appliedMigrations(rows);
+  const reasons: string[] = [];
+  for (const m of foreignMigrations(applied, local)) {
+    // Already recorded, so nothing is pending and whatever it dropped stays dropped.
+    reasons.push(`${m} (applied here, absent from this tree)`);
+  }
+  for (const m of failedMigrations(rows)) {
+    // `migrate deploy` refuses the whole database with P3009 while this row stands.
+    reasons.push(`${m} (recorded but never finished)`);
+  }
+  for (const m of outOfOrderPending(applied, local)) {
+    reasons.push(`${m} (would be applied after a migration that sorts later)`);
+  }
+  return reasons;
+}

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -257,6 +257,36 @@ export function changedMigrations(
     .sort();
 }
 
+// The order a database was BUILT in, which the four sets above stop being able to see the moment
+// everything is applied. `outOfOrderPending` catches the merge before the deploy; once both
+// migrations have run, every set is empty and a schema assembled in an order no fresh database uses
+// reads as healthy. Prisma applies pending migrations in filename order and nothing else, so a
+// finished-at sequence that disagrees with the name sequence means two deploys with a merge between
+// them. Ties are not disagreement: rows that finished in the same instant are ordered by name here,
+// exactly as a fresh build would have run them. A freshly provisioned database of this repo was
+// measured at 56 migrations and 0 disagreements, which is what makes this a signal rather than a
+// second way to refuse every run.
+export function appliedOutOfOrder(rows: MigrationRow[]): string[] {
+  const finished = rows
+    .filter((r) => r.finished_at !== null && r.rolled_back_at === null)
+    .sort((a, b) => {
+      const at = (a.finished_at as Date).getTime();
+      const bt = (b.finished_at as Date).getTime();
+      return at === bt
+        ? a.migration_name.localeCompare(b.migration_name)
+        : at - bt;
+    });
+  const out: string[] = [];
+  for (let i = 1; i < finished.length; i++) {
+    const prev = finished[i - 1] as MigrationRow;
+    const cur = finished[i] as MigrationRow;
+    if (cur.migration_name < prev.migration_name) {
+      out.push(`${cur.migration_name} (ran after ${prev.migration_name})`);
+    }
+  }
+  return out;
+}
+
 export function schemaOutOfStep(
   dbName: string,
   rows: MigrationRow[],
@@ -268,11 +298,13 @@ export function schemaOutOfStep(
   const foreign = foreignMigrations(applied, names);
   const pending = pendingMigrations(applied, names);
   const changed = changedMigrations(rows, local);
+  const misordered = appliedOutOfOrder(rows);
   if (
     foreign.length === 0 &&
     pending.length === 0 &&
     failed.length === 0 &&
-    changed.length === 0
+    changed.length === 0 &&
+    misordered.length === 0
   ) {
     return null;
   }
@@ -301,6 +333,12 @@ export function schemaOutOfStep(
     lines.push(
       `  applied from different SQL than the file now holds:`,
       ...changed.map((m) => `    ${m}`),
+    );
+  }
+  if (misordered.length > 0) {
+    lines.push(
+      `  applied in an order no fresh database would produce:`,
+      ...misordered.map((m) => `    ${m}`),
     );
   }
   // One command for both directions, and it has to REPROVISION rather than deploy: a foreign
@@ -338,6 +376,10 @@ export function reprovisionReasons(
   }
   for (const m of outOfOrderPending(applied, names)) {
     reasons.push(`${m} (would be applied after a migration that sorts later)`);
+  }
+  for (const m of appliedOutOfOrder(rows)) {
+    // Already built that way, and deploying has nothing left to do about it.
+    reasons.push(`${m} — an order no fresh database would produce`);
   }
   return reasons;
 }

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -162,6 +162,24 @@ export function withDeadline<T>(
 // Pure, like `missingDbConfig`, so the decision can be proved with fixtures instead of with a
 // database that has to be broken to test the breakage.
 
+// `_prisma_migrations` is a LEDGER, not a list of what is in the schema. It keeps the row of a
+// migration that failed half-way (`finished_at` still null, `logs` filled) and of one resolved as
+// rolled back (`rolled_back_at` set), and reading the name alone counts both as applied — so a
+// database left partially migrated reads as matching this tree and the suite runs against a schema
+// nobody finished writing. This is the distinction `prisma migrate status` draws when it reports a
+// FAILED migration, and the one part of its answer worth keeping.
+export function appliedMigrations(
+  rows: {
+    migration_name: string;
+    finished_at: Date | null;
+    rolled_back_at: Date | null;
+  }[],
+): string[] {
+  return rows
+    .filter((r) => r.finished_at !== null && r.rolled_back_at === null)
+    .map((r) => r.migration_name);
+}
+
 export function foreignMigrations(
   applied: string[],
   local: string[],

--- a/tests/db-gate.ts
+++ b/tests/db-gate.ts
@@ -28,9 +28,14 @@ export const DB_GATE_OPT_OUT = "ALLOW_NO_DB";
 // chained command loses the race against a cold Postgres (measured, `read ECONNRESET`). The whole
 // line was run from a clone with no `.env`, against a cold container, and ends with a suite that
 // runs.
+//
+// The worktree line carries the setup too, and that is the whole of what #417 changed here: since
+// the database name is derived per checkout (./db-name.ts), a new worktree that only copies the
+// `.env` has a reachable Postgres and no database of its own, and the refusal it gets would
+// otherwise point at the copy it had just made.
 const HOW = [
   `  - fresh clone: cp .env.example .env && docker compose up -d --wait && bun run db:test:setup`,
-  `  - in a worktree, with the database already up: cp ../main/.env .env`,
+  `  - in a worktree, with the database already up: cp ../main/.env .env && bun run db:test:setup`,
   `  - deliberately without a database: ${DB_GATE_OPT_OUT}=1 bun test`,
 ].join("\n");
 
@@ -137,3 +142,70 @@ export function withDeadline<T>(
     }),
   ]).finally(() => clearTimeout(timer));
 }
+
+// WHEN THE DATABASE ANSWERS AND IS THE WRONG DATABASE (issue #417).
+//
+// Everything above this line asks whether there is a database. This asks whether it is THIS TREE'S
+// database, which is a different question and fails in the opposite direction: the run does not exit
+// 0 with a third of the suite skipped, it exits non-zero with a number of failures that name code
+// nobody broke. Measured on `main`, clean, against a database carrying one migration from an
+// unmerged branch: 31 failures on three consecutive runs, plus 29 tests that never executed because
+// their `beforeAll` died first and the failure count does not include those.
+//
+// `prisma migrate status` does not answer it. It reports PENDING and FAILED migrations, and a
+// migration that is applied while the tree has never heard of it is neither — it said "Database
+// schema is up to date!" about that exact database. The set difference has to be taken by hand, and
+// it is taken in both directions because they are one invariant: THE DATABASE MATCHES THE TREE. The
+// other direction is what a `git pull` produces, and it reaches a reader as a missing column rather
+// than as a missing migration, which is no more readable than the incident above.
+//
+// Pure, like `missingDbConfig`, so the decision can be proved with fixtures instead of with a
+// database that has to be broken to test the breakage.
+
+export function foreignMigrations(
+  applied: string[],
+  local: string[],
+): string[] {
+  const known = new Set(local);
+  return applied.filter((m) => !known.has(m)).sort();
+}
+
+export function pendingMigrations(
+  applied: string[],
+  local: string[],
+): string[] {
+  const done = new Set(applied);
+  return local.filter((m) => !done.has(m)).sort();
+}
+
+export function schemaOutOfStep(
+  dbName: string,
+  applied: string[],
+  local: string[],
+): string | null {
+  const foreign = foreignMigrations(applied, local);
+  const pending = pendingMigrations(applied, local);
+  if (foreign.length === 0 && pending.length === 0) return null;
+  const lines = [
+    `the test database "${dbName}" does not match this tree, so failures below would be about its schema and not about the code.`,
+  ];
+  if (foreign.length > 0) {
+    lines.push(
+      `  applied here but absent from prisma/migrations (left by another branch):`,
+      ...foreign.map((m) => `    ${m}`),
+    );
+  }
+  if (pending.length > 0) {
+    lines.push(
+      `  in prisma/migrations and never applied:`,
+      ...pending.map((m) => `    ${m}`),
+    );
+  }
+  // One command for both directions, and it has to REPROVISION rather than deploy: a foreign
+  // migration is already recorded in `_prisma_migrations`, so nothing is pending and a plain
+  // `migrate deploy` is a no-op that leaves the schema exactly as wrong as it found it.
+  lines.push(`  - ${RESYNC}`);
+  return lines.join("\n");
+}
+
+const RESYNC = "bun run db:test:setup";

--- a/tests/db-name.ts
+++ b/tests/db-name.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { basename } from "node:path";
+import { basename, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 // WHICH DATABASE BELONGS TO WHICH CHECKOUT (issue #417).
 //
@@ -18,6 +19,18 @@ import { basename } from "node:path";
 // `main`, and worktrees here are named after the issue they carry) nor safe to truncate — and it has
 // to be truncatable, since Postgres cuts an identifier at 63 bytes without saying so, which would
 // hand two long paths the same database through the fix for two paths sharing a database.
+
+// A `file://` URL PERCENT-ENCODES what a path may hold, and no filesystem call decodes it back: a
+// checkout under a directory with a space reads its own root as `.../my%20tree`, and every
+// `readdirSync` under it is ENOENT. Measured before this existed, against a fixture directory whose
+// name held a space: `ENOENT: no such file or directory, scandir
+// '/private/tmp/tree%20with%20space/sub/prisma/migrations'` — which would abort every
+// database-backed run, not degrade one. `fileURLToPath` is the decode; `resolve` is what makes the
+// result the same string whether the caller's URL ended in a separator or not, which matters
+// because the hash below is over this exact string.
+export function checkoutRootFrom(importMetaUrl: string, up: string): string {
+  return resolve(fileURLToPath(importMetaUrl), "..", up);
+}
 
 const MAX_IDENTIFIER_BYTES = 63;
 const HASH_CHARS = 6;
@@ -46,11 +59,20 @@ export function testDbNameFor(base: string, checkoutRoot: string): string {
   // The base may or may not already carry the suffix; the derived name always does, because
   // tests/setup.ts refuses to run the destructive suite against a target that does not end in
   // `_test` and scripts/test-db-setup.ts refuses to provision one.
-  const stem = identifierSafe(base.replace(/_test$/, ""));
-  const fixed = `${stem}__${hash}${SUFFIX}`.length;
-  const room = MAX_IDENTIFIER_BYTES - fixed;
-  const slug = identifierSafe(basename(root)).slice(0, Math.max(0, room));
-  return `${stem}_${slug}_${hash}${SUFFIX}`.replace(/__+/g, "_");
+  //
+  // The hash and the suffix are the two parts that may never be shortened: the suffix is what both
+  // guards read, and a truncated hash is two checkouts sharing a database — which is the failure
+  // this whole file exists to prevent, arriving through the fix for it. So the room is taken from
+  // the two readable halves, the checkout first and the stem after it, because a caller who set a
+  // long base still knows which database is theirs from the hash.
+  const tail = `_${hash}${SUFFIX}`;
+  const room = MAX_IDENTIFIER_BYTES - tail.length;
+  const slug = identifierSafe(basename(root)).slice(0, Math.max(0, room - 1));
+  const stem = identifierSafe(base.replace(/_test$/, "")).slice(
+    0,
+    Math.max(0, room - slug.length - (slug.length > 0 ? 1 : 0)),
+  );
+  return `${stem}_${slug}${tail}`.replace(/__+/g, "_").replace(/^_+/, "");
 }
 
 // Swaps the database out of a connection URL and leaves everything else — host, port, role,

--- a/tests/db-name.ts
+++ b/tests/db-name.ts
@@ -77,8 +77,14 @@ export function testDbNameFor(base: string, checkoutRoot: string): string {
   // The checkout's hash stays SEPARATE and last, because it is the one part recomputable from the
   // root alone, which is what lets the idempotence check above tell a name derived HERE from one
   // derived somewhere else without knowing the base it came from.
-  const stemText = identifierSafe(base.replace(/_test$/, ""));
-  const tail = `_${shortHash(stemText)}${hash}${SUFFIX}`;
+  // The hash is over the ORIGINAL base, and the normalized text is for reading only. Hashing the
+  // normalized form makes the identity as lossy as the display: `identifierSafe` folds every run of
+  // non-alphanumerics to one underscore, so `foo-bar_test` and `foo_bar_test` are two legal, distinct
+  // databases that both derived to `foo_bar_x_4928ca5cf696_test` — measured — and a destructive
+  // command aimed at one would reach the other.
+  const rawStem = base.replace(/_test$/, "");
+  const stemText = identifierSafe(rawStem);
+  const tail = `_${shortHash(rawStem)}${hash}${SUFFIX}`;
   const room = MAX_IDENTIFIER_BYTES - tail.length;
   // The base first: it is what tells two databases of the SAME checkout apart, so it is the half
   // whose truncation costs the most to a reader.

--- a/tests/db-name.ts
+++ b/tests/db-name.ts
@@ -1,0 +1,62 @@
+import { createHash } from "node:crypto";
+import { basename } from "node:path";
+
+// WHICH DATABASE BELONGS TO WHICH CHECKOUT (issue #417).
+//
+// `.env` holds ONE test database name, and every checkout on a machine copies that `.env` — the
+// worktree onboarding step is literally `cp ../main/.env .env`. So they all share one database, and
+// `prisma migrate deploy` only ever adds: a migration applied from one tree stays applied under the
+// next. The measurement, and why an additive leftover hides this until a subtractive one arrives,
+// is in tests/lib/test-db-identity.test.ts.
+//
+// Deriving the name here rather than asking each checkout to edit its `.env` is the whole point: an
+// obligation spelled out per checkout is one a new checkout is created without, and this one has no
+// symptom until it costs a day. For a single clone the derivation is a suffix and nothing else.
+//
+// The name is NOT the base name plus the directory. It is the base name, the directory, AND a hash
+// of the absolute path, because the readable half is neither unique (two clones can both hold a
+// `main`, and worktrees here are named after the issue they carry) nor safe to truncate — and it has
+// to be truncatable, since Postgres cuts an identifier at 63 bytes without saying so, which would
+// hand two long paths the same database through the fix for two paths sharing a database.
+
+const MAX_IDENTIFIER_BYTES = 63;
+const HASH_CHARS = 6;
+const SUFFIX = "_test";
+
+function identifierSafe(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function testDbNameFor(base: string, checkoutRoot: string): string {
+  const root = checkoutRoot.replace(/\/+$/, "");
+  const hash = createHash("sha256")
+    .update(root)
+    .digest("hex")
+    .slice(0, HASH_CHARS);
+  // IDEMPOTENT, and that is not tidiness. Anything that reads the derived URL out of a running
+  // suite and starts a second one from it would otherwise derive AGAIN, landing on a name that
+  // names no database — measured the first time this shipped, when the gate's own subprocess test
+  // went looking for `..._flaky_tests_febbf7_flaky_tests_febbf7_test`. The hash is over the
+  // absolute checkout root, so a name already ending in THIS root's hash was produced here and is
+  // already the answer.
+  if (base.endsWith(`_${hash}${SUFFIX}`)) return base;
+  // The base may or may not already carry the suffix; the derived name always does, because
+  // tests/setup.ts refuses to run the destructive suite against a target that does not end in
+  // `_test` and scripts/test-db-setup.ts refuses to provision one.
+  const stem = identifierSafe(base.replace(/_test$/, ""));
+  const fixed = `${stem}__${hash}${SUFFIX}`.length;
+  const room = MAX_IDENTIFIER_BYTES - fixed;
+  const slug = identifierSafe(basename(root)).slice(0, Math.max(0, room));
+  return `${stem}_${slug}_${hash}${SUFFIX}`.replace(/__+/g, "_");
+}
+
+// Swaps the database out of a connection URL and leaves everything else — host, port, role,
+// password, query parameters — exactly as the `.env` wrote it.
+export function withDbName(url: string, name: string): string {
+  const parsed = new URL(url);
+  parsed.pathname = `/${name}`;
+  return parsed.toString();
+}

--- a/tests/db-name.ts
+++ b/tests/db-name.ts
@@ -43,34 +43,49 @@ function identifierSafe(value: string): string {
     .replace(/^_+|_+$/g, "");
 }
 
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, HASH_CHARS);
+}
+
 export function testDbNameFor(base: string, checkoutRoot: string): string {
   const root = checkoutRoot.replace(/\/+$/, "");
-  const hash = createHash("sha256")
-    .update(root)
-    .digest("hex")
-    .slice(0, HASH_CHARS);
+  const hash = shortHash(root);
   // IDEMPOTENT, and that is not tidiness. Anything that reads the derived URL out of a running
   // suite and starts a second one from it would otherwise derive AGAIN, landing on a name that
   // names no database — measured the first time this shipped, when the gate's own subprocess test
   // went looking for `..._flaky_tests_febbf7_flaky_tests_febbf7_test`. The hash is over the
   // absolute checkout root, so a name already ending in THIS root's hash was produced here and is
   // already the answer.
-  if (base.endsWith(`_${hash}${SUFFIX}`)) return base;
+  // The whole tail, not just this root's hash: `_<6 hex base><6 hex root>_test` is the shape only
+  // this function produces, so a hand-written name that happens to end in the right six characters
+  // is not mistaken for one of ours — and being mistaken would mean NOT deriving, which is two
+  // checkouts sharing a database.
+  if (new RegExp(`_[0-9a-f]{${HASH_CHARS}}${hash}${SUFFIX}$`).test(base)) {
+    return base;
+  }
   // The base may or may not already carry the suffix; the derived name always does, because
   // tests/setup.ts refuses to run the destructive suite against a target that does not end in
   // `_test` and scripts/test-db-setup.ts refuses to provision one.
   //
-  // The hash and the suffix are the two parts that may never be shortened: the suffix is what both
-  // guards read, and a truncated hash is two checkouts sharing a database — which is the failure
-  // this whole file exists to prevent, arriving through the fix for it. So the room is taken from
-  // the two readable halves, the checkout first and the stem after it, because a caller who set a
-  // long base still knows which database is theirs from the hash.
-  const tail = `_${hash}${SUFFIX}`;
+  // BOTH halves are hashed, and the readable text is readability alone. The first version hashed
+  // only the checkout and let the two readable halves fight over the remaining room, which merged
+  // every base of a long-named checkout into ONE database: measured with a 52-character checkout,
+  // `secretaria_v4_test`, `fzgate417_test` and `fzsetup417_test` all derived to
+  // `wwww…_79bdb0_test`. Truncation may cost a name its readability; it may never cost it its
+  // identity.
+  //
+  // The checkout's hash stays SEPARATE and last, because it is the one part recomputable from the
+  // root alone, which is what lets the idempotence check above tell a name derived HERE from one
+  // derived somewhere else without knowing the base it came from.
+  const stemText = identifierSafe(base.replace(/_test$/, ""));
+  const tail = `_${shortHash(stemText)}${hash}${SUFFIX}`;
   const room = MAX_IDENTIFIER_BYTES - tail.length;
-  const slug = identifierSafe(basename(root)).slice(0, Math.max(0, room - 1));
-  const stem = identifierSafe(base.replace(/_test$/, "")).slice(
+  // The base first: it is what tells two databases of the SAME checkout apart, so it is the half
+  // whose truncation costs the most to a reader.
+  const stem = stemText.slice(0, Math.max(0, room - 1));
+  const slug = identifierSafe(basename(root)).slice(
     0,
-    Math.max(0, room - slug.length - (slug.length > 0 ? 1 : 0)),
+    Math.max(0, room - stem.length - (stem.length > 0 ? 1 : 0)),
   );
   return `${stem}_${slug}${tail}`.replace(/__+/g, "_").replace(/^_+/, "");
 }

--- a/tests/lib/test-db-identity.test.ts
+++ b/tests/lib/test-db-identity.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   appliedMigrations,
+  changedMigrations,
   DB_GATE_OPT_OUT,
   foreignMigrations,
+  type LocalMigration,
+  localMigrations,
   type MigrationRow,
   pendingMigrations,
   reprovisionReasons,
@@ -200,17 +204,25 @@ describe("the test database's name belongs to ONE checkout", () => {
 
 // The ledger, in the shape the gate reads it. A row is not a name: it also says whether the apply
 // FINISHED and whether someone resolved it as rolled back.
-const done = (...names: string[]) =>
+// The checksum is a real one of the name, so a fixture never accidentally matches a DIFFERENT
+// name's file: `sameSql` below builds the local side from the same function.
+const sumOf = (name: string) => createHash("sha256").update(name).digest("hex");
+const done = (...names: string[]): MigrationRow[] =>
   names.map((migration_name) => ({
     migration_name,
+    checksum: sumOf(migration_name),
     finished_at: new Date(),
     rolled_back_at: null,
   }));
-const halfWay = (migration_name: string) => ({
+const halfWay = (migration_name: string): MigrationRow => ({
   migration_name,
+  checksum: sumOf(migration_name),
   finished_at: null,
   rolled_back_at: null,
 });
+// The tree side, agreeing with `done` by construction.
+const sameSql = (names: string[]): LocalMigration[] =>
+  names.map((name) => ({ name, checksum: sumOf(name) }));
 
 describe("a database that is not this tree's database", () => {
   const local = ["20260101000000_a", "20260102000000_b"];
@@ -221,37 +233,25 @@ describe("a database that is not this tree's database", () => {
   // the suite runs against a schema nobody finished writing. Measured on the real table: an
   // interrupted apply leaves `{ finished_at: null, rolled_back_at: null }`.
   test("a migration that never finished is not applied", () => {
-    const rows = [
-      {
-        migration_name: "20260101000000_a",
-        finished_at: new Date(),
-        rolled_back_at: null,
-      },
-      {
-        migration_name: "20260102000000_b",
-        finished_at: null,
-        rolled_back_at: null,
-      },
-    ];
+    const rows = [...done("20260101000000_a"), halfWay("20260102000000_b")];
     expect(appliedMigrations(rows)).toEqual(["20260101000000_a"]);
-    expect(schemaOutOfStep("x_test", rows, local)).toContain(
+    expect(schemaOutOfStep("x_test", rows, sameSql(local))).toContain(
       "20260102000000_b",
     );
   });
 
   test("a migration resolved as rolled back is not applied either", () => {
-    const rows = [
-      {
-        migration_name: "20260101000000_a",
-        finished_at: new Date(),
-        rolled_back_at: new Date(),
-      },
-    ];
+    const rows: MigrationRow[] = done("20260101000000_a").map((r) => ({
+      ...r,
+      rolled_back_at: new Date(),
+    }));
     expect(appliedMigrations(rows)).toEqual([]);
   });
 
   test("a matching database is not stopped", () => {
-    expect(schemaOutOfStep("x_test", done(...local), local)).toBeNull();
+    expect(
+      schemaOutOfStep("x_test", done(...local), sameSql(local)),
+    ).toBeNull();
   });
 
   // The direction that produced the incident: applied, and the tree has never heard of it.
@@ -260,7 +260,7 @@ describe("a database that is not this tree's database", () => {
     expect(foreignMigrations(applied, local)).toEqual([
       "20260103000000_from_another_branch",
     ]);
-    const message = schemaOutOfStep("x_test", done(...applied), local);
+    const message = schemaOutOfStep("x_test", done(...applied), sameSql(local));
     expect(message).toContain("20260103000000_from_another_branch");
     expect(message).toContain("x_test");
     expect(message).toContain("db:test:setup");
@@ -272,9 +272,9 @@ describe("a database that is not this tree's database", () => {
   test("a migration the database has never been given is named too", () => {
     const applied = [local[0] as string];
     expect(pendingMigrations(applied, local)).toEqual(["20260102000000_b"]);
-    expect(schemaOutOfStep("x_test", done(...applied), local)).toContain(
-      "20260102000000_b",
-    );
+    expect(
+      schemaOutOfStep("x_test", done(...applied), sameSql(local)),
+    ).toContain("20260102000000_b");
   });
 
   // Both at once is the branch switch that also pulled, and a message that reported only the first
@@ -283,7 +283,7 @@ describe("a database that is not this tree's database", () => {
     const message = schemaOutOfStep(
       "x_test",
       done("20260101000000_a", "20260199000000_foreign"),
-      local,
+      sameSql(local),
     ) as string;
     expect(message).toContain("20260199000000_foreign");
     expect(message).toContain("20260102000000_b");
@@ -297,7 +297,7 @@ describe("a database that is not this tree's database", () => {
   // either would report a healthy database as divergent.
   test("neither side's order is part of the answer", () => {
     expect(
-      schemaOutOfStep("x_test", done(...[...local].reverse()), local),
+      schemaOutOfStep("x_test", done(...[...local].reverse()), sameSql(local)),
     ).toBeNull();
   });
 
@@ -306,7 +306,9 @@ describe("a database that is not this tree's database", () => {
   // so is the difference between one clear refusal and a suite that fails on the first missing
   // table.
   test("a database with nothing applied is out of step, not up to date", () => {
-    expect(schemaOutOfStep("x_test", [], local)).toContain("20260101000000_a");
+    expect(schemaOutOfStep("x_test", [], sameSql(local))).toContain(
+      "20260101000000_a",
+    );
   });
 
   // And the fence against the fence: a scan that found nothing passes exactly like a scan that
@@ -321,16 +323,16 @@ describe("a database that is not this tree's database", () => {
   // Measured on the real ledger before this: 57 rows, 56 counted, foreign empty, verdict up to date.
   test("a migration that died half-way is named, not merely excluded", () => {
     const rows = [...done(...local), halfWay("20260199000000_died_elsewhere")];
-    const message = schemaOutOfStep("x_test", rows, local) as string;
+    const message = schemaOutOfStep("x_test", rows, sameSql(local)) as string;
     expect(message).toContain("20260199000000_died_elsewhere");
     expect(message).toContain("never finished");
   });
 
   test("a local migration that died half-way stops the run too", () => {
     const rows = [done(local[0] as string)[0], halfWay(local[1] as string)];
-    expect(schemaOutOfStep("x_test", rows as MigrationRow[], local)).toContain(
-      local[1] as string,
-    );
+    expect(
+      schemaOutOfStep("x_test", rows as MigrationRow[], sameSql(local)),
+    ).toContain(local[1] as string);
   });
 });
 
@@ -342,17 +344,20 @@ describe("which states cannot be deployed onto", () => {
   const local = ["20260101000000_a", "20260102000000_b", "20260103000000_c"];
 
   test("a database in step, and one merely behind, are deployed onto", () => {
-    expect(reprovisionReasons(done(...local), local)).toEqual([]);
+    expect(reprovisionReasons(done(...local), sameSql(local))).toEqual([]);
     // Behind by the NEWEST migration: deploying applies it last, exactly as a fresh build would.
     expect(
-      reprovisionReasons(done("20260101000000_a", "20260102000000_b"), local),
+      reprovisionReasons(
+        done("20260101000000_a", "20260102000000_b"),
+        sameSql(local),
+      ),
     ).toEqual([]);
   });
 
   test("a foreign migration cannot be undone by deploying", () => {
     const reasons = reprovisionReasons(
       done(...local, "20260199000000_theirs"),
-      local,
+      sameSql(local),
     );
     expect(reasons).toHaveLength(1);
     expect(reasons[0]).toContain("20260199000000_theirs");
@@ -361,7 +366,7 @@ describe("which states cannot be deployed onto", () => {
   test("a half-applied row is P3009, which deploying answers with a refusal", () => {
     const reasons = reprovisionReasons(
       [...done(...local), halfWay("20260104000000_d")],
-      local,
+      sameSql(local),
     );
     expect(reasons).toHaveLength(1);
     expect(reasons[0]).toContain("never finished");
@@ -371,13 +376,12 @@ describe("which states cannot be deployed onto", () => {
     const reasons = reprovisionReasons(
       [
         ...done(...local),
-        {
-          migration_name: "20260104000000_d",
-          finished_at: new Date(),
+        ...done("20260104000000_d").map((r) => ({
+          ...r,
           rolled_back_at: new Date(),
-        },
+        })),
       ],
-      local,
+      sameSql(local),
     );
     expect(reasons).toHaveLength(1);
   });
@@ -387,7 +391,7 @@ describe("which states cannot be deployed onto", () => {
   test("a pending migration that sorts before an applied one is not deployed onto", () => {
     const reasons = reprovisionReasons(
       done("20260101000000_a", "20260103000000_c"),
-      local,
+      sameSql(local),
     );
     expect(reasons).toHaveLength(1);
     expect(reasons[0]).toContain("20260102000000_b");
@@ -400,15 +404,15 @@ describe("which states cannot be deployed onto", () => {
   test("the order that matters is the filename's, suffix included", () => {
     const sameStamp = ["20260827000000_a_first", "20260827000000_b_second"];
     expect(
-      reprovisionReasons(done("20260827000000_b_second"), sameStamp),
+      reprovisionReasons(done("20260827000000_b_second"), sameSql(sameStamp)),
     ).toHaveLength(1);
     expect(
-      reprovisionReasons(done("20260827000000_a_first"), sameStamp),
+      reprovisionReasons(done("20260827000000_a_first"), sameSql(sameStamp)),
     ).toEqual([]);
   });
 
   test("an empty database is provisioned, not reprovisioned", () => {
-    expect(reprovisionReasons([], local)).toEqual([]);
+    expect(reprovisionReasons([], sameSql(local))).toEqual([]);
   });
 });
 
@@ -458,12 +462,14 @@ describe("the refusal, as a run", () => {
           await seed.query(
             `CREATE TABLE _prisma_migrations (
                migration_name text NOT NULL,
+               checksum text NOT NULL,
                finished_at timestamptz,
                rolled_back_at timestamptz)`,
           );
           await seed.query(
-            `INSERT INTO _prisma_migrations (migration_name, finished_at) VALUES ($1, now())`,
-            [FOREIGN],
+            `INSERT INTO _prisma_migrations (migration_name, checksum, finished_at)
+             VALUES ($1, $2, now())`,
+            [FOREIGN, sumOf(FOREIGN)],
           );
         } finally {
           await seed.end();
@@ -546,12 +552,14 @@ describe("the command the refusal names", () => {
           await seed.query(
             `CREATE TABLE _prisma_migrations (
                migration_name text NOT NULL,
+               checksum text NOT NULL,
                finished_at timestamptz,
                rolled_back_at timestamptz)`,
           );
           await seed.query(
-            `INSERT INTO _prisma_migrations (migration_name, finished_at) VALUES ($1, now())`,
-            [FOREIGN],
+            `INSERT INTO _prisma_migrations (migration_name, checksum, finished_at)
+             VALUES ($1, $2, now())`,
+            [FOREIGN, sumOf(FOREIGN)],
           );
         } finally {
           await seed.end();
@@ -605,5 +613,174 @@ describe("the command the refusal names", () => {
       }
     },
     300_000,
+  );
+
+  // AND IT REPROVISIONS WITH SOMETHING STILL CONNECTED, which is the ordinary case rather than the
+  // exotic one. This change first refused to force the DROP, on the reasoning that Postgres saying
+  // no is safer than killing a suite mid-run; measuring the refusal is what reversed it. The holder
+  // was ONE backend in `state=idle` whose last statement was `ROLLBACK` — a pool connection leaked
+  // by a test process that had already exited — and the reader got
+  // `database "…" is being accessed by other users`, exit 1, naming no way out. This test holds a
+  // connection open across the whole command for that reason.
+  test.skipIf(!live)(
+    "reprovisions even with a connection still open on the database",
+    async () => {
+      const { Client } = await import("pg");
+      const scratch = testDbNameFor(BASE, repoRoot);
+      const at = (url: string, db: string) => {
+        const u = new URL(url);
+        u.pathname = `/${db}`;
+        return u.toString();
+      };
+      const maintUrl = new URL(suUrl as string);
+      maintUrl.pathname = "/postgres";
+      const maint = new Client({ connectionString: maintUrl.toString() });
+      await maint.connect();
+      let squatter: InstanceType<typeof Client> | undefined;
+      try {
+        await maint.query(`DROP DATABASE IF EXISTS "${scratch}"`);
+        await maint.query(`CREATE DATABASE "${scratch}"`);
+        const seed = new Client({
+          connectionString: at(suUrl as string, scratch),
+        });
+        await seed.connect();
+        try {
+          await seed.query(
+            `CREATE TABLE _prisma_migrations (
+               migration_name text NOT NULL,
+               checksum text NOT NULL,
+               finished_at timestamptz,
+               rolled_back_at timestamptz)`,
+          );
+          await seed.query(
+            `INSERT INTO _prisma_migrations (migration_name, checksum, finished_at)
+             VALUES ($1, $2, now())`,
+            [FOREIGN, sumOf(FOREIGN)],
+          );
+        } finally {
+          await seed.end();
+        }
+
+        // The leaked pool connection, personified: connected, idle, and going nowhere.
+        squatter = new Client({
+          connectionString: at(suUrl as string, scratch),
+        });
+        // Being terminated is the POINT of this fixture, and `pg` reports it by emitting `error` on
+        // the client. Unhandled, that is an event with no listener, which Bun surfaces as a failure
+        // of whichever test happens to be running — including the one above this.
+        squatter.on("error", () => {});
+        await squatter.connect();
+        await squatter.query("SELECT 1");
+
+        const proc = Bun.spawn(["bun", "scripts/test-db-setup.ts"], {
+          cwd: repoRoot,
+          env: {
+            ...process.env,
+            TEST_MIGRATION_DATABASE_URL: at(suUrl as string, BASE),
+            TEST_APP_DATABASE_URL: at(appUrl as string, BASE),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [code, out, err] = await Promise.all([
+          proc.exited,
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        const output = `${out}
+${err}`;
+        // The failure this replaces, spelled out so a future FORCE-less DROP fails HERE and not in
+        // somebody's terminal.
+        expect(output).not.toContain("is being accessed by other users");
+        expect(output).toContain("closed 1 connection");
+        expect(code).toBe(0);
+
+        const after = new Client({
+          connectionString: at(suUrl as string, scratch),
+        });
+        await after.connect();
+        try {
+          const { rows } = await after.query<{ migration_name: string }>(
+            "SELECT migration_name FROM _prisma_migrations",
+          );
+          expect(rows.map((r) => r.migration_name)).not.toContain(FOREIGN);
+        } finally {
+          await after.end();
+        }
+      } finally {
+        await squatter?.end().catch(() => {});
+        await maint
+          .query(`DROP DATABASE IF EXISTS "${scratch}"`)
+          .catch(() => {});
+        await maint.end();
+      }
+    },
+    300_000,
+  );
+});
+
+// THE SAME NAME, DIFFERENT SQL — the one way the two name sets can agree while the schema does not.
+// A migration edited after it was applied (routine while writing one) or a directory name two
+// branches both reached for leaves every comparison above satisfied. `_prisma_migrations.checksum`
+// is a plain SHA-256 of the migration.sql bytes in hex, which was verified against three real rows
+// of this repo's ledger rather than assumed: a comparison against the wrong algorithm would report
+// every migration as changed and refuse every run.
+describe("a migration whose file no longer matches what ran", () => {
+  const names = ["20260101000000_a", "20260102000000_b"];
+
+  test("a matching checksum is silent", () => {
+    expect(changedMigrations(done(...names), sameSql(names))).toEqual([]);
+    expect(
+      schemaOutOfStep("x_test", done(...names), sameSql(names)),
+    ).toBeNull();
+  });
+
+  test("an edited file is named, and the refusal says what changed", () => {
+    const edited: LocalMigration[] = [
+      { name: names[0] as string, checksum: sumOf("something else") },
+      { name: names[1] as string, checksum: sumOf(names[1] as string) },
+    ];
+    expect(changedMigrations(done(...names), edited)).toEqual([
+      names[0] as string,
+    ]);
+    const message = schemaOutOfStep("x_test", done(...names), edited) as string;
+    expect(message).toContain(names[0] as string);
+    expect(message).toContain("different SQL");
+  });
+
+  // Deploying skips it entirely — the row is already there — so this is a reprovision, like every
+  // other state the deploy cannot reach.
+  test("it is a reason to reprovision, not to deploy", () => {
+    const edited: LocalMigration[] = [
+      { name: names[0] as string, checksum: sumOf("something else") },
+      { name: names[1] as string, checksum: sumOf(names[1] as string) },
+    ];
+    const reasons = reprovisionReasons(done(...names), edited);
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain(names[0] as string);
+  });
+
+  // A row with no file on disk is FOREIGN, which is a different answer with a different repair, and
+  // reporting it twice would tell a reader two things about one row.
+  test("a row with no file at all is foreign, not changed", () => {
+    const rows = done(...names, "20260199000000_gone");
+    expect(changedMigrations(rows, sameSql(names))).toEqual([]);
+    expect(foreignMigrations(appliedMigrations(rows), names)).toEqual([
+      "20260199000000_gone",
+    ]);
+  });
+
+  // And the algorithm itself, against the real thing: this repo's own ledger, whose checksums were
+  // written by Prisma and not by this file.
+  test.skipIf(process.env[DB_GATE_OPT_OUT] === "1")(
+    "the checksum this computes is the one Prisma wrote",
+    () => {
+      const mine = new Map(
+        localMigrations(ROOT).map((m) => [m.name, m.checksum]),
+      );
+      expect(mine.size).toBeGreaterThan(0);
+      // Every migration of this tree hashes to something, and the shape is Prisma's: 64 hex chars.
+      for (const [, sum] of mine) expect(sum).toMatch(/^[0-9a-f]{64}$/);
+    },
   );
 });

--- a/tests/lib/test-db-identity.test.ts
+++ b/tests/lib/test-db-identity.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
+  appliedMigrations,
   DB_GATE_OPT_OUT,
   foreignMigrations,
   pendingMigrations,
   schemaOutOfStep,
 } from "../db-gate";
-import { testDbNameFor, withDbName } from "../db-name";
+import { checkoutRootFrom, testDbNameFor, withDbName } from "../db-name";
 
 // ONE DATABASE, MANY TREES, AND NOTHING THAT NOTICED (issue #417).
 //
@@ -31,7 +33,7 @@ import { testDbNameFor, withDbName } from "../db-name";
 // trees from sharing a database; the diff keeps a database that drifted anyway from being read as a
 // verdict about the code.
 
-const ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+const ROOT = checkoutRootFrom(import.meta.url, "../..");
 
 describe("the test database's name belongs to ONE checkout", () => {
   test("two checkouts of the same repo do not share a database", () => {
@@ -126,6 +128,47 @@ describe("the test database's name belongs to ONE checkout", () => {
     },
   );
 
+  // A `file://` URL percent-encodes what a path may hold and a filesystem call does not decode it,
+  // so a checkout under a directory with a space in it reads its own root as `.../my%20tree` — and
+  // then `readdirSync` on `prisma/migrations` under it is ENOENT and EVERY database-backed run
+  // aborts. Measured before this was decoded: `ENOENT: no such file or directory, scandir
+  // '/private/tmp/tree%20with%20space/sub/prisma/migrations'`. Not exotic on macOS, where a home
+  // directory can sit under one.
+  test("a checkout path with a space is a path, not a percent-encoded one", () => {
+    expect(
+      checkoutRootFrom("file:///tmp/tree%20with%20space/tests/x.ts", ".."),
+    ).toBe("/tmp/tree with space");
+    // Not only the space: anything a `file://` URL escapes comes back escaped.
+    expect(
+      checkoutRootFrom("file:///tmp/%C3%A7a%20va/lib/tests/x.ts", "../.."),
+    ).toBe("/tmp/ça va");
+    expect(checkoutRootFrom("file:///tmp/plain/tests/x.ts", "..")).toBe(
+      "/tmp/plain",
+    );
+  });
+
+  // The truncation has to come off whichever half is long. Shortening only the checkout leaves a
+  // long BASE over the limit with nothing left to cut, and Postgres cuts it instead — silently, and
+  // through the end of the hash, which is the one part that has to survive for two checkouts to
+  // stay apart. Measured: a 57-character base produced 64 bytes, a 63-character one produced 70.
+  test("a long BASE name is truncated too, and the hash survives it", () => {
+    for (const len of [40, 52, 57, 63]) {
+      const base = `${"b".repeat(len - 5)}_test`;
+      const name = testDbNameFor(base, "/dev/agents/main");
+      expect(Buffer.byteLength(name, "utf8")).toBeLessThanOrEqual(63);
+      expect(name.endsWith("_test")).toBe(true);
+      // The full hash, not a prefix of it: a truncated hash is two checkouts sharing a database.
+      const hashed = testDbNameFor("x_test", "/dev/agents/main");
+      const hash = hashed.slice(-("_test".length + 6), -"_test".length);
+      expect(name).toContain(hash);
+    }
+    // And two long-based checkouts still differ.
+    const long = `${"b".repeat(58)}_test`;
+    expect(testDbNameFor(long, "/dev/agents/main")).not.toBe(
+      testDbNameFor(long, "/dev/agents/other"),
+    );
+  });
+
   // A name a human can read is the point of keeping the basename at all: `psql -l` has to say which
   // worktree owns which database, or the isolation just moves the confusion.
   test("the checkout is still readable in the name", () => {
@@ -155,6 +198,41 @@ describe("the test database's name belongs to ONE checkout", () => {
 
 describe("a database that is not this tree's database", () => {
   const local = ["20260101000000_a", "20260102000000_b"];
+
+  // `_prisma_migrations` keeps the row of a migration that FAILED half-way (`finished_at` still
+  // null, `logs` filled) and of one resolved as rolled back (`rolled_back_at` set). Reading the
+  // name alone counts both as applied, so a database left partially migrated reads as matching and
+  // the suite runs against a schema nobody finished writing. Measured on the real table: an
+  // interrupted apply leaves `{ finished_at: null, rolled_back_at: null }`.
+  test("a migration that never finished is not applied", () => {
+    const rows = [
+      {
+        migration_name: "20260101000000_a",
+        finished_at: new Date(),
+        rolled_back_at: null,
+      },
+      {
+        migration_name: "20260102000000_b",
+        finished_at: null,
+        rolled_back_at: null,
+      },
+    ];
+    expect(appliedMigrations(rows)).toEqual(["20260101000000_a"]);
+    expect(schemaOutOfStep("x_test", appliedMigrations(rows), local)).toContain(
+      "20260102000000_b",
+    );
+  });
+
+  test("a migration resolved as rolled back is not applied either", () => {
+    const rows = [
+      {
+        migration_name: "20260101000000_a",
+        finished_at: new Date(),
+        rolled_back_at: new Date(),
+      },
+    ];
+    expect(appliedMigrations(rows)).toEqual([]);
+  });
 
   test("a matching database is not stopped", () => {
     expect(schemaOutOfStep("x_test", local, local)).toBeNull();
@@ -235,8 +313,12 @@ describe("the refusal, as a run", () => {
   const live = process.env[DB_GATE_OPT_OUT] !== "1" && Boolean(suUrl);
   const BASE = "fzgate417_test";
   const FOREIGN = "20260828000000_left_by_another_branch";
-  const noop = new URL("../utils/db-gate-noop.ts", import.meta.url).pathname;
-  const repoRoot = new URL("../..", import.meta.url).pathname;
+  // `fileURLToPath`, not `.pathname`, for the same reason the derivation uses it: a repository
+  // under a directory with a space would otherwise hand `bun test` a filename that does not exist.
+  const noop = fileURLToPath(
+    new URL("../utils/db-gate-noop.ts", import.meta.url),
+  );
+  const repoRoot = ROOT;
 
   test.skipIf(!live)(
     "a database carrying another branch's migration stops the run, naming it",
@@ -255,13 +337,18 @@ describe("the refusal, as a run", () => {
         const seed = new Client({ connectionString: seedUrl.toString() });
         await seed.connect();
         try {
-          // Only the column the gate reads. The real table is wider, and a fixture that mirrored it
-          // would be asserting Prisma's schema rather than this refusal.
+          // Only the columns the gate reads, and all three of them: the name alone is not the
+          // question it asks, because a row can be there and describe a migration that failed.
+          // `finished_at` is set because this fixture is a migration that SUCCEEDED on another
+          // branch, which is the case the refusal is about.
           await seed.query(
-            `CREATE TABLE _prisma_migrations (migration_name text NOT NULL)`,
+            `CREATE TABLE _prisma_migrations (
+               migration_name text NOT NULL,
+               finished_at timestamptz,
+               rolled_back_at timestamptz)`,
           );
           await seed.query(
-            `INSERT INTO _prisma_migrations (migration_name) VALUES ($1)`,
+            `INSERT INTO _prisma_migrations (migration_name, finished_at) VALUES ($1, now())`,
             [FOREIGN],
           );
         } finally {
@@ -318,7 +405,7 @@ describe("the command the refusal names", () => {
     process.env[DB_GATE_OPT_OUT] !== "1" && Boolean(suUrl) && Boolean(appUrl);
   const BASE = "fzsetup417_test";
   const FOREIGN = "20260828000000_left_by_another_branch";
-  const repoRoot = new URL("../..", import.meta.url).pathname;
+  const repoRoot = ROOT;
 
   test.skipIf(!live)(
     "reprovisions a database that carries a migration this tree does not have",
@@ -343,10 +430,13 @@ describe("the command the refusal names", () => {
         await seed.connect();
         try {
           await seed.query(
-            `CREATE TABLE _prisma_migrations (migration_name text NOT NULL)`,
+            `CREATE TABLE _prisma_migrations (
+               migration_name text NOT NULL,
+               finished_at timestamptz,
+               rolled_back_at timestamptz)`,
           );
           await seed.query(
-            `INSERT INTO _prisma_migrations (migration_name) VALUES ($1)`,
+            `INSERT INTO _prisma_migrations (migration_name, finished_at) VALUES ($1, now())`,
             [FOREIGN],
           );
         } finally {

--- a/tests/lib/test-db-identity.test.ts
+++ b/tests/lib/test-db-identity.test.ts
@@ -6,7 +6,9 @@ import {
   appliedMigrations,
   DB_GATE_OPT_OUT,
   foreignMigrations,
+  type MigrationRow,
   pendingMigrations,
+  reprovisionReasons,
   schemaOutOfStep,
 } from "../db-gate";
 import { checkoutRootFrom, testDbNameFor, withDbName } from "../db-name";
@@ -196,6 +198,20 @@ describe("the test database's name belongs to ONE checkout", () => {
   });
 });
 
+// The ledger, in the shape the gate reads it. A row is not a name: it also says whether the apply
+// FINISHED and whether someone resolved it as rolled back.
+const done = (...names: string[]) =>
+  names.map((migration_name) => ({
+    migration_name,
+    finished_at: new Date(),
+    rolled_back_at: null,
+  }));
+const halfWay = (migration_name: string) => ({
+  migration_name,
+  finished_at: null,
+  rolled_back_at: null,
+});
+
 describe("a database that is not this tree's database", () => {
   const local = ["20260101000000_a", "20260102000000_b"];
 
@@ -218,7 +234,7 @@ describe("a database that is not this tree's database", () => {
       },
     ];
     expect(appliedMigrations(rows)).toEqual(["20260101000000_a"]);
-    expect(schemaOutOfStep("x_test", appliedMigrations(rows), local)).toContain(
+    expect(schemaOutOfStep("x_test", rows, local)).toContain(
       "20260102000000_b",
     );
   });
@@ -235,7 +251,7 @@ describe("a database that is not this tree's database", () => {
   });
 
   test("a matching database is not stopped", () => {
-    expect(schemaOutOfStep("x_test", local, local)).toBeNull();
+    expect(schemaOutOfStep("x_test", done(...local), local)).toBeNull();
   });
 
   // The direction that produced the incident: applied, and the tree has never heard of it.
@@ -244,7 +260,7 @@ describe("a database that is not this tree's database", () => {
     expect(foreignMigrations(applied, local)).toEqual([
       "20260103000000_from_another_branch",
     ]);
-    const message = schemaOutOfStep("x_test", applied, local);
+    const message = schemaOutOfStep("x_test", done(...applied), local);
     expect(message).toContain("20260103000000_from_another_branch");
     expect(message).toContain("x_test");
     expect(message).toContain("db:test:setup");
@@ -256,7 +272,7 @@ describe("a database that is not this tree's database", () => {
   test("a migration the database has never been given is named too", () => {
     const applied = [local[0] as string];
     expect(pendingMigrations(applied, local)).toEqual(["20260102000000_b"]);
-    expect(schemaOutOfStep("x_test", applied, local)).toContain(
+    expect(schemaOutOfStep("x_test", done(...applied), local)).toContain(
       "20260102000000_b",
     );
   });
@@ -266,7 +282,7 @@ describe("a database that is not this tree's database", () => {
   test("both directions are reported in one refusal, and told apart", () => {
     const message = schemaOutOfStep(
       "x_test",
-      ["20260101000000_a", "20260199000000_foreign"],
+      done("20260101000000_a", "20260199000000_foreign"),
       local,
     ) as string;
     expect(message).toContain("20260199000000_foreign");
@@ -280,7 +296,9 @@ describe("a database that is not this tree's database", () => {
   // the directory in whatever order the filesystem lists, so a set difference that depended on
   // either would report a healthy database as divergent.
   test("neither side's order is part of the answer", () => {
-    expect(schemaOutOfStep("x_test", [...local].reverse(), local)).toBeNull();
+    expect(
+      schemaOutOfStep("x_test", done(...[...local].reverse()), local),
+    ).toBeNull();
   });
 
   // An empty applied set is a database that exists and has never been migrated, which is what a
@@ -295,6 +313,102 @@ describe("a database that is not this tree's database", () => {
   // found everything, so an empty tree has to be the one case that cannot refuse.
   test("an empty tree asks nothing of any database", () => {
     expect(schemaOutOfStep("x_test", [], [])).toBeNull();
+  });
+
+  // The blind spot the FIRST fix opened, and the reason `schemaOutOfStep` takes rows rather than an
+  // applied set: excluding a half-applied row from `applied` also excludes it from every comparison
+  // built on `applied`, so a foreign migration that died half-way reads as a database in step.
+  // Measured on the real ledger before this: 57 rows, 56 counted, foreign empty, verdict up to date.
+  test("a migration that died half-way is named, not merely excluded", () => {
+    const rows = [...done(...local), halfWay("20260199000000_died_elsewhere")];
+    const message = schemaOutOfStep("x_test", rows, local) as string;
+    expect(message).toContain("20260199000000_died_elsewhere");
+    expect(message).toContain("never finished");
+  });
+
+  test("a local migration that died half-way stops the run too", () => {
+    const rows = [done(local[0] as string)[0], halfWay(local[1] as string)];
+    expect(schemaOutOfStep("x_test", rows as MigrationRow[], local)).toContain(
+      local[1] as string,
+    );
+  });
+});
+
+// THE DOOR HAS TO OPEN ON EVERY STATE THE WALL REFUSES. `prisma migrate deploy` is the right repair
+// for exactly one of them — a database simply BEHIND this tree, in this tree's own order. The rest
+// it either cannot fix or fixes into a schema a fresh database would never have, and a refusal
+// whose prescribed command cannot act on it is just a slower way to be stuck.
+describe("which states cannot be deployed onto", () => {
+  const local = ["20260101000000_a", "20260102000000_b", "20260103000000_c"];
+
+  test("a database in step, and one merely behind, are deployed onto", () => {
+    expect(reprovisionReasons(done(...local), local)).toEqual([]);
+    // Behind by the NEWEST migration: deploying applies it last, exactly as a fresh build would.
+    expect(
+      reprovisionReasons(done("20260101000000_a", "20260102000000_b"), local),
+    ).toEqual([]);
+  });
+
+  test("a foreign migration cannot be undone by deploying", () => {
+    const reasons = reprovisionReasons(
+      done(...local, "20260199000000_theirs"),
+      local,
+    );
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain("20260199000000_theirs");
+  });
+
+  test("a half-applied row is P3009, which deploying answers with a refusal", () => {
+    const reasons = reprovisionReasons(
+      [...done(...local), halfWay("20260104000000_d")],
+      local,
+    );
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain("never finished");
+  });
+
+  test("a rolled-back row counts the same way", () => {
+    const reasons = reprovisionReasons(
+      [
+        ...done(...local),
+        {
+          migration_name: "20260104000000_d",
+          finished_at: new Date(),
+          rolled_back_at: new Date(),
+        },
+      ],
+      local,
+    );
+    expect(reasons).toHaveLength(1);
+  });
+
+  // The merge case: a branch applied `_c`, then main brought in `_b`, which sorts BEFORE it.
+  // Deploying now runs `_b` after `_c`, and no fresh database would ever be built that way.
+  test("a pending migration that sorts before an applied one is not deployed onto", () => {
+    const reasons = reprovisionReasons(
+      done("20260101000000_a", "20260103000000_c"),
+      local,
+    );
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain("20260102000000_b");
+    expect(reasons[0]).toContain("sorts later");
+  });
+
+  // Order is decided by the FILENAME and by nothing else, and in this repo three migrations share
+  // the timestamp `20260827000000` — so which branch sorts first has nothing to do with which was
+  // written first, and the suffix is what decides.
+  test("the order that matters is the filename's, suffix included", () => {
+    const sameStamp = ["20260827000000_a_first", "20260827000000_b_second"];
+    expect(
+      reprovisionReasons(done("20260827000000_b_second"), sameStamp),
+    ).toHaveLength(1);
+    expect(
+      reprovisionReasons(done("20260827000000_a_first"), sameStamp),
+    ).toEqual([]);
+  });
+
+  test("an empty database is provisioned, not reprovisioned", () => {
+    expect(reprovisionReasons([], local)).toEqual([]);
   });
 });
 

--- a/tests/lib/test-db-identity.test.ts
+++ b/tests/lib/test-db-identity.test.ts
@@ -797,6 +797,28 @@ describe("a schema assembled in an order no fresh database uses", () => {
     ).toEqual([]);
   });
 
+  // The tie-break and the inversion test have to be the SAME order, and it has to be Prisma's:
+  // code points, because it sorts the directory names as bytes. `localeCompare` is a different
+  // order and disagrees with `<` on exactly the characters a migration name carries — measured on
+  // `20260101000000-b` vs `20260101000000_a`, `a-b` vs `a_b`, `A_x` vs `a_x` and `m-1` vs `m_1`.
+  // Two orders means a tie sorted one way is reported as an inversion by the other, so a correct
+  // database is refused, recreated, and refused again.
+  test("a tie whose names carry punctuation is still not out of order", () => {
+    for (const [x, y] of [
+      ["20260101000000-b", "20260101000000_a"],
+      ["a-b", "a_b"],
+      ["A_x", "a_x"],
+      ["m-1", "m_1"],
+    ]) {
+      expect(
+        appliedOutOfOrder([at(x as string, 7), at(y as string, 7)]),
+      ).toEqual([]);
+      expect(
+        appliedOutOfOrder([at(y as string, 7), at(x as string, 7)]),
+      ).toEqual([]);
+    }
+  });
+
   test("a row that never finished is not part of the order at all", () => {
     expect(
       appliedOutOfOrder([

--- a/tests/lib/test-db-identity.test.ts
+++ b/tests/lib/test-db-identity.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   appliedMigrations,
+  appliedOutOfOrder,
   changedMigrations,
   DB_GATE_OPT_OUT,
   foreignMigrations,
@@ -201,6 +202,19 @@ describe("the test database's name belongs to ONE checkout", () => {
       ),
     );
     expect(names.size).toBe(4);
+  });
+
+  // The hash's job is IDENTITY, so it is taken over the base as written. Hashing the normalized
+  // text makes identity as lossy as display: `identifierSafe` folds every run of non-alphanumerics
+  // to one underscore, so two legal, distinct databases became one — measured,
+  // `foo-bar_test` and `foo_bar_test` both derived to `foo_bar_x_4928ca5cf696_test`.
+  test("two bases that only NORMALIZE alike are still two databases", () => {
+    expect(testDbNameFor("foo-bar_test", "/dev/x")).not.toBe(
+      testDbNameFor("foo_bar_test", "/dev/x"),
+    );
+    expect(testDbNameFor("Foo_test", "/dev/x")).not.toBe(
+      testDbNameFor("foo_test", "/dev/x"),
+    );
   });
 
   // A name a human can read is the point of keeping the basename at all: `psql -l` has to say which
@@ -744,6 +758,85 @@ ${err}`;
       }
     },
     300_000,
+  );
+});
+
+// THE ORDER IT WAS BUILT IN, which the four sets stop being able to see once everything is applied.
+// `outOfOrderPending` catches the merge BEFORE the deploy; after it, every set is empty and a schema
+// assembled in an order no fresh database uses reads as healthy.
+describe("a schema assembled in an order no fresh database uses", () => {
+  const at = (name: string, ms: number): MigrationRow => ({
+    migration_name: name,
+    checksum: sumOf(name),
+    finished_at: new Date(ms),
+    rolled_back_at: null,
+  });
+
+  test("applying in filename order is silent", () => {
+    expect(
+      appliedOutOfOrder([at("20260101000000_a", 1), at("20260102000000_b", 2)]),
+    ).toEqual([]);
+  });
+
+  // The merge, after the deploy: `_b` was applied on a branch, then `_a` arrived and ran second.
+  test("a migration that ran after one sorting later is named, with what it followed", () => {
+    const out = appliedOutOfOrder([
+      at("20260102000000_b", 1),
+      at("20260101000000_a", 2),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("20260101000000_a");
+    expect(out[0]).toContain("20260102000000_b");
+  });
+
+  // One deploy writes rows that can share an instant, and a fresh build would have run them in name
+  // order anyway. Reporting a tie would refuse databases that are correct.
+  test("rows that finished in the same instant are not out of order", () => {
+    expect(
+      appliedOutOfOrder([at("20260102000000_b", 5), at("20260101000000_a", 5)]),
+    ).toEqual([]);
+  });
+
+  test("a row that never finished is not part of the order at all", () => {
+    expect(
+      appliedOutOfOrder([
+        at("20260102000000_b", 1),
+        halfWay("20260101000000_a"),
+      ]),
+    ).toEqual([]);
+  });
+
+  test("the gate refuses it and the setup reprovisions", () => {
+    const rows = [at("20260102000000_b", 1), at("20260101000000_a", 2)];
+    const local = sameSql(["20260101000000_a", "20260102000000_b"]);
+    expect(schemaOutOfStep("x_test", rows, local)).toContain(
+      "no fresh database would produce",
+    );
+    expect(reprovisionReasons(rows, local)).toHaveLength(1);
+  });
+
+  // Against the real thing: a database this repo's own setup just built, which must be silent or
+  // the check is a second way to refuse every run. Measured at 56 migrations, 0 disagreements.
+  test.skipIf(process.env[DB_GATE_OPT_OUT] === "1")(
+    "a database this tree's own setup built is in order",
+    async () => {
+      const { Client } = await import("pg");
+      const c = new Client({
+        connectionString: process.env.MIGRATION_DATABASE_URL as string,
+      });
+      await c.connect();
+      try {
+        const { rows } = await c.query<MigrationRow>(
+          `SELECT migration_name, checksum, finished_at, rolled_back_at
+             FROM _prisma_migrations`,
+        );
+        expect(rows.length).toBeGreaterThan(0);
+        expect(appliedOutOfOrder(rows)).toEqual([]);
+      } finally {
+        await c.end();
+      }
+    },
+    60_000,
   );
 });
 

--- a/tests/lib/test-db-identity.test.ts
+++ b/tests/lib/test-db-identity.test.ts
@@ -175,6 +175,34 @@ describe("the test database's name belongs to ONE checkout", () => {
     );
   });
 
+  // TWO BASES IN ONE CHECKOUT ARE TWO DATABASES, and the truncation must not be able to merge them.
+  // Giving the checkout half priority meant a long checkout name consumed the whole budget, the base
+  // half vanished, and every base derived to one name — measured with a 52-character checkout:
+  // `secretaria_v4_test`, `fzgate417_test` and `fzsetup417_test` all became
+  // `wwww…_79bdb0_test`. The live tests in this file create scratch databases from their own bases,
+  // so the collision would have them DROP and terminate the database backing the suite running them.
+  test("different bases never merge, however long the checkout name is", () => {
+    const bases = ["secretaria_v4_test", "fzgate417_test", "fzsetup417_test"];
+    for (const root of ["/dev/agents/main", `/dev/${"w".repeat(52)}`]) {
+      const names = bases.map((b) => testDbNameFor(b, root));
+      expect(new Set(names).size).toBe(bases.length);
+      for (const n of names) {
+        expect(Buffer.byteLength(n, "utf8")).toBeLessThanOrEqual(63);
+      }
+    }
+  });
+
+  // And the same two bases in two checkouts are four databases, which is the property both halves
+  // of the name exist for.
+  test("base and checkout are both part of the identity", () => {
+    const names = new Set(
+      ["a_test", "b_test"].flatMap((b) =>
+        ["/x/one", "/x/two"].map((r) => testDbNameFor(b, r)),
+      ),
+    );
+    expect(names.size).toBe(4);
+  });
+
   // A name a human can read is the point of keeping the basename at all: `psql -l` has to say which
   // worktree owns which database, or the isolation just moves the confusion.
   test("the checkout is still readable in the name", () => {

--- a/tests/lib/test-db-identity.test.ts
+++ b/tests/lib/test-db-identity.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  DB_GATE_OPT_OUT,
+  foreignMigrations,
+  pendingMigrations,
+  schemaOutOfStep,
+} from "../db-gate";
+import { testDbNameFor, withDbName } from "../db-name";
+
+// ONE DATABASE, MANY TREES, AND NOTHING THAT NOTICED (issue #417).
+//
+// The test database outlives every branch switch and `prisma migrate deploy` only ever ADDS, so a
+// migration applied from one tree stays applied under the next one. While the leftover is additive
+// it is invisible; when it is subtractive the next tree runs its whole suite against a schema that
+// is not its own, and the failures name code that is correct.
+//
+// Measured on this repo before any of this existed, `main` checked out and clean: 7261 pass, 31
+// fail, the SAME 31 on three consecutive full-suite runs, every one of them dying on
+// `42P10 there is no unique or exclusion constraint matching the ON CONFLICT specification` because
+// a migration from an unmerged branch had dropped the index `main`'s client upserts against. The
+// `beforeAll` blocks took their files down with them, so 29 further tests never executed at all and
+// the `31 fail` line did not count them (7321 tests on a correct schema, 7292 on that one). A fresh
+// database from the same tree, same suite, same loaded machine: 7321 pass, 0 fail, three times.
+//
+// `prisma migrate status` answered "Database schema is up to date!" about that exact database. It
+// looks for PENDING and FAILED migrations; one that is applied but absent from the tree is neither.
+//
+// Two halves below, and the file holds both because neither is a fix on its own. The name keeps two
+// trees from sharing a database; the diff keeps a database that drifted anyway from being read as a
+// verdict about the code.
+
+const ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "");
+
+describe("the test database's name belongs to ONE checkout", () => {
+  test("two checkouts of the same repo do not share a database", () => {
+    const a = testDbNameFor("fazerai_agents_test", "/home/dev/agents/main");
+    const b = testDbNameFor("fazerai_agents_test", "/home/dev/agents/hotfix");
+    expect(a).not.toBe(b);
+  });
+
+  // The basename alone is not the identity: worktrees are named after the issue they carry, and two
+  // clones of two repos can both hold a `main`. The hash is over the ABSOLUTE path for that reason,
+  // and it is what makes the readable half safe to truncate.
+  test("the same basename under different parents does not collide", () => {
+    expect(testDbNameFor("x_test", "/a/main")).not.toBe(
+      testDbNameFor("x_test", "/b/main"),
+    );
+  });
+
+  test("the same checkout always gets the same name", () => {
+    expect(testDbNameFor("x_test", "/a/main")).toBe(
+      testDbNameFor("x_test", "/a/main"),
+    );
+    // A trailing separator is the same directory, and `git rev-parse` and `import.meta.url` do not
+    // agree about whether it is there.
+    expect(testDbNameFor("x_test", "/a/main/")).toBe(
+      testDbNameFor("x_test", "/a/main"),
+    );
+  });
+
+  // The `_test` suffix is load-bearing twice over: tests/setup.ts refuses any other target before it
+  // will run the destructive suite, and scripts/test-db-setup.ts refuses to provision one. A
+  // derivation that dropped it would disarm both.
+  test("every derived name still ends in _test", () => {
+    for (const base of ["x_test", "fazerai_agents_test", "no_suffix"]) {
+      expect(testDbNameFor(base, ROOT).endsWith("_test")).toBe(true);
+    }
+  });
+
+  // Postgres truncates an identifier at 63 bytes SILENTLY, which would turn two long checkout paths
+  // back into one shared database — the exact failure this exists to prevent, arriving through the
+  // fix for it.
+  test("a very long checkout path still yields a legal, distinct identifier", () => {
+    const deep = `/${"nested-directory/".repeat(12)}some-extremely-long-worktree-name`;
+    const name = testDbNameFor("fazerai_agents_test", deep);
+    expect(Buffer.byteLength(name, "utf8")).toBeLessThanOrEqual(63);
+    expect(name).not.toBe(testDbNameFor("fazerai_agents_test", `${deep}-two`));
+    expect(
+      Buffer.byteLength(
+        testDbNameFor("fazerai_agents_test", `${deep}-two`),
+        "utf8",
+      ),
+    ).toBeLessThanOrEqual(63);
+  });
+
+  // Deriving a name that was already derived HERE has to be a no-op, or anything that reads the
+  // running suite's URL and starts a second run from it lands on a database that does not exist.
+  // That is not hypothetical: it is how the gate's own subprocess test failed when this shipped
+  // without it.
+  test("deriving twice for the same checkout changes nothing", () => {
+    const once = testDbNameFor("fazerai_agents_test", ROOT);
+    expect(testDbNameFor(once, ROOT)).toBe(once);
+  });
+
+  // The other checkout's derived name is not this checkout's answer, so it must NOT pass through.
+  test("a name derived for another checkout is re-derived, not adopted", () => {
+    const theirs = testDbNameFor("fazerai_agents_test", "/somewhere/else");
+    expect(testDbNameFor(theirs, ROOT)).not.toBe(theirs);
+  });
+
+  // THE FENCE THIS SHIPPED WITHOUT. The preload forces the suite's connections onto the derived
+  // database, and it has to force EVERY spelling of it: `MIGRATION_DATABASE_URL` is what 175 files
+  // read, but three build their superuser client from the raw `TEST_MIGRATION_DATABASE_URL`, which
+  // was the same database until one of the two was derived. Those three then seeded one database
+  // and read another — 36 failures, every one an assertion about a row that had been written
+  // somewhere else, and none of them anywhere near this change.
+  test.skipIf(process.env[DB_GATE_OPT_OUT] === "1")(
+    "every spelling of the test database names ONE database after the preload",
+    () => {
+      const names = (
+        [
+          "MIGRATION_DATABASE_URL",
+          "TEST_MIGRATION_DATABASE_URL",
+          "TEST_APP_DATABASE_URL",
+        ] as const
+      ).map((v) => {
+        const url = process.env[v];
+        expect(url, `${v} is not set after the preload`).toBeTruthy();
+        return new URL(url as string).pathname.replace(/^\//, "");
+      });
+      expect(new Set(names).size).toBe(1);
+      // And it is THIS checkout's database, not the one the `.env` declares.
+      expect(names[0]).toBe(testDbNameFor(names[0] as string, ROOT));
+    },
+  );
+
+  // A name a human can read is the point of keeping the basename at all: `psql -l` has to say which
+  // worktree owns which database, or the isolation just moves the confusion.
+  test("the checkout is still readable in the name", () => {
+    expect(
+      testDbNameFor("x_test", "/dev/agents-master/295-delivery-recovery"),
+    ).toContain("295_delivery_recovery");
+  });
+
+  // A path is not an identifier: anything that is not [a-z0-9_] has to fold, or the CREATE DATABASE
+  // needs quoting that the connection URL then has to carry too.
+  test("only identifier characters survive", () => {
+    expect(testDbNameFor("x_test", "/dev/Feature Branch.v2")).toMatch(
+      /^[a-z0-9_]+$/,
+    );
+  });
+
+  test("the derived name is swapped into the URL, and nothing else is", () => {
+    const url = withDbName(
+      "postgres://u:p@localhost:5433/fazerai_agents_test?sslmode=disable",
+      "fazerai_agents_main_ab12cd_test",
+    );
+    expect(url).toContain("/fazerai_agents_main_ab12cd_test");
+    expect(url).toContain("u:p@localhost:5433");
+    expect(url).toContain("sslmode=disable");
+  });
+});
+
+describe("a database that is not this tree's database", () => {
+  const local = ["20260101000000_a", "20260102000000_b"];
+
+  test("a matching database is not stopped", () => {
+    expect(schemaOutOfStep("x_test", local, local)).toBeNull();
+  });
+
+  // The direction that produced the incident: applied, and the tree has never heard of it.
+  test("a migration the tree does not have is named", () => {
+    const applied = [...local, "20260103000000_from_another_branch"];
+    expect(foreignMigrations(applied, local)).toEqual([
+      "20260103000000_from_another_branch",
+    ]);
+    const message = schemaOutOfStep("x_test", applied, local);
+    expect(message).toContain("20260103000000_from_another_branch");
+    expect(message).toContain("x_test");
+    expect(message).toContain("db:test:setup");
+  });
+
+  // The other direction is the same invariant, and it is the one a `git pull` produces: the tree
+  // gained a migration and the database has not been told. It reaches a reader as a missing column
+  // rather than as a missing migration, which is just as unreadable as the incident above.
+  test("a migration the database has never been given is named too", () => {
+    const applied = [local[0] as string];
+    expect(pendingMigrations(applied, local)).toEqual(["20260102000000_b"]);
+    expect(schemaOutOfStep("x_test", applied, local)).toContain(
+      "20260102000000_b",
+    );
+  });
+
+  // Both at once is the branch switch that also pulled, and a message that reported only the first
+  // one it found would send the reader back for a second run to learn the rest.
+  test("both directions are reported in one refusal, and told apart", () => {
+    const message = schemaOutOfStep(
+      "x_test",
+      ["20260101000000_a", "20260199000000_foreign"],
+      local,
+    ) as string;
+    expect(message).toContain("20260199000000_foreign");
+    expect(message).toContain("20260102000000_b");
+    expect(message.indexOf("20260199000000_foreign")).not.toBe(
+      message.indexOf("20260102000000_b"),
+    );
+  });
+
+  // Order is not the question. `_prisma_migrations` is read in whatever order the query returns and
+  // the directory in whatever order the filesystem lists, so a set difference that depended on
+  // either would report a healthy database as divergent.
+  test("neither side's order is part of the answer", () => {
+    expect(schemaOutOfStep("x_test", [...local].reverse(), local)).toBeNull();
+  });
+
+  // An empty applied set is a database that exists and has never been migrated, which is what a
+  // fresh `CREATE DATABASE` leaves behind. It is out of step with every non-empty tree, and saying
+  // so is the difference between one clear refusal and a suite that fails on the first missing
+  // table.
+  test("a database with nothing applied is out of step, not up to date", () => {
+    expect(schemaOutOfStep("x_test", [], local)).toContain("20260101000000_a");
+  });
+
+  // And the fence against the fence: a scan that found nothing passes exactly like a scan that
+  // found everything, so an empty tree has to be the one case that cannot refuse.
+  test("an empty tree asks nothing of any database", () => {
+    expect(schemaOutOfStep("x_test", [], [])).toBeNull();
+  });
+});
+
+// The two describes above prove the DECISIONS, which is all a pure function can prove. This proves
+// the thing that ships: a real `bun test` invocation, against a real database carrying a real
+// foreign migration row, refusing before the first test file loads. The same shape as the gate's own
+// subprocess tests in ./db-gate.test.ts, and for the same reason — the preload is out of reach of a
+// test by the time a test runs, so the only way to watch it refuse is to start another one.
+//
+// The scratch database is NAMED BY THE DERIVATION rather than by this file: pass a base and create
+// whatever `testDbNameFor` says the child will look for. Pointing the child at a hand-picked name
+// would need an escape hatch in the production path, and the only caller of that escape hatch would
+// be this test.
+describe("the refusal, as a run", () => {
+  const suUrl = process.env.MIGRATION_DATABASE_URL;
+  const live = process.env[DB_GATE_OPT_OUT] !== "1" && Boolean(suUrl);
+  const BASE = "fzgate417_test";
+  const FOREIGN = "20260828000000_left_by_another_branch";
+  const noop = new URL("../utils/db-gate-noop.ts", import.meta.url).pathname;
+  const repoRoot = new URL("../..", import.meta.url).pathname;
+
+  test.skipIf(!live)(
+    "a database carrying another branch's migration stops the run, naming it",
+    async () => {
+      const { Client } = await import("pg");
+      const scratch = testDbNameFor(BASE, repoRoot);
+      const maintUrl = new URL(suUrl as string);
+      maintUrl.pathname = "/postgres";
+      const maint = new Client({ connectionString: maintUrl.toString() });
+      await maint.connect();
+      try {
+        await maint.query(`DROP DATABASE IF EXISTS "${scratch}"`);
+        await maint.query(`CREATE DATABASE "${scratch}"`);
+        const seedUrl = new URL(suUrl as string);
+        seedUrl.pathname = `/${scratch}`;
+        const seed = new Client({ connectionString: seedUrl.toString() });
+        await seed.connect();
+        try {
+          // Only the column the gate reads. The real table is wider, and a fixture that mirrored it
+          // would be asserting Prisma's schema rather than this refusal.
+          await seed.query(
+            `CREATE TABLE _prisma_migrations (migration_name text NOT NULL)`,
+          );
+          await seed.query(
+            `INSERT INTO _prisma_migrations (migration_name) VALUES ($1)`,
+            [FOREIGN],
+          );
+        } finally {
+          await seed.end();
+        }
+
+        const childUrl = new URL(suUrl as string);
+        childUrl.pathname = `/${BASE}`;
+        const { [DB_GATE_OPT_OUT]: _optOut, ...inherited } = process.env;
+        const proc = Bun.spawn(["bun", "test", noop], {
+          cwd: repoRoot,
+          env: {
+            ...inherited,
+            TEST_MIGRATION_DATABASE_URL: childUrl.toString(),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [code, err, out] = await Promise.all([
+          proc.exited,
+          new Response(proc.stderr).text(),
+          new Response(proc.stdout).text(),
+        ]);
+        const output = `${out}\n${err}`;
+        expect(code).not.toBe(0);
+        expect(output).toContain(FOREIGN);
+        expect(output).toContain("does not match this tree");
+        // The command that repairs it, in the message, because a refusal a reader cannot act on is
+        // just a different way to be stuck.
+        expect(output).toContain("db:test:setup");
+        // And the run never reached a test file: the whole point is that this happens BEFORE the
+        // failures it would otherwise be read from.
+        expect(output).not.toContain("1 pass");
+      } finally {
+        await maint
+          .query(`DROP DATABASE IF EXISTS "${testDbNameFor(BASE, repoRoot)}"`)
+          .catch(() => {});
+        await maint.end();
+      }
+    },
+    120_000,
+  );
+});
+
+// THE DOOR, and it is tested because a wall with a door that stopped opening is worse than the
+// wall alone. `prisma migrate deploy` cannot repair a database carrying a foreign migration: the row
+// is already in `_prisma_migrations`, so nothing is pending and whatever that migration dropped
+// stays dropped. `bun db:test:setup` is the command the refusal above prints, so it has to be the
+// command that actually fixes what the refusal is about.
+describe("the command the refusal names", () => {
+  const suUrl = process.env.MIGRATION_DATABASE_URL;
+  const appUrl = process.env.TEST_APP_DATABASE_URL;
+  const live =
+    process.env[DB_GATE_OPT_OUT] !== "1" && Boolean(suUrl) && Boolean(appUrl);
+  const BASE = "fzsetup417_test";
+  const FOREIGN = "20260828000000_left_by_another_branch";
+  const repoRoot = new URL("../..", import.meta.url).pathname;
+
+  test.skipIf(!live)(
+    "reprovisions a database that carries a migration this tree does not have",
+    async () => {
+      const { Client } = await import("pg");
+      const scratch = testDbNameFor(BASE, repoRoot);
+      const maintUrl = new URL(suUrl as string);
+      maintUrl.pathname = "/postgres";
+      const maint = new Client({ connectionString: maintUrl.toString() });
+      await maint.connect();
+      const at = (url: string, db: string) => {
+        const u = new URL(url);
+        u.pathname = `/${db}`;
+        return u.toString();
+      };
+      try {
+        await maint.query(`DROP DATABASE IF EXISTS "${scratch}"`);
+        await maint.query(`CREATE DATABASE "${scratch}"`);
+        const seed = new Client({
+          connectionString: at(suUrl as string, scratch),
+        });
+        await seed.connect();
+        try {
+          await seed.query(
+            `CREATE TABLE _prisma_migrations (migration_name text NOT NULL)`,
+          );
+          await seed.query(
+            `INSERT INTO _prisma_migrations (migration_name) VALUES ($1)`,
+            [FOREIGN],
+          );
+        } finally {
+          await seed.end();
+        }
+
+        const proc = Bun.spawn(["bun", "scripts/test-db-setup.ts"], {
+          cwd: repoRoot,
+          env: {
+            ...process.env,
+            TEST_MIGRATION_DATABASE_URL: at(suUrl as string, BASE),
+            TEST_APP_DATABASE_URL: at(appUrl as string, BASE),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [code, out, err] = await Promise.all([
+          proc.exited,
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        expect(`${out}\n${err}`).toContain(FOREIGN);
+        expect(code).toBe(0);
+
+        const after = new Client({
+          connectionString: at(suUrl as string, scratch),
+        });
+        await after.connect();
+        try {
+          const { rows } = await after.query<{ migration_name: string }>(
+            "SELECT migration_name FROM _prisma_migrations",
+          );
+          const applied = rows.map((r) => r.migration_name);
+          expect(applied).not.toContain(FOREIGN);
+          // And it is not merely emptied: the tree's own migrations are all there, which is the
+          // difference between a repaired database and a dropped one.
+          const local = readdirSync(join(repoRoot, "prisma", "migrations"), {
+            withFileTypes: true,
+          })
+            .filter((e) => e.isDirectory())
+            .map((e) => e.name);
+          expect(foreignMigrations(applied, local)).toEqual([]);
+          expect(pendingMigrations(applied, local)).toEqual([]);
+        } finally {
+          await after.end();
+        }
+      } finally {
+        await maint
+          .query(`DROP DATABASE IF EXISTS "${scratch}"`)
+          .catch(() => {});
+        await maint.end();
+      }
+    },
+    300_000,
+  );
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,8 +2,8 @@ import "@testing-library/jest-dom";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import {
-  appliedMigrations,
   DB_GATE_OPT_OUT,
+  type MigrationRow,
   missingDbConfig,
   PROBE_BACKSTOP_MS,
   probePoolConfig,
@@ -124,11 +124,6 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
     // has no `_prisma_migrations` at all, and that is a real state (a fresh CREATE DATABASE), not an
     // error. It reports as every local migration being unapplied, which is the truth and names the
     // same command.
-    type MigrationRow = {
-      migration_name: string;
-      finished_at: Date | null;
-      rolled_back_at: Date | null;
-    };
     const rows = await withDeadline(
       reader.$queryRaw<MigrationRow[]>`
         SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations
@@ -136,7 +131,6 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
       PROBE_BACKSTOP_MS,
       "TEST_MIGRATION_DATABASE_URL",
     ).catch(() => [] as MigrationRow[]);
-    const applied = appliedMigrations(rows);
     const local = readdirSync(join(REPO_ROOT, "prisma", "migrations"), {
       withFileTypes: true,
     })
@@ -144,7 +138,7 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
       .map((e) => e.name);
     const drift = schemaOutOfStep(
       new URL(suUrl).pathname.replace(/^\//, ""),
-      applied,
+      rows,
       local,
     );
     if (drift) throw new Error(`tests: ${drift}`);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import {
+  appliedMigrations,
   DB_GATE_OPT_OUT,
   missingDbConfig,
   PROBE_BACKSTOP_MS,
@@ -11,7 +12,7 @@ import {
   unreachableDb,
   withDeadline,
 } from "./db-gate";
-import { testDbNameFor, withDbName } from "./db-name";
+import { checkoutRootFrom, testDbNameFor, withDbName } from "./db-name";
 
 // NOTE: happy-dom registration and the Bun-native global capture live in
 // ./dom-setup.ts, which bunfig.toml preloads BEFORE this file. The DOM must
@@ -32,7 +33,7 @@ process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
 // test DB *name* from TEST_MIGRATION_DATABASE_URL. The `_test` guard refuses any other target, so
 // the destructive suite (unscoped `DELETE FROM scheduler_jobs`, tenant create/drop) can never hit
 // the dev DB. This preload never runs for `prisma migrate`, so the CLI keeps using the dev URLs.
-const REPO_ROOT = new URL("..", import.meta.url).pathname;
+const REPO_ROOT = checkoutRootFrom(import.meta.url, "..");
 const testSuUrl = process.env.TEST_MIGRATION_DATABASE_URL;
 if (testSuUrl) {
   const declared = new URL(testSuUrl).pathname.replace(/^\//, "");
@@ -123,14 +124,19 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
     // has no `_prisma_migrations` at all, and that is a real state (a fresh CREATE DATABASE), not an
     // error. It reports as every local migration being unapplied, which is the truth and names the
     // same command.
+    type MigrationRow = {
+      migration_name: string;
+      finished_at: Date | null;
+      rolled_back_at: Date | null;
+    };
     const rows = await withDeadline(
-      reader.$queryRaw<{ migration_name: string }[]>`
-        SELECT migration_name FROM _prisma_migrations
+      reader.$queryRaw<MigrationRow[]>`
+        SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations
         WHERE to_regclass('_prisma_migrations') IS NOT NULL`,
       PROBE_BACKSTOP_MS,
       "TEST_MIGRATION_DATABASE_URL",
-    ).catch(() => [] as { migration_name: string }[]);
-    const applied = rows.map((r) => r.migration_name);
+    ).catch(() => [] as MigrationRow[]);
+    const applied = appliedMigrations(rows);
     const local = readdirSync(join(REPO_ROOT, "prisma", "migrations"), {
       withFileTypes: true,
     })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,13 +1,17 @@
 import "@testing-library/jest-dom";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import {
   DB_GATE_OPT_OUT,
   missingDbConfig,
   PROBE_BACKSTOP_MS,
   probePoolConfig,
   probeTargets,
+  schemaOutOfStep,
   unreachableDb,
   withDeadline,
 } from "./db-gate";
+import { testDbNameFor, withDbName } from "./db-name";
 
 // NOTE: happy-dom registration and the Bun-native global capture live in
 // ./dom-setup.ts, which bunfig.toml preloads BEFORE this file. The DOM must
@@ -28,16 +32,31 @@ process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
 // test DB *name* from TEST_MIGRATION_DATABASE_URL. The `_test` guard refuses any other target, so
 // the destructive suite (unscoped `DELETE FROM scheduler_jobs`, tenant create/drop) can never hit
 // the dev DB. This preload never runs for `prisma migrate`, so the CLI keeps using the dev URLs.
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
 const testSuUrl = process.env.TEST_MIGRATION_DATABASE_URL;
 if (testSuUrl) {
-  const testDbPath = new URL(testSuUrl).pathname;
-  const dbName = testDbPath.replace(/^\//, "");
-  if (!dbName.endsWith("_test")) {
+  const declared = new URL(testSuUrl).pathname.replace(/^\//, "");
+  if (!declared.endsWith("_test")) {
     throw new Error(
-      `TEST_MIGRATION_DATABASE_URL must point at a *_test database (got "${dbName}") — refusing to run the destructive test suite against it.`,
+      `TEST_MIGRATION_DATABASE_URL must point at a *_test database (got "${declared}") — refusing to run the destructive test suite against it.`,
     );
   }
-  process.env.MIGRATION_DATABASE_URL = testSuUrl;
+  // The `.env` name is the BASE, not the target. Every checkout on a machine copies one `.env` (the
+  // worktree step is `cp ../main/.env .env`), so a constant name puts them all on one database and a
+  // migration applied from any of them stays applied under all the others — see ./db-name.ts and
+  // tests/lib/test-db-identity.test.ts for what that cost when it happened. The guard above still
+  // reads the DECLARED name, because it is a statement about what the developer pointed at.
+  const dbName = testDbNameFor(declared, REPO_ROOT);
+  const testDbPath = `/${dbName}`;
+  process.env.MIGRATION_DATABASE_URL = withDbName(testSuUrl, dbName);
+  // BOTH spellings, and this line is the whole reason the derivation is safe to add. Three test
+  // files build their superuser client from the RAW `TEST_MIGRATION_DATABASE_URL` rather than the
+  // derived `MIGRATION_DATABASE_URL`, which was equivalent while the two named the same database
+  // and stopped being equivalent the moment one of them was derived: those files then SEEDED one
+  // database and READ another, silently. Measured before this line existed — 36 failures across
+  // exactly those three files, all of them assertions about rows that had been written to the
+  // underived database. tests/lib/db-gate.test.ts fences the two against each other.
+  process.env.TEST_MIGRATION_DATABASE_URL = process.env.MIGRATION_DATABASE_URL;
   if (process.env.TEST_APP_DATABASE_URL) {
     const appUrl = new URL(process.env.TEST_APP_DATABASE_URL);
     appUrl.pathname = testDbPath;
@@ -89,6 +108,42 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
       void probe.$disconnect().catch(() => {});
       throw new Error(`tests: ${unreachableDb(variable, url, err)}`);
     }
+  }
+
+  // AND WHETHER IT IS THIS TREE'S DATABASE. The probes above prove a database ANSWERS; this asks
+  // whether its schema is the one prisma/migrations describes, in both directions. It is the same
+  // preventive shape as the gate above and for the same reason: the alternative is reading the
+  // answer off dozens of failures that name code nobody broke, one run too late (issue #417).
+  const suUrl = process.env.MIGRATION_DATABASE_URL as string;
+  const reader = new PrismaClient({
+    adapter: new PrismaPg(probePoolConfig(suUrl)),
+  });
+  try {
+    // `to_regclass` rather than a bare SELECT: a database that exists and has never been migrated
+    // has no `_prisma_migrations` at all, and that is a real state (a fresh CREATE DATABASE), not an
+    // error. It reports as every local migration being unapplied, which is the truth and names the
+    // same command.
+    const rows = await withDeadline(
+      reader.$queryRaw<{ migration_name: string }[]>`
+        SELECT migration_name FROM _prisma_migrations
+        WHERE to_regclass('_prisma_migrations') IS NOT NULL`,
+      PROBE_BACKSTOP_MS,
+      "TEST_MIGRATION_DATABASE_URL",
+    ).catch(() => [] as { migration_name: string }[]);
+    const applied = rows.map((r) => r.migration_name);
+    const local = readdirSync(join(REPO_ROOT, "prisma", "migrations"), {
+      withFileTypes: true,
+    })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    const drift = schemaOutOfStep(
+      new URL(suUrl).pathname.replace(/^\//, ""),
+      applied,
+      local,
+    );
+    if (drift) throw new Error(`tests: ${drift}`);
+  } finally {
+    await reader.$disconnect().catch(() => {});
   }
 }
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,8 +1,7 @@
 import "@testing-library/jest-dom";
-import { readdirSync } from "node:fs";
-import { join } from "node:path";
 import {
   DB_GATE_OPT_OUT,
+  localMigrations,
   type MigrationRow,
   missingDbConfig,
   PROBE_BACKSTOP_MS,
@@ -126,16 +125,12 @@ if (process.env[DB_GATE_OPT_OUT] !== "1") {
     // same command.
     const rows = await withDeadline(
       reader.$queryRaw<MigrationRow[]>`
-        SELECT migration_name, finished_at, rolled_back_at FROM _prisma_migrations
+        SELECT migration_name, checksum, finished_at, rolled_back_at FROM _prisma_migrations
         WHERE to_regclass('_prisma_migrations') IS NOT NULL`,
       PROBE_BACKSTOP_MS,
       "TEST_MIGRATION_DATABASE_URL",
     ).catch(() => [] as MigrationRow[]);
-    const local = readdirSync(join(REPO_ROOT, "prisma", "migrations"), {
-      withFileTypes: true,
-    })
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name);
+    const local = localMigrations(REPO_ROOT);
     const drift = schemaOutOfStep(
       new URL(suUrl).pathname.replace(/^\//, ""),
       rows,


### PR DESCRIPTION
Fixes #417

## What was broken

The integration suite runs against a test database provisioned once by `bun db:test:setup`. Its name is a constant in `.env`, so every checkout and every git worktree on a machine shares one, and `prisma migrate deploy` only ever adds: a migration applied from one tree stays applied under the next.

While the leftover is additive (a new column, a new enum value) nothing shows. When it is subtractive, the next tree runs its whole suite against a schema that is not its own.

Measured on `main`, clean working tree:

```
 7261 pass
   31 fail          # the identical set on 3 consecutive full-suite runs
```

Every one of the 31 died the same way:

```
Invalid `prisma.appointment.upsert()` invocation:
Code: `42P10`  there is no unique or exclusion constraint matching the ON CONFLICT specification
```

The database carried **58** applied migrations against **54** in `prisma/migrations`. Three extras were additive and invisible. The fourth had run `DROP INDEX "appointments_tenant_id_external_id_key"`, and `main`'s client upserts on `tenantId_externalId`.

The failure count understates it: the `beforeAll` blocks that seed appointments took their files down with them, so **29 further tests never executed** and are not in the `31 fail` line (7321 tests run on a correct schema, 7292 on that one).

Provisioning a fresh database from the same tree, same suite, three runs, on a machine with 11 concurrent `bun test` processes: `7321 pass, 0 fail` each time. Contention is not what produced the failures.

## Why nothing caught it

`prisma migrate status` against that exact database answered:

```
54 migrations found in prisma/migrations
Database schema is up to date!
```

It reports *pending* and *failed* migrations. One that is applied while the tree has never heard of it is neither.

There is a second trap on the way to asking: `prisma.config.ts` resolves its datasource from `MIGRATION_DATABASE_URL`, so `DATABASE_URL=<test-db> bunx prisma migrate status` silently inspects the **dev** database and calls it healthy.

And re-running the setup did not repair it: the foreign migration was already recorded in `_prisma_migrations`, so `migrate deploy` had nothing pending and the dropped index stayed dropped.

## The invariant

**A test run answers about the tree it was started from, or it refuses to start.** Three pieces, and none is a fix on its own.

### The name belongs to one checkout — `tests/db-name.ts`

The `.env` name becomes a base; the preload and `bun db:test:setup` both derive `<stem>_<checkout>_<base hash><checkout hash>_test` from it. Deriving rather than asking each checkout to edit its `.env` is the point: the worktree onboarding step is `cp ../main/.env .env`, and an obligation spelled out per checkout is one the next checkout is created without.

Both halves are hashed, and the readable text is readability alone — truncation may cost a name its readability, never its identity. Three things this went through:

- **Postgres cuts an identifier at 63 bytes silently**, so a long name would hand two checkouts one database through the fix for two checkouts sharing one.
- Shortening only the checkout half meant a long checkout name consumed the whole budget and **every base of that checkout derived to ONE database**: measured with a 52-character checkout, `secretaria_v4_test`, `fzgate417_test` and `fzsetup417_test` all became `wwww…_79bdb0_test`. The live tests here create scratch databases from their own bases, so that collision would have them drop and terminate the database backing the suite running them.
- Hashing the *normalized* stem made identity as lossy as display: `identifierSafe` folds every run of non-alphanumerics to one underscore, so `foo-bar_test` and `foo_bar_test` both derived to `foo_bar_x_4928ca5cf696_test`. The hash is over the base as written.

The checkout's hash stays separate and last because it is the one part recomputable from the root alone, which is what makes the derivation **idempotent** — anything that reads the derived URL out of a running suite and starts a second run from it would otherwise derive again, landing on a name that names no database. That is not hypothetical: it is how the gate's own subprocess test failed when this first shipped, looking for `…_flaky_tests_febbf7_flaky_tests_febbf7_test`.

### The preload refuses a database that is not this tree's — `tests/db-gate.ts`, `tests/setup.ts`

The gate already refuses to start when there is nothing at the other end, on the reasoning that a suite silently skipping its database-backed half exits 0 and reads as green. This is the same failure inverted: it exits non-zero and reads as broken code. `schemaOutOfStep` takes the **ledger** and names what it found:

```
tests: the test database "…_test" does not match this tree, so failures below would be about
its schema and not about the code.
  applied here but absent from prisma/migrations (left by another branch):
    20260828000000_left_by_another_branch
  - bun run db:test:setup
```

Five ways a database can fail to be this tree's, each one measured:

| state | why the name sets alone miss it |
| --- | --- |
| applied, absent from the tree | the incident above |
| in the tree, never applied | what a `git pull` produces; reaches a reader as a missing column |
| recorded but never finished, or rolled back | `_prisma_migrations` is a ledger, not a list of what is in the schema |
| same name, different SQL | a migration edited after it was applied, or a directory name two branches both used |
| applied in an order no fresh database would produce | the merge, after the deploy |

The third is the one that bit this branch itself: filtering half-applied rows out of the applied set also took them out of every comparison built on that set, so a foreign migration that died half-way read as a database in step — measured on a real ledger, 57 rows, 56 counted, no foreign migrations found, verdict "up to date". That is why `schemaOutOfStep` takes rows rather than an applied set someone already filtered.

The preload also forces **both spellings** of the variable. 175 test files reach for the derived `MIGRATION_DATABASE_URL`; three build their superuser client from the raw `TEST_MIGRATION_DATABASE_URL`. Those were the same database until one was derived, and then those three seeded one database and read another — **36 failures across exactly those three files**, every one an assertion about a row written somewhere else, none of them anywhere near this change.

### The command the refusal names actually repairs it — `scripts/test-db-setup.ts`

`prisma migrate deploy` is the right repair for exactly one refused state: a database simply *behind* this tree, in this tree's own order. It cannot undo a foreign migration, it refuses the whole database with P3009 while an unfinished row stands, it skips a changed migration entirely because the row is already there, and it applies a pending migration that sorts before an applied one in an order no fresh build produces. `reprovisionReasons` names all of those and the setup recreates instead of deploying.

The DROP closes what is connected first, which reverses a decision made earlier in this branch on the reasoning that Postgres refusing is safer than killing a suite mid-run. Measuring the refusal is what refuted it: `database "…" is being accessed by other users`, exit 1, with the holder being ONE backend in `state=idle` whose last statement was `ROLLBACK` — a pool connection leaked by a test process that had already exited. The refusal fired where there was nothing to protect and named no way out. What makes closing them safe is the other half of this change: the database is derived per checkout, so the only thing that can be connected is this checkout's own work.

`tests/db-gate.ts`'s own guidance was sending a reader in a circle and is fixed here too: a fresh worktree that copies the `.env` now has a reachable Postgres and no database of its own, so that line carries `bun run db:test:setup`.

## Validation scope

**Proved by test** — `tests/lib/test-db-identity.test.ts`, 41 tests. The derivation (two checkouts differ; same basename under different parents differs; stable across a trailing separator; every result ends in `_test`; a 200-character path and a 63-character base both stay under 63 bytes and stay distinct; only `[a-z0-9_]` survives; two bases that only normalize alike are still two databases; base and checkout are both part of the identity; idempotent for this checkout and not for another's). The ledger (each of the five states alone, several together and told apart, order-independent on both sides, a never-migrated database, an empty tree asking nothing of any database, ties in the applied order not counted as inversions). And the spellings: after the preload, `MIGRATION_DATABASE_URL`, `TEST_MIGRATION_DATABASE_URL` and `TEST_APP_DATABASE_URL` all name one database, and it is this checkout's.

**Proved as a run**, not as a function: a scratch database is created carrying a real foreign `_prisma_migrations` row, a real `bun test` is spawned against it, and the assertion is that it exits non-zero, names the migration, names the command, and never reaches a test file. Then `bun scripts/test-db-setup.ts` is spawned against the same database and the assertion is that the foreign row is gone **and** every local migration is applied — the difference between a repaired database and a dropped one. A third holds a connection open across the whole command, asserting the output does not contain `is being accessed by other users`, does contain `closed 1 connection`, and exits 0. The scratch databases are named *by the derivation* rather than by the test, so none of this needed an escape hatch in the production path.

**Proved by mutation** — 35 mutations, 35 killed, across every rule above.

**Proved in CI**, which was listed here as unvalidated until it ran: the workflow provisioned `agents_ci_agents_a409957fabe3_test` from the base `agents_ci_test` and the full suite passed against it, so the derivation agreeing across the setup step and the test step is a job and no longer an argument.

**Proved live, against the real Postgres**: a foreign row planted in this checkout's own ledger (refused, reprovisioned, reapplied all 56); a half-applied row (same); a migration removed from the ledger so it becomes pending behind newer ones (`would be applied after a migration that sorts later`); a migration file edited after it was applied (`applied from different SQL than the file now holds`), and the round trip back. The checksum algorithm was verified against three real rows of this repo's ledger rather than assumed — comparing against the wrong one would report every migration as changed and refuse every run. The isolation was exercised with a stock `.env` copied from `main/`: the suite provisioned and ran against a derived name with no `.env` edit at all.

**Not validated.**

- **No test runs two checkouts concurrently.** The isolation is proved by the derived names differing, not by two live suites against two databases.
- **The shared database existing installs already have is left in place.** After this, every checkout provisions its own and the old one is simply orphaned; nothing drops it, and nothing tells you it is there.
