### PR TITLE
Make the wait for a flow-log write checkable, not a per-site comment

### DIFF
--- a/tests/graph/duplicate-tool-name-visible.test.ts
+++ b/tests/graph/duplicate-tool-name-visible.test.ts
@@ -14,7 +14,7 @@ import type { FlowContext } from "@/modules/flowlog/service";
 import { HANDOFF_DEFAULTS } from "@/modules/handoff/settings";
 import { SEND_IMAGE_DEFAULTS } from "@/modules/images/settings";
 import { KANBAN_DEFAULTS } from "@/modules/kanban/settings";
-import { clearFlowLog } from "../utils/flowlog";
+import { clearFlowLog, flowLogRows } from "../utils/flowlog";
 
 // ── A TOOL DROPPED FOR A DUPLICATE NAME HAS TO SAY SO WHERE THE OPERATOR LOOKS (#389) ──
 //
@@ -134,7 +134,7 @@ function flow(turnId: string): FlowContext {
 // exists, so a read without it can run first and see nothing.
 async function droppedLines(turnId: string) {
   await settleFlowEvents();
-  const rows = await suDb.executionLog.findMany({
+  const rows = await flowLogRows(suDb, {
     where: { turnId, stage: "tool" },
     orderBy: { id: "asc" },
   });

--- a/tests/graph/history-ceiling-turn.test.ts
+++ b/tests/graph/history-ceiling-turn.test.ts
@@ -9,6 +9,7 @@ import { runAgentTurn } from "@/graph/runtime";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 
 // Issue #55 end-to-end. The unit tests cover the rule; this one covers the two things only a real
 // turn can show. First, that the ceiling configured on the agent row actually reaches the model
@@ -123,7 +124,7 @@ async function setCeiling(maxHistoryTokens: number | null) {
 // read across the tenant is a claim about its neighbour: swapping the two `test()` blocks used to
 // turn this file red with `Received length: 2`, so the green depended on declaration order (#258).
 async function generateLines(convId: number) {
-  return suDb.executionLog.findMany({
+  return flowLogRows(suDb, {
     where: {
       tenantId,
       stage: "generate",

--- a/tests/graph/nudge.test.ts
+++ b/tests/graph/nudge.test.ts
@@ -35,6 +35,7 @@ import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { selectClosedPrefix } from "@/modules/memory/cut";
 import { withJobHandler } from "@/tests/utils/job-registry";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 import {
   EmptyThenReplyModel,
   guardrailModel,
@@ -1626,7 +1627,7 @@ describe.skipIf(!dbUp)("runAgentNudge", () => {
       // Scoped to this nudge's own thread: 76 tests share the tenant, and `outcome`/`step` are
       // values several of them write. Filtered by tenant alone this poll can exit on a neighbour's
       // row and report a trail this turn never left (#258).
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: {
           tenantId,
           stage: "generate",
@@ -1843,7 +1844,7 @@ describe.skipIf(!dbUp)("runAgentNudge", () => {
     expect(s.resolved).toEqual([9908]);
     // And the trail carries no `messaged` line for this step. Checked after the run returned, so
     // there is no write left in flight: markFollowUp is called synchronously or not at all.
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: {
         tenantId,
         stage: "generate",
@@ -3702,7 +3703,7 @@ describe.skipIf(!dbUp)("runAgentNudge", () => {
     // emitFlowEvent is fire-and-forget, so poll for the row instead of racing it.
     let logged = false;
     for (let i = 0; i < 30 && !logged; i++) {
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: {
           tenantId,
           stage: "generate",

--- a/tests/graph/runtime.test.ts
+++ b/tests/graph/runtime.test.ts
@@ -30,6 +30,7 @@ import { createDocumentTemplate } from "@/modules/documents/templates";
 import { readGuardrailHealth } from "@/modules/guardrails/health";
 import { selectClosedPrefix } from "@/modules/memory/cut";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRow, flowLogRows } from "../utils/flowlog";
 import {
   EmptyThenReplyModel,
   guardrailModel,
@@ -397,7 +398,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     // emitFlowEvent is fire-and-forget, so poll briefly.
     let retryLogged = false;
     for (let i = 0; i < 30 && !retryLogged; i++) {
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: {
           tenantId,
           stage: "generate",
@@ -1152,7 +1153,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     const conversation = await suDb.conversation.findFirstOrThrow({
       where: { tenantId, chatwootConversationId: convId },
     });
-    return suDb.executionLog.findFirst({
+    return flowLogRow(suDb, {
       where: { tenantId, stage: "handoff", conversationId: conversation.id },
       orderBy: { id: "desc" },
       select: { detail: true },
@@ -1167,7 +1168,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     // yet does not answer wrong, it THROWS, so what the scoping converted was a silent wrong answer
     // into a spurious failure. Poll for the row this conversation owes (#258).
     for (let i = 0; i < 30; i++) {
-      const row = await suDb.executionLog.findFirst({
+      const row = await flowLogRow(suDb, {
         where: { tenantId, stage: "handoff", conversationId: conversation.id },
         orderBy: { id: "desc" },
       });
@@ -1328,7 +1329,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
     // emitFlowEvent is fire-and-forget, so poll briefly.
     let resolvedLogged = false;
     for (let i = 0; i < 30 && !resolvedLogged; i++) {
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: {
           tenantId,
           stage: "handoff",
@@ -2331,7 +2332,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       // line had simply not landed when the assertion read the table (#258).
       let named = false;
       for (let i = 0; i < 30 && !named; i++) {
-        const flow = await suDb.executionLog.findMany({
+        const flow = await flowLogRows(suDb, {
           where: {
             tenantId,
             stage: "tool",
@@ -2433,7 +2434,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       // fails on timing, which is a test that reports the wrong thing.
       let skipLogged = false;
       for (let i = 0; i < 30 && !skipLogged; i++) {
-        const flow = await suDb.executionLog.findMany({
+        const flow = await flowLogRows(suDb, {
           where: {
             tenantId,
             stage: "tool",
@@ -2712,7 +2713,7 @@ describe.skipIf(!dbUp)("runAgentTurn", () => {
       let flow: { detail: unknown; status: string | null }[] = [];
       let unknown: typeof flow = [];
       for (let i = 0; i < 30 && unknown.length === 0; i++) {
-        flow = await suDb.executionLog.findMany({
+        flow = await flowLogRows(suDb, {
           where: {
             tenantId,
             stage: "tool",

--- a/tests/graph/side-effect-flowlog.test.ts
+++ b/tests/graph/side-effect-flowlog.test.ts
@@ -10,6 +10,7 @@ import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import { createAlertChannel } from "@/modules/flowlog/channels";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 import { outboundUrl } from "../utils/outbound";
 
 // NOTE: Issue #46 end-to-end — a tool that SUCCEEDS for the model but whose side effect fails
@@ -97,7 +98,7 @@ async function pollToolRows(
 ): Promise<ToolRow[]> {
   let rows: ToolRow[] = [];
   for (let i = 0; i < 50; i++) {
-    rows = await suDb.executionLog.findMany({
+    rows = await flowLogRows(suDb, {
       where: {
         tenantId,
         stage: "tool",

--- a/tests/graph/tool-flowlog.test.ts
+++ b/tests/graph/tool-flowlog.test.ts
@@ -16,6 +16,7 @@ import { failableTool, toolFailure } from "@/graph/tools/failure";
 import type { TenantContext } from "@/lib/tenancy";
 import { createAlertChannel } from "@/modules/flowlog/channels";
 import type { FlowContext } from "@/modules/flowlog/service";
+import { flowLogRows } from "../utils/flowlog";
 import { outboundUrl } from "../utils/outbound";
 
 // NOTE: The tool line of the execution-flow log must distinguish integration failures from successes:
@@ -66,7 +67,7 @@ type LogRow = {
 // NOTE: emitFlowEvent is fire-and-forget; poll until the expected row count lands.
 async function pollToolRows(turnId: string, count: number): Promise<LogRow[]> {
   for (let i = 0; i < 50; i++) {
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { tenantId, turnId, stage: "tool" },
       select: {
         level: true,

--- a/tests/modules/chatwoot-command-dropped.test.ts
+++ b/tests/modules/chatwoot-command-dropped.test.ts
@@ -18,6 +18,7 @@ import { encryptJson } from "@/api/lib/crypto";
 import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
 const suUrl = process.env.MIGRATION_DATABASE_URL;
@@ -238,32 +239,28 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
     });
   }
 
-  // Scoped to the conversation by its INTERNAL id, and polled for the count the test EXPECTS: the
-  // emit is fire-and-forget, so an unscoped read answers with a neighbour's row and one that stops
-  // at the first row reads the fan-out's first delivery while the second is still in flight, then
-  // calls that the answer. Zero is the same rule from the other side: nothing to wait for, so the
-  // window is spent before reading rather than short-circuited.
-  async function commandRows(convId: number, expected: number, waitMs = 2000) {
+  // Scoped to the conversation by its INTERNAL id, and SETTLED rather than polled: the emit is
+  // fire-and-forget, so an unscoped read answers with a neighbour's row and one that does not wait
+  // reads before the row lands. This used to poll for the count the test EXPECTS, which answered the
+  // presence cases correctly and could not answer the absence ones at all: a poll for zero spends
+  // its whole deadline and then reports the empty read it opened with. `flowLogRows` settles the
+  // scheduled writes first, so both directions are answered by the same read (#419), and `expected`
+  // stops being an input to HOW the read is taken.
+  async function commandRows(convId: number) {
     const conv = await suDb.conversation.findFirst({
       where: { tenantId, chatwootConversationId: convId },
       select: { id: true },
     });
     if (!conv) return [];
-    const deadline = Date.now() + waitMs;
-    for (;;) {
-      const rows = await suDb.executionLog.findMany({
-        where: { tenantId, stage: "command", conversationId: conv.id },
-        orderBy: { id: "asc" },
-      });
-      if (expected > 0 && rows.length >= expected) return rows;
-      if (Date.now() > deadline) return rows;
-      await new Promise((r) => setTimeout(r, 50));
-    }
+    return flowLogRows(suDb, {
+      where: { tenantId, stage: "command", conversationId: conv.id },
+      orderBy: { id: "asc" },
+    });
   }
 
   test("a command at a production agent is ordinary text, and the line says which mode dropped it", async () => {
     await deliver(9201, PROD_INBOX, "/teste", OUR_BOT);
-    const rows = await commandRows(9201, 1);
+    const rows = await commandRows(9201);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("info");
     expect(rows[0]?.status).toBe("skipped");
@@ -278,7 +275,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
 
   test("a command at an inbox nobody bound names the mode as unresolved", async () => {
     await deliver(9301, UNBOUND_INBOX, "/reset", OUR_BOT);
-    const rows = await commandRows(9301, 1);
+    const rows = await commandRows(9301);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.detail).toMatchObject({
       command: "reset",
@@ -291,7 +288,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
       where: { tenantId, chatwootConversationId: 9301 },
       select: { id: true },
     });
-    const route = await suDb.executionLog.findMany({
+    const route = await flowLogRows(suDb, {
       where: { tenantId, stage: "route", conversationId: conv.id },
     });
     expect(route).toHaveLength(1);
@@ -299,7 +296,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
 
   test("a delivery on another persona's route says it left the command to the inbox's", async () => {
     await deliver(9101, TEST_INBOX, "/teste", OTHER_BOT);
-    const rows = await commandRows(9101, 1);
+    const rows = await commandRows(9101);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("info");
     expect(rows[0]?.detail).toMatchObject({
@@ -315,7 +312,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
   // misconfiguration to repair rather than a route deferring to its sibling.
   test("an inbox whose agent has no bot identity drops the command on every route, at warn", async () => {
     await deliver(9401, NO_PERSONA_INBOX, "/teste", OUR_BOT);
-    const rows = await commandRows(9401, 1);
+    const rows = await commandRows(9401);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.level).toBe("warn");
     expect(rows[0]?.status).toBe("skipped");
@@ -333,7 +330,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
   test("the fan-out reports one command, not the same drop twice", async () => {
     await deliver(9202, PROD_INBOX, "/teste", OUR_BOT);
     await deliver(9202, PROD_INBOX, "/teste", OTHER_BOT, { sameMessage: true });
-    const rows = await commandRows(9202, 2);
+    const rows = await commandRows(9202);
     expect(rows).toHaveLength(2);
     expect(
       rows.map((r) => (r.detail as { reason: string }).reason).sort(),
@@ -360,7 +357,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
       sparse: true,
       sameMessage: true,
     });
-    const rows = await commandRows(9203, 2);
+    const rows = await commandRows(9203);
     expect(rows).toHaveLength(2);
     for (const r of rows) expect(r.agentId).toBe(prodAgentId);
     expect(
@@ -380,7 +377,7 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
   // committed, leaving the ledger row on PROCESSING with nothing running and no upstream retry.
   test("an unreadable persona still writes the line, and the delivery finishes", async () => {
     await deliver(9501, BAD_TOKEN_INBOX, "/teste", OUR_BOT);
-    const rows = await commandRows(9501, 1);
+    const rows = await commandRows(9501);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.detail).toMatchObject({
       command: "teste",
@@ -396,13 +393,13 @@ describe.skipIf(!dbUp)("a control command that did not run says so", () => {
 
   test("a command that RUNS writes no dropped line", async () => {
     await deliver(9102, TEST_INBOX, "/teste", OUR_BOT);
-    const rows = await commandRows(9102, 0, 400);
+    const rows = await commandRows(9102);
     expect(rows).toHaveLength(0);
   });
 
   test("an ordinary message writes no dropped line", async () => {
     await deliver(9103, PROD_INBOX, "bom dia", OUR_BOT);
-    const rows = await commandRows(9103, 0, 400);
+    const rows = await commandRows(9103);
     expect(rows).toHaveLength(0);
   });
 });

--- a/tests/modules/chatwoot-gate-trail.test.ts
+++ b/tests/modules/chatwoot-gate-trail.test.ts
@@ -5,6 +5,7 @@ import { encryptJson } from "@/api/lib/crypto";
 import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 
 // The webhook's own ownership gate, and the line it leaves behind.
 //
@@ -203,7 +204,7 @@ describe.skipIf(!dbUp)("the webhook gate leaves a trail", () => {
     if (!conv) return [];
     const deadline = Date.now() + waitMs;
     for (;;) {
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: { tenantId, stage: "handoff", conversationId: conv.id },
         orderBy: { id: "asc" },
       });

--- a/tests/modules/chatwoot-inbox-remove.test.ts
+++ b/tests/modules/chatwoot-inbox-remove.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/modules/chatwoot/client";
 import { remoteInboxIsGone, removeInbox } from "@/modules/chatwoot/management";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogCount } from "../utils/flowlog";
 
 // #307: an inbox deleted in Chatwoot leaves its mirror behind FOREVER. Sync deliberately never
 // prunes (keeping a binding beats pruning one), and the explicit action that comment points at does
@@ -342,7 +343,7 @@ describe.skipIf(!dbUp)("#307 removing the mirror of a deleted inbox", () => {
     // for the removal. Asserting it here so a later cascade cannot delete an operator's spend record.
     expect(await suDb.llmUsage.count({ where: { inboxId: inbox.id } })).toBe(1);
     expect(
-      await suDb.executionLog.count({
+      await flowLogCount(suDb, {
         // flowlog-scope: seeded — the subject is the ONE line this test wrote, addressed by an
         // inbox id no other test uses. There is no turn here: the question is whether removing an
         // inbox takes its log lines with it, which is about the row, not about a trail.

--- a/tests/modules/chatwoot-unbound-inbox.test.ts
+++ b/tests/modules/chatwoot-unbound-inbox.test.ts
@@ -5,6 +5,7 @@ import { encryptJson } from "@/api/lib/crypto";
 import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 
 // AN INBOX NOBODY BOUND, AND THE MESSAGES IT SWALLOWS.
 //
@@ -197,7 +198,7 @@ describe.skipIf(!dbUp)("an unbound inbox says so", () => {
     if (!conv) return [];
     const deadline = Date.now() + waitMs;
     for (;;) {
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: { tenantId, stage: "route", conversationId: conv.id },
         orderBy: { id: "asc" },
       });

--- a/tests/modules/contact-auth-gate-e2e.test.ts
+++ b/tests/modules/contact-auth-gate-e2e.test.ts
@@ -20,6 +20,7 @@ import {
   contactAuthNoticeEntries,
 } from "@/modules/contact-auth/state";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRow, flowLogRows } from "../utils/flowlog";
 import { PromptCapturingModel } from "../utils/scripted-models";
 
 // The contact authorization gate, wired end to end through processChatwootDelivery: what a denied /
@@ -244,7 +245,7 @@ async function deliverCustomerMessage(params: {
 async function flowRows(convId: number) {
   const threadId = `${tenantId}:${instanceId}:${convId}`;
   for (let i = 0; i < 200; i++) {
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { tenantId, threadId, stage: "contact_auth" },
       select: { level: true, status: true, detail: true },
       orderBy: { id: "asc" },
@@ -263,7 +264,7 @@ async function handoffDetail(convId: number): Promise<unknown> {
     select: { id: true },
   });
   for (let i = 0; i < 200; i++) {
-    const row = await suDb.executionLog.findFirst({
+    const row = await flowLogRow(suDb, {
       where: { tenantId, stage: "handoff", conversationId: conv.id },
       select: { detail: true },
       orderBy: { id: "desc" },
@@ -278,7 +279,7 @@ async function handoffDetail(convId: number): Promise<unknown> {
 async function auditedPrompt(convId: number): Promise<string> {
   const threadId = `${tenantId}:${instanceId}:${convId}`;
   for (let i = 0; i < 200; i++) {
-    const row = await suDb.executionLog.findFirst({
+    const row = await flowLogRow(suDb, {
       where: { tenantId, threadId, stage: "generate" },
       select: { detail: true },
       orderBy: { id: "asc" },

--- a/tests/modules/debounce.test.ts
+++ b/tests/modules/debounce.test.ts
@@ -31,7 +31,12 @@ import {
   enqueueJob,
   retireJobsByDedupeKey,
 } from "@/modules/scheduler/service";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import {
+  clearFlowLog,
+  flowLogCount,
+  flowLogRow,
+  flowLogRows,
+} from "@/tests/utils/flowlog";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import {
   EmptyThenReplyModel,
@@ -274,7 +279,7 @@ async function correctionLine(convId: number) {
   const deadline = Date.now() + 2000;
   let lines: Array<{ level: string; detail: unknown }> = [];
   while (Date.now() < deadline) {
-    lines = await suDb.executionLog.findMany({
+    lines = await flowLogRows(suDb, {
       where: { tenantId, conversationId, stage: "delivery" },
       select: { level: true, detail: true },
     });
@@ -756,7 +761,7 @@ describe.skipIf(!dbUp)("debounce", () => {
     });
     await new Promise((r) => setTimeout(r, 200));
     expect(
-      await suDb.executionLog.count({
+      await flowLogCount(suDb, {
         where: { tenantId, conversationId: conv.id, stage: "delivery" },
       }),
     ).toBe(0);
@@ -1829,7 +1834,7 @@ describe.skipIf(!dbUp)("debounce", () => {
       select: { id: true },
     });
     for (let i = 0; i < 40; i++) {
-      const row = await suDb.executionLog.findFirst({
+      const row = await flowLogRow(suDb, {
         where: { tenantId, stage: "handoff", conversationId: conversation.id },
         orderBy: { id: "desc" },
       });
@@ -1845,7 +1850,7 @@ describe.skipIf(!dbUp)("debounce", () => {
       select: { id: true },
     });
     for (let i = 0; i < 40; i++) {
-      const row = await suDb.executionLog.findFirst({
+      const row = await flowLogRow(suDb, {
         where: { tenantId, stage: "route", conversationId: conversation.id },
         orderBy: { id: "desc" },
       });
@@ -3406,7 +3411,7 @@ describe.skipIf(!dbUp)("debounce", () => {
       expect(notes).toEqual([]);
       // ...and no refusal line, because nothing was refused.
       await settleFlowEvents();
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         // Scoped to this flush's own thread, not to the tenant: the fixture is shared with the
         // refusals above, and a tenant-wide read would be asserting about their rows too.
         where: { tenantId, threadId: threadOf(914), stage: "spend_ceiling" },
@@ -3481,7 +3486,7 @@ describe.skipIf(!dbUp)("debounce", () => {
       // also swallow the window a real refusal needs later. The shape of the row this asserts the
       // absence of is proved by the refusals in the sibling tests above.
       await settleFlowEvents();
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         // This flush's own thread, not the tenant: the fixture is shared with those refusals.
         where: { tenantId, threadId: threadOf(913), stage: "spend_ceiling" },
         select: { level: true },
@@ -3533,7 +3538,7 @@ describe.skipIf(!dbUp)("debounce", () => {
       expect(await run()).toEqual({ outcome: "done" });
 
       await settleFlowEvents();
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: { tenantId, threadId: threadOf(916), stage: "spend_ceiling" },
         select: { level: true },
       });
@@ -3585,7 +3590,7 @@ describe.skipIf(!dbUp)("debounce", () => {
       expect(notes).toEqual([]);
       // ...and no refusal line, because nothing was refused.
       await settleFlowEvents();
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: { tenantId, threadId: threadOf(915), stage: "spend_ceiling" },
         select: { level: true },
       });

--- a/tests/modules/delivery-sweep.test.ts
+++ b/tests/modules/delivery-sweep.test.ts
@@ -19,7 +19,7 @@ import {
   processChatwootDelivery,
   recordAndProcessChatwootDelivery,
 } from "@/modules/chatwoot/webhook";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
 // A Chatwoot delivery stranded by a process death, and the sweep that says so (issue #228).
@@ -143,7 +143,7 @@ async function statusOf(rowId: bigint) {
 async function deliveryLines(convDbId: bigint, waitMs = 2000) {
   const started = Date.now();
   while (true) {
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { tenantId, stage: "delivery", conversationId: convDbId },
       select: { level: true, status: true, source: true, detail: true },
     });
@@ -164,7 +164,7 @@ async function correctionOutcome(convId: number) {
   const deadline = Date.now() + 2000;
   let lines: Array<{ detail: unknown }> = [];
   while (Date.now() < deadline) {
-    lines = await suDb.executionLog.findMany({
+    lines = await flowLogRows(suDb, {
       where: { tenantId, conversationId: conv.id, stage: "delivery" },
       select: { detail: true },
     });
@@ -182,7 +182,7 @@ async function correctionOutcome(convId: number) {
 async function unscopedDeliveryLines(waitMs = 2000) {
   const started = Date.now();
   while (true) {
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { tenantId, stage: "delivery", conversationId: null },
       select: { level: true, detail: true },
     });

--- a/tests/modules/eager-media-flow-context.test.ts
+++ b/tests/modules/eager-media-flow-context.test.ts
@@ -6,6 +6,7 @@ import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRow } from "../utils/flowlog";
 
 // The eager-media stages (`stt`, `vision`) are the ONLY inbox-source flow lines that used to be
 // written with no conversation, agent or inbox: `runEagerMedia`'s context carried a threadId and
@@ -262,7 +263,7 @@ describe.skipIf(!dbUp)("the eager-media flow context", () => {
       | undefined;
     for (let i = 0; i < 200 && !row; i++) {
       row =
-        (await suDb.executionLog.findFirst({
+        (await flowLogRow(suDb, {
           where: { tenantId, threadId, stage: "stt" },
           select: { conversationId: true, agentId: true, inboxId: true },
         })) ?? undefined;
@@ -348,7 +349,7 @@ describe.skipIf(!dbUp)("the eager-media flow context", () => {
       | undefined;
     for (let i = 0; i < 200 && !row; i++) {
       row =
-        (await suDb.executionLog.findFirst({
+        (await flowLogRow(suDb, {
           where: { tenantId, threadId, stage: "stt" },
           select: { conversationId: true, agentId: true, inboxId: true },
         })) ?? undefined;

--- a/tests/modules/flowlog-astral-detail.test.ts
+++ b/tests/modules/flowlog-astral-detail.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { emitFlowEvent, type FlowContext } from "@/modules/flowlog/service";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import { clearFlowLog, flowLogRow } from "@/tests/utils/flowlog";
 
 // THE EFFECT THE ISSUE NAMES: the stage line is not there.
 //
@@ -49,7 +49,7 @@ let tenantId = 0n;
 // amount: a fixed sleep either flakes on a slow machine or wastes the difference on a fast one.
 async function rowFor(turnId: string): Promise<unknown | null> {
   for (let i = 0; i < 100; i++) {
-    const row = await suDb.executionLog.findFirst({
+    const row = await flowLogRow(suDb, {
       where: { tenantId, turnId },
     });
     if (row) return row.detail;

--- a/tests/modules/flowlog-debug-mode-e2e.test.ts
+++ b/tests/modules/flowlog-debug-mode-e2e.test.ts
@@ -10,6 +10,7 @@ import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import { DEBUG_MAX_STRING, emitFlowEvent } from "@/modules/flowlog/service";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRow } from "../utils/flowlog";
 import { UsageReportingModel } from "../utils/scripted-models";
 
 // Issue #58 END TO END, at the effect the operator complained about: "I cannot see the whole prompt
@@ -124,7 +125,7 @@ async function setWindow(endsAt: Date | null) {
 async function generateRow(convId: number) {
   const threadId = `${tenantId}:${instanceId}:${convId}`;
   for (let i = 0; i < 200; i++) {
-    const row = await suDb.executionLog.findFirst({
+    const row = await flowLogRow(suDb, {
       where: { tenantId, threadId, stage: "generate" },
       select: { detail: true },
     });
@@ -282,7 +283,7 @@ describe.skipIf(!dbUp)("the log debug mode, on a real turn", () => {
     );
     let row: { detail: unknown } | null = null;
     for (let i = 0; i < 200 && row === null; i++) {
-      row = await suDb.executionLog.findFirst({
+      row = await flowLogRow(suDb, {
         where: { tenantId, turnId },
         select: { detail: true },
       });

--- a/tests/modules/flowlog-detail-pii.test.ts
+++ b/tests/modules/flowlog-detail-pii.test.ts
@@ -12,6 +12,7 @@ import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { clearContactAuthState } from "@/modules/contact-auth/state";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 import { guardrailModel, UsageReportingModel } from "../utils/scripted-models";
 
 // `docs/logs.md` promises that `execution_logs.detail` carries allowlisted ids, counts and enums and
@@ -118,7 +119,7 @@ async function seedConv(convId: number) {
 async function turnRows(convId: number, stages: readonly string[]) {
   const threadId = `${tenantId}:${instanceId}:${convId}`;
   for (let i = 0; i < 200; i++) {
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { tenantId, threadId },
       select: { stage: true, detail: true, errorMessage: true },
     });

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -16,14 +16,28 @@ import { describe, expect, test } from "bun:test";
 //          only scheduled lands after the DELETE, into a table this case believes it owns, and
 //          `orderBy: { id: "asc" }` hands that row back FIRST (issue #375).
 //
-// This file guards the first and the third. The second cannot be read off the source: "is there a
-// wait" is a question about control flow, and a poll loop is only correct when the assertion is that
-// a line EXISTS — polling for an absence just spends the timeout before answering. Those live as
-// comments at the call sites.
+// This file guards all three, and the second only since #419. It used to say the second "cannot be
+// read off the source", because "is there a wait" is a question about control flow, which was true
+// of the wait it had. The wait was a POLL LOOP, and a loop is a shape rather than a name, so there
+// was nothing to grep for. The observation underneath it was also right and is worth keeping: a poll
+// is only correct when the assertion is that a line EXISTS, since polling for an absence just spends
+// the timeout before answering the empty read it opened with.
 //
-// The third is checkable because it has one correct spelling: `clearFlowLog` (tests/utils/flowlog.ts)
-// settles the scheduled writes and then deletes. A raw DELETE is the defect, so the guard is that
-// there are no raw ones rather than a per-site judgement.
+// What changed is not the analysis, it is the wait. `flowLogRows` / `flowLogRow` / `flowLogCount`
+// settle the scheduled writes and then read, which makes the obligation checkable the same way the
+// third already was: by having ONE SPELLING. It also answers the objection rather than working
+// around it, because a settle is exact in both directions where a poll could only do presence.
+//
+// The argument for spending that is that the comments this obligation was left to did not hold.
+// chatwoot-command-dropped.test.ts polled for its `command` row and read its `route` row raw, three
+// lines apart, under a comment explaining the hazard for the first one, and the raw read turned CI
+// red on a branch touching no server file (#419). An obligation spelled out per site is one a new
+// site is written without, which is the reason tests/utils/flowlog.ts gives for the clear helper
+// existing at all.
+//
+// The third is checkable for the same reason: `clearFlowLog` (tests/utils/flowlog.ts) settles the
+// scheduled writes and then deletes. A raw DELETE is the defect, so the guard is that there are no
+// raw ones rather than a per-site judgement.
 //
 // WHAT IT DOES NOT COVER, said out loud rather than left to be discovered: 29 files end with a loop
 // over a table list, `execution_logs` among the entries and the name interpolated into
@@ -124,8 +138,13 @@ function markerAbove(source: string, line: number): Scoping | null {
 // the list instead of 9 — a scan that is generous in the direction that creates work nobody needs.
 export function flowlogReaders(source: string): Reader[] {
   const out: Reader[] = [];
+  // Both spellings, because the WAIT obligation (#419) moved every reader onto `flowLogRows` and
+  // friends and this scan would otherwise go blind on the day that landed, reporting a tree with no
+  // readers at all as a tree with nothing to check. The helper takes the client and then the SAME
+  // args object, so `where` still sits at the call site and everything below reads it unchanged;
+  // that is why the helper passes its args through instead of wrapping them away.
   const call =
-    /executionLog\.(?:findMany|findFirst|findFirstOrThrow|findUnique|findUniqueOrThrow|count|aggregate|groupBy)\s*\(/g;
+    /(?:executionLog\.(?:findMany|findFirst|findFirstOrThrow|findUnique|findUniqueOrThrow|count|aggregate|groupBy)|\bflowLog(?:Rows|Row|Count))\s*\(/g;
   for (const m of source.matchAll(call)) {
     const open = m.index + m[0].length - 1;
     const close = matchDelimiter(source, open, "(", ")");
@@ -223,6 +242,12 @@ const FLOWLOG_READERS: Record<string, number> = {
 // The one file the scan skips, because its fixtures below are unscoped reads written on purpose.
 const SELF = "tests/modules/flowlog-reader-scope.test.ts";
 
+// The helper file, skipped by BOTH scans below and for the same reason each time: it is where the
+// one correct spelling is DEFINED, so it holds the raw clear and the raw reads that every other file
+// is forbidden. Exempting it is not a hole: nothing in it asserts on a row, so neither obligation
+// has anything to be about.
+const HELPER = "tests/utils/flowlog.ts";
+
 // A clear of `execution_logs` written by hand, in any spelling a test has reached for. `TRUNCATE` is
 // listed because it is the same act under a different verb, and a guard that only knew `DELETE`
 // would wave it through. `\s` inside the pattern rather than a literal space for the same reason
@@ -231,6 +256,26 @@ const SELF = "tests/modules/flowlog-reader-scope.test.ts";
 // run per line would report the file as clean.
 const RAW_CLEAR =
   /executionLog\s*\.\s*deleteMany\s*\(|(?:DELETE\s+FROM|TRUNCATE(?:\s+TABLE)?)\s+"?execution_logs"?/gi;
+
+// A READ of `execution_logs` written against the client instead of the settling helper. Same shape
+// as RAW_CLEAR above and for the same reason: `\s` rather than a literal space, because
+// `executionLog\n  .findMany(…)` is what the formatter produces on a long enough line and a
+// per-line predicate would call that file clean.
+//
+// Only the READING methods. `deleteMany` has its own guard above, and `create` is how a test SEEDS
+// rows it then reads, awaited, with no emit in the path, so the wait obligation has nothing to be about.
+const RAW_READ =
+  /executionLog\s*\.\s*(?:findMany|findFirst|findFirstOrThrow|findUnique|findUniqueOrThrow|count|aggregate|groupBy)\s*\(/g;
+
+export function rawReadLines(src: string): number[] {
+  const out: number[] = [];
+  const re = new RegExp(RAW_READ.source, "gi");
+  for (;;) {
+    const hit = re.exec(src);
+    if (!hit) return out;
+    out.push(src.slice(0, hit.index).split("\n").length);
+  }
+}
 
 export function rawClearLines(src: string): number[] {
   const out: number[] = [];
@@ -251,7 +296,17 @@ export function rawClearLines(src: string): number[] {
 // behind, so it has to write the wrong one to assert what it costs; and this file, like the reader
 // scan above it, holds fixtures of the very thing it flags.
 const CLEAR_EXEMPT = new Set([
-  "tests/utils/flowlog.ts",
+  HELPER,
+  "tests/modules/flowlog-settle.test.ts",
+  SELF,
+]);
+
+// `flowLogRows` / `flowLogRow` / `flowLogCount` are the correct spellings. The same three files are
+// exempt as for the clear, and the middle one for a sharper reason than there: flowlog-settle's
+// SUBJECT is that the row is not there when the emit returns, so it has to read without settling to
+// assert what settling buys. A guard that forced it to settle would delete its premise.
+const READ_EXEMPT = new Set([
+  HELPER,
   "tests/modules/flowlog-settle.test.ts",
   SELF,
 ]);
@@ -261,7 +316,7 @@ async function scanTests(): Promise<Map<string, Reader[]>> {
   const found = new Map<string, Reader[]>();
   for await (const rel of new Glob("**/*.{ts,tsx}").scan("tests")) {
     const path = `tests/${rel}`;
-    if (path === SELF) continue;
+    if (path === SELF || path === HELPER) continue;
     const readers = flowlogReaders(await Bun.file(path).text());
     if (readers.length > 0) found.set(path, readers);
   }
@@ -452,6 +507,67 @@ describe("nothing empties the flow log by hand", () => {
     }
     // A raw clear empties the table of the rows that exist and of nothing else, so the case that runs
     // next inherits whatever the case before it had only scheduled. `clearFlowLog` settles first.
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("nothing reads the flow log without waiting for the write", () => {
+  test("it flags a raw read in each of its methods, and across a line break", () => {
+    expect(
+      rawReadLines("const r = await db.executionLog.findMany({ w });"),
+    ).toEqual([1]);
+    expect(rawReadLines("await db.executionLog.findFirst({ w });")).toEqual([
+      1,
+    ]);
+    expect(rawReadLines("await db.executionLog.count({ w });")).toEqual([1]);
+    // What Biome emits once the chain is long enough, and the shape a per-line predicate misses.
+    expect(
+      rawReadLines("await suDb.executionLog\n  .findMany({ w });"),
+    ).toEqual([1]);
+    // Two of them, so the scan cannot stop at the first and call the rest of the file clean.
+    expect(
+      rawReadLines(
+        "await db.executionLog.findMany({ a });\nawait db.executionLog.count({ b });",
+      ),
+    ).toEqual([1, 2]);
+  });
+
+  test("it does not flag the helper calls, a seeding create, nor another table", () => {
+    // The positive control above is what makes this line mean something: a predicate that flagged
+    // nothing would pass this test and the sweep below without reading anything.
+    expect(
+      rawReadLines("const r = await flowLogRows(suDb, { where });"),
+    ).toEqual([]);
+    expect(
+      rawReadLines("const r = await flowLogRow(suDb, { where });"),
+    ).toEqual([]);
+    expect(
+      rawReadLines("const n = await flowLogCount(suDb, { where });"),
+    ).toEqual([]);
+    // A test that INSERTS its own rows awaits the write, so there is no emit to outrun.
+    expect(rawReadLines("await suDb.executionLog.create({ data });")).toEqual(
+      [],
+    );
+    expect(
+      rawReadLines("await suDb.alertDelivery.findMany({ where });"),
+    ).toEqual([]);
+  });
+
+  test("every read in the suite goes through the settling helper", async () => {
+    const { Glob } = await import("bun");
+    const offenders: string[] = [];
+    for await (const rel of new Glob("**/*.{ts,tsx}").scan("tests")) {
+      const path = `tests/${rel}`;
+      if (READ_EXEMPT.has(path)) continue;
+      for (const line of rawReadLines(await Bun.file(path).text())) {
+        offenders.push(`${path}:${line}`);
+      }
+    }
+    // A read that does not settle answers before the row lands. For an assertion that a line EXISTS
+    // that is a flake; for one that a line does NOT exist it is worse, because the read passes for
+    // exactly the reason that makes it wrong. Measured on chatwoot-command-dropped with the write
+    // delayed 200ms: seven of its nine cases fail without the settle, and the two that pass are the
+    // two asserting an absence.
     expect(offenders).toEqual([]);
   });
 });

--- a/tests/modules/flowlog-retention.test.ts
+++ b/tests/modules/flowlog-retention.test.ts
@@ -5,7 +5,7 @@ import config from "@/config";
 import { registerFlowlogRetentionHandler } from "@/modules/flowlog/retention";
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import { getJobHandler, type JobResult } from "@/modules/scheduler/worker";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
 
 // FLOWLOG_SWEEP retention handler: deletes execution_logs (+ terminal alert_deliveries) older than
 // the retention window, RLS-scoped to the job's tenant, and reschedules +24h (no attempt consumed).
@@ -90,7 +90,7 @@ describe.skipIf(!dbUp)("flowlog retention", () => {
     }
     // flowlog-scope: tenant-wide — the assertion is WHICH rows survived the sweep, so it has to
     // read the tenant exhaustively; a scoped read could not say that old1/old2 are gone.
-    const remaining = await suDb.executionLog.findMany({
+    const remaining = await flowLogRows(suDb, {
       where: { tenantId },
       select: { turnId: true },
     });

--- a/tests/modules/flowlog.test.ts
+++ b/tests/modules/flowlog.test.ts
@@ -13,6 +13,7 @@ import {
 import { listExecutionLogs } from "@/modules/flowlog/read";
 import type { FlowContext } from "@/modules/flowlog/service";
 import { withFlowStage } from "@/modules/flowlog/service";
+import { flowLogRow } from "../utils/flowlog";
 import { outboundUrl } from "../utils/outbound";
 
 // withFlowStage control flow is pure when no flow context is wired (zero overhead, just runs fn).
@@ -263,7 +264,7 @@ describe.skipIf(!dbUp)("flowlog", () => {
     // emit is fire-and-forget → poll until the row lands.
     let row: { level: string; status: string | null } | null = null;
     for (let i = 0; i < 100 && !row; i++) {
-      row = await suDb.executionLog.findFirst({
+      row = await flowLogRow(suDb, {
         where: { tenantId: tenantA, turnId: "b8-warn", stage: "tts" },
         select: { level: true, status: true },
       });

--- a/tests/modules/guardrail-health.test.ts
+++ b/tests/modules/guardrail-health.test.ts
@@ -7,7 +7,7 @@ import {
   guardrailHealthWindowStart,
   readGuardrailHealth,
 } from "@/modules/guardrails/health";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import { clearFlowLog, flowLogRow } from "@/tests/utils/flowlog";
 
 // What the guardrail screen actually did, read back from the flow log. The reason this read exists
 // at all: analysis is fail-open, so a screen that can never run is indistinguishable from one that
@@ -335,7 +335,7 @@ describe.skipIf(!dbUp)("readGuardrailHealth", () => {
     });
     // flowlog-scope: seeded — reads the row this test inserted above with `create`, awaited. No
     // emit in the path, so neither the scope nor the wait obligation applies.
-    const newer = await suDb.executionLog.findFirst({
+    const newer = await flowLogRow(suDb, {
       where: { tenantId: tenantA, turnId: "g6" },
       select: { id: true },
     });

--- a/tests/modules/memory-compaction.test.ts
+++ b/tests/modules/memory-compaction.test.ts
@@ -38,6 +38,7 @@ import { MEMORY_HEAD_MAX_ATTENDANCES } from "@/modules/memory/cut";
 import type { JobResult } from "@/modules/scheduler/worker";
 import { withJobHandler } from "@/tests/utils/job-registry";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogCount, flowLogRow } from "../utils/flowlog";
 import { UsageReportingModel } from "../utils/scripted-models";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
@@ -242,7 +243,7 @@ describe.skipIf(!dbUp)("memory compaction", () => {
   }
 
   function countFlowLines(threadId: string) {
-    return suDb.executionLog.count({
+    return flowLogCount(suDb, {
       where: { tenantId, stage: "memory", threadId },
     });
   }
@@ -1029,7 +1030,7 @@ describe.skipIf(!dbUp)("memory compaction", () => {
     // The trail names the attendance that was actually folded, not the one this job was armed for.
     // Those differ exactly on a retry, which is when an operator most needs the line to be right.
     await waitForFlowLines(threadId, 1);
-    const trail = await suDb.executionLog.findFirst({
+    const trail = await flowLogRow(suDb, {
       where: { tenantId, stage: "memory", threadId },
     });
     expect(JSON.stringify(trail?.detail ?? {})).toContain(
@@ -1887,7 +1888,7 @@ describe.skipIf(!dbUp)("memory compaction", () => {
     );
 
     await waitForFlowLines(threadId, 1);
-    const row = await suDb.executionLog.findFirst({
+    const row = await flowLogRow(suDb, {
       where: { tenantId, stage: "memory", threadId },
     });
     expect(row).not.toBeNull();

--- a/tests/modules/memory-dead-letter.test.ts
+++ b/tests/modules/memory-dead-letter.test.ts
@@ -20,6 +20,7 @@ import {
 import { runCompactionTick } from "@/modules/memory/worker";
 import { getDeadLetterHandler, runClaimed } from "@/modules/scheduler/worker";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 
 // A compaction that will never happen has to SAY SO, in the trail the operator already reads by
 // conversation (issue #196).
@@ -265,7 +266,7 @@ describe.skipIf(!dbUp)("a compaction that will never happen", () => {
   }
 
   function memoryLines(threadId: string) {
-    return suDb.executionLog.findMany({
+    return flowLogRows(suDb, {
       where: { tenantId, stage: "memory", threadId },
       orderBy: { id: "asc" },
     });

--- a/tests/modules/model-fallback-turn.test.ts
+++ b/tests/modules/model-fallback-turn.test.ts
@@ -7,6 +7,7 @@ import { runAgentTurn } from "@/graph/runtime";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 import { FailingModel, UsageReportingModel } from "../utils/scripted-models";
 
 // WHAT THE CUSTOMER GETS WHEN THE AGENT'S PROVIDER CANNOT TAKE THE TURN (issue #143).
@@ -113,7 +114,7 @@ function usageRows(threadId: string) {
 }
 
 function generateRows(threadId: string) {
-  return suDb.executionLog.findMany({
+  return flowLogRows(suDb, {
     where: { tenantId, threadId, stage: "generate" },
     select: { level: true, provider: true, model: true, detail: true },
     orderBy: { id: "asc" },

--- a/tests/modules/playground-guardrails.test.ts
+++ b/tests/modules/playground-guardrails.test.ts
@@ -18,6 +18,7 @@ import {
   rebuildPlaygroundTurns,
 } from "@/modules/playground/sessions";
 import { listThreadTurnNotes } from "@/modules/playground/turn-notes";
+import { flowLogRow } from "../utils/flowlog";
 import { guardrailModel } from "../utils/scripted-models";
 
 // The context a console operator carries. The playground takes the REQUEST's context now, not an id
@@ -400,7 +401,7 @@ describe.skipIf(!dbUp)("playground guardrails (issue #136)", () => {
     let detail: unknown;
     for (let i = 0; i < 50 && !detail; i++) {
       detail = (
-        await suDb.executionLog.findFirst({
+        await flowLogRow(suDb, {
           // flowlog-scope: agent — every test here shares the tenant but owns its agent, which is
           // what fences this read (the note above says which neighbour it would otherwise take).
           where: {

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -9,6 +9,7 @@ import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { reengageConversation } from "@/modules/conversations/reengage";
 import { settleFlowEvents } from "@/modules/flowlog/scheduled";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 import { PromptCapturingModel } from "../utils/scripted-models";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
@@ -728,7 +729,7 @@ describe.skipIf(!dbUp)("reengage", () => {
       expect(res.outcome).toBe("empty");
       expect(sent).toEqual([]);
       await settleFlowEvents();
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: {
           tenantId,
           threadId: `${tenantId}:${instanceId}:923`,
@@ -764,7 +765,7 @@ describe.skipIf(!dbUp)("reengage", () => {
       expect(sent).toEqual([]);
       // ...and no refusal on the record, because nothing was refused.
       await settleFlowEvents();
-      const rows = await suDb.executionLog.findMany({
+      const rows = await flowLogRows(suDb, {
         where: {
           tenantId,
           threadId: `${tenantId}:${instanceId}:922`,

--- a/tests/modules/spend-ceiling-gate-e2e.test.ts
+++ b/tests/modules/spend-ceiling-gate-e2e.test.ts
@@ -19,7 +19,7 @@ import { clearContactAuthState } from "@/modules/contact-auth/state";
 import { settleFlowEvents } from "@/modules/flowlog/scheduled";
 import { clearSpendCeilingFlights } from "@/modules/spend-ceiling/notice";
 import { seedChatwootInstance } from "../utils/chatwoot";
-import { clearFlowLog } from "../utils/flowlog";
+import { clearFlowLog, flowLogRows } from "../utils/flowlog";
 
 // The spend ceiling, wired end to end through processChatwootDelivery (issue #146). The rule is
 // pinned without a database in ./spend-ceiling-decide.test.ts; what these pin is that it reaches the
@@ -223,7 +223,7 @@ async function deliverCustomerMessage(params: {
 async function ceilingRows(convId: number, onSecond = false) {
   await settleFlowEvents();
   const threadId = `${tenantId}:${onSecond ? instance2Id : instanceId}:${convId}`;
-  return suDb.executionLog.findMany({
+  return flowLogRows(suDb, {
     where: { tenantId, threadId, stage: "spend_ceiling" },
     select: { level: true, status: true, detail: true },
     orderBy: { id: "asc" },

--- a/tests/modules/spend-ceiling-paths-e2e.test.ts
+++ b/tests/modules/spend-ceiling-paths-e2e.test.ts
@@ -24,7 +24,7 @@ import {
   extractPlaygroundFile,
 } from "@/modules/vision/service";
 import { seedChatwootInstance } from "../utils/chatwoot";
-import { clearFlowLog } from "../utils/flowlog";
+import { clearFlowLog, flowLogRows } from "../utils/flowlog";
 
 // The two paths the webhook gate does NOT stand in front of (issue #146).
 //
@@ -367,7 +367,7 @@ describe.skipIf(!dbUp)("the spend ceiling on the playground and vision", () => {
     expect(result).toBeNull();
     expect(s.providerCalls).toEqual([]);
     await settleFlowEvents();
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { turnId },
       select: { stage: true, detail: true },
     });
@@ -452,7 +452,7 @@ describe.skipIf(!dbUp)("the spend ceiling on the playground and vision", () => {
     // NOTE: the assertion is that a line EXISTS and another does NOT, so the settle is required
     // rather than a poll: polling for the absence would only spend the timeout before answering.
     await settleFlowEvents();
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { turnId },
       select: { stage: true, status: true, detail: true },
     });
@@ -505,7 +505,7 @@ describe.skipIf(!dbUp)("the spend ceiling on the playground and vision", () => {
     ).toBeNull();
     expect(s.providerCalls.length).toBe(1);
     await settleFlowEvents();
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { turnId, stage: "spend_ceiling" },
       select: { level: true, status: true, detail: true },
     });

--- a/tests/modules/stt.test.ts
+++ b/tests/modules/stt.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@/modules/stt/service";
 import type { SttConfig } from "@/modules/stt/settings";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
 const suUrl = process.env.MIGRATION_DATABASE_URL;
@@ -266,7 +267,7 @@ describe.skipIf(!dbUp)("stt", () => {
     // NOTE: The lost write-back is observable on the flow log (stt stage, warn, step write_back).
     let warned = false;
     for (let i = 0; i < 30 && !warned; i++) {
-      const logs = await suDb.executionLog.findMany({
+      const logs = await flowLogRows(suDb, {
         where: { tenantId, turnId, stage: "stt", level: "warn" },
         select: { detail: true },
       });

--- a/tests/modules/terminal-failure-announces.test.ts
+++ b/tests/modules/terminal-failure-announces.test.ts
@@ -22,7 +22,7 @@ import {
   processInboundDelivery,
   receiveInbound,
 } from "@/modules/webhooks/inbound/service";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
 import { withJobHandler } from "@/tests/utils/job-registry";
 
 // ── A UNIT OF WORK THAT DIES PERMANENTLY HAS TO SAY SO (issue #356) ──
@@ -79,7 +79,7 @@ const past = () => new Date(Date.now() - 60_000);
 async function deadRows(expected: number, waitMs = 4000) {
   const deadline = Date.now() + waitMs;
   for (;;) {
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       // flowlog-scope: tenant-wide — the subject is HOW MANY lines a terminal failure wrote, so a
       // reader scoped to one turn would answer a different question and stay green while a second,
       // duplicate line existed. None of these units HAS a turn; this file's tenant is its own, and

--- a/tests/modules/tool-precondition-alerting.test.ts
+++ b/tests/modules/tool-precondition-alerting.test.ts
@@ -9,6 +9,7 @@ import {
 import type { ToolPrecondition } from "@/modules/agents/tool-preconditions";
 import type { FlowContext } from "@/modules/flowlog/service";
 import { writeFlowEvent } from "@/modules/flowlog/service";
+import { flowLogCount } from "../utils/flowlog";
 
 // PR #378 states, in its body and in the seam's own header, that a precondition refusing a call does
 // NOT page an alert channel — the rule doing its job is the system working, not an incident. That
@@ -98,7 +99,7 @@ describe.skipIf(!dbUp)("a precondition refusal does not page anyone", () => {
     );
     expect(delivered).toBe(true);
 
-    const logs = await suDb.executionLog.count({
+    const logs = await flowLogCount(suDb, {
       where: { tenantId, stage: "tool", turnId: ctx.turnId },
     });
     expect(logs).toBe(1);

--- a/tests/modules/tts-normalize-observability.test.ts
+++ b/tests/modules/tts-normalize-observability.test.ts
@@ -9,6 +9,7 @@ import { runAgentTurn } from "@/graph/runtime";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRow } from "../utils/flowlog";
 import { UsageReportingModel } from "../utils/scripted-models";
 
 // The speech normalizer is a BILLED model call on the audio path, and it used to leave no trace at
@@ -119,7 +120,7 @@ async function seedConversation(convId: number) {
 // The flow emit is fire-and-forget, so the row lands shortly AFTER the turn returns.
 async function waitForLog(convChatwootId: number, stage: string) {
   for (let i = 0; i < 100; i++) {
-    const row = await suDb.executionLog.findFirst({
+    const row = await flowLogRow(suDb, {
       where: {
         tenantId,
         stage,

--- a/tests/modules/tts.test.ts
+++ b/tests/modules/tts.test.ts
@@ -12,6 +12,7 @@ import type { FlowContext } from "@/modules/flowlog/service";
 import { synthesizeReply } from "@/modules/tts/service";
 import { TTS_DEFAULTS, type TtsConfig } from "@/modules/tts/settings";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRow } from "../utils/flowlog";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
 const suUrl = process.env.MIGRATION_DATABASE_URL;
@@ -289,7 +290,7 @@ describe.skipIf(!dbUp)("tts", () => {
     // emit is fire-and-forget → poll for the row.
     let row: { level: string; status: string | null } | null = null;
     for (let i = 0; i < 100 && !row; i++) {
-      row = await suDb.executionLog.findFirst({
+      row = await flowLogRow(suDb, {
         where: { tenantId, turnId: "tts-skip-novoice", stage: "tts" },
         select: { level: true, status: true },
       });
@@ -348,7 +349,7 @@ describe.skipIf(!dbUp)("tts", () => {
       detail: unknown;
     } | null = null;
     for (let i = 0; i < 100 && !row; i++) {
-      row = await suDb.executionLog.findFirst({
+      row = await flowLogRow(suDb, {
         where: { tenantId, turnId: "tts-fail-400", stage: "tts" },
         select: {
           level: true,

--- a/tests/modules/vision-retry.test.ts
+++ b/tests/modules/vision-retry.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@/modules/vision/service";
 import type { VisionConfig } from "@/modules/vision/settings";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { flowLogRows } from "../utils/flowlog";
 
 // A class that names a timeout without setting `name` — both vendor SDKs do this, which is why the
 // shared reducer matches the CONSTRUCTOR name too.
@@ -582,7 +583,7 @@ describe.skipIf(!dbUp)("vision retry", () => {
     // emit is fire-and-forget → poll until every line lands.
     let rows: Array<{ detail: unknown }> = [];
     for (let i = 0; i < 100 && rows.length < VISION_MAX_ATTEMPTS; i++) {
-      rows = await suDb.executionLog.findMany({
+      rows = await flowLogRows(suDb, {
         where: { tenantId, turnId, stage: "vision" },
         select: { detail: true },
         orderBy: { id: "asc" },

--- a/tests/modules/webhooks-outbound-dead-alert.test.ts
+++ b/tests/modules/webhooks-outbound-dead-alert.test.ts
@@ -4,7 +4,7 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { createAlertChannel } from "@/modules/flowlog/channels";
 import { processOutboundBatch } from "@/modules/webhooks/outbound/worker";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
 
 // ── A DEAD DELIVERY HAS TO SAY SO WHERE THE OPERATOR READS (issue #325) ──
 // Integration, real DB, real RLS: the claim runs cross-tenant under asSuperAdmin and the outcome
@@ -85,7 +85,7 @@ async function webhookRows(expected: number, waitMs = 3000) {
     // tenant is this file's own and `clearRows` empties it before each case — through `clearFlowLog`,
     // which settles the scheduled writes first, or the emptying would not include the line the
     // previous case had scheduled and not yet written (issue #375).
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { tenantId, stage: "webhook" },
       orderBy: { id: "asc" },
     });

--- a/tests/modules/webhooks-outbound-deliveries.test.ts
+++ b/tests/modules/webhooks-outbound-deliveries.test.ts
@@ -10,7 +10,7 @@ import {
   requeueWebhookDelivery,
 } from "@/modules/webhooks/outbound/deliveries";
 import { processOutboundBatch } from "@/modules/webhooks/outbound/worker";
-import { clearFlowLog } from "@/tests/utils/flowlog";
+import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
 
 // ── THE DELIVERY LEDGER AS A SUPPORTED SURFACE (issue #305) ──
 // Integration, real DB, real RLS: every call goes through `runScopedOn` exactly as the controller
@@ -101,7 +101,7 @@ async function webhookLines(expected: number, waitMs = 3000) {
     // clear site in the tree exposed, which is why issue #375 was answered at the clear instead: the
     // tenant is this file's own, and `clearFlowLog` settles the scheduled writes before deleting, so
     // the table is empty of the previous case's line AND of the one it had not written yet.
-    const rows = await suDb.executionLog.findMany({
+    const rows = await flowLogRows(suDb, {
       where: { tenantId, stage: "webhook" },
       orderBy: { id: "asc" },
     });

--- a/tests/utils/flowlog.ts
+++ b/tests/utils/flowlog.ts
@@ -21,3 +21,50 @@ export async function clearFlowLog(
   await settleFlowEvents();
   await db.executionLog.deleteMany({ where });
 }
+
+// READING `execution_logs` IN A TEST, WITHOUT ANSWERING BEFORE THE ROW LANDS (#419).
+//
+// The WAIT obligation, and the third of the three named in tests/modules/flowlog-reader-scope.test.ts.
+// That file guards SCOPE and CLEAR and says this one "cannot be read off the source", because "is
+// there a wait" is a question about control flow. That was true of the wait it had: a poll loop,
+// which is a shape rather than a name. It stops being true once the wait has ONE SPELLING, which is
+// the same move that made CLEAR checkable, and the argument for making it is that the comments the
+// obligation was left to failed in the field. `chatwoot-command-dropped.test.ts` polls for the
+// `command` row and reads the `route` row raw, three lines apart, and the raw one turned the CI red
+// on a branch that touches no server file.
+//
+// A settle rather than a poll, and the difference is not only that it is faster and exact:
+//
+//   PRESENCE  a poll answers correctly, spending 50ms increments until the row shows up.
+//   ABSENCE   a poll cannot answer at all: it spends the whole deadline and then reports the empty
+//             read it started with. A raw read is worse: it passes BECAUSE the write has not landed,
+//             so a test asserting "nothing was logged" is green for the reason that would make it
+//             wrong. Settling is the only form that answers this one, and roughly a third of the
+//             readers in the tree assert an absence.
+//
+// The args pass through rather than being wrapped away, and that is deliberate: the SCOPE guard
+// reads the `where` keys off the call site, so a helper that swallowed them would buy this
+// obligation by blinding the one already in place.
+export async function flowLogRows(
+  db: PrismaClient,
+  args: Prisma.ExecutionLogFindManyArgs,
+) {
+  await settleFlowEvents();
+  return db.executionLog.findMany(args);
+}
+
+export async function flowLogRow(
+  db: PrismaClient,
+  args: Prisma.ExecutionLogFindFirstArgs,
+) {
+  await settleFlowEvents();
+  return db.executionLog.findFirst(args);
+}
+
+export async function flowLogCount(
+  db: PrismaClient,
+  args: Prisma.ExecutionLogCountArgs,
+) {
+  await settleFlowEvents();
+  return db.executionLog.count(args);
+}


### PR DESCRIPTION
Fixes #419.

## O que estava errado

`emitFlowEvent` é fire-and-forget, então um teste que lê `execution_logs` tem que esperar a escrita. O `flowlog-reader-scope.test.ts` nomeia essa obrigação ao lado de SCOPE e CLEAR, guarda as duas outras, e diz sobre esta:

> The second cannot be read off the source: "is there a wait" is a question about control flow.

Isso valia para a espera que existia. Um poll loop é uma forma, não um nome, então não havia o que procurar na fonte. Deixa de valer quando a espera passa a ter **uma grafia**, que é exatamente como o CLEAR virou checável.

O argumento para gastar isso é que os comentários a que a obrigação foi deixada não seguraram. O `chatwoot-command-dropped.test.ts` faz polling para a linha `command` e lê a linha `route` crua, três linhas depois, sob um comentário que explica o perigo para a primeira. A leitura crua deixou a CI vermelha numa branch que não toca arquivo de servidor.

## Medição

Com o write atrasado 200ms, no arquivo acima:

| | resultado |
|---|---|
| com `settleFlowEvents()` | 9 pass |
| sem (a mutação) | **7 fail**, 2 pass |

Os 2 que passam sem a espera são exatamente os dois que afirmam uma **ausência**, verdes porque a escrita não chegou. Esse é o defeito, não a aprovação, e é a razão de settle ser melhor que poll aqui:

- **PRESENÇA**: um poll responde certo, gastando incrementos de 50ms.
- **AUSÊNCIA**: um poll não responde. Ele gasta o deadline inteiro e reporta a leitura vazia com que começou. Uma leitura crua é pior, porque passa *porque* a escrita não chegou.

Também medido, para saber se a espera resolve ou apenas mascara: no retorno de `processChatwootDelivery`, `scheduledFlowWrites()` é 1. A escrita já está agendada, então o settle a alcança.

## O que mudou

`flowLogRows` / `flowLogRow` / `flowLogCount` esperam as escritas agendadas e leem. Recebem o client e **o mesmo objeto de args**, de propósito: o `where` continua no call site, e um helper que embrulhasse os args teria comprado esta obrigação cegando o guard de SCOPE que já existia.

- 61 leitores em 31 arquivos convertidos (mais 4 arquivos que chegaram no rebase).
- Guard novo com a mesma forma do guard de clear, incluindo as fixtures de controle positivo.
- Três arquivos isentos: o helper define a grafia, e o assunto do `flowlog-settle` é que a linha **não** está lá quando o emit retorna, então forçá-lo a esperar apagaria a premissa dele.
- Os dois casos de ausência do `chatwoot-command-dropped` deixam de gastar 400ms de deadline cada.
- O comentário do topo do guard foi reescrito: ele afirmava que a obrigação não era checável, e deixá-lo seria o arquivo se contradizendo.

## Validação

`bun check` verde (lint, tipos, `check:editions`, suíte completa). A suíte de `tests/modules` + `tests/graph` rodada 3x seguidas: 5259 pass, 0 fail nas três.
