### PR TITLE
Give each writing form its own held refusal

### DIFF
--- a/src/client/lib/fieldRefusal.ts
+++ b/src/client/lib/fieldRefusal.ts
@@ -167,3 +167,55 @@ export function sameValue(a: unknown, b: unknown): boolean {
 function escapeName(name: string): string {
   return name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
+
+// THE TWO RULES A PAGE WITH MORE THAN ONE HOLDER NEEDS, AS FUNCTIONS RATHER THAN AS SHAPE (#415).
+//
+// The agent editor keeps one holder per writing form. Both rules below were first written inline in
+// the page and guarded by reading its source, and a mutation battery showed what that is worth: a
+// loop narrowed to its first entry still contains the text the guard looked for, so the check
+// stayed green while the aggregate consulted one holder out of six. Behaviour is what was being
+// claimed, so behaviour is what is tested.
+
+/** What a holder answers for one control: its sentence, or null. */
+export type RefusalReader = (field: string, value: unknown) => string | null;
+
+// FIRST match wins. One control draws ONE value, so two holders answering for it would be two
+// refusals about the same box, and the older is the one the operator has already been shown. A
+// holder whose mark has expired by value is silent here rather than shadowing a live one behind it,
+// which is what makes the order safe to fix.
+export function firstRefusalAt(
+  readers: readonly RefusalReader[],
+  field: string,
+  value: unknown,
+): string | null {
+  for (const read of readers) {
+    const message = read(field, value);
+    if (message) return message;
+  }
+  return null;
+}
+
+// WHOSE VALUE IS THIS, asked of one holder at a time.
+//
+// The half that one-holder-per-form does not get for free, and the reason this is a function with a
+// name. The obvious reading is that a form's own save settles its own holder, and it is wrong: a
+// refusal does not stay inside the section that produced it. A Behavior save can be refused about
+// `guardrails.output.templateMessage`, and the operator answers that by fixing the value on the
+// GUARDRAILS tab and saving THERE, while the mark sits in the Behavior holder. Settling only the
+// saving form's own holder would leave it standing on a value the server has since accepted, which
+// is the stale hold #349 removed.
+//
+// So a PLACED refusal is settled by the tab that draws its value, whoever wrote it, and one the
+// holder could place nowhere is about a SAVE rather than a value, so its own section answers it.
+export function settlesRefusal(args: {
+  /** The tab that draws the refused value, or null when the refusal was placed nowhere. */
+  drawnBy: string | null;
+  /** The section whose holder is being visited. */
+  owner: string;
+  /** The section that just saved or discarded. */
+  settled: string;
+}): boolean {
+  return args.drawnBy !== null
+    ? args.drawnBy === args.settled
+    : args.owner === args.settled;
+}

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -47,6 +47,7 @@ import { BusinessHoursForm } from "@/client/components/BusinessHoursForm";
 import type { DiscoveredMcpTool } from "@/client/components/mcp/DiscoveredMcpTools";
 import { useBreadcrumbLabel } from "@/client/contexts/BreadcrumbContext";
 import { useNavGuard } from "@/client/contexts/NavGuardContext";
+import type { FieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { useTenantEvents } from "@/client/hooks/useTenantEvents";
 import { api } from "@/client/lib/api";
@@ -61,7 +62,11 @@ import {
   hasNoConsoleControl,
   sentFromPatch,
 } from "@/client/lib/editorRefusal";
-import { readRefusal } from "@/client/lib/fieldRefusal";
+import {
+  firstRefusalAt,
+  readRefusal,
+  settlesRefusal,
+} from "@/client/lib/fieldRefusal";
 import { formatRelativeTime, slugify } from "@/client/lib/utils";
 import {
   invalidateVault,
@@ -571,6 +576,17 @@ function AgentEditorSkeleton() {
 // the abstention is recorded in tests/client/field-refusal-fence.test.ts).
 const CLONE_FIELDS = ["name"] as const;
 
+// The forms that write, as a union rather than loose strings: each one holds its own refusal (#415),
+// and a section name that does not match a holder would otherwise be a holder nobody ever captures
+// into, which is the orphan the fence exists to catch.
+type RefusalSection =
+  | "general"
+  | "behavior"
+  | "knowledge"
+  | "tools"
+  | "guardrails"
+  | "channelRedirect";
+
 export function AgentEditorPage() {
   const { id = "" } = useParams();
   return <AgentEditor key={id} />;
@@ -618,10 +634,11 @@ function AgentEditor() {
   //
   // Written by every `capture` and read only while the holder has a sentence, so neither can go stale
   // against it.
-  const [refusedSave, setRefusedSave] = useState<{
-    section: string;
-    named: string | null;
-  } | null>(null);
+  // Keyed by section since #415: each writing form holds its own, so a second refused save no longer
+  // erases what the first one had to say about a different form.
+  const [refusedSave, setRefusedSave] = useState<
+    Partial<Record<RefusalSection, { named: string | null } | null>>
+  >({});
   const refusedSaveRef = useRef(refusedSave);
   refusedSaveRef.current = refusedSave;
   const [savingGrants, setSavingGrants] = useState(false);
@@ -895,15 +912,80 @@ function AgentEditor() {
     followUpSteps: followUp.steps.length,
   };
   const refusalFields = editorRefusalFields(refusalView);
-  const refusal = useFieldRefusal(refusalFields.drawn, refusalFields.owned);
+
+  // ONE HELD REFUSAL PER FORM THAT WRITES, WHICH IS WHAT THE HOLDER ALWAYS ASKED FOR (#415).
+  //
+  // `useFieldRefusal` says it in its own header: "PER FORM, not per page and not in a context". This
+  // page had six independently savable forms behind ONE holder, and `capture` is also the clear, so
+  // the second refusal erased the first. No concurrency needed: refuse a Behavior save, switch to
+  // Guardrails, refuse that one, and the operator returns to a Behavior form that looks clean and is
+  // still refused.
+  //
+  // Six fixed calls rather than a loop, because hooks cannot be called in one. Every holder is given
+  // the SAME drawn/owned lists on purpose: a refusal does not stay inside the section that produced
+  // it. `saveAgent("behavior")` sends the whole settings bag and can be refused about
+  // `guardrails.output.templateMessage`, whose control the Guardrails tab draws. Splitting the lists
+  // per section would mean a holder that cannot place the very refusal its own save provoked.
+  const generalRefusal = useFieldRefusal(
+    refusalFields.drawn,
+    refusalFields.owned,
+  );
+  const behaviorRefusal = useFieldRefusal(
+    refusalFields.drawn,
+    refusalFields.owned,
+  );
+  const knowledgeRefusal = useFieldRefusal(
+    refusalFields.drawn,
+    refusalFields.owned,
+  );
+  const toolsRefusal = useFieldRefusal(
+    refusalFields.drawn,
+    refusalFields.owned,
+  );
+  const guardrailsRefusal = useFieldRefusal(
+    refusalFields.drawn,
+    refusalFields.owned,
+  );
+  // Sixth, and it did not answer a refusal at all before this. `saveChannelRedirect` writes the whole
+  // settings bag and its catch showed a bare toast, so a refusal naming a value this editor draws
+  // came back with no mark and nothing to jump to. That is the defect #349 fixed, at the one form
+  // #349 did not reach.
+  const channelRedirectRefusal = useFieldRefusal(
+    refusalFields.drawn,
+    refusalFields.owned,
+  );
+  const refusals: Record<RefusalSection, FieldRefusal> = {
+    general: generalRefusal,
+    behavior: behaviorRefusal,
+    knowledge: knowledgeRefusal,
+    tools: toolsRefusal,
+    guardrails: guardrailsRefusal,
+    channelRedirect: channelRedirectRefusal,
+  };
+  const REFUSAL_SECTIONS = Object.keys(refusals) as RefusalSection[];
+
+  // The reading every marked control does, now that there is more than one holder to ask. First
+  // match wins: a control draws ONE value, so two holders answering for it would be two refusals
+  // about the same box, and the older one is the one the operator has already been shown.
+  //
+  // Each holder still expires its own mark by value, so a stale one is silent here rather than
+  // shadowing a live one behind it.
+  const refusal = {
+    at: (field: string, value: unknown): string | null =>
+      firstRefusalAt(
+        REFUSAL_SECTIONS.map((section) => refusals[section].at),
+        field,
+        value,
+      ),
+  };
   // The holder as it is NOW, for the success and failure paths of a request that started earlier.
   //
   // Same reason the hook keeps its own refs: a save handler closes over the render that launched it,
   // and this page's saves are long enough for another tab's save to fail while one is still in
   // flight. Answering from the closure would let an older success clear a refusal that arrived after
   // it — `refusal.at` is memoized on the hold, so even the comparison would be the old one.
-  const refusalRef = useRef(refusal);
-  refusalRef.current = refusal;
+  const refusalRef = useRef(refusals);
+  refusalRef.current = refusals;
   // What every placeable input holds right now, keyed by the SERVER'S name for it, readable from
   // inside a save that started before them: this page's saves are long and the operator keeps typing
   // during them. Keyed by the wire name rather than by the state variable because that is the name a
@@ -986,13 +1068,23 @@ function AgentEditor() {
   function answerRefusal(
     e: unknown,
     fallback: string,
-    section: string,
+    section: RefusalSection,
     sent: Record<string, unknown>,
   ): void {
-    const left = refusal.capture(e, fallback, sent, currentRef.current);
-    setRefusedSave(
-      left ? { section, named: readRefusal(e)?.field ?? null } : null,
+    // The holder of the form that WROTE, so a refusal about another section's save is not
+    // overwritten by this one. Indexed directly rather than through a local: `RefusalSection` is a
+    // union, so there is no missing entry to guard against, and the direct spelling is what lets the
+    // fence prove every declared holder is reachable.
+    const left = refusals[section].capture(
+      e,
+      fallback,
+      sent,
+      currentRef.current,
     );
+    setRefusedSave((prev) => ({
+      ...prev,
+      [section]: left ? { named: readRefusal(e)?.field ?? null } : null,
+    }));
     setRefusalSeq((n) => n + 1);
   }
 
@@ -1011,20 +1103,41 @@ function AgentEditor() {
   //
   // A refusal the holder could place nowhere is about a SAVE rather than a value, so its own section
   // answers it.
-  function settleRefusalFor(section: string): void {
-    const now = refusalRef.current;
-    const held = now.field;
-    const target = held
-      ? editorTargetFor(held, { guardrailsEnabled: guardrails.enabled })
-      : null;
-    if (
-      held
-        ? target?.tab === section
-        : refusedSaveRef.current?.section === section
-    ) {
-      now.clear();
+  // Scoped by the tab that DRAWS the value, across EVERY holder, and that is the half of this the
+  // per-form split does not get for free. The obvious reading of "one holder per form" is that a
+  // form's own save settles its own holder, and that is wrong here for the same reason the split is
+  // right: a refusal does not stay inside the section that produced it. Refuse a Behavior save about
+  // `guardrails.output.templateMessage`, then go to Guardrails, fix the value and save it: the
+  // refusal is answered, and it is sitting in the BEHAVIOR holder. Settling only the saving form's
+  // own holder would leave that mark standing on a value the server has since accepted, which is the
+  // stale hold #349 removed.
+  //
+  // So the question stays "whose value is this", answered by the tab, and the loop is what makes it
+  // reach all six. A refusal the holder could place nowhere is about a SAVE rather than a value, so
+  // there the holder's own section answers it.
+  function settleRefusalFor(section: RefusalSection): void {
+    for (const owner of REFUSAL_SECTIONS) {
+      const now = refusalRef.current[owner];
+      const held = now.field;
+      const target = held
+        ? editorTargetFor(held, { guardrailsEnabled: guardrails.enabled })
+        : null;
+      if (
+        settlesRefusal({
+          drawnBy: held ? (target?.tab ?? null) : null,
+          owner,
+          settled: section,
+        })
+      ) {
+        now.clear();
+      }
     }
-    setRefusedSave((prev) => (prev?.section === section ? null : prev));
+    setRefusedSave((prev) => {
+      if (!prev?.[section]) return prev;
+      const next = { ...prev };
+      delete next[section];
+      return next;
+    });
   }
 
   // WHAT THE BANNER SAYS: every standing refusal, whichever of them is standing.
@@ -1045,40 +1158,49 @@ function AgentEditor() {
   // input, and the same sentence above the tabs. That is the shape a form-level error summary has
   // everywhere it is used, it does not interrupt and it does not scroll away, and it is the trade
   // this takes over being silent on a case nobody enumerated yet.
-  const heldField = refusal.field;
-  const heldMessage = heldField
-    ? refusal.at(heldField, currentRef.current[heldField])
-    : null;
-  // The mark expires by VALUE, so a placed sentence has to be asked for through `at`; one the holder
-  // could place nowhere has no value to expire against and is read straight off the holder. Either
-  // way there is one copy, and it is the holder's.
-  const bannerMessage = heldField ? heldMessage : refusal.message;
-  // A jump only when there is somewhere to send them: a mark on the open tab is already as close as
-  // the operator can get, and a sentence with no mark has no control to point at.
-  const heldTarget = heldField
-    ? editorTargetFor(heldField, { guardrailsEnabled: guardrails.enabled })
-    : null;
-  // Somewhere to send them, from the mark when there is one and from the name the server used when
-  // there is not: a refusal this editor cannot MARK can still be about a value it draws (a tool
-  // precondition is edited as a list, so there is no single box to put the sentence in).
-  const namedTarget =
-    !heldField && refusedSave?.named
-      ? editorTargetFor(refusedSave.named, {
-          guardrailsEnabled: guardrails.enabled,
-        })
-      : null;
-  const jumpTo = heldMessage ? heldTarget : namedTarget;
-  const bannerTarget = jumpTo && jumpTo.tab !== tab ? jumpTo : null;
-  // Said only when the server NAMED a value and this editor draws no control for it. Not for a
-  // refusal about no input at all (a 403, a conflict), where there is no value to go and change.
-  // BRING IT INTO VIEW, because the banner sits above the tabs and the button that produced it does
-  // not. Behavior and Tools are long, their Save lives in a sticky bar at the bottom, and the toast
-  // that used to answer from down there is gone — so a sighted operator would watch the save stop
-  // and see nothing until they scrolled back up. `role="alert"` already answers for a screen reader;
-  // this is the other half.
+  // WITH SIX HOLDERS THE BANNER IS A LIST, because "the refusal in force" stopped being one thing.
+  // Two forms can each be refused about something different, and a banner that showed the newest
+  // would be the erasure this issue is about, moved from the holder into the render.
   //
-  // Once per sentence, not once per render: the banner stays up until the refusal is answered, and
-  // re-scrolling on every keystroke would take the page out from under whoever is fixing the value.
+  // Built in section order rather than in arrival order, so the list does not reshuffle under the
+  // operator when one entry settles and another arrives.
+  const refusalRows = REFUSAL_SECTIONS.flatMap((section) => {
+    const holder = refusals[section];
+    const held = holder.field;
+    // The mark expires by VALUE, so a placed sentence has to be asked for through `at`; one the
+    // holder could place nowhere has no value to expire against and is read straight off the holder.
+    // Either way there is one copy, and it is the holder's.
+    const placed = held ? holder.at(held, currentRef.current[held]) : null;
+    const message = held ? placed : holder.message;
+    if (!message) return [];
+    const named = refusedSave[section]?.named ?? null;
+    // A jump only when there is somewhere to send them: a mark on the open tab is already as close
+    // as the operator can get, and a sentence with no mark has no control to point at. From the mark
+    // when there is one and from the name the server used when there is not, because a refusal this
+    // editor cannot MARK can still be about a value it draws (a tool precondition is edited as a
+    // list, so there is no single box to put the sentence in).
+    const target = held
+      ? placed
+        ? editorTargetFor(held, { guardrailsEnabled: guardrails.enabled })
+        : null
+      : named
+        ? editorTargetFor(named, { guardrailsEnabled: guardrails.enabled })
+        : null;
+    return [
+      {
+        section,
+        message,
+        // Said only where it can be PROVED. It used to be read off a map having no entry, and absence
+        // proves nothing about the console: the map was missing `settings.modelFallback.model` and
+        // `observability.fullDetailUntil`, both of which have a visible control, so the banner told
+        // the operator the opposite of the truth about them. `hasNoConsoleControl` answers from the
+        // closed set it can derive, the ten native-tool notes the editor draws no field for.
+        noControl: !held && named != null && hasNoConsoleControl(named),
+        target: target && target.tab !== tab ? target : null,
+      },
+    ];
+  });
+
   const bannerRef = useRef<HTMLDivElement | null>(null);
   // Counted, not compared by text. Two transport failures in a row produce the SAME fallback
   // sentence, and a second failure the operator has scrolled away from would have scrolled nothing
@@ -1086,21 +1208,12 @@ function AgentEditor() {
   // Every answered request bumps this, so each one is announced once whatever it says.
   const [refusalSeq, setRefusalSeq] = useState(0);
   const announcedRef = useRef(0);
+  const hasRefusalRow = refusalRows.length > 0;
   useEffect(() => {
-    if (!bannerMessage || announcedRef.current === refusalSeq) return;
+    if (!hasRefusalRow || announcedRef.current === refusalSeq) return;
     announcedRef.current = refusalSeq;
     bannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
-  }, [bannerMessage, refusalSeq]);
-
-  // Said only where it can be PROVED. It used to be read off this map having no entry, and absence
-  // proves nothing about the console: the map was missing `settings.modelFallback.model` and
-  // `observability.fullDetailUntil`, both of which have a visible control, so the banner told the
-  // operator the opposite of the truth about them. `hasNoConsoleControl` answers from the closed set
-  // it can derive -- the ten native-tool notes the editor draws no field for.
-  const bannerNoControl =
-    !heldField &&
-    refusedSave?.named != null &&
-    hasNoConsoleControl(refusedSave.named);
+  }, [hasRefusalRow, refusalSeq]);
 
   // The clone dialog is its own form: one input, and the route refuses a name already taken by name.
   // Separate from the editor's holder, because the two are on screen together.
@@ -2441,9 +2554,11 @@ function AgentEditor() {
       danger: true,
       confirmLabel: t("editor.discardAll", "Discard all"),
       onConfirm: () => {
-        // Every section at once, so every refusal goes with them.
-        refusalRef.current.clear();
-        setRefusedSave(null);
+        // Every section at once, so every refusal goes with them: six holders now, and a discard
+        // that cleared only one would put values back while a mark about them stayed up.
+        for (const owner of REFUSAL_SECTIONS)
+          refusalRef.current[owner]?.clear();
+        setRefusedSave({});
         const a = syncedAgentRef.current;
         if (a) {
           applyAgent(a);
@@ -2705,6 +2820,9 @@ function AgentEditor() {
   async function saveChannelRedirect(force = false) {
     savingRef.current += 1;
     setSavingChannelRedirect(true);
+    // Declared out here so the catch can read it: the snapshot has to be taken before the request,
+    // and a `const` inside the try would not be in scope where the refusal is answered.
+    let sent: Record<string, unknown> = {};
     try {
       const expected = expectedFor(force);
       const syncedSettings = (syncedAgentRef.current?.settings ?? {}) as Record<
@@ -2712,10 +2830,14 @@ function AgentEditor() {
         unknown
       >;
       const crJson = fromChannelRedirectForm(channelRedirect);
-      const { data, error: err } = await api.api.v1.agents({ id }).patch({
+      const patch = {
         settings: { ...syncedSettings, channelRedirect: crJson },
         ...(expected ? { expectedUpdatedAt: expected } : {}),
-      });
+      };
+      // Snapshot BEFORE the request, never read in the catch: `currentRef` is live, so comparing it
+      // with itself there can never fire the staleness check.
+      sent = sentFor(patch);
+      const { data, error: err } = await api.api.v1.agents({ id }).patch(patch);
       if (handleConflict(err, () => void saveChannelRedirect(true))) return;
       if (err || !data) throw err ?? new Error("no data");
       applyChannelRedirect(data.agent);
@@ -2725,11 +2847,16 @@ function AgentEditor() {
       markSynced(String(data.agent.updatedAt));
       bumpSync("channelRedirect");
       showToast(t("editor.saved", "Agent saved."), "success");
+      settleRefusalFor("channelRedirect");
     } catch (e) {
-      showToast(
-        apiErrorMessage(e) ||
-          t("editor.saveError", "Could not save the agent."),
-        "error",
+      // It writes the WHOLE settings bag, so it can be refused about any value in it, and until #415
+      // this catch showed a bare toast: the sentence named a field, the field had a control, and
+      // nothing marked it or offered to go there.
+      answerRefusal(
+        e,
+        t("editor.saveError", "Could not save the agent."),
+        "channelRedirect",
+        sent,
       );
     } finally {
       savingRef.current -= 1;
@@ -3221,32 +3348,38 @@ function AgentEditor() {
                 a toast: the sentence is the only copy of the reason, and a toast takes it away after
                 five seconds while the input it is about is still refused. It goes when the operator
                 answers the refusal, or when they reach the tab that draws the mark. */}
-            {bannerMessage && (
-              <div
-                ref={bannerRef}
-                role="alert"
-                className="flex scroll-mt-4 items-baseline justify-between gap-3 rounded-lg border border-error bg-error-soft px-4 py-3"
-              >
-                <span className="min-w-0 text-sm text-text-primary">
-                  {bannerMessage}
-                  {bannerNoControl && (
-                    <span className="block text-text-secondary text-xs">
-                      {t(
-                        "editor.refusalNoControl",
-                        "This value has no field in the console, so it can only be changed through the API.",
+            {refusalRows.length > 0 && (
+              <div ref={bannerRef} className="flex scroll-mt-4 flex-col gap-2">
+                {refusalRows.map((entry) => (
+                  <div
+                    key={entry.section}
+                    role="alert"
+                    className="flex items-baseline justify-between gap-3 rounded-lg border border-error bg-error-soft px-4 py-3"
+                  >
+                    <span className="min-w-0 text-sm text-text-primary">
+                      {entry.message}
+                      {entry.noControl && (
+                        <span className="block text-text-secondary text-xs">
+                          {t(
+                            "editor.refusalNoControl",
+                            "This value has no field in the console, so it can only be changed through the API.",
+                          )}
+                        </span>
                       )}
                     </span>
-                  )}
-                </span>
-                {bannerTarget && (
-                  <button
-                    type="button"
-                    onClick={() => goToEditorTarget(bannerTarget)}
-                    className="shrink-0 rounded font-medium text-accent text-xs hover:underline focus-visible:underline"
-                  >
-                    {t("editor.goToIssue", "Fix")}
-                  </button>
-                )}
+                    {entry.target && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          entry.target && goToEditorTarget(entry.target)
+                        }
+                        className="shrink-0 rounded font-medium text-accent text-xs hover:underline focus-visible:underline"
+                      >
+                        {t("editor.goToIssue", "Fix")}
+                      </button>
+                    )}
+                  </div>
+                ))}
               </div>
             )}
 

--- a/tests/client/editor-save-errors.test.ts
+++ b/tests/client/editor-save-errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { firstRefusalAt, settlesRefusal } from "@/client/lib/fieldRefusal";
 
 // The server refuses a write whose settings text is over a cap, and the refusal is only actionable
 // because it names the field, the length and the limit — a handler that swallows it and shows its
@@ -10,6 +11,34 @@ import { readFileSync } from "node:fs";
 // and the toast text these handlers produce is the whole subject. apiErrorMessage.test.ts proves the
 // extraction itself; this proves nobody writes a new save that forgets to use it.
 const SRC = readFileSync("src/client/pages/agents/AgentEditorPage.tsx", "utf8");
+
+// SLICING THE SOURCE, WITH THE ANCHOR PROVED TO EXIST.
+//
+// `String.indexOf` answers -1 for something that is not there, and -1 is a legal argument to
+// `slice`: it silently means "one character from the end", and a `slice(start, -1)` where the END
+// anchor is missing runs to the end of the FILE. Every assertion made against that span then passes
+// on some unrelated code further down, which is a fence that reports green while guarding nothing.
+//
+// Round 1 of review on #425 found exactly that: this file looked for `hasRefusalRow` while the page
+// declared `hasStandingRefusal`, so the "banner is brought into view" span covered most of the
+// remainder of the file and would have been satisfied by any later `scrollIntoView`. A rename is all
+// it takes, which is why the guard cannot be "remember to check".
+function between(src: string, from: string, to: string): string {
+  const start = src.indexOf(from);
+  expect(start, `anchor not found: ${from}`).toBeGreaterThan(-1);
+  const end = src.indexOf(to, start + from.length);
+  expect(end, `closing anchor not found after ${from}: ${to}`).toBeGreaterThan(
+    -1,
+  );
+  return src.slice(start, end);
+}
+
+// The same proof for a span that runs to the end of what it opens.
+function after(src: string, from: string): string {
+  const start = src.indexOf(from);
+  expect(start, `anchor not found: ${from}`).toBeGreaterThan(-1);
+  return src.slice(start);
+}
 
 // A write to the agent row: what settings text caps are enforced on.
 const WRITES = /\.patch\(|\.clone\.post\(/;
@@ -39,28 +68,40 @@ describe("agent editor save errors", () => {
     // the old value.
     expect(SRC).not.toContain("clearRefusalFor");
     expect(SRC).not.toContain("discardRefusalFor");
-    const start = SRC.indexOf("function settleRefusalFor");
-    expect(start).toBeGreaterThan(-1);
-    const body = SRC.slice(start, SRC.indexOf("\n  }", start));
+    const body = between(SRC, "function settleRefusalFor", "\n  }");
 
     // By the tab that DRAWS the value, not by what the request serialized: a Behavior save spreads
     // the last-synced `settings`, so it carries `guardrails.customPolicy` holding what is STORED
-    // rather than the edit the Guardrails tab still has unsaved.
-    expect(body).toContain("target?.tab === section");
+    // rather than the edit the Guardrails tab still has unsaved. The rule itself is `settlesRefusal`
+    // and is tested by behaviour below; what is asked here is that this is the function used.
+    expect(body).toContain("settlesRefusal({");
+    expect(body).toContain("drawnBy: held ? (target?.tab ?? null) : null");
     expect(body).not.toContain("Object.hasOwn(sent");
-    // A refusal the holder could place nowhere is about a SAVE, so its own section answers it.
-    expect(body).toContain("refusedSaveRef.current?.section === section");
+    // A refusal the holder could place nowhere is about a SAVE, so its own section answers it. With
+    // one holder per writing form (#415) "its own section" is the holder being visited, not a single
+    // page-level record: `owner` is the loop's holder and `settled` is the form that just settled.
+    expect(body).toContain("owner,");
+    expect(body).toContain("settled: section,");
+    // And it reaches ALL of them, which is the half the per-form split does not get for free. A
+    // refusal does not stay inside the section that produced it, so a Behavior save refused about a
+    // Guardrails path is answered by saving GUARDRAILS, and that mark is sitting in the Behavior
+    // holder. Settling only the saving form's own holder would leave it standing on a value the
+    // server has since accepted.
+    expect(body).toContain("for (const owner of REFUSAL_SECTIONS)");
     // Through refs, never the closure: a save handler closes over the render that launched it, and
     // this page's saves are long enough for another tab's save to fail while one is in flight.
     expect(body).toContain("refusalRef.current");
     expect(body).not.toContain("refusal.field");
 
-    // Every settling path goes through it: five saves and six discards.
+    // Every settling path goes through it: six saves and six discards. `channelRedirect` appears
+    // twice since #415: it settles on its own successful save now, where before only its discard
+    // did, because it did not take part in the refusal mechanism at all.
     const settled = [
       ...SRC.matchAll(/(?<!function )settleRefusalFor\(([^)]*)\)/g),
     ].map((m) => (m[1] as string).replace(/"/g, ""));
     expect(settled.sort()).toEqual([
       "behavior",
+      "channelRedirect",
       "channelRedirect",
       "general",
       "guardrails",
@@ -71,8 +112,12 @@ describe("agent editor save errors", () => {
       "tools",
       "tools",
     ]);
-    // Discard-all settles every section at once.
-    expect(SRC).toContain("refusalRef.current.clear();");
+    // Discard-all settles every section at once, which is now six holders rather than one.
+    // Whitespace-insensitive: the formatter breaks this across lines once the body grows, and a
+    // guard pinned to one spelling of it would go red on a reformat that changed nothing.
+    expect(SRC.replace(/\s+/g, " ")).toContain(
+      "for (const owner of REFUSAL_SECTIONS) refusalRef.current[owner]?.clear();",
+    );
   });
 
   test("the page keeps no copy of the sentence", () => {
@@ -85,11 +130,14 @@ describe("agent editor save errors", () => {
     expect(SRC).not.toContain("standingRefusal");
     // What the page does keep is what the HOLDER cannot know: which form's write failed, and the name
     // the server used. Neither is a sentence, and neither is read unless the holder has one.
-    const start = SRC.indexOf("const [refusedSave, setRefusedSave]");
-    expect(start).toBeGreaterThan(-1);
     expect(
-      SRC.slice(start, SRC.indexOf("} | null>(null)", start)),
+      between(SRC, "const [refusedSave, setRefusedSave]", ">({});"),
     ).not.toContain("message");
+    // Keyed by section since #415, because a single record meant the second refused save erased what
+    // the first had to say about a different form.
+    expect(SRC).toContain(
+      "Partial<Record<RefusalSection, { named: string | null } | null>>",
+    );
   });
 
   // THE SECOND CHANNEL, FOR A REFUSAL NO INPUT ON SCREEN IS CARRYING.
@@ -101,51 +149,45 @@ describe("agent editor save errors", () => {
   // Source-level because mounting this page pulls auth, theme, toast and a live catalog; the mark
   // reaching a box is proved on the tab that CAN be mounted (pages/GuardrailsTab.test.tsx).
   test("the banner carries every standing refusal, unconditionally", () => {
-    const start = SRC.indexOf("const bannerMessage =");
-    expect(start).toBeGreaterThan(-1);
-    const decl = SRC.slice(start, SRC.indexOf(";", start));
+    const decl = between(SRC, "const refusalRows =", "\n  });");
     // No visibility test of any kind. Two earlier versions asked whether the marked control was on
     // screen — first by tab, then by tab plus each section's switch — and each one missed a way a
     // control can be hidden that lives inside the tab components: a guardrails field turned off by
     // its own action, a native-tool note in a collapsed card. Every miss reads as a failed save with
     // nothing on screen saying so, and the list is not this file's to close.
-    expect(decl).toContain("refusal.message");
+    expect(decl).toContain("holder.message");
     expect(decl).not.toContain("drawn");
-    expect(decl).not.toContain("tab ===");
     // A PLACED mark is still asked for through `at`, which is what makes it expire with the value.
-    expect(decl).toContain("heldMessage");
+    expect(decl).toContain("holder.at(held");
+    // EVERY holder, not the newest: two forms can each be refused about something different, and a
+    // banner that showed one of them would be the erasure #415 is about, moved into the render.
+    expect(decl).toContain("REFUSAL_SECTIONS.flatMap");
 
     // The jump is the part that is conditional, and only on there being somewhere to send anyone.
-    const target = SRC.slice(
-      SRC.indexOf("const jumpTo ="),
-      SRC.indexOf(";", SRC.indexOf("const bannerTarget =")),
-    );
-    expect(target).toContain("jumpTo.tab !== tab");
+    expect(decl).toContain("target.tab !== tab");
     // From the mark when there is one and from the name the server used when there is not: a refusal
     // this editor cannot MARK can still be about a value it draws, and a tool precondition is edited
     // as a list so there is no single box to put the sentence in.
-    expect(target).toContain("namedTarget");
+    expect(decl).toContain("editorTargetFor(named");
 
-    const banner = SRC.slice(SRC.indexOf("{bannerMessage && ("));
-    const body = banner.slice(0, banner.indexOf("\n            )}"));
-    expect(body).toContain("{bannerMessage}");
-    expect(body).toContain("goToEditorTarget(bannerTarget)");
+    const body = between(
+      SRC,
+      "{refusalRows.length > 0 && (",
+      "\n            )}",
+    );
+    expect(body).toContain("{entry.message}");
+    expect(body).toContain("goToEditorTarget(entry.target)");
     // And it says WHY when it offers no way: `toolGuidance` takes a note for thirteen native tools
     // and the console draws three, so a refusal about one of the other ten is about a value no
     // screen here edits. The server's sentence names the field and cannot know that.
-    expect(body).toContain("bannerNoControl");
-    const noControl = SRC.slice(
-      SRC.indexOf("const bannerNoControl ="),
-      SRC.indexOf(";", SRC.indexOf("const bannerNoControl =")),
-    );
+    expect(body).toContain("entry.noControl");
     // Said only where it can be PROVED, never read off the map having no entry: absence proves
     // nothing about the console, and the map WAS missing `settings.modelFallback.model` and
     // `observability.fullDetailUntil`, both of which have a visible control. The banner told the
-    // operator the opposite of the truth about them.
-    expect(noControl).toContain("hasNoConsoleControl");
-    expect(noControl).not.toContain("editorTargetFor");
-    // Never for a refusal about no input at all, where there is no value to go and change.
-    expect(noControl).toContain("refusedSave?.named != null");
+    // operator the opposite of the truth about them. Never for a refusal about no input at all,
+    // where there is no value to go and change.
+    expect(decl).toContain("hasNoConsoleControl(named)");
+    expect(decl).toContain("!held && named != null");
   });
 
   test("nothing the holder hands back is dropped", () => {
@@ -154,10 +196,12 @@ describe("agent editor save errors", () => {
     // hook did with it, and the two come apart: a mapped name can still fail to be placed (the value
     // was edited during the request, the follow-up step no longer exists), and then the sentence went
     // nowhere and no mark existed to render it. A save that fails in silence.
-    const start = SRC.indexOf("function answerRefusal");
-    expect(start).toBeGreaterThan(-1);
-    const body = SRC.slice(start, SRC.indexOf("\n  }", start));
-    expect(body).toContain("refusal.capture(");
+    const body = between(SRC, "function answerRefusal", "\n  }");
+    // The holder of the form that WROTE, which is the whole of #415: one page-wide holder meant the
+    // second refused save overwrote the first. Indexed at the call site rather than through a local,
+    // which is what lets the fence in field-refusal-fence.test.ts prove every declared holder is
+    // reachable, the same move that made the wait checkable in #419.
+    expect(body).toContain("refusals[section].capture(");
     // The holder keeps the sentence; the page records only which save failed and what it named.
     expect(body).toContain("setRefusedSave");
     expect(body).not.toContain("editorTargetFor");
@@ -171,11 +215,10 @@ describe("agent editor save errors", () => {
     // and their Save lives in a sticky bar at the bottom. Dropping the toast (round 2) took away the
     // thing that answered from down there, so without this a sighted operator watches the save stop
     // and sees nothing. `role="alert"` covers the screen reader; this is the other half.
-    const start = SRC.indexOf("const bannerRef =");
-    expect(start).toBeGreaterThan(-1);
-    const effect = SRC.slice(
-      start,
-      SRC.indexOf("}, [bannerMessage, refusalSeq]);", start),
+    const effect = between(
+      SRC,
+      "const bannerRef =",
+      "}, [hasRefusalRow, refusalSeq]);",
     );
     expect(effect).toContain("scrollIntoView");
     // Once per ANSWERED REQUEST, counted rather than compared by text. The banner stays up until the
@@ -222,9 +265,7 @@ describe("agent editor save errors", () => {
     // `sent` is read off the patch and `current` off this map, so a value the patch trims and the map
     // keeps raw reads as "edited while the request was out" — and the refusal lands in the banner
     // instead of on the textarea it is about, over nothing but surrounding whitespace.
-    const start = SRC.indexOf("currentRef.current = {");
-    expect(start).toBeGreaterThan(-1);
-    const body = SRC.slice(start, SRC.indexOf("\n  };", start));
+    const body = between(SRC, "currentRef.current = {", "\n  };");
     for (const [field, writer] of [
       ["availability.awayMessage", "awayMessage.trim()"],
       ["contactAuth.denyMessage", "contactAuth.denyMessage.trim()"],
@@ -240,14 +281,12 @@ describe("agent editor save errors", () => {
   });
 
   test("the tools preflight compares against the stored bag, re-read when forced", () => {
-    const start = SRC.indexOf("function settingsTextError");
-    expect(start).toBeGreaterThan(-1);
-    expect(SRC.slice(start, SRC.indexOf("\n  }", start))).toContain(
+    expect(between(SRC, "function settingsTextError", "\n  }")).toContain(
       "collectOversizedTextChanges",
     );
     // A forced overwrite follows a 409, so the synced bag is stale by definition: comparing against
     // it can pass a check the PATCH then fails, with the grants PUT already persisted.
-    const save = SRC.slice(SRC.indexOf("async function saveTools"));
+    const save = after(SRC, "async function saveTools");
     const call = save.slice(0, save.indexOf("settingsTextError("));
     expect(call).toContain("force");
     expect(call).toContain("agents({ id }).get()");
@@ -276,16 +315,149 @@ describe("agent editor save errors", () => {
     // the only thing any handler here says. Asking for the literal `refusal.capture` inside every
     // handler would demand the duplication the helper exists to remove.
     const routers = handlers(SRC)
-      .filter((h) => /apiErrorMessage|[Rr]efusal\.capture/.test(h.body))
+      .filter((h) =>
+        /apiErrorMessage|[Rr]efusal(?:s\[section\])?\.capture/.test(h.body),
+      )
       .map((h) => h.name);
     // Guards this half of the parser the same way the list above guards the other: a helper that
     // stops reading the server's message would empty this list and pass every handler below.
     expect(routers).toContain("answerRefusal");
     const shows = new RegExp(
-      `apiErrorMessage|[Rr]efusal\\.capture|\\b(?:${routers.join("|")})\\(`,
+      `apiErrorMessage|[Rr]efusal(?:s\\[section\\])?\\.capture|\\b(?:${routers.join("|")})\\(`,
     );
     expect(
       writers.filter((h) => !shows.test(h.body)).map((h) => h.name),
     ).toEqual([]);
+  });
+});
+
+// ONE REFUSAL PER FORM THAT WRITES (#415).
+//
+// The editor has six independently savable forms and had ONE holder, and `capture` is also the
+// clear. Refuse a Behavior save, switch to Guardrails, refuse that one, and the first sentence is
+// gone: the operator comes back to a Behavior form that looks clean and is still refused. No
+// concurrency needed for it, though the tabs do stay live during a save.
+//
+// Source-level for the same reason the rest of this file is: mounting this page pulls auth, theme,
+// toast and a live catalog. What is asserted here is the SHAPE that makes the erasure impossible,
+// not a rendering of it.
+describe("one refusal per form that writes", () => {
+  test("every writing form has its own holder, and they share the field lists", () => {
+    const holders = [
+      ...SRC.matchAll(/const (\w+Refusal) = useFieldRefusal\(/g),
+    ].map((m) => m[1]);
+    // The clone dialog is a form too and keeps its own, which is the same rule and not this list.
+    expect(holders).toEqual([
+      "generalRefusal",
+      "behaviorRefusal",
+      "knowledgeRefusal",
+      "toolsRefusal",
+      "guardrailsRefusal",
+      "channelRedirectRefusal",
+      "cloneRefusal",
+    ]);
+    // The SAME drawn/owned lists, because a refusal does not stay inside the section that produced
+    // it: `saveAgent("behavior")` sends the whole settings bag and can be refused about
+    // `guardrails.output.templateMessage`, whose control the Guardrails tab draws. Per-section lists
+    // would leave a holder unable to place the refusal its own save provoked.
+    const shared = [
+      ...SRC.matchAll(
+        /useFieldRefusal\(\s*refusalFields\.drawn,\s*refusalFields\.owned,?\s*\)/g,
+      ),
+    ];
+    expect(shared).toHaveLength(6);
+  });
+
+  test("the section a refusal is filed under is the form that wrote, not the tab it lands on", () => {
+    // Typed rather than loose strings: a section name matching no holder would be a holder nothing
+    // ever captures into, which is silent.
+    const decl = between(SRC, "type RefusalSection =", ";");
+    for (const section of [
+      "general",
+      "behavior",
+      "knowledge",
+      "tools",
+      "guardrails",
+      "channelRedirect",
+    ]) {
+      expect(decl).toContain(`"${section}"`);
+    }
+  });
+
+  test("every holder is asked before a control is left unmarked", () => {
+    // Behaviour, not shape. This was a source check for the text of the loop, and the mutation
+    // battery walked straight through it: narrowing the loop to its first entry leaves that text in
+    // place, so the guard stayed green while five of the six holders went unread. The rule lives in
+    // `firstRefusalAt` now and is asked to answer.
+    const silent = () => null;
+    const says = (what: string) => () => what;
+    expect(
+      firstRefusalAt([silent, silent, says("from the sixth")], "f", 1),
+    ).toBe("from the sixth");
+    // First match wins: one control draws one value, so the older sentence is the one already shown.
+    expect(firstRefusalAt([says("first"), says("second")], "f", 1)).toBe(
+      "first",
+    );
+    expect(firstRefusalAt([silent, silent], "f", 1)).toBeNull();
+    expect(firstRefusalAt([], "f", 1)).toBeNull();
+    // And the page hands it every holder rather than a slice of them.
+    expect(SRC).toContain(
+      "REFUSAL_SECTIONS.map((section) => refusals[section].at)",
+    );
+  });
+
+  test("a refusal is settled by the tab that draws it, whichever form wrote it", () => {
+    // The half the per-form split does not get for free, and the one the issue's plan would have
+    // got wrong: it proposed that `clearRefusalFor` lose its section argument because "the holder IS
+    // the section". Measured against this case, that drops a mark the server has already accepted.
+    //
+    // Behavior save refused about a Guardrails path: the operator fixes it on Guardrails and saves
+    // THERE, and the mark is sitting in the Behavior holder.
+    expect(
+      settlesRefusal({
+        drawnBy: "guardrails",
+        owner: "behavior",
+        settled: "guardrails",
+      }),
+    ).toBe(true);
+    // Saving Behavior again does NOT settle it: the value belongs to the Guardrails tab, and a
+    // Behavior save spreads the last-synced settings rather than the edit still unsaved there.
+    expect(
+      settlesRefusal({
+        drawnBy: "guardrails",
+        owner: "behavior",
+        settled: "behavior",
+      }),
+    ).toBe(false);
+    // A refusal the holder could place nowhere is about a SAVE rather than a value, so its own
+    // section answers it, and nobody else's does.
+    expect(
+      settlesRefusal({ drawnBy: null, owner: "tools", settled: "tools" }),
+    ).toBe(true);
+    expect(
+      settlesRefusal({ drawnBy: null, owner: "tools", settled: "general" }),
+    ).toBe(false);
+  });
+
+  test("the form that only toasted its refusal now answers like the others", () => {
+    // `saveChannelRedirect` writes the whole settings bag and its catch showed a bare toast, so a
+    // refusal naming a value this editor draws came back with no mark and nothing to jump to. That
+    // is the defect #349 fixed, at the one form #349 did not reach.
+    const body = between(SRC, "async function saveChannelRedirect", "\n  }");
+    expect(body).toContain("answerRefusal(");
+    expect(body).toContain('"channelRedirect"');
+    expect(body).toContain('settleRefusalFor("channelRedirect")');
+    // Snapshotted before the request goes out, never read from the live ref in the catch: comparing
+    // `currentRef` with itself there can never fire the staleness check.
+    expect(body).toContain("sent = sentFor(patch)");
+    // And it stops being a toast, which is the container that takes the only copy of the reason away
+    // after five seconds while the input it is about is still refused. Asserted against what the
+    // catch actually READS rather than against a spelling of the old call: round 1 of review caught
+    // the first version pinning a formatting that never existed, so reintroducing the toast beside
+    // `answerRefusal` would have left this green and reported the failure twice.
+    const cr = between(SRC, "async function saveChannelRedirect", "\n  }");
+    const catchBody = cr.slice(cr.indexOf("} catch ("));
+    expect(catchBody).not.toContain("apiErrorMessage(");
+    expect(catchBody).not.toContain("showToast(");
   });
 });

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -298,12 +298,66 @@ function splitArgs(args: string): string[] {
 // A holder that is declared and then half-used. Either half alone is silence: a holder nobody
 // captures into can only ever answer null at every `at(…)` reading it, and a holder nobody reads
 // keeps the toast quiet about a refusal it has placed nowhere.
+// A holder can also be used through a REGISTER: the agent editor keeps one per writing form (#415)
+// and reaches them as `refusals[section].capture(...)`, so no holder is ever named at a call site.
+// The obligation is unchanged and so is its force, since a holder that is declared and left out of
+// the register is exactly the orphan this flags, but the proof moves: the register is what has to be
+// captured and read, and each holder has to be IN it.
+//
+// Deliberately keyed off the `Record<_, FieldRefusal>` annotation rather than any object that
+// mentions a holder. An unannotated bag would let a file opt out of this check by listing its
+// holders somewhere, which is the same hole as not checking at all.
+function registeredHolders(src: string): {
+  register: string | null;
+  members: Set<string>;
+} {
+  const m = /const (\w+): Record<[^,]+, FieldRefusal> = \{/.exec(src);
+  if (!m) return { register: null, members: new Set() };
+  const open = m.index + m[0].length - 1;
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close < 0) return { register: null, members: new Set() };
+  const body = src.slice(open + 1, close);
+  const members = new Set<string>();
+  for (const entry of body.matchAll(/[\w"']+\s*:\s*(\w+)\s*,/g)) {
+    members.add(entry[1] as string);
+  }
+  return { register: m[1] as string, members };
+}
+
 export function halfUsedHolders(src: string): string[] {
   const out: string[] = [];
+  const { register, members } = registeredHolders(src);
+  // The register itself answers for its members, so it has to be whole on both sides. Read through
+  // any name, because the aggregator that consults every holder is not the register variable.
+  const registerCaptures =
+    !!register &&
+    new RegExp(`\\b${register}\\[[^\\]]+\\]\\??\\.capture\\(`).test(src);
+  // `.at\b` rather than `.at(`: a page with several holders reads them through an aggregate, and
+  // the natural spelling passes the method as a REFERENCE (`refusals[s].at`) instead of calling it
+  // there. Requiring the call site would have forced a worse shape to satisfy the guard.
+  const registerReads =
+    !!register &&
+    new RegExp(`\\b${register}\\[[^\\]]+\\]\\??\\.at\\b`).test(src);
   for (const m of src.matchAll(/const (\w+) = useFieldRefusal\(/g)) {
     const name = m[1] as string;
-    const captures = new RegExp(`\\b${name}\\.capture\\(`).test(src);
-    const reads = new RegExp(`\\b${name}\\.at\\(`).test(src);
+    const viaRegister = members.has(name);
+    const captures = viaRegister
+      ? registerCaptures
+      : new RegExp(`\\b${name}\\.capture\\(`).test(src);
+    const reads = viaRegister
+      ? registerReads
+      : new RegExp(`\\b${name}\\.at\\(`).test(src);
     if (!captures || !reads)
       out.push(`${name} (${captures ? "never read" : "never captured"})`);
   }


### PR DESCRIPTION
Fixes #415.

## O defeito

`useFieldRefusal` diz no próprio cabeçalho: "**PER FORM**, not per page and not in a context". O editor tinha seis formulários salváveis de forma independente atrás de **um** holder, e `capture` também é o clear. A segunda recusa apagava a primeira.

Sem concorrência nenhuma: recusa um save de Behavior, troca para Guardrails, recusa aquele, e a operadora volta para um formulário de Behavior que parece limpo e continua recusado.

## Duas coisas que a medição mudou em relação à issue

**A issue conta cinco formulários. São seis.** `saveChannelRedirect` escreve o bag de settings inteiro e não participava do mecanismo: o catch dele mostrava um toast puro, então uma recusa nomeando um valor que este editor desenha voltava sem marca e sem para onde ir. É o defeito que a #349 corrigiu, no único formulário que a #349 não alcançou. Corrigido aqui, em vez de virar um sétimo site para voltar depois.

**O plano da issue erraria o settle.** Ele propunha que `clearRefusalFor` perdesse o argumento de seção, porque "o holder É a seção". Mas o settle não é por quem escreve, é pela aba que **desenha** o valor, e os dois se separam exatamente no caso que justifica o split:

> save de Behavior recusado sobre `guardrails.output.templateMessage` → a operadora corrige na aba Guardrails e salva **ali** → a marca está no holder de **Behavior**.

Settlar só o holder do formulário que salvou deixaria a marca em pé sobre um valor que o servidor já aceitou, que é justamente o hold velho que a #349 removeu. Então o loop visita todos os holders e pergunta de quem é o valor.

## Por que as regras viraram funções

`firstRefusalAt` e `settlesRefusal` são funções puras testadas por comportamento, não forma verificada lendo a fonte da página. A bateria de mutação é o motivo:

| mutação | fence de fonte | teste de comportamento |
|---|---|---|
| capture sempre no holder geral | mata | mata |
| **agregador lê só um holder** | **sobrevive** | mata |
| settle só o próprio holder | mata | mata |
| primeiro match ignorado | (não coberto) | mata |
| **channelRedirect só toasta** | **sobrevive** | mata |

Estreitar o loop do agregador para a primeira entrada deixa intacto o texto que o fence procurava, então ele ficava verde enquanto cinco dos seis holders não eram lidos. Duas de cinco mutações sobreviviam à versão por fonte; todas as cinco morrem na versão por comportamento.

## Resto

- O banner vira lista: "a recusa em pé" deixou de ser uma coisa só, e mostrar a mais nova seria a mesma erasure movida do holder para o render.
- As seções viram union type em vez de strings soltas, o que também é o que permite ao fence provar que todo holder declarado é alcançável.
- `halfUsedHolders` passa a provar uso através do registro: um holder declarado e deixado de fora dele é exatamente o órfão que a regra existe para pegar, então a força é a mesma e só a prova muda.

## Validação

`bun check` verde (lint, tipos, `check:editions`, suíte completa): 7661 pass, 0 fail.

Achado adjacente registrado como #424: o sweep de corte astral conta `.slice(` dentro de comentário, e a saída fácil arma um waiver falso.
