### PR TITLE
Count the code a sweep is looking for, not the prose that names it

### DIFF
--- a/tests/api/lib/refusal-callsites.test.ts
+++ b/tests/api/lib/refusal-callsites.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import { expectWaiverLedger } from "@/tests/utils/ledger";
+import { codeOnly as sourceCodeOnly } from "@/tests/utils/source-text";
 
 // THE GUARD AGAINST THE NEXT REFUSAL THAT KNOWS A FIELD AND DOES NOT SAY SO.
 //
@@ -194,7 +195,10 @@ async function sources(): Promise<Map<string, string>> {
   const { Glob } = await import("bun");
   const files = new Map<string, string>();
   for await (const file of new Glob("src/**/*.{ts,tsx}").scan(".")) {
-    files.set(file, await Bun.file(file).text());
+    // Through the shared scan, so prose naming a refusal is not swept as one (#424). The local
+    // `codeOnly` below is a DIFFERENT thing that happens to share the word: it extracts the code of
+    // one ARGUMENT, keeping `${…}` holes that live inside a string. This is the file read.
+    files.set(file, sourceCodeOnly(await Bun.file(file).text()));
   }
   return files;
 }

--- a/tests/api/v1/write-body-required.test.ts
+++ b/tests/api/v1/write-body-required.test.ts
@@ -9,6 +9,7 @@ import {
   mockUser,
   setupPrismaMock,
 } from "@/tests/utils/prisma-mock";
+import { codeOnly } from "@/tests/utils/source-text";
 
 // Issue #301. Three create routes declared the body schema their PATCH sibling uses, where every
 // field being optional is correct. A request missing a required field therefore passed the transport
@@ -275,7 +276,11 @@ describe("a refusal about a value inside the request names the whole path", () =
 // below itself, so no issue can carry a key the caller wrote. That holds for every record in src/
 // today, and it is the same hazard the transport's own refusal walks the schema to avoid
 // (api/lib/schema-refusal.ts), so it is pinned rather than left as a reading.
-export function recordConstrainsItsValues(source: string): boolean {
+// Takes RAW source and strips it itself. Leaving that to the caller is how the sweep below read a
+// comment quoting the constrained shape as a declaration of it (#424), and a predicate whose contract
+// is "give me source" cannot be handed the wrong kind of source if it does the reading.
+export function recordConstrainsItsValues(raw: string): boolean {
+  const source = codeOnly(raw);
   // Written as "read the value expression and compare it" rather than as a negative lookahead: with
   // `\s*` before the lookahead the regex backtracks over the whitespace and matches anyway, which is
   // what the control below caught the first time this was written.
@@ -300,6 +305,18 @@ describe("no zod record can put a caller's key in a refusal", () => {
         "z.record(\n    z.string(),\n    z.number(),\n  )",
       ),
     ).toBe(true);
+    // Prose naming the constrained shape is not a declaration of it, and neither is a string spelling
+    // it. Both were offenders before the predicate started stripping what it reads (#424).
+    expect(
+      recordConstrainsItsValues(
+        "// never write z.record(z.string(), z.string())",
+      ),
+    ).toBe(false);
+    expect(
+      recordConstrainsItsValues(
+        'const doc = "z.record(z.string(), z.string())";',
+      ),
+    ).toBe(false);
   });
 
   test("no file under src declares one", async () => {
@@ -322,18 +339,28 @@ describe("no zod record can put a caller's key in a refusal", () => {
 //
 // Keyed on the CALL SITE and not on the file: an exemption attached to a file adopts the next parse
 // written into it, which is the exact failure #258 measured.
+//
+// TWO VIEWS OF THE SAME LINE, and mixing them up is how this predicate breaks. The CALL is looked for
+// in the stripped source, so a comment naming `schema.parse(input)` — including one warning against
+// writing it — is not reported as one (#424). The MARKER is looked for in the raw line, because an
+// exemption is written in a comment and stripping is exactly what would take it away. They line up by
+// index because the scan replaces removed characters in place and keeps every newline.
 export function unmarkedServiceParse(source: string): string[] {
   const lines = source.split("\n");
+  const code = codeOnly(source).split("\n");
   const offenders: string[] = [];
   for (const [i, line] of lines.entries()) {
+    const statement = code[i] ?? "";
     // Keyed on `.parse(` itself and not on what precedes it: a chained schema
     // (`z.string().min(1).parse(x)`) and a multiline chain whose line begins with `.parse(` both put
     // a `)` or a line start there, and the first spelling of this predicate matched neither — so the
     // sweep reported a clean tree while the exact shape this PR converted could be written back in.
     // Found by review on PR #309.
-    if (!line.includes(".parse(")) continue;
+    if (!statement.includes(".parse(")) continue;
     if (
-      /JSON\.parse|Number\.parse|Date\.parse|\.parseAsync|safeParse/.test(line)
+      /JSON\.parse|Number\.parse|Date\.parse|\.parseAsync|safeParse/.test(
+        statement,
+      )
     ) {
       continue;
     }

--- a/tests/graph/prepare.test.ts
+++ b/tests/graph/prepare.test.ts
@@ -5,6 +5,7 @@ import { MemorySaver } from "@langchain/langgraph";
 import type { ResolvedModelConfig } from "@/graph/models";
 import { buildModelAndGraph, buildSpeechNormalizer } from "@/graph/prepare";
 import { TTS_DEFAULTS } from "@/modules/tts/settings";
+import { codeOnly } from "@/tests/utils/source-text";
 import { makeConfig } from "../utils/agent-config";
 
 describe("buildModelAndGraph — effective baseURL resolution", () => {
@@ -324,7 +325,10 @@ describe("prepare — a draft cannot widen what is recorded", () => {
       new URL("../../", import.meta.url).pathname,
     )) {
       if (f.endsWith("modules/flowlog/settings.ts")) continue; // the definition
-      const src = await Bun.file(new URL(`../../${f}`, import.meta.url)).text();
+      // Through the scan, so a comment naming the reader is not counted as a call to it (#424).
+      const src = codeOnly(
+        await Bun.file(new URL(`../../${f}`, import.meta.url)).text(),
+      );
       if (src.includes("readObservabilityConfig(")) found.push(f);
     }
     // The turn's own read, the settings DTO, the shared derivation, and the console's form pair.

--- a/tests/graph/refused-turn-callsites.test.ts
+++ b/tests/graph/refused-turn-callsites.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { withoutComments } from "@/tests/utils/source-text";
+import { codeOnly, withoutComments } from "@/tests/utils/source-text";
 
 // THE RULE THE ROLLBACK DEPENDS ON, AND THE ONE A PATCH CAN SILENTLY BREAK.
 //
@@ -33,9 +33,14 @@ const TURN_REFUSALS = ["stale", "superseded", "blocked", "taken-over"] as const;
 // every pre-invoke refusal into range — the exact thing the offset exists to exclude — and the floor
 // below would count a `refuse(` written in prose as a routed one (#424).
 export function refuseSection(source: string): string | null {
-  const code = withoutComments(source);
-  const at = code.indexOf("const refuse = async (");
-  return at === -1 ? null : code.slice(at);
+  // TWO VIEWS, AND THE OFFSET CROSSES BETWEEN THEM. The anchor is located in the fully stripped text,
+  // because a string or a comment that spells the closure would otherwise start the section above the
+  // real one and drag every pre-invoke refusal into range. The section itself is the comment-stripped
+  // text, because the pattern downstream READS a string literal. They line up because the scan
+  // replaces removed characters in place. (Comments alone were the first version; review pointed out
+  // a literal does it too.)
+  const at = codeOnly(source).indexOf("const refuse = async (");
+  return at === -1 ? null : withoutComments(source).slice(at);
 }
 
 export function bareRefusalsAfterTheRollback(
@@ -136,6 +141,19 @@ describe("every post-generation refusal rolls the turn back", () => {
   // The two things the section itself has to get right, and neither is visible from the predicate's
   // own cases: prose naming the closure must not move the start, and a `refuse(` written in a comment
   // must not count toward the floor below.
+  // A LITERAL does it too, which is the half the first version missed: `withoutComments` keeps string
+  // contents, so a stored snippet spelling the closure moved the start. Found by review.
+  test("the section starts past a closure spelled inside a string", () => {
+    const stored =
+      'const doc = "const refuse = async (o) => o;";\n' +
+      '  if (!(await stillWanted())) return "stale";\n' +
+      "  const refuse = async (o) => o;\n" +
+      '  if (x) return refuse("stale");\n';
+    const section = refuseSection(stored) ?? "";
+    expect(section.startsWith("const refuse = async (")).toBe(true);
+    expect(section).not.toContain("stillWanted");
+  });
+
   test("the section starts at the real closure, not at one named in prose", () => {
     const prosey =
       "// the const refuse = async ( closure lives further down\n" +

--- a/tests/graph/refused-turn-callsites.test.ts
+++ b/tests/graph/refused-turn-callsites.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { withoutComments } from "@/tests/utils/source-text";
 
 // THE RULE THE ROLLBACK DEPENDS ON, AND THE ONE A PATCH CAN SILENTLY BREAK.
 //
@@ -23,26 +24,37 @@ import { describe, expect, test } from "bun:test";
 const NUDGE_REFUSALS = ["stale", "live-unavailable"] as const;
 const TURN_REFUSALS = ["stale", "superseded", "blocked", "taken-over"] as const;
 
-// Everything above the closure is a refusal BEFORE the invoke, where there is no generated turn to
-// take back and `refuse` would be a checkpointer round trip for nothing.
+// The stretch below the closure, stripped, or `null` when the closure is gone. Everything above it is
+// a refusal BEFORE the invoke, where there is no generated turn to take back and `refuse` would be a
+// checkpointer round trip for nothing.
+//
+// THE ANCHOR IS SOUGHT IN THE STRIPPED TEXT TOO, which is why this is one function and not an offset
+// each caller computes. A comment naming the closure would start the scan above the real one and drag
+// every pre-invoke refusal into range — the exact thing the offset exists to exclude — and the floor
+// below would count a `refuse(` written in prose as a routed one (#424).
+export function refuseSection(source: string): string | null {
+  const code = withoutComments(source);
+  const at = code.indexOf("const refuse = async (");
+  return at === -1 ? null : code.slice(at);
+}
+
 export function bareRefusalsAfterTheRollback(
   source: string,
   outcomes: readonly string[],
 ): string[] {
-  const at = source.indexOf("const refuse = async (");
-  if (at === -1) return ["the `refuse` closure is gone"];
+  const code = refuseSection(source);
+  if (code === null) return ["the `refuse` closure is gone"];
   const any = outcomes.join("|");
+  // COMMENTS FIRST, and this is not tidiness. Collapsing whitespace below makes a statement one
+  // string, and prose has no `;` in it — so the word "returning" in a NOTE two paragraphs above a
+  // routed refusal pairs with that refusal's literal and reports a site that does not exist. This
+  // file's comments are long and quote the outcomes by name, so that is the normal case, not a corner
+  // one. The two phantom sites it cost here are why the scan is shared now (#424); `withoutComments`
+  // rather than `codeOnly` because the pattern below READS a string literal.
+  //
   // What is already routed stops being a candidate, so what the match reports is the spelling that
   // was left behind rather than a count of anything.
-  const below = source
-    .slice(at)
-    // COMMENTS FIRST, and this is not tidiness. Collapsing whitespace below makes a statement one
-    // string, and prose has no `;` in it — so the word "returning" in a NOTE two paragraphs above a
-    // routed refusal pairs with that refusal's literal and reports a site that does not exist. This
-    // file's comments are long and quote the outcomes by name, so that is the normal case, not a
-    // corner one. (`[^:]` keeps a `https://` out of it.)
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/(^|[^:])\/\/[^\n]*/g, "$1")
+  const below = code
     .replace(new RegExp(`refuse\\("(?:${any})"\\)`, "g"), "refuse(ROUTED)")
     // Collapsed so a statement is one string no matter how the formatter broke it: `[^;]` is what
     // bounds a match to a single statement, and a `return` split across lines would otherwise be
@@ -121,13 +133,29 @@ describe("every post-generation refusal rolls the turn back", () => {
     expect(bareRefusalsAfterTheRollback(before, NUDGE_REFUSALS)).toEqual([]);
   });
 
+  // The two things the section itself has to get right, and neither is visible from the predicate's
+  // own cases: prose naming the closure must not move the start, and a `refuse(` written in a comment
+  // must not count toward the floor below.
+  test("the section starts at the real closure, not at one named in prose", () => {
+    const prosey =
+      "// the const refuse = async ( closure lives further down\n" +
+      '  if (!(await stillWanted())) return "stale";\n' +
+      "  const refuse = async (outcome) => outcome;\n" +
+      '  // …and a NOTE that spells refuse("stale") while explaining the gate below.\n' +
+      '  if (owned === "gone") return refuse("live-unavailable");\n';
+    const section = refuseSection(prosey) ?? "";
+    expect(section.startsWith("const refuse = async (")).toBe(true);
+    // The pre-invoke refusal stayed above the start, where it belongs.
+    expect(section).not.toContain("stillWanted");
+    // One routed call, not two: the one in the NOTE is prose.
+    expect((section.match(/refuse\(/g) ?? []).length).toBe(1);
+  });
+
   // A floor, not a census: more sites routed through `refuse` is a better state, never a worse one,
   // so pinning the exact number would only cost a second edit to a PR that adds a gate correctly.
   // What it guards is the subject going EMPTY, which is how a sweep starts passing blind.
-  const routedCount = (source: string) => {
-    const at = source.indexOf("const refuse = async (");
-    return (source.slice(at).match(/refuse\(/g) ?? []).length;
-  };
+  const routedCount = (source: string) =>
+    ((refuseSection(source) ?? "").match(/refuse\(/g) ?? []).length;
 
   test("nudge.ts has none", async () => {
     const source = await Bun.file("src/graph/nudge.ts").text();

--- a/tests/lib/astral-cap-sweep.test.ts
+++ b/tests/lib/astral-cap-sweep.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { DEBUG_MAX_STRING } from "@/modules/flowlog/service";
+import { countInSrc } from "@/tests/utils/source-text";
 
 // THE GUARD AGAINST THE NEXT CAP THAT CUTS A CHARACTER IN HALF.
 //
@@ -466,16 +467,12 @@ const BARE_SLICES: Record<
 
 describe("every bare cut left in src/ is accounted for", () => {
   test("the file list and the per-file counts still match", async () => {
-    const { Glob } = await import("bun");
-    const found: Record<string, number> = {};
-    for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
-      const src = await Bun.file(`src/${rel}`).text();
-      const n = (
-        src.match(/\.slice\(\s*(?:0\s*,|-|[A-Za-z_$][\w$.]*\.length\s*-)/g) ??
-        []
-      ).length;
-      if (n > 0) found[`src/${rel}`] = n;
-    }
+    // Through `countInSrc`, so a comment explaining a cut is not counted as one. A phantom entry here
+    // is not a chore: the fix that suggests itself is to add the file to the ledger, which arms a
+    // waiver over a file with no cut in it and silences the day it grows one (#424).
+    const found = await countInSrc(
+      /\.slice\(\s*(?:0\s*,|-|[A-Za-z_$][\w$.]*\.length\s*-)/g,
+    );
     const expected = Object.fromEntries(
       Object.entries(BARE_SLICES).map(([f, [n]]) => [f, n]),
     );

--- a/tests/lib/caller-id-spelling.test.ts
+++ b/tests/lib/caller-id-spelling.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 import { Glob } from "bun";
 import { expectWaiverLedger } from "@/tests/utils/ledger";
+import { codeOnly } from "@/tests/utils/source-text";
 
 // Every `BigInt` in the tree whose argument is not a literal, and the reason each one is allowed.
 //
@@ -287,7 +288,8 @@ export function unwaived(
 async function sources(): Promise<Map<string, string>> {
   const files = new Map<string, string>();
   for await (const file of new Glob("src/**/*.{ts,tsx}").scan(".")) {
-    files.set(file, await Bun.file(file).text());
+    // Through the scan, so a comment naming a `BigInt(` is not counted as one (#424).
+    files.set(file, codeOnly(await Bun.file(file).text()));
   }
   return files;
 }

--- a/tests/lib/caller-id-spelling.test.ts
+++ b/tests/lib/caller-id-spelling.test.ts
@@ -5,7 +5,6 @@
 import { describe, expect, test } from "bun:test";
 import { Glob } from "bun";
 import { expectWaiverLedger } from "@/tests/utils/ledger";
-import { codeOnly } from "@/tests/utils/source-text";
 
 // Every `BigInt` in the tree whose argument is not a literal, and the reason each one is allowed.
 //
@@ -288,8 +287,11 @@ export function unwaived(
 async function sources(): Promise<Map<string, string>> {
   const files = new Map<string, string>();
   for await (const file of new Glob("src/**/*.{ts,tsx}").scan(".")) {
-    // Through the scan, so a comment naming a `BigInt(` is not counted as one (#424).
-    files.set(file, codeOnly(await Bun.file(file).text()));
+    // RAW on purpose. `bigIntArgs` runs its own `blankNonCode` for the detection and then takes the
+    // argument's TEXT as the ledger key, so pre-stripping rewrites the keys: `BigInt(ref.slice(
+    // "vault:".length))` becomes an argument full of spaces and the waiver stops matching. The one
+    // sweep in this family that must not be handed stripped source (found by review).
+    files.set(file, await Bun.file(file).text());
   }
   return files;
 }

--- a/tests/lib/provider-boundary-sweep.test.ts
+++ b/tests/lib/provider-boundary-sweep.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { codeOnly } from "@/tests/utils/source-text";
 
 // THE GUARD AGAINST THE TENTH CALL SITE.
 //
@@ -59,7 +60,9 @@ async function candidates(): Promise<string[]> {
   const { Glob } = await import("bun");
   const found: string[] = [];
   for await (const file of new Glob("src/**/*.ts").scan(".")) {
-    if (isCandidate(await Bun.file(file).text())) found.push(file);
+    // Through the scan, so a comment naming `await fetch(` does not make a file a provider boundary
+    // (#424). Measured: same six files with and without, which is what makes it safe to adopt.
+    if (isCandidate(codeOnly(await Bun.file(file).text()))) found.push(file);
   }
   return found.sort();
 }
@@ -89,7 +92,7 @@ describe("every provider boundary answers for the other end's text", () => {
   test("each answer is the one the file actually gives", async () => {
     const offenders: string[] = [];
     for (const [file, discharge] of Object.entries(BOUNDARIES)) {
-      const src = await Bun.file(file).text();
+      const src = codeOnly(await Bun.file(file).text());
       if (discharge === "throughProvider") {
         // Per ENTRY POINT, not per file. Checking the file only asks whether the wrapper appears
         // somewhere in it, and a module with two exported calls satisfies that with one of them

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -29,6 +29,19 @@ describe("the scan removes prose and keeps code", () => {
       "template around an interpolation",
       `const a = \`s.slice(0, 1) \${x}\`;\n`,
     ],
+    // A REGEX WHOSE BODY BEGINS WITH `>` IS STILL A REGEX, and this is the row that keeps the JSX
+    // slash rule from eating it. `/>` closing a tag and `/>/` matching a `>` are the same two
+    // characters; what separates them is that the regex CLOSES on its line and the tag does not. Both
+    // spellings are in `src/`.
+    ["a regex body opening with `>`", 'x.replace(/>s.slice(0, 1)/g, "");\n'],
+    // THE ANCHOR OF THE URL-SCHEME RULE, PINNED BY THE COMMENT IT WOULD STOP REMOVING. The rule only
+    // fires when the lookback ENDS in `http:` or `https:`; drop the `$` and a scheme name anywhere in
+    // the window matches, so an ordinary comment after a label called `file` or `http` is read as a
+    // URL and its prose goes back to being counted as code.
+    [
+      "a comment after a label spelled like a scheme",
+      "switch (k) { case http: // s.slice(0, 1)\n}\n",
+    ],
   ];
   for (const [name, source] of REMOVED) {
     test(`${name} is not a cut`, () => {
@@ -118,13 +131,18 @@ describe("the scan removes prose and keeps code", () => {
     // nothing left open to notice. Two characters of rule, and it is what makes the removal safe:
     // what stays uncovered is JSX TEXT, which produces a phantom rather than a swallowed site.
     // Found by review.
+    // WITH A LATER `/` ON THE LINE, WHICH IS WHAT MAKES A MISREAD COST ANYTHING NOW. Since a regex
+    // reading that reaches the newline is backed out, a `</Foo>` read as an opener only damages the
+    // line when a second slash CLOSES it — so a fixture without one measures the back-out rather than
+    // the tag rule, and a mutation run showed exactly that: `closesTag` could return false for every
+    // input with these rows still green.
     [
-      "a cut after a JSX closing tag",
-      "const x = <Foo></Foo>;\nconst a = s.slice(0, 10);\n",
+      "a cut before a division, after a JSX closing tag",
+      "const x = <Foo></Foo>; const a = s.slice(0, 10); const r = b / c;\n",
     ],
     [
-      "a cut after a closing tag on the same line",
-      "const x = <Foo></Foo>; const a = s.slice(0, 10);\n",
+      "a cut after a closing tag, with a division later on the line",
+      "const x = <Foo></Foo>; const a = s.slice(0, 10); const q = d / e;\n",
     ],
     [
       "a cut after a division on an object literal",
@@ -143,6 +161,38 @@ describe("the scan removes prose and keeps code", () => {
     // that eats the rest of the line, and a name in there is counted as the call it merely spells.
     // So the tag is matched as a whole shape now, not by the character before the slash. Found by
     // review, on the previous round's fix.
+    // THE SELF-CLOSING TAG, WHICH THE `</Foo>` RULE DID NOT COVER. `/>` is not a regex either, and it
+    // was being read as one in 135 files — blanking whatever followed it on the line, with nothing
+    // left open to notice. No JSX state answers it: the regex simply never finds its closing `/`
+    // before the newline, and a reading that cannot close is backed out rather than applied.
+    // Written with the spread, which is the spelling that actually breaks and the one all 135 files
+    // use: `<Foo />` puts an IDENTIFIER before the slash, so `endsValue` is true and the regex branch
+    // is never entered — a fixture that reproduces nothing. The `}` of `{...props}` closes a block and
+    // leaves no value, which is what sends the `/` down that branch.
+    [
+      "a cut after a self-closing tag",
+      "const el = <div {...props} />; const a = s.slice(0, 10);\n",
+    ],
+    // The same signal, on the shape review actually reported: a `}` that closes a BLOCK leaves no
+    // value, so the `/` after it opened a regex that ran to the newline and ate the call.
+    [
+      "a cut after a division on a function expression",
+      "const r = function () {} / d; const a = s.slice(0, 10);\n",
+    ],
+    // A URL WRITTEN BARE IN JSX TEXT, whose `//` is not a comment. Every other position puts a URL
+    // inside a string or template, which the branches above consume first; JSX text has no branch, by
+    // the omission this file argues for at the top. The cut here is the real interpolation that the
+    // comment reading swallowed.
+    [
+      "a cut in an interpolation after a URL in JSX text",
+      "const el = <p>Visit https://x {s.slice(0, 10)}</p>;\n",
+    ],
+    // Both schemes, because `https?` is one optional character and a mutation that dropped it to
+    // `https` survived on the row above alone.
+    [
+      "a cut in an interpolation after a plain http URL",
+      "const el = <p>Visit http://x {s.slice(0, 10)}</p>;\n",
+    ],
     [
       "a cut after a regex compared with `<`",
       'const r = a < /["]/.source.length; const x = s.slice(0, 10);\n',
@@ -152,14 +202,14 @@ describe("the scan removes prose and keeps code", () => {
     // fragment from the tag pattern passed a next-line version of this row.
     [
       "a cut after a fragment's closing tag",
-      "const x = <></>; const a = s.slice(0, 10);\n",
+      "const x = <></>; const a = s.slice(0, 10); const r = b / c;\n",
     ],
     // The tag is matched as a WHOLE SHAPE, not by the character before the slash, so a name longer
     // than any fixed lookahead window still closes. Written long on purpose: the first fix used a
     // bounded slice, and this row is what a reintroduced bound fails on.
     [
       "a cut after a closing tag whose name is long",
-      "const x = <UmNomeDeComponenteBemMaisLongoQueQualquerJanelaFixaDeLookahead></UmNomeDeComponenteBemMaisLongoQueQualquerJanelaFixaDeLookahead>;\nconst a = s.slice(0, 10);\n",
+      "const x = <UmNomeDeComponenteBemMaisLongoQueQualquerJanelaFixaDeLookahead></UmNomeDeComponenteBemMaisLongoQueQualquerJanelaFixaDeLookahead>; const a = s.slice(0, 10); const r = b / c;\n",
     ],
     // `else` clears `endsValue` like every keyword and leaves no terminator for the statement-start
     // check to read, so the else body was recorded as an OBJECT — and the `}` of an object ends a
@@ -194,7 +244,7 @@ describe("the scan removes prose and keeps code", () => {
     // statements above the brace being classified.
     [
       "a cut after an object literal written inside an `else` body",
-      "if (x) {} else { o = {} / 2; const a = s.slice(0, 10); }\n",
+      "if (x) {} else { o = {} / 2; const a = s.slice(0, 10); const r = b / c; }\n",
     ],
     // A postfix non-null assertion leaves the value it applied to, so the `/` after it divides.
     [
@@ -290,6 +340,13 @@ describe("the scan removes prose and keeps code", () => {
     expect(codeOnly("f();")).toBe("f();");
   });
 
+  // AND WITH A SECOND `/` ON IT, once the reading is a `/` decision. A regex that reaches the newline
+  // is now BACKED OUT rather than applied, so a misread opener costs nothing unless a later slash
+  // closes it and the text between them goes. A mutation run is what said so: with the closing-tag
+  // rule returning false for every input, four rows written before the back-out stayed green, because
+  // each one measured the back-out instead of the rule it was named for. The DIVIDED rows below are
+  // unaffected — they turn on a quote or a comment, not on a second slash.
+  //
   // ON THE SAME LINE, and that is the whole point of this table rather than the KEPT rows above. A
   // regex the scan opens by mistake runs to the end of the LINE, so a cut on the NEXT line survives
   // either way and proves nothing — a mutation run showed every "cut after a division" row passing

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -38,6 +38,14 @@ describe("the scan removes prose and keeps code", () => {
     // Text that OPENS ON A PARENTHESIS, which is what a type argument list is recognised by. Without
     // the third signal in `typeArgumentList` this reads as a generic and the text counts as code.
     ["JSX text starting with a parenthesis", "<div>(s.slice(0, 1))</div>\n"],
+    // After a keyword that OPENS AN EXPRESSION. `default` and `throw` were read as ordinary
+    // identifiers, so the `<` after them was a comparison and the JSX text counted as code. Found by
+    // review; the row is the keyword list being exercised rather than asserted.
+    [
+      "JSX text after `export default`",
+      "export default <p>s.slice(0, 1)</p>;\n",
+    ],
+    ["JSX text after `throw`", "throw <p>s.slice(0, 1)</p>;\n"],
     ["JSX text after an attribute", '<Foo a="x">(s.slice(0, 1))</Foo>\n'],
     // A `>` inside an attribute value must not close the tag early, which is what skipping the string
     // (rather than refusing on it) buys in both directions.
@@ -329,6 +337,16 @@ describe("every Glob sweep over src/ counts through the scan", () => {
 });
 
 describe("countInSrc is the shared counter", () => {
+  // A pattern without `g` cannot count, and `String.prototype.match` does not say so: it returns the
+  // first match plus its capture GROUPS, so the length is a group count wearing an occurrence count's
+  // clothes. Refused rather than repaired, because silently adding the flag would leave the caller
+  // believing a pattern that cannot count is counting. Found by review.
+  test("it refuses a pattern that cannot count", async () => {
+    expect(countInSrc(/\bexport function (clipText)\b/)).rejects.toThrow(
+      /needs a \/g pattern/,
+    );
+  });
+
   // THE ONE THAT PROVES IT SCANS AT ALL, and it exists because the obvious assertions do not. Every
   // ledger in the tree counts the same through raw text and through the scan today — that is the
   // acceptance check this change had to pass — so a `countInSrc` quietly reading raw text breaks

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bigIntArgs } from "@/tests/lib/caller-id-spelling.test";
 import {
   codeOnly,
   countInSrc,
@@ -111,6 +112,20 @@ describe("the scan removes prose and keeps code", () => {
     ],
     // A `{` written where a VALUE was expected is an object, so the `}` that closes it ends a value
     // and the `/` after it divides. This used to be a documented gap; the scan tracks it now.
+    //
+    // A `</…>` IS NOT A REGEX. Removing the JSX mode left `<` not ending a value, so the slash in a
+    // closing tag opened a regex and swallowed the rest of its line — a real call site gone, with
+    // nothing left open to notice. Two characters of rule, and it is what makes the removal safe:
+    // what stays uncovered is JSX TEXT, which produces a phantom rather than a swallowed site.
+    // Found by review.
+    [
+      "a cut after a JSX closing tag",
+      "const x = <Foo></Foo>;\nconst a = s.slice(0, 10);\n",
+    ],
+    [
+      "a cut after a closing tag on the same line",
+      "const x = <Foo></Foo>; const a = s.slice(0, 10);\n",
+    ],
     [
       "a cut after a division on an object literal",
       "const ratio = <any>{} / 2;\nconst a = s.slice(0, 10);\n",
@@ -488,7 +503,14 @@ describe("every Glob sweep over src/ counts through the scan", () => {
       // THE IMPORT, NOT THE NAME. `refusal-callsites.test.ts` defines a LOCAL function called
       // `codeOnly` — a different thing that happens to share a word — and a name-matching fence read
       // that as adoption and let it through. A fence measures the spelling it was given, always.
-      if (!/from "@\/tests\/utils\/source-text"/.test(code)) {
+      // ONE EXEMPTION, AND IT IS A PROVED ONE. `caller-id-spelling` blanks non-code itself and then
+      // takes the argument's TEXT as its ledger key, so handing it stripped source rewrites the keys
+      // — `BigInt(ref.slice("vault:".length))` becomes an argument full of spaces and every waiver
+      // stops matching. It must read raw, and this fence would otherwise be satisfied by deleting the
+      // adoption from any file. So the exemption is not a name on a list: the test below drives that
+      // file's own predicate with prose and requires it to count zero.
+      const provesItself = /\bblankNonCode\b/.test(code);
+      if (!/from "@\/tests\/utils\/source-text"/.test(code) && !provesItself) {
         offenders.push(path);
       }
     }
@@ -498,6 +520,20 @@ describe("every Glob sweep over src/ counts through the scan", () => {
     // Review named a fourth it could not see; widening it to the second spelling surfaced five more.
     // A fence that names a spelling measures the spelling, never the rule.
     expect(sweeps.length).toBeGreaterThanOrEqual(9);
+  });
+});
+
+// The proof behind the one exemption above. A waiver that says "this file handles it" and is never
+// exercised is the waiver this whole PR is about; this one is executed.
+describe("the exempt sweep really does ignore prose", () => {
+  test("caller-id-spelling counts no BigInt written in a comment", () => {
+    expect(bigIntArgs("const id = BigInt(raw);\n")).toEqual(["raw"]);
+    expect(bigIntArgs("// never write BigInt(raw) here\n")).toEqual([]);
+    expect(bigIntArgs('const s = "BigInt(raw)";\n')).toEqual([]);
+    // …and the literal inside a real argument survives, which is why it reads raw source.
+    expect(
+      bigIntArgs('const id = BigInt(ref.slice("vault:".length));\n'),
+    ).toEqual(['ref.slice("vault:".length)']);
   });
 });
 

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -46,6 +46,9 @@ describe("the scan removes prose and keeps code", () => {
       "export default <p>s.slice(0, 1)</p>;\n",
     ],
     ["JSX text after `throw`", "throw <p>s.slice(0, 1)</p>;\n"],
+    // A component name may begin with `_` or `$`, which the first character class did not admit.
+    ["JSX text in an underscore component", "<_Foo>s.slice(0, 1)</_Foo>\n"],
+    ["JSX text in a dollar component", "<$Foo>s.slice(0, 1)</$Foo>\n"],
     ["JSX text after an attribute", '<Foo a="x">(s.slice(0, 1))</Foo>\n'],
     // A `>` inside an attribute value must not close the tag early, which is what skipping the string
     // (rather than refusing on it) buys in both directions.
@@ -108,6 +111,37 @@ describe("the scan removes prose and keeps code", () => {
     // A generic carrying a STRING-LITERAL type. The first version of the generic detector refused any
     // type list holding a quote, which recognised `<div title="a > b">` correctly by accident and
     // swallowed this one.
+    // THE FOUR SHAPES ONE ROUND OF REVIEW FOUND IN A DETECTOR THAT RULED GENERICS OUT FROM THE LEFT.
+    // None of them closes as an element, which is the whole reason the scan now asks for a `</tag>` or
+    // a `/>` instead of trying to enumerate what a type parameter list can look like.
+    [
+      "a cut after a generic with a structural constraint",
+      "const f = <T extends { id: string }>(x: T) => x;\nconst a = s.slice(0, 10);\n",
+    ],
+    [
+      "a cut after a plain generic arrow in a .ts file",
+      "const id = <T>(x: T) => x;\nconst a = s.slice(0, 10);\n",
+    ],
+    [
+      "a cut after a generic with a function-type constraint",
+      "const g = <T extends (x: number) => string>(f: T) => f;\nconst a = s.slice(0, 10);\n",
+    ],
+    // …and the shape that DOES close as an element while carrying a type argument.
+    // A `<` that does not close as an element is not an element, so the code after it is untouched —
+    // which is the direction this model deliberately errs in.
+    [
+      "a cut after an unclosed tag that is therefore not one",
+      "f(<div class=\nconst a = s.slice(0, 10);\n",
+    ],
+    [
+      "a cut after a JSX element with a type argument",
+      'const el = <Foo<string> label="x" />;\nconst a = s.slice(0, 10);\n',
+    ],
+    // A postfix non-null assertion leaves the value it applied to, so the `/` after it divides.
+    [
+      "a cut after a division on a non-null assertion",
+      "const r = value! / 2;\nconst a = s.slice(0, 10);\n",
+    ],
     [
       "a cut after a generic with a string-literal type",
       'const f = <T extends "a" | "b",>(x: T) => x;\nconst a = s.slice(0, 10);\n',
@@ -153,6 +187,27 @@ describe("the scan removes prose and keeps code", () => {
   // The distinction the two exports exist for, and the reason this is not one function with a flag
   // nobody would pass: `refused-turn-callsites` matches ON a string literal, so stripping contents
   // there would blind the sweep rather than sharpen it.
+  // A REGEX BODY IS A PATTERN THAT NAMES A CALL, NOT A CALL, and it needs its own row because the
+  // table above measures one spelling: a regex naming a cut writes it escaped (`\\.slice\\(`), which
+  // is not what a sweep for cuts matches. The sweep it DOES fool is the one whose shape survives
+  // escaping — `sanitizeErrorMessage\(` — and that is a real ledger in this repo. Found by review.
+  test("a regex body naming a call is not a call", () => {
+    // The unescaped `(` is a capture group, which is how a pattern comes to spell a call site exactly.
+    const guard = /sanitizeErrorMessage\(/g;
+    const source = "const re = /sanitizeErrorMessage(Deep)?/;\n";
+    expect((source.match(guard) ?? []).length).toBe(1);
+    expect((codeOnly(source).match(guard) ?? []).length).toBe(0);
+    // …and the delimiters stay, so the regex is still a regex to anything reading structure.
+    expect(codeOnly(source)).toMatch(/^const re = \/ +\/;$/m);
+  });
+
+  test("a regex body naming a column is not a column", () => {
+    const column = /\b(?:lastError|errorMessage)\s*:/g;
+    const source = "const re = /lastError: (.+)/;\n";
+    expect((source.match(column) ?? []).length).toBe(1);
+    expect((codeOnly(source).match(column) ?? []).length).toBe(0);
+  });
+
   // What `codeOnly` keeps of a literal, and it is not nothing: the quotes. An emptied literal is still
   // a literal, so a pattern that requires an argument does not stop matching because the argument
   // turned out to be prose.
@@ -176,6 +231,17 @@ describe("the scan removes prose and keeps code", () => {
     ["an increment", "const r = i++ / 2; // s.slice(0, 1)\n"],
     ["a number", "const r = 2 / 2; // s.slice(0, 1)\n"],
     ["a regex", "const r = /x/ / 2; // s.slice(0, 1)\n"],
+    ["a non-null assertion", "const r = value! / 2; // s.slice(0, 1)\n"],
+    // The `!` of `!==` is the OTHER one: an inequality is followed by a value, so a `/` after it opens
+    // a regex. Treating every `!` as postfix would read that regex as a division and run on.
+    [
+      "nothing, after `!==` (the regex still opens)",
+      'if (a !== /x"/.test(b)) f(); // s.slice(0, 1)\n',
+    ],
+    [
+      "a less-than between identifiers",
+      "if (a<b && c) f(); // s.slice(0, 1)\n",
+    ],
     ["an identifier", "const r = n / 2; // s.slice(0, 1)\n"],
   ];
   for (const [what, source] of DIVIDED) {
@@ -190,6 +256,30 @@ describe("the scan removes prose and keeps code", () => {
     expect(withoutComments(source)).toContain('refuse("stale")');
     expect(withoutComments(source)).not.toContain("would replay");
     expect(codeOnly(source)).not.toContain("stale");
+  });
+});
+
+// THE DRY RUN IS MEMOISED, AND THAT IS A CORRECTNESS PROPERTY OF THE SUITE, NOT A SPEED ONE.
+//
+// Recognising an element by its closing tag means probing and then replaying, and the replay probes
+// again one level down — so a `<div>{cond && <div>{…}}</div>` nest doubles per level. Measured before
+// the memo: 386 characters took 72 ms, and a mutation to tag depth turned the same shape into a
+// mutation battery that ran nine minutes without finishing. Nothing in `src/` nests that deep today,
+// which is exactly why this is pinned rather than left to be rediscovered.
+describe("nested JSX does not cost exponentially", () => {
+  const nest = (n: number): string =>
+    n === 0 ? "<b>x</b>" : `<div>{cond && ${nest(n - 1)}}</div>`;
+  test("depth 18 costs about what depth 10 does", () => {
+    const time = (src: string) => {
+      const t0 = Bun.nanoseconds();
+      codeOnly(src);
+      return (Bun.nanoseconds() - t0) / 1e6;
+    };
+    time(nest(10));
+    // A floor of 50 ms rather than a ratio: the numbers here are fractions of a millisecond, where a
+    // ratio measures scheduler noise. What this refuses is the exponential, which was 72 ms at this
+    // depth and grows by 2x per level.
+    expect(time(nest(18))).toBeLessThan(50);
   });
 });
 
@@ -225,11 +315,10 @@ describe("the scan is positionally transparent", () => {
 describe("an unterminated literal is reported rather than swallowed", () => {
   // The self-check, and it needs its own positive control: a scan that never opens anything reports
   // `null` for a healthy tree AND for a broken one.
-  const OPEN: ["string" | "template" | "block-comment" | "jsx", string][] = [
+  const OPEN: ["string" | "template" | "block-comment", string][] = [
     ["string", 'const a = "oops;\nconst b = s.slice(0, 10);\n'],
     ["template", "const a = `oops;\nconst b = 1;\n"],
     ["block-comment", "/* oops\nconst b = 1;\n"],
-    ["jsx", "<div>never closed\n"],
   ];
   for (const [expected, source] of OPEN) {
     test(`an open ${expected} is named`, () => {
@@ -242,6 +331,14 @@ describe("an unterminated literal is reported rather than swallowed", () => {
   test("an unclosed interpolation is reported as an open template", () => {
     expect(unterminatedLiteral("const a = `x${y")).toBe("template");
   });
+  // An element that never closes is not an element, so nothing is left open and the `<` stays an
+  // ordinary character. This is the model change made visible: the old scan reported an open JSX
+  // state here, and the state no longer exists.
+  test("an unclosed element leaves nothing open, because it is not an element", () => {
+    expect(unterminatedLiteral("<div>never closed\n")).toBeNull();
+    expect(codeOnly("<div>s.slice(0, 1)\n")).toContain("s.slice");
+  });
+
   test("a healthy file reports nothing", () => {
     expect(unterminatedLiteral('const a = "ok";\n')).toBeNull();
   });

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -199,6 +199,47 @@ describe("the scan removes prose and keeps code", () => {
       "a cut after a division on a function expression",
       "const r = function () {} / d; const a = s.slice(0, 10);\n",
     ],
+    // WITH A SECOND SLASH CLOSING THE LINE, which is what makes the misread cost anything now — the
+    // row above passes on the back-out alone. A function or class written where a VALUE was expected
+    // is an expression and its `}` closes a value; read as a plain block it opened a regex here that
+    // ate the cut between the two slashes. Found by review.
+    [
+      "a cut between two divisions after a function expression",
+      "const r = function () {} / d || s.slice(0, 10) / c;\n",
+    ],
+    [
+      "a cut between two divisions after a class expression",
+      "const r = class {} / d || s.slice(0, 10) / c;\n",
+    ],
+    // The other side, and the reason `atStatementStart` is the whole test: a DECLARATION is not a
+    // value, so the brace after it stays a block and the `/` that follows still opens a regex.
+    // Measured THROUGH THAT SLASH — a first version put the division further down the line, where the
+    // identifiers before it set `endsValue` anyway and the row passed with the rule inverted.
+    [
+      "a cut after a regex following a function declaration",
+      'function f() {} /["]/.test(y); const a = s.slice(0, 10);\n',
+    ],
+    [
+      "a cut after a regex following a class declaration",
+      'class F {} /["]/.test(y); const a = s.slice(0, 10);\n',
+    ],
+    // The flag is consumed by the brace in BLOCK position, never by a destructured parameter, and it
+    // does not leak into a nested declaration.
+    [
+      "a cut after a function expression with a destructured parameter",
+      "const r = function ({ a }) {} / d || s.slice(0, 10) / c;\n",
+    ],
+    [
+      "a cut after a function expression holding a declaration",
+      "const r = function () { function g() {} } / d || s.slice(0, 10) / c;\n",
+    ],
+    // …and the flag is CLEARED by the brace that consumes it, so it cannot arrive at the next
+    // function in the file. The declaration here would inherit the expression's body reading and its
+    // `}` would start ending a value, turning the regex two tokens later into a division.
+    [
+      "a cut after a declaration following a function expression",
+      'const r = function () {}; function g() {} /["]/.test(y); const a = s.slice(0, 10);\n',
+    ],
     // A URL WRITTEN BARE IN JSX TEXT, whose `//` is not a comment. Every other position puts a URL
     // inside a string or template, which the branches above consume first; JSX text has no branch, by
     // the omission this file argues for at the top. The cut here is the real interpolation that the

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -28,34 +28,6 @@ describe("the scan removes prose and keeps code", () => {
       "template around an interpolation",
       `const a = \`s.slice(0, 1) \${x}\`;\n`,
     ],
-    // JSX TEXT IS A LITERAL, and nothing else in this file would treat it as one. Found by review.
-    ["JSX text", "<p>s.slice(0, 1)</p>\n"],
-    ["JSX text in a nested element", "<div>\n  <b>s.slice(0, 1)</b>\n</div>\n"],
-    [
-      "a comment inside a JSX tag",
-      "<iframe\n  // s.slice(0, 1)\n  src={x}\n/>\n",
-    ],
-    // Text that OPENS ON A PARENTHESIS, which is what a type argument list is recognised by. Without
-    // the third signal in `typeArgumentList` this reads as a generic and the text counts as code.
-    ["JSX text starting with a parenthesis", "<div>(s.slice(0, 1))</div>\n"],
-    // After a keyword that OPENS AN EXPRESSION. `default` and `throw` were read as ordinary
-    // identifiers, so the `<` after them was a comparison and the JSX text counted as code. Found by
-    // review; the row is the keyword list being exercised rather than asserted.
-    [
-      "JSX text after `export default`",
-      "export default <p>s.slice(0, 1)</p>;\n",
-    ],
-    ["JSX text after `throw`", "throw <p>s.slice(0, 1)</p>;\n"],
-    // A component name may begin with `_` or `$`, which the first character class did not admit.
-    ["JSX text in an underscore component", "<_Foo>s.slice(0, 1)</_Foo>\n"],
-    ["JSX text in a dollar component", "<$Foo>s.slice(0, 1)</$Foo>\n"],
-    ["JSX text after an attribute", '<Foo a="x">(s.slice(0, 1))</Foo>\n'],
-    // A `>` inside an attribute value must not close the tag early, which is what skipping the string
-    // (rather than refusing on it) buys in both directions.
-    [
-      "JSX text after an attribute holding a >",
-      '<div title="a > b">s.slice(0, 1)</div>\n',
-    ],
   ];
   for (const [name, source] of REMOVED) {
     test(`${name} is not a cut`, () => {
@@ -499,23 +471,33 @@ describe("every Glob sweep over src/ counts through the scan", () => {
       // fence caught itself on that the first time it ran — `codeOnly` blanked the `"src"` it was
       // matching on and the sweep list came back empty, which reads exactly like a clean tree.
       const code = withoutComments(await Bun.file(path).text());
-      if (!/\.scan\(\s*"src"/.test(code)) continue;
+      // TWO SPELLINGS, and the second is why this is a pattern rather than a string. `scan("src")`
+      // puts the directory in the call; `new Glob("src/**/*.ts").scan(".")` puts it in the GLOB and
+      // walks from the repo root. Review found `provider-boundary-sweep.test.ts` written the second
+      // way and therefore invisible to the first draft of this fence — a fence that named one
+      // spelling and reported a clean tree.
+      const globsSrc =
+        /\.scan\(\s*"src/.test(code) || /Glob\(\s*["'`]src\//.test(code);
+      if (!globsSrc) continue;
       // Globbing `src/` is not enough to be one of these: `agent-settings-mcp-parity` walks the same
       // tree to IMPORT each module and probe it with a Proxy, and never reads a character of source.
-      // Flagging it was this fence's first result, and it is the shape a fence that accuses everything
-      // takes on the way to being waived into silence.
+      // Flagging it was this fence's first result, and it is the shape a fence that accuses
+      // everything takes on the way to being waived into silence.
       if (!/Bun\.file\([^)]*\)[\s\S]{0,20}\.text\(\)/.test(code)) continue;
       sweeps.push(path);
-      // Either it counts through `countInSrc`, or it strips what it read itself. A sweep that imports
-      // the module and does not use it on the text it globbed is the case this cannot see, and the
-      // whole-file read below is what would be left to catch it.
-      if (!/\bcountInSrc\b|\bcodeOnly\b|\bwithoutComments\b/.test(code)) {
+      // THE IMPORT, NOT THE NAME. `refusal-callsites.test.ts` defines a LOCAL function called
+      // `codeOnly` — a different thing that happens to share a word — and a name-matching fence read
+      // that as adoption and let it through. A fence measures the spelling it was given, always.
+      if (!/from "@\/tests\/utils\/source-text"/.test(code)) {
         offenders.push(path);
       }
     }
     expect(offenders).toEqual([]);
-    // …and the fence is looking at something. Two today: this file and `write-body-required`.
-    expect(sweeps.length).toBeGreaterThanOrEqual(2);
+    // …and the fence is looking at something. NINE today, and the count is the finding: the first
+    // draft of this fence recognised one spelling of the glob and saw three of them.
+    // Review named a fourth it could not see; widening it to the second spelling surfaced five more.
+    // A fence that names a spelling measures the spelling, never the rule.
+    expect(sweeps.length).toBeGreaterThanOrEqual(9);
   });
 });
 

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from "bun:test";
+import {
+  codeOnly,
+  countInSrc,
+  unterminatedLiteral,
+  withoutComments,
+} from "@/tests/utils/source-text";
+
+// The table for the scan every source sweep now counts through, and the two directions it has to be
+// right in. Reading LESS than the file is the cheap failure — a phantom site, red CI, someone
+// annoyed. Reading MORE is the expensive one: a swallowed region is a site the sweep silently stops
+// counting, which is the same shape as the false waiver #424 exists to prevent, reached from the
+// other side. So every row below asserts BOTH what goes and what stays.
+
+const CUT = /\.slice\(\s*0\s*,/g;
+const hits = (s: string) => (s.match(CUT) ?? []).length;
+
+describe("the scan removes prose and keeps code", () => {
+  const REMOVED: [string, string][] = [
+    ["line comment", "// a cut: s.slice(0, 1)\n"],
+    ["block comment", "/* a cut: s.slice(0, 1) */\n"],
+    ["jsdoc", "/**\n * a cut: s.slice(0, 1)\n */\n"],
+    ["comment after code", "const a = 1; // s.slice(0, 1)\n"],
+    ["double-quoted string", 'const a = "s.slice(0, 1)";\n'],
+    ["single-quoted string", "const a = 's.slice(0, 1)';\n"],
+    ["template literal", "const a = `s.slice(0, 1)`;\n"],
+    [
+      "template around an interpolation",
+      `const a = \`s.slice(0, 1) \${x}\`;\n`,
+    ],
+  ];
+  for (const [name, source] of REMOVED) {
+    test(`${name} is not a cut`, () => {
+      expect(hits(source)).toBe(1);
+      expect(hits(codeOnly(source))).toBe(0);
+    });
+  }
+
+  const KEPT: [string, string][] = [
+    ["a head cut", "const a = s.slice(0, 10);\n"],
+    ["a cut inside an interpolation", `const a = \`x\${s.slice(0, 10)}y\`;\n`],
+    ["a cut after a line comment", "// prose\nconst a = s.slice(0, 10);\n"],
+    [
+      "a cut after a string that mentions one",
+      'f("s.slice(0, 1)");\ns.slice(0, 10);\n',
+    ],
+    [
+      "a cut after a regex holding a quote",
+      'x.replace(/"/g, "");\ns.slice(0, 10);\n',
+    ],
+    [
+      "a cut after a regex holding a backtick",
+      "x.replace(/`+/g, '');\ns.slice(0, 10);\n",
+    ],
+    [
+      "a cut after a regex holding both quotes",
+      'x.replace(/^["\'`]+/g, "");\ns.slice(0, 10);\n',
+    ],
+    [
+      "a cut after a divided value",
+      "const r = (a + b) / 2;\ns.slice(0, 10);\n",
+    ],
+    [
+      "a cut after an apostrophe in prose",
+      "// don't do this\nconst a = s.slice(0, 10);\n",
+    ],
+    ["a cut after a URL in a string", 'f("https://x/y");\ns.slice(0, 10);\n'],
+  ];
+  for (const [name, source] of KEPT) {
+    test(`${name} survives`, () => {
+      expect(hits(codeOnly(source))).toBe(1);
+    });
+  }
+
+  // The distinction the two exports exist for, and the reason this is not one function with a flag
+  // nobody would pass: `refused-turn-callsites` matches ON a string literal, so stripping contents
+  // there would blind the sweep rather than sharpen it.
+  // What `codeOnly` keeps of a literal, and it is not nothing: the quotes. An emptied literal is still
+  // a literal, so a pattern that requires an argument does not stop matching because the argument
+  // turned out to be prose.
+  test("codeOnly empties a literal without deleting it", () => {
+    const call = 'f("s.slice(0, 1)");';
+    expect(codeOnly(call)).toMatch(/^f\(" +"\);$/);
+    expect(codeOnly(call)).toHaveLength(call.length);
+    expect(codeOnly("f();")).toBe("f();");
+  });
+
+  test("withoutComments keeps a literal the pattern reads", () => {
+    const source =
+      '// returning "stale" would replay\nreturn refuse("stale");\n';
+    expect(withoutComments(source)).toContain('refuse("stale")');
+    expect(withoutComments(source)).not.toContain("would replay");
+    expect(codeOnly(source)).not.toContain("stale");
+  });
+});
+
+describe("the scan is positionally transparent", () => {
+  // What lets a sweep strip and keep reporting WHERE it found something: `refused-turn-callsites`
+  // finds its anchor in the stripped text and slices it, and `flowlog-reader-scope`-shaped readers
+  // report a line number from an index.
+  const source = "const a = 1; // s.slice(0, 1)\nconst b = s.slice(0, 10);\n";
+  // A BLOCK comment spanning lines is what separates "blank everything" from "blank everything but
+  // the newlines", and a one-line fixture cannot tell the two apart: the line count only moves when a
+  // removed region had a newline in it.
+  const multiline =
+    "const a = 1;\n/* a cut\n   s.slice(0, 1)\n   over three lines */\nconst b = s.slice(0, 10);\n";
+  test("a multi-line comment keeps its newlines", () => {
+    const out = codeOnly(multiline);
+    expect(out.split("\n").length).toBe(multiline.split("\n").length);
+    expect(out.split("\n")[4]).toBe("const b = s.slice(0, 10);");
+  });
+  test("length, newlines and every kept character stay where they were", () => {
+    const out = codeOnly(source);
+    expect(out.length).toBe(source.length);
+    expect(out.split("\n").length).toBe(source.split("\n").length);
+    for (let i = 0; i < source.length; i++) {
+      if (out[i] !== source[i]) expect(out[i]).toBe(" ");
+    }
+  });
+  test("an index into the stripped text names the same line", () => {
+    const at = codeOnly(source).indexOf("s.slice(0, 10)");
+    expect(source.slice(0, at).split("\n").length).toBe(2);
+  });
+});
+
+describe("an unterminated literal is reported rather than swallowed", () => {
+  // The self-check, and it needs its own positive control: a scan that never opens anything reports
+  // `null` for a healthy tree AND for a broken one.
+  const OPEN: ["string" | "template" | "block-comment", string][] = [
+    ["string", 'const a = "oops;\nconst b = s.slice(0, 10);\n'],
+    ["template", "const a = `oops;\nconst b = 1;\n"],
+    ["block-comment", "/* oops\nconst b = 1;\n"],
+  ];
+  for (const [expected, source] of OPEN) {
+    test(`an open ${expected} is named`, () => {
+      expect(unterminatedLiteral(source)).toBe(expected);
+    });
+  }
+  // An interpolation that never closes is a THIRD way to end mid-literal, reported by a different
+  // line than the two above: the template's own scan finished, and it was the code inside `${…}` that
+  // ran off the end of the file.
+  test("an unclosed interpolation is reported as an open template", () => {
+    expect(unterminatedLiteral("const a = `x${y")).toBe("template");
+  });
+  test("a healthy file reports nothing", () => {
+    expect(unterminatedLiteral('const a = "ok";\n')).toBeNull();
+  });
+
+  // The whole-tree assertion, and the only one that can catch the regex heuristic guessing wrong: a
+  // `/` read as division opens a literal on the quote inside the regex, and that literal runs to the
+  // end of the file. 601 files at the time of writing, and it costs about a second.
+  test("no file under src/ ends inside a literal", async () => {
+    const { Glob } = await import("bun");
+    const offenders: string[] = [];
+    let scanned = 0;
+    for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
+      scanned++;
+      const open = unterminatedLiteral(await Bun.file(`src/${rel}`).text());
+      if (open) offenders.push(`src/${rel}: ${open}`);
+    }
+    expect(offenders).toEqual([]);
+    expect(scanned).toBeGreaterThan(500);
+  });
+});
+
+// THE ONE SHAPE THE HEURISTIC GETS WRONG, MEASURED RATHER THAN REASONED ABOUT.
+//
+// `if (x) /re/.test(y)` puts a regex after a `)`, and a `)` ends a value, so the scan divides instead.
+// Nothing in `src/` is written that way and this says so out loud: the day one is, this goes red and
+// whoever wrote it learns the rule from the failure rather than from a swallowed count.
+describe("the regex heuristic's known miss is not in the tree", () => {
+  test("no `/` follows a closing parenthesis except to end a regex", async () => {
+    const { Glob } = await import("bun");
+    const suspects: string[] = [];
+    for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
+      const code = codeOnly(await Bun.file(`src/${rel}`).text());
+      for (const m of code.matchAll(/\)\s*\/(?![\s/*=])/g)) {
+        // A regex the scan consumed keeps its own text, so its closing `/` and flags are still there.
+        // What would NOT be there is a regex the scan misread — that one opened a literal instead.
+        const after = code.slice((m.index ?? 0) + 1);
+        if (!/^\s*\/[gimsuyd]*[\s,;)\].]/.test(after)) {
+          suspects.push(
+            `src/${rel}: ${code.slice(m.index, (m.index ?? 0) + 40)}`,
+          );
+        }
+      }
+    }
+    expect(suspects).toEqual([]);
+  });
+});
+
+// THE FENCE, AND WHAT IT DOES NOT REACH.
+//
+// A sweep that walks `src/` with a Glob and counts a shape is the form that arms a false waiver: the
+// ledger is per file, the phantom entry looks like every other entry, and adding it silences the file
+// for good. Every one of those goes through this module, so the raw-text spelling has to be chosen on
+// purpose rather than reached by copying the file next door.
+//
+// NOT REACHED, and the number is why this is written down instead of widened: 53 call sites in
+// `tests/` read a NAMED source file as text, and most of them are doing something a strip would break
+// (a migration's SQL, a handler body counted as prose and code together). `refused-turn-callsites` is
+// one of those 53 and adopts the scan by judgement, not because anything here obliges it. Widening
+// this to all 53 would flag dozens of readers that are correct today, which is the sweep that accuses
+// everything and gets waived into silence.
+describe("every Glob sweep over src/ counts through the scan", () => {
+  test("and nothing reads the raw text of a globbed source file", async () => {
+    const { Glob } = await import("bun");
+    const offenders: string[] = [];
+    const sweeps: string[] = [];
+    for await (const rel of new Glob("**/*.{ts,tsx}").scan("tests")) {
+      const path = `tests/${rel}`;
+      if (path === "tests/utils/source-text.ts") continue;
+      // `withoutComments`, not `codeOnly`: the thing being looked for IS a string literal, and this
+      // fence caught itself on that the first time it ran — `codeOnly` blanked the `"src"` it was
+      // matching on and the sweep list came back empty, which reads exactly like a clean tree.
+      const code = withoutComments(await Bun.file(path).text());
+      if (!/\.scan\(\s*"src"/.test(code)) continue;
+      // Globbing `src/` is not enough to be one of these: `agent-settings-mcp-parity` walks the same
+      // tree to IMPORT each module and probe it with a Proxy, and never reads a character of source.
+      // Flagging it was this fence's first result, and it is the shape a fence that accuses everything
+      // takes on the way to being waived into silence.
+      if (!/Bun\.file\([^)]*\)[\s\S]{0,20}\.text\(\)/.test(code)) continue;
+      sweeps.push(path);
+      // Either it counts through `countInSrc`, or it strips what it read itself. A sweep that imports
+      // the module and does not use it on the text it globbed is the case this cannot see, and the
+      // whole-file read below is what would be left to catch it.
+      if (!/\bcountInSrc\b|\bcodeOnly\b|\bwithoutComments\b/.test(code)) {
+        offenders.push(path);
+      }
+    }
+    expect(offenders).toEqual([]);
+    // …and the fence is looking at something. Two today: this file and `write-body-required`.
+    expect(sweeps.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("countInSrc is the shared counter", () => {
+  // THE ONE THAT PROVES IT SCANS AT ALL, and it exists because the obvious assertions do not. Every
+  // ledger in the tree counts the same through raw text and through the scan today — that is the
+  // acceptance check this change had to pass — so a `countInSrc` quietly reading raw text breaks
+  // nothing and no sweep goes red. What separates the two is a pattern that matches PROSE, and an
+  // English word is the one shape guaranteed to be in the comments and absent from the code.
+  test("it counts code and not the prose around it", async () => {
+    const { Glob } = await import("bun");
+    const RE = /\bthe\b/g;
+    let raw = 0;
+    for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
+      raw += ((await Bun.file(`src/${rel}`).text()).match(RE) ?? []).length;
+    }
+    // 37_032 at the time of writing, so the floor is not a number this has to be kept in step with.
+    expect(raw).toBeGreaterThan(10_000);
+    expect(await countInSrc(RE)).toEqual({});
+  });
+
+  test("it finds a shape and reports it per file", async () => {
+    const found = await countInSrc(/\bexport function opensRegex\b/g);
+    // The helper lives under tests/, so a pattern naming it must come back empty from a src/ sweep.
+    expect(found).toEqual({});
+  });
+  test("and it counts a shape that is really there", async () => {
+    const found = await countInSrc(/\bexport function clipText\b/g);
+    expect(found).toEqual({ "src/lib/text.ts": 1 });
+  });
+});

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -138,6 +138,64 @@ describe("the scan removes prose and keeps code", () => {
       "a cut after a JSX element with a type argument",
       'const el = <Foo<string> label="x" />;\nconst a = s.slice(0, 10);\n',
     ],
+    // THE SHAPE THAT MADE THE RULE ABOVE TOO WIDE. `value < /re/` also puts a `/` after a `<`, and
+    // reading it as a closing tag scans the PATTERN'S BODY as code — a quote in there opens a string
+    // that eats the rest of the line, and a name in there is counted as the call it merely spells.
+    // So the tag is matched as a whole shape now, not by the character before the slash. Found by
+    // review, on the previous round's fix.
+    [
+      "a cut after a regex compared with `<`",
+      'const r = a < /["]/.source.length; const x = s.slice(0, 10);\n',
+    ],
+    // ON THE SAME LINE, for the reason the DIVIDED table below spells out: a misread `/` runs to the
+    // end of its own line, so a cut on the NEXT one survives either way. A mutation that dropped the
+    // fragment from the tag pattern passed a next-line version of this row.
+    [
+      "a cut after a fragment's closing tag",
+      "const x = <></>; const a = s.slice(0, 10);\n",
+    ],
+    // The tag is matched as a WHOLE SHAPE, not by the character before the slash, so a name longer
+    // than any fixed lookahead window still closes. Written long on purpose: the first fix used a
+    // bounded slice, and this row is what a reintroduced bound fails on.
+    [
+      "a cut after a closing tag whose name is long",
+      "const x = <UmNomeDeComponenteBemMaisLongoQueQualquerJanelaFixaDeLookahead></UmNomeDeComponenteBemMaisLongoQueQualquerJanelaFixaDeLookahead>;\nconst a = s.slice(0, 10);\n",
+    ],
+    // `else` clears `endsValue` like every keyword and leaves no terminator for the statement-start
+    // check to read, so the else body was recorded as an OBJECT — and the `}` of an object ends a
+    // value, turning the regex on the next line into a division that never blanks its body. Found by
+    // review; the cut here is inside that regex's line, which is what the misread would expose.
+    [
+      "a cut after an `else` block, not an object",
+      'if (x) {} else {}\n/["]/.test(y); const a = s.slice(0, 10);\n',
+    ],
+    // `try` and `finally` are right for a DIFFERENT reason: they are absent from
+    // `KEYWORD_BEFORE_VALUE`, so they leave `endsValue` true and their braces are blocks before the
+    // `else` rule is ever consulted. The row exists to hold that second path — the day one of them is
+    // added to the keyword list, this is what goes red.
+    [
+      "a cut after a `try`/`finally` block, which never needed the rule",
+      'try {} finally {}\n/["]/.test(y); const a = s.slice(0, 10);\n',
+    ],
+    // THE TWO HALVES OF `\belse\s*$`, EACH PINNED BY THE OBJECT IT WOULD TURN INTO A BLOCK. Both
+    // mutations survived a first draft of these rows, and both fail open — they call an ordinary
+    // object literal a block, so its `}` stops ending a value and the `/` after it opens a regex that
+    // eats the rest of the line. That is the swallowed-call-site failure, reintroduced by the fix for
+    // it.
+    //
+    // The fail-open direction, pinned: the rule must not reach an IDENTIFIER ending in those four
+    // letters. It does not, and the `\b` is not what stops it — `orelse` ends a value, so the check is
+    // short-circuited before the pattern is consulted. This row holds that ordering.
+    [
+      "a cut after an object held by a name ending in `else`",
+      "const orelse = {} / 2; const a = s.slice(0, 10);\n",
+    ],
+    // Without the `$`, an `else` anywhere in the lookback window matches — including one several
+    // statements above the brace being classified.
+    [
+      "a cut after an object literal written inside an `else` body",
+      "if (x) {} else { o = {} / 2; const a = s.slice(0, 10); }\n",
+    ],
     // A postfix non-null assertion leaves the value it applied to, so the `/` after it divides.
     [
       "a cut after a division on a non-null assertion",

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -129,6 +129,20 @@ describe("the scan removes prose and keeps code", () => {
     // …and the shape that DOES close as an element while carrying a type argument.
     // A `<` that does not close as an element is not an element, so the code after it is untouched —
     // which is the direction this model deliberately errs in.
+    // A `</…>` WRITTEN IN A COMMENT does not close anything, because the closing tag has to name the
+    // element that opened. Without that, `const id = <T>(x: T)` in a `.ts` file swallowed every line
+    // up to a comment mentioning `</x>` — taking a real call site out of a ledger with nothing left
+    // open to notice. Found by review.
+    [
+      "a cut before a comment naming some other closing tag",
+      "const id = <T>(x: T) => x;\nconst a = s.slice(0, 10);\n// closes the </x> element\n",
+    ],
+    // A `{` written where a VALUE was expected is an object, so the `}` that closes it ends a value
+    // and the `/` after it divides. This used to be a documented gap; the scan tracks it now.
+    [
+      "a cut after a division on an object literal",
+      "const ratio = <any>{} / 2;\nconst a = s.slice(0, 10);\n",
+    ],
     [
       "a cut after an unclosed tag that is therefore not one",
       "f(<div class=\nconst a = s.slice(0, 10);\n",
@@ -191,6 +205,19 @@ describe("the scan removes prose and keeps code", () => {
   // table above measures one spelling: a regex naming a cut writes it escaped (`\\.slice\\(`), which
   // is not what a sweep for cuts matches. The sweep it DOES fool is the one whose shape survives
   // escaping — `sanitizeErrorMessage\(` — and that is a real ledger in this repo. Found by review.
+  // The other side of the object-vs-block rule, and the one a naive "`}` ends a value" would break: a
+  // `{` written where a value was NOT expected is a block, so the `/` after it still opens a regex.
+  test("a block's closing brace does not end a value", () => {
+    // Measured through the QUOTE, not through a comment: a comment is removed either way, because
+    // that branch runs before the `/` decision, so a comment-based fixture cannot tell block from
+    // object. What separates them is whether the regex on the next line is READ as one, and a regex
+    // holding a quote says so — as a division it opens a string and eats the rest of its line.
+    const block =
+      'if (x) { f(); }\n/["]/.test(y);\nsanitizeErrorMessage(err);\n';
+    expect(unterminatedLiteral(block)).toBeNull();
+    expect(codeOnly(block)).toContain("sanitizeErrorMessage");
+  });
+
   test("a regex body naming a call is not a call", () => {
     // The unescaped `(` is a capture group, which is how a pattern comes to spell a call site exactly.
     const guard = /sanitizeErrorMessage\(/g;
@@ -232,6 +259,8 @@ describe("the scan removes prose and keeps code", () => {
     ["a number", "const r = 2 / 2; // s.slice(0, 1)\n"],
     ["a regex", "const r = /x/ / 2; // s.slice(0, 1)\n"],
     ["a non-null assertion", "const r = value! / 2; // s.slice(0, 1)\n"],
+    ["an object literal", "const r = {} / 2; // s.slice(0, 1)\n"],
+    ["a type-asserted object", "const r = <any>{} / 2; // s.slice(0, 1)\n"],
     // The `!` of `!==` is the OTHER one: an inequality is followed by a value, so a `/` after it opens
     // a regex. Treating every `!` as postfix would read that regex as a division and run on.
     [
@@ -360,31 +389,88 @@ describe("an unterminated literal is reported rather than swallowed", () => {
   });
 });
 
-// THE TWO SHAPES THE HEURISTIC GETS WRONG, MEASURED RATHER THAN REASONED ABOUT.
+// THE SHAPE THE HEURISTIC STILL GETS WRONG, MEASURED RATHER THAN REASONED ABOUT.
 //
-// A `)` ends a value and a `}` reads as the end of a block, so `if (x) /re/.test(y)` and `({}) / 2`
-// are each decided the wrong way. Telling either apart needs a real parser; both are absent from
-// `src/` and this says so out loud, so the day one is written the failure teaches the rule instead of
-// a count quietly changing.
-describe("the heuristic's known misses are not in the tree", () => {
-  test("no `/` follows a closing bracket except to end a regex", async () => {
+// A `)` ends a value, so `if (x) /re/.test(y)` is read as a division. Telling that apart needs a real
+// parser; it is absent from `src/` and this says so out loud, so the day one is written the failure
+// teaches the rule instead of a count quietly changing.
+//
+// THE SUSPECT IS SOUGHT IN `withoutComments`, NOT IN `codeOnly`, AND THAT IS THE POINT. Review found
+// the first version of this probe scanning the stripped output — where a misread `/` has ALREADY
+// blanked its line, so the very shape being hunted is the one thing guaranteed not to be there. A
+// probe that reads its own subject's corpse reports a clean tree no matter what. The `}` case this
+// used to cover is gone from the list because the scan now tracks object-vs-block rather than
+// documenting the gap.
+// The predicate, extracted so it can be shown an offender. A sweep that finds nothing passes whether
+// or not it is looking at anything, and this one had a sharper version of that problem: review found
+// the first draft scanning `codeOnly` output, where a misread `/` has ALREADY blanked its line — so
+// the very shape being hunted was the one thing guaranteed not to be there.
+export function slashesAfterAParenthesis(source: string): string[] {
+  // Comments out (a `)` before a `/` in prose is not code), literals kept, and crucially the scan's
+  // own `/` decisions NOT applied — a probe that reads its own subject's output is reading the corpse
+  // of the thing it is hunting.
+  //
+  // NOTE: a mutation run cannot currently tell this apart from `codeOnly`, and the note is here
+  // instead of a row because that is a fact about today's tree rather than about the rule. A `/`
+  // after `)` is read as a division and therefore never blanked, so both inputs agree. The case that
+  // did diverge was `}`, which the scan no longer gets wrong; the ordering stays because the next
+  // shape to be misread would hide from a probe written the other way.
+  const code = withoutComments(source);
+  const found: string[] = [];
+  for (const m of code.matchAll(/\)\s*\/(?![\s/*=>])/g)) {
+    // A regex the scan read correctly ends with its own `/` and flags; that is not the miss.
+    const after = code.slice((m.index ?? 0) + 1);
+    if (!/^\s*\/[gimsuyd]*[\s,;)\].]/.test(after)) {
+      found.push(code.slice(m.index, (m.index ?? 0) + 40));
+    }
+  }
+  return found;
+}
+
+describe("the heuristic's known miss is not in the tree", () => {
+  // The control, first: the predicate sees the shape when it is there. Without this the sweep below
+  // is an assertion that nothing was looked at.
+  test("the predicate flags a regex written after a parenthesis", () => {
+    expect(slashesAfterAParenthesis('if (x) /["]/.test(y);\n')).toHaveLength(1);
+    expect(slashesAfterAParenthesis("const r = f() / 2;\n")).toEqual([]);
+    // …and it is not fooled by prose, which is the whole subject of this file.
+    expect(slashesAfterAParenthesis('// if (x) /["]/.test(y)\n')).toEqual([]);
+  });
+
+  test("no `/` follows a closing parenthesis except to end a regex", async () => {
     const { Glob } = await import("bun");
     const suspects: string[] = [];
+    let scanned = 0;
     for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
-      const code = codeOnly(await Bun.file(`src/${rel}`).text());
-      // `=>` is excluded because a JSX self-close `} />` puts a `/` right after a brace.
-      for (const m of code.matchAll(/[)}]\s*\/(?![\s/*=>])/g)) {
-        // A regex the scan consumed keeps its own text, so its closing `/` and flags are still there.
-        // What would NOT be there is a regex the scan misread — that one opened a literal instead.
-        const after = code.slice((m.index ?? 0) + 1);
-        if (!/^\s*\/[gimsuyd]*[\s,;)\].]/.test(after)) {
-          suspects.push(
-            `src/${rel}: ${code.slice(m.index, (m.index ?? 0) + 40)}`,
-          );
-        }
+      scanned++;
+      for (const hit of slashesAfterAParenthesis(
+        await Bun.file(`src/${rel}`).text(),
+      )) {
+        suspects.push(`src/${rel}: ${hit}`);
       }
     }
     expect(suspects).toEqual([]);
+    expect(scanned).toBeGreaterThan(500);
+  });
+
+  // The positive control the sweep cannot give itself, and it narrows the gap rather than just
+  // confirming it. A regex misread as a division is usually harmless — the scan keeps reading the
+  // line as code and the comment on it is still removed, because the comment branch runs first. It
+  // only does damage when the regex CARRIES A QUOTE, and that case is caught by the whole-tree probe,
+  // which reports the string it leaves open.
+  test("the miss is harmless unless the regex carries a quote", () => {
+    const plain = "if (x) /re/.test(y); // s.slice(0, 1)\n";
+    expect(codeOnly(plain)).not.toContain("s.slice");
+    expect(unterminatedLiteral(plain)).toBeNull();
+
+    // A quote inside the misread regex opens a string, which costs the REST OF THAT LINE — a string
+    // stops at the newline, so the damage never reaches the next one.
+    const quoted =
+      'if (x) /["]/.test(y); sanitizeErrorMessage(err);\nconst a = 1;\n';
+    expect(codeOnly(quoted)).not.toContain("sanitizeErrorMessage");
+    expect(codeOnly(quoted)).toContain("const a = 1;");
+    // …and it does not get to hide: this is what `no file under src/ ends inside a literal` reads.
+    expect(unterminatedLiteral(quoted)).toBe("string");
   });
 });
 

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -28,6 +28,23 @@ describe("the scan removes prose and keeps code", () => {
       "template around an interpolation",
       `const a = \`s.slice(0, 1) \${x}\`;\n`,
     ],
+    // JSX TEXT IS A LITERAL, and nothing else in this file would treat it as one. Found by review.
+    ["JSX text", "<p>s.slice(0, 1)</p>\n"],
+    ["JSX text in a nested element", "<div>\n  <b>s.slice(0, 1)</b>\n</div>\n"],
+    [
+      "a comment inside a JSX tag",
+      "<iframe\n  // s.slice(0, 1)\n  src={x}\n/>\n",
+    ],
+    // Text that OPENS ON A PARENTHESIS, which is what a type argument list is recognised by. Without
+    // the third signal in `typeArgumentList` this reads as a generic and the text counts as code.
+    ["JSX text starting with a parenthesis", "<div>(s.slice(0, 1))</div>\n"],
+    ["JSX text after an attribute", '<Foo a="x">(s.slice(0, 1))</Foo>\n'],
+    // A `>` inside an attribute value must not close the tag early, which is what skipping the string
+    // (rather than refusing on it) buys in both directions.
+    [
+      "JSX text after an attribute holding a >",
+      '<div title="a > b">s.slice(0, 1)</div>\n',
+    ],
   ];
   for (const [name, source] of REMOVED) {
     test(`${name} is not a cut`, () => {
@@ -38,6 +55,59 @@ describe("the scan removes prose and keeps code", () => {
 
   const KEPT: [string, string][] = [
     ["a head cut", "const a = s.slice(0, 10);\n"],
+    // THE OTHER HALF OF THE `/` DECISION, and the expensive half: a division misread as a regex
+    // opener swallows to the end of the line, taking a trailing comment back OUT of view and counting
+    // it as code. Every one of these ends in a value whose last character is not a word character,
+    // which is why the scan tracks the token and not the character. Found by review.
+    [
+      "a cut after a division on a string",
+      'const r = "a" / 2;\nconst a = s.slice(0, 10);\n',
+    ],
+    [
+      "a cut after a division on a template",
+      "const r = `a` / 2;\nconst a = s.slice(0, 10);\n",
+    ],
+    [
+      "a cut after a division on a call",
+      "const r = f() / 2;\nconst a = s.slice(0, 10);\n",
+    ],
+    [
+      "a cut after a division on an increment",
+      "const r = i++ / 2;\nconst a = s.slice(0, 10);\n",
+    ],
+    // The apostrophe in ordinary JSX prose used to open a string that ran to the next quote,
+    // swallowing whatever code sat in between.
+    [
+      "a cut after an apostrophe in JSX text",
+      "<p>Don't retry</p>\nconst a = s.slice(0, 10);\n",
+    ],
+    [
+      "a cut after an apostrophe in a JSX tag comment",
+      "<b\n  // the tabs' border\n/>\nconst a = s.slice(0, 10);\n",
+    ],
+    // `<K extends …>(` occupies the same syntactic position as a JSX element, and TypeScript itself
+    // cannot always tell them apart — hence the `<T,>` spelling. Reading one as JSX swallows the rest.
+    [
+      "a cut after a generic arrow",
+      "const set = <K extends keyof C>(k: K) => k;\nconst a = s.slice(0, 10);\n",
+    ],
+    // The other spelling TypeScript accepts in a `.tsx` file, and the reason the trailing comma is a
+    // signal rather than a curiosity.
+    [
+      "a cut after a comma-disambiguated generic",
+      "const id = <T,>(x: T) => x;\nconst a = s.slice(0, 10);\n",
+    ],
+    // A generic carrying a STRING-LITERAL type. The first version of the generic detector refused any
+    // type list holding a quote, which recognised `<div title="a > b">` correctly by accident and
+    // swallowed this one.
+    [
+      "a cut after a generic with a string-literal type",
+      'const f = <T extends "a" | "b",>(x: T) => x;\nconst a = s.slice(0, 10);\n',
+    ],
+    [
+      "a cut after a multi-line type argument",
+      "type A = z.infer<\n  z.ZodObject<typeof S>\n>;\nconst a = s.slice(0, 10);\n",
+    ],
     ["a cut inside an interpolation", `const a = \`x\${s.slice(0, 10)}y\`;\n`],
     ["a cut after a line comment", "// prose\nconst a = s.slice(0, 10);\n"],
     [
@@ -85,6 +155,27 @@ describe("the scan removes prose and keeps code", () => {
     expect(codeOnly("f();")).toBe("f();");
   });
 
+  // ON THE SAME LINE, and that is the whole point of this table rather than the KEPT rows above. A
+  // regex the scan opens by mistake runs to the end of the LINE, so a cut on the NEXT line survives
+  // either way and proves nothing — a mutation run showed every "cut after a division" row passing
+  // with the bug restored. What the misread actually swallows is the rest of its own line, so the
+  // trailing comment is the only thing that makes it observable.
+  const DIVIDED: [string, string][] = [
+    ["a string", 'const r = "a" / 2; // s.slice(0, 1)\n'],
+    ["a template", "const r = `a` / 2; // s.slice(0, 1)\n"],
+    ["a call", "const r = f() / 2; // s.slice(0, 1)\n"],
+    ["an index", "const r = a[0] / 2; // s.slice(0, 1)\n"],
+    ["an increment", "const r = i++ / 2; // s.slice(0, 1)\n"],
+    ["a number", "const r = 2 / 2; // s.slice(0, 1)\n"],
+    ["a regex", "const r = /x/ / 2; // s.slice(0, 1)\n"],
+    ["an identifier", "const r = n / 2; // s.slice(0, 1)\n"],
+  ];
+  for (const [what, source] of DIVIDED) {
+    test(`a comment after a division on ${what} is still removed`, () => {
+      expect(codeOnly(source)).not.toContain("s.slice");
+    });
+  }
+
   test("withoutComments keeps a literal the pattern reads", () => {
     const source =
       '// returning "stale" would replay\nreturn refuse("stale");\n';
@@ -126,10 +217,11 @@ describe("the scan is positionally transparent", () => {
 describe("an unterminated literal is reported rather than swallowed", () => {
   // The self-check, and it needs its own positive control: a scan that never opens anything reports
   // `null` for a healthy tree AND for a broken one.
-  const OPEN: ["string" | "template" | "block-comment", string][] = [
+  const OPEN: ["string" | "template" | "block-comment" | "jsx", string][] = [
     ["string", 'const a = "oops;\nconst b = s.slice(0, 10);\n'],
     ["template", "const a = `oops;\nconst b = 1;\n"],
     ["block-comment", "/* oops\nconst b = 1;\n"],
+    ["jsx", "<div>never closed\n"],
   ];
   for (const [expected, source] of OPEN) {
     test(`an open ${expected} is named`, () => {
@@ -163,18 +255,20 @@ describe("an unterminated literal is reported rather than swallowed", () => {
   });
 });
 
-// THE ONE SHAPE THE HEURISTIC GETS WRONG, MEASURED RATHER THAN REASONED ABOUT.
+// THE TWO SHAPES THE HEURISTIC GETS WRONG, MEASURED RATHER THAN REASONED ABOUT.
 //
-// `if (x) /re/.test(y)` puts a regex after a `)`, and a `)` ends a value, so the scan divides instead.
-// Nothing in `src/` is written that way and this says so out loud: the day one is, this goes red and
-// whoever wrote it learns the rule from the failure rather than from a swallowed count.
-describe("the regex heuristic's known miss is not in the tree", () => {
-  test("no `/` follows a closing parenthesis except to end a regex", async () => {
+// A `)` ends a value and a `}` reads as the end of a block, so `if (x) /re/.test(y)` and `({}) / 2`
+// are each decided the wrong way. Telling either apart needs a real parser; both are absent from
+// `src/` and this says so out loud, so the day one is written the failure teaches the rule instead of
+// a count quietly changing.
+describe("the heuristic's known misses are not in the tree", () => {
+  test("no `/` follows a closing bracket except to end a regex", async () => {
     const { Glob } = await import("bun");
     const suspects: string[] = [];
     for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
       const code = codeOnly(await Bun.file(`src/${rel}`).text());
-      for (const m of code.matchAll(/\)\s*\/(?![\s/*=])/g)) {
+      // `=>` is excluded because a JSX self-close `} />` puts a `/` right after a brace.
+      for (const m of code.matchAll(/[)}]\s*\/(?![\s/*=>])/g)) {
         // A regex the scan consumed keeps its own text, so its closing `/` and flags are still there.
         // What would NOT be there is a regex the scan misread — that one opened a literal instead.
         const after = code.slice((m.index ?? 0) + 1);

--- a/tests/lib/source-text.test.ts
+++ b/tests/lib/source-text.test.ts
@@ -34,6 +34,11 @@ describe("the scan removes prose and keeps code", () => {
     // characters; what separates them is that the regex CLOSES on its line and the tag does not. Both
     // spellings are in `src/`.
     ["a regex body opening with `>`", 'x.replace(/>s.slice(0, 1)/g, "");\n'],
+    // A KEYWORD *CAN* TOUCH A QUOTE, WHICH IS WHY THE APOSTROPHE RULE ALSO ASKS `endsValue`. This is
+    // valid JavaScript that no formatter writes, so the tree cannot hold the rule and a row must: drop
+    // `endsValue` from that test and the string here is read as prose, putting its contents back in
+    // front of every sweep.
+    ["a string glued to `return`", "function f() { return's.slice(0, 1)'; }\n"],
     // THE ANCHOR OF THE URL-SCHEME RULE, PINNED BY THE COMMENT IT WOULD STOP REMOVING. The rule only
     // fires when the lookback ENDS in `http:` or `https:`; drop the `$` and a scheme name anywhere in
     // the window matches, so an ordinary comment after a label called `file` or `http` is read as a
@@ -77,6 +82,21 @@ describe("the scan removes prose and keeps code", () => {
     [
       "a cut after an apostrophe in JSX text",
       "<p>Don't retry</p>\nconst a = s.slice(0, 10);\n",
+    ],
+    // ON THE SAME LINE, AND BETWEEN TWO OF THEM, which is the case the row above gave false comfort
+    // about. A single apostrophe opens a string that dies at the newline, so it costs one line and
+    // the next-line cut survives whatever happens. A PAIR closes properly and blanks the real code
+    // between them, silently — `unterminatedLiteral` has nothing to report. Found by review.
+    [
+      "a cut between two apostrophes in JSX text",
+      "const el = <p>Don't {s.slice(0, 10)} user's choice</p>;\n",
+    ],
+    // The other side of the same rule: a quote that does NOT touch a word still opens a string, which
+    // is what every import specifier in the tree depends on. Without this the adjacency test would be
+    // `endsValue` alone, and six files under `src/` lose theirs.
+    [
+      "a cut after an import specifier",
+      'import { x } from "@/lib/x";\nconst a = s.slice(0, 10);\n',
     ],
     [
       "a cut after an apostrophe in a JSX tag comment",
@@ -519,11 +539,32 @@ export function slashesAfterAParenthesis(source: string): string[] {
   // shape to be misread would hide from a probe written the other way.
   const code = withoutComments(source);
   const found: string[] = [];
-  for (const m of code.matchAll(/\)\s*\/(?![\s/*=>])/g)) {
-    // A regex the scan read correctly ends with its own `/` and flags; that is not the miss.
-    const after = code.slice((m.index ?? 0) + 1);
-    if (!/^\s*\/[gimsuyd]*[\s,;)\].]/.test(after)) {
-      found.push(code.slice(m.index, (m.index ?? 0) + 40));
+  // WHITESPACE AFTER THE SLASH IS NOT AN EXCLUSION, and excluding it was a hole exactly where the
+  // probe is supposed to see. A regex body may begin with a space, so `if (x) / sanitizeErrorMessage/`
+  // is the miss written in the one spelling the old lookahead skipped — the scan read it as a
+  // division, left a phantom call, and the probe reported nothing. Found by review.
+  for (const m of code.matchAll(/\)\s*\/(?![/*=>])/g)) {
+    const at = m.index ?? 0;
+    // Only a reading that CLOSES on its line can cost anything: one that reaches the newline is
+    // backed out by the scan and blanks nothing.
+    //
+    // JUST "IS THERE ANOTHER SLASH", not the scan's own regex walk. A first draft tracked character
+    // classes and escapes the way `scan` does, and a mutation run removed both without turning a test
+    // red — correctly, because the answer here is a BOOLEAN. Honouring `[/]` or `\/` can only find
+    // FEWER slashes than ignoring them, and the real closer is still there in every case where one
+    // exists. The two would differ only on an unterminated regex containing `[/`, which is not valid
+    // source.
+    const slash = code.indexOf("/", at);
+    const eol = code.indexOf("\n", slash);
+    if (!code.slice(slash + 1, eol === -1 ? code.length : eol).includes("/")) {
+      continue;
+    }
+    // A regex the scan read correctly ends with its own `/` and flags; that is not the miss. The `/`
+    // sits AGAINST the `)` there — `/foo(bar)/g` — so no whitespace is allowed before it. Allowing it
+    // was what swallowed the case above: `) / ` reads as a regex end with zero flags.
+    const after = code.slice(at + 1);
+    if (!/^\/[gimsuyd]*[\s,;)\].]/.test(after)) {
+      found.push(code.slice(at, at + 40));
     }
   }
   return found;
@@ -537,6 +578,36 @@ describe("the heuristic's known miss is not in the tree", () => {
     expect(slashesAfterAParenthesis("const r = f() / 2;\n")).toEqual([]);
     // …and it is not fooled by prose, which is the whole subject of this file.
     expect(slashesAfterAParenthesis('// if (x) /["]/.test(y)\n')).toEqual([]);
+  });
+
+  // THE SPELLING THE PREDICATE USED TO SKIP. A regex body may open with a space, and the old
+  // lookahead treated whitespace as proof of a division — so the one shape the probe exists to find
+  // was the one it could not see. Found by review.
+  test("the predicate flags a regex whose body opens with a space", () => {
+    expect(
+      slashesAfterAParenthesis(
+        "if (x) / sanitizeErrorMessage(Deep)?/.test(y);\n",
+      ),
+    ).toHaveLength(1);
+  });
+
+  // A reading that never closes on its line is backed out by the scan and costs nothing, so it is not
+  // a suspect. This is what keeps the widened predicate from reporting every division in the tree.
+  test("the predicate ignores a slash that closes nothing on its line", () => {
+    expect(slashesAfterAParenthesis("const r = (a + b) / 2;\n")).toEqual([]);
+    expect(
+      slashesAfterAParenthesis("const x = f(a) / b;\nconst y = 1;\n"),
+    ).toEqual([]);
+  });
+
+  // AND THE FALSE POSITIVE IT ACCEPTS, PINNED SO IT IS NOT A SURPRISE. Two divisions on one line are
+  // indistinguishable from a regex with spaces in it without a real parser — that ambiguity IS the
+  // miss this probe documents, so it reports the shape and a person reads it. Nothing in `src/`
+  // writes it today, which is why the sweep below can still require zero.
+  test("the predicate also flags two divisions sharing a line", () => {
+    expect(
+      slashesAfterAParenthesis("const r = (a + b) / 2 + c / d;\n"),
+    ).toHaveLength(1);
   });
 
   test("no `/` follows a closing parenthesis except to end a regex", async () => {

--- a/tests/lib/storable-write-sweep.test.ts
+++ b/tests/lib/storable-write-sweep.test.ts
@@ -4,6 +4,9 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { sanitizeErrorMessage } from "@/lib/redact";
 import { unstorableProblem } from "@/lib/text";
 import { claimDueJobs, enqueueJob, failJob } from "@/modules/scheduler/service";
+// Both ledgers below count through the shared scan, so prose that NAMES a column or the guard is not
+// counted as a use of it (#424).
+import { countInSrc } from "@/tests/utils/source-text";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
 // THE GUARD AGAINST THE NEXT COLUMN THAT LOSES AN ERROR MESSAGE.
@@ -385,17 +388,6 @@ const GUARD_CALLS: Record<string, number> = {
   "src/modules/scheduler/service.ts": 2,
   "src/modules/webhooks/outbound/worker.ts": 1,
 };
-
-async function countInSrc(re: RegExp): Promise<Record<string, number>> {
-  const { Glob } = await import("bun");
-  const found: Record<string, number> = {};
-  for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
-    const src = await Bun.file(`src/${rel}`).text();
-    const n = (src.match(re) ?? []).length;
-    if (n > 0) found[`src/${rel}`] = n;
-  }
-  return found;
-}
 
 describe("every line that names an error column is accounted for", () => {
   test("the file list and the per-file counts still match", async () => {

--- a/tests/modules/memory-dead-letter.test.ts
+++ b/tests/modules/memory-dead-letter.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@/modules/memory/compact";
 import { runCompactionTick } from "@/modules/memory/worker";
 import { getDeadLetterHandler, runClaimed } from "@/modules/scheduler/worker";
+import { codeOnly } from "@/tests/utils/source-text";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import { flowLogRows } from "../utils/flowlog";
 
@@ -619,7 +620,8 @@ test("every reaper announces the rows it dead-letters", async () => {
   const { Glob } = await import("bun");
   const offenders: string[] = [];
   for await (const file of new Glob("src/**/*.ts").scan(".")) {
-    const src = await Bun.file(file).text();
+    // Through the scan, so prose naming the shape is not counted as one (#424).
+    const src = codeOnly(await Bun.file(file).text());
     // The definition itself, not a call site.
     if (file.endsWith("scheduler/service.ts")) continue;
     if (!/\breapStaleJobs\b/.test(src)) continue;

--- a/tests/modules/playground-tenant-selector.test.ts
+++ b/tests/modules/playground-tenant-selector.test.ts
@@ -22,7 +22,7 @@ import {
 import { listThreadTurnNotes } from "@/modules/playground/turn-notes";
 import { transcribePlaygroundAudio } from "@/modules/stt/service";
 import { extractPlaygroundFile } from "@/modules/vision/service";
-import { codeOnly } from "@/tests/utils/source-text";
+import { withoutComments } from "@/tests/utils/source-text";
 
 // The playground was the one console surface that took the caller's tenant selector and handed it to
 // the database as an internally-trusted id, so the gate #223 put at `runScopedOn` never applied to
@@ -325,6 +325,16 @@ describe("no playground module builds a tenant context of its own", () => {
 
   test("the predicate catches the shape that was there", () => {
     expect(buildsATenantContext(OFFENDER)).toBe(true);
+    // …AND through the reader the sweep actually uses. Calling the predicate on raw text cannot see
+    // an adoption that strips the literal it matches on, which is how `codeOnly` silenced this sweep
+    // for a round (#424).
+    expect(buildsATenantContext(withoutComments(OFFENDER))).toBe(true);
+    // The prose the strip is there for: a comment naming the shape is not one.
+    expect(
+      buildsATenantContext(
+        withoutComments('// never write role: "TENANT_ADMIN" here\n'),
+      ),
+    ).toBe(false);
     expect(
       buildsATenantContext(
         "await runScopedOn(base, ctx, (db) => db.x.findMany())",
@@ -338,8 +348,11 @@ describe("no playground module builds a tenant context of its own", () => {
     for await (const rel of new Glob("**/*.ts").scan(
       "src/modules/playground",
     )) {
-      // Through the scan, so prose naming the shape is not counted as one (#424).
-      const src = codeOnly(
+      // `withoutComments`, not `codeOnly`: the predicate matches ON a literal (`role: "TENANT_ADMIN"`),
+      // so blanking string contents hides the offender instead of the prose. Adopting the wrong one
+      // here silenced the sweep, and its own control could not see that — it calls the predicate on
+      // unstripped text (found by review).
+      const src = withoutComments(
         await Bun.file(`src/modules/playground/${rel}`).text(),
       );
       if (buildsATenantContext(src)) offenders.push(rel);

--- a/tests/modules/playground-tenant-selector.test.ts
+++ b/tests/modules/playground-tenant-selector.test.ts
@@ -22,6 +22,7 @@ import {
 import { listThreadTurnNotes } from "@/modules/playground/turn-notes";
 import { transcribePlaygroundAudio } from "@/modules/stt/service";
 import { extractPlaygroundFile } from "@/modules/vision/service";
+import { codeOnly } from "@/tests/utils/source-text";
 
 // The playground was the one console surface that took the caller's tenant selector and handed it to
 // the database as an internally-trusted id, so the gate #223 put at `runScopedOn` never applied to
@@ -337,7 +338,10 @@ describe("no playground module builds a tenant context of its own", () => {
     for await (const rel of new Glob("**/*.ts").scan(
       "src/modules/playground",
     )) {
-      const src = await Bun.file(`src/modules/playground/${rel}`).text();
+      // Through the scan, so prose naming the shape is not counted as one (#424).
+      const src = codeOnly(
+        await Bun.file(`src/modules/playground/${rel}`).text(),
+      );
       if (buildsATenantContext(src)) offenders.push(rel);
     }
     expect(offenders).toEqual([]);

--- a/tests/modules/tenant-selector-entry-points.test.ts
+++ b/tests/modules/tenant-selector-entry-points.test.ts
@@ -28,6 +28,7 @@ import {
   retryDocument,
   updateDocument,
 } from "@/modules/rag/documents";
+
 import {
   approveApprovalItem,
   createKnowledgeBase,
@@ -42,6 +43,7 @@ import {
   searchKnowledge,
   updateKnowledgeBase,
 } from "@/modules/rag/service";
+import { codeOnly, withoutComments } from "@/tests/utils/source-text";
 
 // #268 fixed the playground and said the playground was the one console surface that handed a
 // module a bare tenant id. It was four more: knowledge/RAG, experiments, integrations and
@@ -410,7 +412,8 @@ describe("no REST controller hands a module a bare tenant id", () => {
     const { Glob } = await import("bun");
     const offenders: string[] = [];
     for await (const rel of new Glob("**/*.ts").scan("src/api")) {
-      const src = await Bun.file(`src/api/${rel}`).text();
+      // Through the scan, so prose naming the shape is not counted as one (#424).
+      const src = codeOnly(await Bun.file(`src/api/${rel}`).text());
       if (handsOutABareTenantId(src)) offenders.push(rel);
     }
     expect(offenders).toEqual([]);
@@ -521,7 +524,9 @@ async function sweepRoutes(): Promise<
   }> = [];
   for await (const rel of new Glob("**/*.controller.ts").scan("src/api")) {
     const file = `src/api/${rel}`;
-    const source = await Bun.file(file).text();
+    // `withoutComments`, not `codeOnly`: the patterns below READ string literals (the route path, the
+    // declared status), so blanking their contents would blind the sweep rather than sharpen it.
+    const source = withoutComments(await Bun.file(file).text());
     const prefix = /new Elysia\(\{[^}]*prefix:\s*"([^"]+)"/.exec(source)?.[1];
     if (!prefix) continue;
     for (const block of routeBlocks(source)) {

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -18,7 +18,10 @@
 type Scanned = {
   text: string;
   // What was still open when the file ended. A misread `/` or `<` announces itself here.
-  open: "string" | "template" | "block-comment" | "jsx" | null;
+  // NOTE: there is no "jsx" here. An element is recognised by closing, so one that never closes is
+  // simply not an element and the `<` stays an ordinary character — the state stopped existing when
+  // that model replaced the one that decided on the opening tag.
+  open: "string" | "template" | "block-comment" | null;
 };
 
 type Options = {
@@ -45,64 +48,21 @@ type Options = {
 const KEYWORD_BEFORE_VALUE =
   /^(?:return|typeof|instanceof|in|of|new|delete|void|case|do|else|yield|await|throw|default|export|extends|as|satisfies)$/;
 
-// `<K extends keyof C>(k: K) => …` sits in exactly the position a JSX element does, and TypeScript
-// itself cannot always tell them apart — which is why the `<T,>` spelling exists at all. Three signals:
-//
-//   1. it closes on `>(`, which a JSX element followed by anything else does not;
-//   2. it holds no backtick or `{` — a tag with an expression attribute does, a type argument list
-//      effectively never does;
-//   3. it declares a parameter — ` extends ` or a trailing `,`, the two spellings TypeScript accepts
-//      in a `.tsx` file.
-//
-// The third was added after review: on 1 and 2 alone, `<div>(x)</div>` reads as a type argument list,
-// because the `>` that closes the tag is followed by the text's own parenthesis.
-//
-// NOTE: 3 turns out to decide every case in this tree on its own — a mutation run that dropped the
-// `>(` requirement broke nothing. It stays because it is the specific signal and 3 is the textual
-// one: a tag whose last attribute ends in a bare comma would satisfy 3 and is caught only by 1. That
-// is a hypothesis about code nobody has written, so it is written down as one rather than claimed as
-// a necessity the mutation run refuted.
-//
-// UNBOUNDED ON PURPOSE. An earlier version stopped after 200 characters so a stray `<` could not walk
-// the file; measured over `src/`, the whole scan takes 80 ms with that bound and 77 ms without, so the
-// bound was buying nothing and a mechanism with no measured behaviour behind it is debt.
-//
-// QUOTES ARE SKIPPED, NOT REFUSED, and that is the third round's finding. Refusing them recognised
-// `<div title="a > b">` correctly by accident and broke `<T extends "a" | "b",>(x: T) => …`, which is
-// an ordinary generic carrying a string-literal type. Skipping the string answers both: the `>` inside
-// it stops counting toward the depth, and the type parameters around it are still read.
-function typeArgumentList(source: string, from: number): boolean {
-  let depth = 0;
-  for (let j = from; j < source.length; j++) {
-    const ch = source[j] as string;
-    if (ch === '"' || ch === "'") {
-      const q = ch;
-      j++;
-      while (j < source.length && source[j] !== q && source[j] !== "\n") {
-        j += source[j] === "\\" ? 2 : 1;
-      }
-      continue;
-    }
-    if (ch === "`" || ch === "{") return false;
-    if (ch === "<") depth++;
-    else if (ch === ">") {
-      depth--;
-      if (depth === 0) {
-        let k = j + 1;
-        while (k < source.length && /\s/.test(source[k] as string)) k++;
-        if (source[k] !== "(") return false;
-        const inner = source.slice(from + 1, j);
-        return / extends /.test(inner) || /,\s*$/.test(inner);
-      }
-    }
-  }
-  return false;
-}
-
 function scan(source: string, { strings }: Options): Scanned {
   const out = source.split("");
   let open: Scanned["open"] = null;
+  // A JSX element is recognised by CLOSING, not by opening (see `jsx`), so the scan has to be able to
+  // try one and take it back. While `applying` is false nothing is written and nothing is reported.
+  let applying = true;
+  // The dry run is memoised by start index, and that is not an optimisation. Without it the cost is
+  // exponential in the JSX/`{…}` alternation depth, because each level probes and then replays, and
+  // the replay probes again: measured on a synthetic nest, 386 characters took 72 ms and each further
+  // level doubled it. A mutation that broke tag depth turned the same shape into a battery that ran
+  // for nine minutes without finishing, which is how this was found. Safe because the answer depends
+  // only on the index and the source, and the source never changes.
+  const elementEnd = new Map<number, number | null>();
   const blank = (from: number, to: number) => {
+    if (!applying) return;
     for (let i = from; i < to; i++) if (out[i] !== "\n") out[i] = " ";
   };
 
@@ -150,18 +110,38 @@ function scan(source: string, { strings }: Options): Scanned {
     return source.length;
   }
 
-  // From the `<` of an opening element; returns the index just past the element. JSX TEXT IS A
-  // LITERAL and nothing else in this file would treat it as one: `<p>s.slice(0, 1)</p>` is a phantom
-  // cut to every sweep here, and an ordinary `<p>Don't retry</p>` opens a string on the apostrophe
-  // that runs on until the next quote, swallowing whatever code is in between.
-  function jsx(from: number): number {
+  // From the `<` of an opening element; returns the index just past it, or `null` when what follows is
+  // not a well-formed element.
+  //
+  // RECOGNISED BY CLOSING, NOT BY OPENING, and that is what replaced a detector that tried to rule out
+  // generics from the left. Ruling out is unbounded — review found four separate shapes it got wrong
+  // in one round (`<Foo<string> …/>`, `<T extends { id: string }>(`, `<_Foo>`, and plain `<T>(x: T)` in
+  // a `.ts` file) — while requiring a `</tag>` or `/>` answers all of them at once and needs no list:
+  // a type parameter list simply never closes as an element. The failure it leaves is the cheap one
+  // (JSX text counted as code) instead of the expensive one (the rest of the file swallowed).
+  //
+  // JSX TEXT IS A LITERAL and nothing else here would treat it as one: `<p>s.slice(0, 1)</p>` is a
+  // phantom cut to every sweep, and the apostrophe in `<p>Don't retry</p>` opens a string that runs on.
+  function jsx(from: number): number | null {
+    if (!applying) {
+      const seen = elementEnd.get(from);
+      if (seen !== undefined) return seen;
+    }
+    const end = scanElement(from);
+    if (!applying) elementEnd.set(from, end);
+    return end;
+  }
+
+  function scanElement(from: number): number | null {
     let i = from + 1;
+    if (!/[A-Za-z_$>]/.test(source[i] ?? "")) return null;
     let selfClosing = false;
-    // The tag: attribute values are literals, `{…}` in an attribute is code.
+    // The tag. `<` and `>` are balanced so a type argument (`<Foo<string> …/>`) does not end it early;
+    // attribute values are literals, `{…}` in one is code. Starts at 1: the `<` this was entered on
+    // counts, and starting at 0 made the closing `>` of a plain `<Foo>` read as one too many.
+    let depth = 1;
     while (i < source.length) {
       const c = source[i];
-      // A comment inside the tag is ordinary JS and this file is full of them. Missed on the first
-      // pass, and the apostrophe in `// the tabs' own border` opened a string that ran on.
       if (c === "/" && source[i + 1] === "/") {
         const nl = source.indexOf("\n", i);
         const to = nl === -1 ? source.length : nl;
@@ -184,17 +164,27 @@ function scan(source: string, { strings }: Options): Scanned {
         i = code(i + 1, "brace") + 1;
         continue;
       }
-      if (c === "/" && source[i + 1] === ">") {
+      if (c === "<") {
+        depth++;
+        i++;
+        continue;
+      }
+      if (c === "/" && source[i + 1] === ">" && depth === 1) {
         selfClosing = true;
         i += 2;
         break;
       }
       if (c === ">") {
+        depth--;
         i++;
-        break;
+        if (depth === 0) break;
+        continue;
       }
       i++;
     }
+    // NOTE: no `if (!closed) return null` here. The tag loop only exits without closing by running out
+    // of source, and the children loop below then finds no `</` and returns null anyway — a mutation
+    // run showed the explicit check could not be made to matter.
     if (selfClosing) return i;
     // The children.
     let start = i;
@@ -210,17 +200,21 @@ function scan(source: string, { strings }: Options): Scanned {
         if (strings) blank(start, i);
         if (source[i + 1] === "/") {
           const gt = source.indexOf(">", i);
-          return gt === -1 ? source.length : gt + 1;
+          return gt === -1 ? null : gt + 1;
         }
-        i = jsx(i);
+        const child = jsx(i);
+        // A child that is not an element makes the parent not one either. Both this and the `null` on
+        // a missing `>` below survive the mutation battery: the only inputs that reach them are
+        // syntactically invalid source, where every variant is already harmless. Kept as the
+        // conservative answer rather than deleted, and the gap is written down rather than implied.
+        if (child === null) return null;
+        i = child;
         start = i;
         continue;
       }
       i++;
     }
-    if (strings) blank(start, source.length);
-    open = "jsx";
-    return source.length;
+    return null;
   }
 
   // Consumes code from `from`. With `stop === "brace"` it is inside a `${…}` or a JSX `{…}` and
@@ -250,8 +244,9 @@ function scan(source: string, { strings }: Options): Scanned {
         continue;
       }
       if (c === "/" && !endsValue) {
-        // Consumed and never blanked: a regex is code. Skipping it is what keeps the quotes inside it
-        // from being read as the start of a string.
+        // The DELIMITERS stay and the body goes, exactly like a string: `/sanitizeErrorMessage\(/` is
+        // a pattern that names a call, not a call, and a sweep counting calls was counting it (found
+        // by review). Skipping it is also what keeps a quote inside it from opening a string.
         let j = i + 1;
         let inClass = false;
         while (j < source.length) {
@@ -269,6 +264,7 @@ function scan(source: string, { strings }: Options): Scanned {
           }
           j++;
         }
+        if (strings) blank(i + 1, j - 1);
         i = j;
         endsValue = true;
         continue;
@@ -283,15 +279,21 @@ function scan(source: string, { strings }: Options): Scanned {
         endsValue = true;
         continue;
       }
-      if (
-        c === "<" &&
-        !endsValue &&
-        /[A-Za-z>]/.test(d ?? "") &&
-        !typeArgumentList(source, i)
-      ) {
-        i = jsx(i);
-        endsValue = true;
-        continue;
+      if (c === "<" && !endsValue && /[A-Za-z_$>]/.test(d ?? "")) {
+        // Tried without writing anything, then replayed for real. The dry run is what lets the scan
+        // recognise an element by its closing tag without having to undo a half-consumed one.
+        const wasApplying = applying;
+        const wasOpen = open;
+        applying = false;
+        const end = jsx(i);
+        applying = wasApplying;
+        open = wasOpen;
+        if (end !== null) {
+          jsx(i);
+          i = end;
+          endsValue = true;
+          continue;
+        }
       }
       if (/[A-Za-z_$]/.test(c)) {
         let j = i;
@@ -315,6 +317,16 @@ function scan(source: string, { strings }: Options): Scanned {
         // Whitespace is not a token, so it cannot change what the last one was. Letting it through to
         // the reset below was the first version's bug: `"a" / 2` recovered `endsValue` on the quote
         // and lost it again on the space, which is every real occurrence of the shape.
+        i++;
+        continue;
+      }
+      if (c === "!") {
+        // A postfix non-null assertion leaves the value it was applied to, so `value! / 2` divides.
+        // Falling through to the reset below made that `/` a regex opener (found by review).
+        //
+        // NOTE: no `d !== "="` guard, and a mutation run is why. In `a !== /re/` the `=` that follows
+        // resets the state on its own, so excluding the comparison here changed nothing — it only
+        // read as though it were load-bearing.
         i++;
         continue;
       }

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -88,6 +88,10 @@ const KEYWORD_BEFORE_VALUE =
 // the keyword, and `\b` is saying what the regex means rather than deciding anything. It stays for
 // that reason, not because a test holds it.
 const KEYWORD_BEFORE_BLOCK = /\belse\s*$/;
+// The two keywords whose body is a VALUE when they are written as an expression. `function` and
+// `class` are the whole list: an arrow's body already lands on the object side of the brace rule and
+// so already ends a value, and no other construct puts a block where a value belongs.
+const FUNCTION_OR_CLASS = /^(?:function|class)$/;
 // Enough to clear `else` plus the whitespace before the brace.
 const KEYWORD_LOOKBACK = 16;
 
@@ -206,6 +210,9 @@ function scan(source: string, { strings }: Options): Scanned {
     // always, so that division opened a regex and swallowed the rest of the line together with a real
     // call site (found by review).
     const braces: boolean[] = [];
+    // Set when a `function` or `class` keyword is read in a value position, cleared by the brace that
+    // opens its body. See both sites below.
+    let expressionBody = false;
     while (i < source.length) {
       const c = source[i] as string;
       const d = source[i + 1];
@@ -359,6 +366,24 @@ function scan(source: string, { strings }: Options): Scanned {
           i = j;
           continue;
         }
+        // A FUNCTION OR CLASS WRITTEN WHERE A VALUE WAS EXPECTED IS AN EXPRESSION, and its `}` closes
+        // a VALUE — `const r = function () {} / d` divides. The brace itself cannot tell: the token
+        // before it is the `)` of the parameter list either way, exactly as in `if (x) {`, so the
+        // difference lives back here at the keyword. Recorded now and consumed by that brace.
+        //
+        // `!atStatementStart` is the WHOLE test, and it is the whole test because a mutation run said
+        // so: a first draft also asked `!endsValue`, which came out without a red row. Nothing valid
+        // puts a value in front of these two keywords — `=`, `(`, `,`, `return` and the rest all
+        // clear the flag — so the only thing it could still reject is `if (x) function f() {}`, which
+        // TypeScript does not accept. Found by review: with the body read as a plain block, the `/`
+        // after it opened a regex and, when a second slash closed it later on the line, blanked the
+        // real call in between.
+        if (
+          FUNCTION_OR_CLASS.test(source.slice(i, j)) &&
+          !atStatementStart(i)
+        ) {
+          expressionBody = true;
+        }
         // A keyword cannot end a value, and that is what lets `return /re/` and `case "x"` through.
         endsValue = !KEYWORD_BEFORE_VALUE.test(source.slice(i, j));
         i = j;
@@ -400,11 +425,16 @@ function scan(source: string, { strings }: Options): Scanned {
         // A `{` where a VALUE was expected is an object, EXCEPT at a statement boundary, where no
         // value was expected either because nothing precedes it. `endsValue` alone called `{}` on a
         // fresh statement an object, so the regex after it read as a division (found by review).
-        braces.push(
-          !endsValue &&
-            !atStatementStart(i) &&
-            !KEYWORD_BEFORE_BLOCK.test(before(i, KEYWORD_LOOKBACK)),
-        );
+        // The pending flag is consumed by the first brace in BLOCK position, and CLEARED there so it
+        // cannot arrive at the next function in the file. A destructured parameter cannot eat it:
+        // `function ({ a }) {}` pushes that first `{` where a value was expected, so it is an object
+        // and the body is still to come.
+        const block =
+          endsValue ||
+          atStatementStart(i) ||
+          KEYWORD_BEFORE_BLOCK.test(before(i, KEYWORD_LOOKBACK));
+        braces.push(!block || expressionBody);
+        if (block) expressionBody = false;
         endsValue = false;
         i++;
         continue;

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -135,6 +135,14 @@ function scan(source: string, { strings }: Options): Scanned {
   function scanElement(from: number): number | null {
     let i = from + 1;
     if (!/[A-Za-z_$>]/.test(source[i] ?? "")) return null;
+    // The NAME, so the closing tag can be required to match it. Without that, any `</…>` further down
+    // closed the element — including one written inside a comment, which made `const id = <T>(x: T)`
+    // in a `.ts` file swallow every line up to a `// … </x> …` and take a real call site out of a
+    // ledger, silently and with nothing left open (found by review).
+    let n = i;
+    while (n < source.length && /[A-Za-z0-9_$.:-]/.test(source[n] as string))
+      n++;
+    const name = source.slice(i, n);
     let selfClosing = false;
     // The tag. `<` and `>` are balanced so a type argument (`<Foo<string> …/>`) does not end it early;
     // attribute values are literals, `{…}` in one is code. Starts at 1: the `<` this was entered on
@@ -200,7 +208,8 @@ function scan(source: string, { strings }: Options): Scanned {
         if (strings) blank(start, i);
         if (source[i + 1] === "/") {
           const gt = source.indexOf(">", i);
-          return gt === -1 ? null : gt + 1;
+          if (gt === -1) return null;
+          return source.slice(i + 2, gt).trim() === name ? gt + 1 : null;
         }
         const child = jsx(i);
         // A child that is not an element makes the parent not one either. Both this and the `null` on
@@ -224,6 +233,12 @@ function scan(source: string, { strings }: Options): Scanned {
     let i = from;
     let depth = 0;
     let endsValue = false;
+    // Whether each open `{` began an OBJECT (a value) or a BLOCK. A `{` written where a value was
+    // expected is an object, and the `}` that closes it therefore ends a value: `<any>{} / 2` divides,
+    // while `if (x) { } …` does not. This replaces a documented gap — `}` used to read as a block
+    // always, so that division opened a regex and swallowed the rest of the line together with a real
+    // call site (found by review).
+    const braces: boolean[] = [];
     while (i < source.length) {
       const c = source[i] as string;
       const d = source[i + 1];
@@ -335,16 +350,22 @@ function scan(source: string, { strings }: Options): Scanned {
         i += 2;
         continue;
       }
-      if (stop === "brace") {
-        if (c === "{") depth++;
-        else if (c === "}") {
+      if (c === "{") {
+        if (stop === "brace") depth++;
+        braces.push(!endsValue);
+        endsValue = false;
+        i++;
+        continue;
+      }
+      if (c === "}") {
+        if (stop === "brace") {
           if (depth === 0) return i;
           depth--;
         }
+        endsValue = braces.pop() ?? false;
+        i++;
+        continue;
       }
-      // NOTE: `}` reads as the end of a BLOCK, never of an object literal, so `({}) / 2` is misread
-      // as a regex. Telling the two apart needs a real parser, and a block is the overwhelmingly
-      // common case; the whole-tree probe beside this file is what says the tree has no instance.
       endsValue = c === ")" || c === "]";
       i++;
     }

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -11,6 +11,20 @@
 // invariant, and nothing obliging the third — so the strip lives here, and `countInSrc` exists so the
 // raw-text spelling is not the convenient one.
 //
+// JSX TEXT IS NOT HANDLED, AND THAT IS A MEASURED DECISION RATHER THAN AN OMISSION.
+//
+// An earlier version of this file recognised JSX elements so their text would not be counted as code.
+// It was correct about the fixture and bought nothing real: with the whole JSX mode removed, all three
+// ledgers in this repo count byte-identically and the whole-tree probe below still reports zero files
+// ending inside a literal. What it cost was five rounds of review — recognising an element needs a
+// dry run, a memo, tag-depth balancing, closing-name matching, multi-line attribute strings — every
+// one of them a mechanism justified by a hypothesis rather than by a number.
+//
+// So the scan removes what is unambiguous (comments, string and template bodies, regex bodies) and
+// leaves `<` alone. The failure that leaves is the cheap one and it is bounded: JSX text spelling a
+// swept shape would count as code, which is a phantom entry — visible, red, and fixable — rather than
+// a swallowed site. Nothing in `src/` does it today; the ledgers are the check.
+//
 // OFFSETS AND LINE NUMBERS SURVIVE. Every removed character becomes a space and every newline is
 // kept, so `source.slice(0, m.index)` still names the same position and `.split("\n").length` still
 // names the same line. A sweep can strip and keep reporting where it found things.
@@ -51,18 +65,22 @@ const KEYWORD_BEFORE_VALUE =
 function scan(source: string, { strings }: Options): Scanned {
   const out = source.split("");
   let open: Scanned["open"] = null;
-  // A JSX element is recognised by CLOSING, not by opening (see `jsx`), so the scan has to be able to
-  // try one and take it back. While `applying` is false nothing is written and nothing is reported.
-  let applying = true;
-  // The dry run is memoised by start index, and that is not an optimisation. Without it the cost is
-  // exponential in the JSX/`{…}` alternation depth, because each level probes and then replays, and
-  // the replay probes again: measured on a synthetic nest, 386 characters took 72 ms and each further
-  // level doubled it. A mutation that broke tag depth turned the same shape into a battery that ran
-  // for nine minutes without finishing, which is how this was found. Safe because the answer depends
-  // only on the index and the source, and the source never changes.
-  const elementEnd = new Map<number, number | null>();
+  // BOTH OF THESE READ `out`, NEVER `source`, AND THE BUG THAT TAUGHT IT IS THIS FILE'S OWN SUBJECT.
+  // Written against the raw text, the member-access check matched the full stop ending a comment's
+  // last sentence — `…(RFC 4180).` two lines above a `return /[",\n\r]/` turned that regex into a
+  // division and opened a string on the quote inside it. Prose read as code, in the module whose
+  // whole purpose is to stop exactly that. `out` has the comment already blanked, so it cannot.
+  const before = (at: number, n: number) =>
+    out.slice(Math.max(0, at - n), at).join("");
+  // Whether the token just before `at` is a `.`, making what follows a property name rather than a
+  // keyword: `obj.default / 2` divides.
+  const afterDot = (at: number) => /\.\s*$/.test(before(at, 8));
+  // Whether nothing but a statement terminator precedes `at`, making a `{` there a block.
+  const atStatementStart = (at: number) => {
+    const b = before(at, 64).replace(/\s+$/, "");
+    return b === "" || b.endsWith(";") || b.endsWith("}");
+  };
   const blank = (from: number, to: number) => {
-    if (!applying) return;
     for (let i = from; i < to; i++) if (out[i] !== "\n") out[i] = " ";
   };
 
@@ -108,122 +126,6 @@ function scan(source: string, { strings }: Options): Scanned {
     if (strings) blank(start, source.length);
     open = "template";
     return source.length;
-  }
-
-  // From the `<` of an opening element; returns the index just past it, or `null` when what follows is
-  // not a well-formed element.
-  //
-  // RECOGNISED BY CLOSING, NOT BY OPENING, and that is what replaced a detector that tried to rule out
-  // generics from the left. Ruling out is unbounded — review found four separate shapes it got wrong
-  // in one round (`<Foo<string> …/>`, `<T extends { id: string }>(`, `<_Foo>`, and plain `<T>(x: T)` in
-  // a `.ts` file) — while requiring a `</tag>` or `/>` answers all of them at once and needs no list:
-  // a type parameter list simply never closes as an element. The failure it leaves is the cheap one
-  // (JSX text counted as code) instead of the expensive one (the rest of the file swallowed).
-  //
-  // JSX TEXT IS A LITERAL and nothing else here would treat it as one: `<p>s.slice(0, 1)</p>` is a
-  // phantom cut to every sweep, and the apostrophe in `<p>Don't retry</p>` opens a string that runs on.
-  function jsx(from: number): number | null {
-    if (!applying) {
-      const seen = elementEnd.get(from);
-      if (seen !== undefined) return seen;
-    }
-    const end = scanElement(from);
-    if (!applying) elementEnd.set(from, end);
-    return end;
-  }
-
-  function scanElement(from: number): number | null {
-    let i = from + 1;
-    if (!/[A-Za-z_$>]/.test(source[i] ?? "")) return null;
-    // The NAME, so the closing tag can be required to match it. Without that, any `</…>` further down
-    // closed the element — including one written inside a comment, which made `const id = <T>(x: T)`
-    // in a `.ts` file swallow every line up to a `// … </x> …` and take a real call site out of a
-    // ledger, silently and with nothing left open (found by review).
-    let n = i;
-    while (n < source.length && /[A-Za-z0-9_$.:-]/.test(source[n] as string))
-      n++;
-    const name = source.slice(i, n);
-    let selfClosing = false;
-    // The tag. `<` and `>` are balanced so a type argument (`<Foo<string> …/>`) does not end it early;
-    // attribute values are literals, `{…}` in one is code. Starts at 1: the `<` this was entered on
-    // counts, and starting at 0 made the closing `>` of a plain `<Foo>` read as one too many.
-    let depth = 1;
-    while (i < source.length) {
-      const c = source[i];
-      if (c === "/" && source[i + 1] === "/") {
-        const nl = source.indexOf("\n", i);
-        const to = nl === -1 ? source.length : nl;
-        blank(i, to);
-        i = to;
-        continue;
-      }
-      if (c === "/" && source[i + 1] === "*") {
-        const end = source.indexOf("*/", i + 2);
-        const to = end === -1 ? source.length : end + 2;
-        blank(i, to);
-        i = to;
-        continue;
-      }
-      if (c === '"' || c === "'") {
-        i = quoted(i);
-        continue;
-      }
-      if (c === "{") {
-        i = code(i + 1, "brace") + 1;
-        continue;
-      }
-      if (c === "<") {
-        depth++;
-        i++;
-        continue;
-      }
-      if (c === "/" && source[i + 1] === ">" && depth === 1) {
-        selfClosing = true;
-        i += 2;
-        break;
-      }
-      if (c === ">") {
-        depth--;
-        i++;
-        if (depth === 0) break;
-        continue;
-      }
-      i++;
-    }
-    // NOTE: no `if (!closed) return null` here. The tag loop only exits without closing by running out
-    // of source, and the children loop below then finds no `</` and returns null anyway — a mutation
-    // run showed the explicit check could not be made to matter.
-    if (selfClosing) return i;
-    // The children.
-    let start = i;
-    while (i < source.length) {
-      const c = source[i];
-      if (c === "{") {
-        if (strings) blank(start, i);
-        i = code(i + 1, "brace") + 1;
-        start = i;
-        continue;
-      }
-      if (c === "<") {
-        if (strings) blank(start, i);
-        if (source[i + 1] === "/") {
-          const gt = source.indexOf(">", i);
-          if (gt === -1) return null;
-          return source.slice(i + 2, gt).trim() === name ? gt + 1 : null;
-        }
-        const child = jsx(i);
-        // A child that is not an element makes the parent not one either. Both this and the `null` on
-        // a missing `>` below survive the mutation battery: the only inputs that reach them are
-        // syntactically invalid source, where every variant is already harmless. Kept as the
-        // conservative answer rather than deleted, and the gap is written down rather than implied.
-        if (child === null) return null;
-        i = child;
-        start = i;
-        continue;
-      }
-      i++;
-    }
-    return null;
   }
 
   // Consumes code from `from`. With `stop === "brace"` it is inside a `${…}` or a JSX `{…}` and
@@ -294,26 +196,19 @@ function scan(source: string, { strings }: Options): Scanned {
         endsValue = true;
         continue;
       }
-      if (c === "<" && !endsValue && /[A-Za-z_$>]/.test(d ?? "")) {
-        // Tried without writing anything, then replayed for real. The dry run is what lets the scan
-        // recognise an element by its closing tag without having to undo a half-consumed one.
-        const wasApplying = applying;
-        const wasOpen = open;
-        applying = false;
-        const end = jsx(i);
-        applying = wasApplying;
-        open = wasOpen;
-        if (end !== null) {
-          jsx(i);
-          i = end;
-          endsValue = true;
-          continue;
-        }
-      }
       if (/[A-Za-z_$]/.test(c)) {
         let j = i;
         while (j < source.length && /[A-Za-z0-9_$]/.test(source[j] as string))
           j++;
+        // AFTER A DOT IT IS A PROPERTY NAME, not a keyword: `obj.default / 2` divides, and reading
+        // `default` as expression-opening there made the `/` a regex and hid the rest of the line
+        // (found by review). `endsValue` is already true from the dot's own operand, so keeping the
+        // state is exactly right.
+        if (afterDot(i)) {
+          endsValue = true;
+          i = j;
+          continue;
+        }
         // A keyword cannot end a value, and that is what lets `return /re/` and `case "x"` through.
         endsValue = !KEYWORD_BEFORE_VALUE.test(source.slice(i, j));
         i = j;
@@ -352,7 +247,10 @@ function scan(source: string, { strings }: Options): Scanned {
       }
       if (c === "{") {
         if (stop === "brace") depth++;
-        braces.push(!endsValue);
+        // A `{` where a VALUE was expected is an object, EXCEPT at a statement boundary, where no
+        // value was expected either because nothing precedes it. `endsValue` alone called `{}` on a
+        // fresh statement an object, so the regex after it read as a division (found by review).
+        braces.push(!endsValue && !atStatementStart(i));
         endsValue = false;
         i++;
         continue;

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -62,6 +62,45 @@ type Options = {
 const KEYWORD_BEFORE_VALUE =
   /^(?:return|typeof|instanceof|in|of|new|delete|void|case|do|else|yield|await|throw|default|export|extends|as|satisfies)$/;
 
+// `else` is the one keyword whose `{` opens a BLOCK and that still reaches this check. It clears
+// `endsValue` like every expression-introducing keyword, and it leaves no terminator for
+// `atStatementStart` to read, so `if (x) {} else {}` recorded the else body as an OBJECT — and an
+// object's `}` ends a value, turning the regex on the next line into a division that never blanks its
+// body (found by review).
+//
+// THE LIST IS ONE WORD BECAUSE THE OTHER CANDIDATES ARE UNMEASURABLE, NOT BECAUSE THEY WERE
+// FORGOTTEN. A first draft read `else|try|finally|do`; a mutation run then removed `try|finally|do`
+// without turning a single test red. `try` and `finally` are absent from `KEYWORD_BEFORE_VALUE`, so
+// they leave `endsValue` true and the `&&` below short-circuits before ever asking this — dead
+// alternatives, indistinguishable from a typo. `do` does clear `endsValue`, but its body's `}` is
+// always followed by `while (…)`, so the misclassification has nowhere to surface. Adding either back
+// would be a rule no test could hold.
+//
+// NOTE: A MUTATION RUN CANNOT REMOVE THE `\b`, AND THE NOTE IS HERE INSTEAD OF A ROW. Reaching this
+// check at all requires `endsValue` to be false, and any identifier ending in those four letters —
+// `orelse` — sets it true and short-circuits. So the only token that can both reach here and match is
+// the keyword, and `\b` is saying what the regex means rather than deciding anything. It stays for
+// that reason, not because a test holds it.
+const KEYWORD_BEFORE_BLOCK = /\belse\s*$/;
+// Enough to clear `else` plus the whitespace before the brace.
+const KEYWORD_LOOKBACK = 16;
+
+// A closing JSX tag or fragment, anchored with the sticky flag so no arbitrary lookahead window has
+// to bound the component name. `lastIndex` is assigned on every call, so nothing leaks between scans.
+//
+// WHAT IS STILL AMBIGUOUS, AND WHAT CLOSES IT. `a</b>/` is a comparison against the regex `/b>/`, and
+// it is indistinguishable from a closing tag without a real parser — the scan calls it a tag and
+// blanks nothing. It needs the `<` GLUED to the `/`, which is a spelling the formatter does not
+// produce: `bun format` rewrites that line to `a < /b>/`, where the space breaks the adjacency and
+// the regex is read correctly. So the residue is held out of the tree by `bun check`, not by luck,
+// and the formatted spelling has its own row in the decision table.
+const CLOSING_TAG = /<\/\s*(?:[A-Za-z_$][\w$.:-]*\s*)?>/y;
+
+function closesTag(source: string, at: number): boolean {
+  CLOSING_TAG.lastIndex = at;
+  return CLOSING_TAG.test(source);
+}
+
 function scan(source: string, { strings }: Options): Scanned {
   const out = source.split("");
   let open: Scanned["open"] = null;
@@ -163,7 +202,12 @@ function scan(source: string, { strings }: Options): Scanned {
       // A `/` right after a `<` closes a JSX tag; it never opens a regex. Removing the JSX mode left
       // `<` not ending a value, so `</Foo>` entered the regex branch and swallowed the rest of its
       // line — including a real call site, with nothing left open to notice (found by review).
-      if (c === "/" && !endsValue && before(i, 2).trimEnd().endsWith("<")) {
+      //
+      // Matched as the WHOLE closing tag rather than by the single character before it, because
+      // `value < /sanitizeErrorMessage/` puts a letter after that `/` too, and reading it as a tag
+      // scans the pattern's body as code — inventing the call the sweep then counts (found by
+      // review, on the fix above).
+      if (c === "/" && !endsValue && closesTag(source, i - 1)) {
         i++;
         continue;
       }
@@ -257,7 +301,11 @@ function scan(source: string, { strings }: Options): Scanned {
         // A `{` where a VALUE was expected is an object, EXCEPT at a statement boundary, where no
         // value was expected either because nothing precedes it. `endsValue` alone called `{}` on a
         // fresh statement an object, so the regex after it read as a division (found by review).
-        braces.push(!endsValue && !atStatementStart(i));
+        braces.push(
+          !endsValue &&
+            !atStatementStart(i) &&
+            !KEYWORD_BEFORE_BLOCK.test(before(i, KEYWORD_LOOKBACK)),
+        );
         endsValue = false;
         i++;
         continue;

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -25,6 +25,12 @@
 // swept shape would count as code, which is a phantom entry — visible, red, and fixable — rather than
 // a swallowed site. Nothing in `src/` does it today; the ledgers are the check.
 //
+// THAT LAST SENTENCE WAS TOO STRONG ONCE, AND REVIEW CAUGHT IT. JSX text is the one position where a
+// URL can be written bare, and its `//` was read as a comment — a SWALLOW, not a phantom, taking a
+// real interpolation with it. `http` and `https` are answered now (see `URL_SCHEME`); a bare
+// `ws://x` in JSX prose is still a swallow, counted at zero and written down rather than claimed
+// away. The bound holds for everything else JSX text can spell.
+//
 // OFFSETS AND LINE NUMBERS SURVIVE. Every removed character becomes a space and every newline is
 // kept, so `source.slice(0, m.index)` still names the same position and `.split("\n").length` still
 // names the same line. A sweep can strip and keep reporting where it found things.
@@ -84,6 +90,26 @@ const KEYWORD_BEFORE_VALUE =
 const KEYWORD_BEFORE_BLOCK = /\belse\s*$/;
 // Enough to clear `else` plus the whitespace before the brace.
 const KEYWORD_LOOKBACK = 16;
+
+// The scheme whose `//` is part of a URL rather than the start of a comment. See the branch that
+// reads it: only JSX text can carry one bare, because every other position is inside a literal.
+//
+// TWO NARROWER SPELLINGS WERE TRIED AND BOTH WERE REMOVED BY A MUTATION RUN WITHOUT TURNING A TEST
+// RED. `\b(?:https?|wss?|ftps?|file)` claimed five more schemes and a token boundary; nothing reaches
+// either, because the only position where this branch can fire is bare JSX text and there is no
+// `ws://` written as visible prose in `src/`. What survives is what a person actually types where a
+// reader will see it.
+//
+// A bare `ws://x` in JSX text would still be read as a comment and swallow its line. THAT RESIDUE IS
+// COUNTED, NOT ASSUMED: `src/` holds five non-http `scheme://` today, every one inside a `//`
+// comment, where the leading slashes are consumed first and these are never examined; none is in a
+// `.tsx` file at all. No probe guards it, and that is deliberate — every version of one reads a
+// corpse. The swallow happens in the COMMENT branch, so by the time a sweep sees the text the `//`
+// is already blanked, and a raw-text probe cannot tell JSX prose from a websocket URL in a string.
+//
+// The `$` is NOT decoration and has its own row: without it, `case file: // …` matches inside the
+// lookback window and the comment stops being removed.
+const URL_SCHEME = /https?:$/;
 
 // A closing JSX tag or fragment, anchored with the sticky flag so no arbitrary lookahead window has
 // to bound the component name. `lastIndex` is assigned on every call, so nothing leaks between scans.
@@ -184,6 +210,21 @@ function scan(source: string, { strings }: Options): Scanned {
       const c = source[i] as string;
       const d = source[i + 1];
 
+      // A `//` THAT CLOSES A URL SCHEME IS NOT A COMMENT, and JSX text is where one can be written
+      // bare. `<p>Visit https://x {value.slice(0, 1)}</p>` blanked from the `//` to the end of the
+      // line — taking a real interpolation with it, silently, since a comment leaves nothing open.
+      // Everywhere else a URL is already inside a string or template, whose branch consumes it before
+      // this one is reached; JSX text has no such branch, by the deliberate omission at the top of
+      // this file. Found by review.
+      //
+      // The scheme is spelled out rather than matched as `[a-z][a-z0-9+.-]*:`, because that pattern
+      // also covers `case x: //` and a label, where the `//` IS a comment. These are the schemes that
+      // are followed by `//`; a bare `custom://` in JSX text would still be misread, and the probe
+      // below pins that none is written.
+      if (c === "/" && d === "/" && URL_SCHEME.test(before(i, 8))) {
+        i += 2;
+        continue;
+      }
       if (c === "/" && d === "/") {
         const nl = source.indexOf("\n", i);
         const to = nl === -1 ? source.length : nl;
@@ -217,6 +258,7 @@ function scan(source: string, { strings }: Options): Scanned {
         // by review). Skipping it is also what keeps a quote inside it from opening a string.
         let j = i + 1;
         let inClass = false;
+        let closed = false;
         while (j < source.length) {
           const r = source[j];
           if (r === "\\") {
@@ -228,9 +270,37 @@ function scan(source: string, { strings }: Options): Scanned {
           else if (r === "]") inClass = false;
           else if (r === "/" && !inClass) {
             j++;
+            closed = true;
             break;
           }
           j++;
+        }
+        // A REGEX LITERAL CANNOT SPAN A NEWLINE, SO ONE THAT REACHES IT WAS NEVER A REGEX — back the
+        // reading out instead of blanking to the end of the line. Review found the blanking version
+        // erasing a real call site in `function () {} / d && sanitizeErrorMessage(err)` with nothing
+        // left open to notice, and asked for the miss to be REPORTED; reporting turned out to be the
+        // smaller half of the answer, because the same signal identifies the misread.
+        //
+        // It is the whole disambiguator for the JSX slash, and it needs no JSX state: `/>` at the end
+        // of a tag never finds its closing `/` on that line, while `.replace(/>/g, "&gt;")` — a real
+        // regex whose body is `>` — closes two characters later. Both are in `src/`; the first is in
+        // 135 files and was being read as a regex, silently swallowing whatever followed it on the
+        // line. `</Foo>` is answered earlier, by shape; this answers the other half.
+        //
+        // Backing out errs toward the PHANTOM and away from the swallow, which is the direction this
+        // whole module is built to err in: an unterminated regex in genuinely invalid source now shows
+        // its body as code, which a ledger reports loudly, rather than eating the line in silence.
+        //
+        // NOTE: `endsValue = false` HERE IS UNOBSERVABLE, and the note is here instead of a row. It
+        // says what a division operator means — a value is expected after it — but for the flag to
+        // change anything the next token would have to be another `/`, and a `/` that reaches this
+        // line has already scanned forward looking for exactly that. If one were there the regex
+        // would have CLOSED on it and never reached the back-out. A row written for it measured
+        // something else: in `{} / /re/` the first slash closes on the second.
+        if (!closed) {
+          i++;
+          endsValue = false;
+          continue;
         }
         if (strings) blank(i + 1, j - 1);
         i = j;

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -160,6 +160,13 @@ function scan(source: string, { strings }: Options): Scanned {
         i = to;
         continue;
       }
+      // A `/` right after a `<` closes a JSX tag; it never opens a regex. Removing the JSX mode left
+      // `<` not ending a value, so `</Foo>` entered the regex branch and swallowed the rest of its
+      // line — including a real call site, with nothing left open to notice (found by review).
+      if (c === "/" && !endsValue && before(i, 2).trimEnd().endsWith("<")) {
+        i++;
+        continue;
+      }
       if (c === "/" && !endsValue) {
         // The DELIMITERS stay and the body goes, exactly like a string: `/sanitizeErrorMessage\(/` is
         // a pattern that names a call, not a call, and a sweep counting calls was counting it (found

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -39,8 +39,11 @@ type Options = {
 //
 // The token, not the character: `"a" / 2`, `` `x` / 2 ``, `i++ / 2` and `f() / 2` all end in a value
 // whose last character is not a word character.
+// Every keyword after which an EXPRESSION begins, so a `/` there opens a regex and a `<` opens a JSX
+// element. Missing one is not a stylistic gap: `export default <p>x</p>` was read as a comparison and
+// the JSX text counted as code, which is the phantom this module exists to prevent (found by review).
 const KEYWORD_BEFORE_VALUE =
-  /^(?:return|typeof|instanceof|in|of|new|delete|void|case|do|else|yield|await)$/;
+  /^(?:return|typeof|instanceof|in|of|new|delete|void|case|do|else|yield|await|throw|default|export|extends|as|satisfies)$/;
 
 // `<K extends keyof C>(k: K) => …` sits in exactly the position a JSX element does, and TypeScript
 // itself cannot always tell them apart — which is why the `<T,>` spelling exists at all. Three signals:
@@ -363,6 +366,17 @@ export function unterminatedLiteral(source: string): Scanned["open"] {
 // The one way a sweep counts a shape across `src/`, so that the raw-text spelling has to be written on
 // purpose rather than reached by copying the file next door.
 export async function countInSrc(re: RegExp): Promise<Record<string, number>> {
+  // REFUSED, not repaired, and the difference matters here. Without `g`, `String.prototype.match`
+  // returns the first match plus its capture GROUPS, so `.length` is one more than the group count
+  // and has nothing to do with how many times the shape occurs — a ledger built on it is wrong in a
+  // direction nobody would think to check. Measured: `/\bexport function (clipText)\b/` reports 2 for
+  // a file with one. Silently adding the flag would leave the caller believing a pattern that cannot
+  // count is counting (found by review).
+  if (!re.flags.includes("g")) {
+    throw new Error(
+      `countInSrc needs a /g pattern to count occurrences; ${re} would report a capture-group count instead.`,
+    );
+  }
   const { Glob } = await import("bun");
   const found: Record<string, number> = {};
   for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -307,6 +307,35 @@ function scan(source: string, { strings }: Options): Scanned {
         endsValue = true;
         continue;
       }
+      // A QUOTE THAT DIRECTLY FOLLOWS A VALUE IS NOT A QUOTE, and this is the third ambiguity the one
+      // fact settles. `identifier'x'` is not TypeScript — a string literal never touches the token
+      // before it — so a `'` sitting against a word is an apostrophe in JSX prose. `<p>Don't
+      // {sanitizeErrorMessage(err)} user's choice</p>` opened a string at the first one and closed it
+      // at the second, blanking the real call in between and leaving nothing open to notice. An
+      // earlier row covered only the SINGLE apostrophe, whose string dies at the newline and so costs
+      // one line; the pair is the silent case. Found by review.
+      //
+      // TWO CONDITIONS, AND THE SECOND IS NOT REDUNDANT. `endsValue` survives whitespace by design —
+      // that was itself a fix on this PR — so it alone also rejects the string in `import x from "y"`,
+      // where `from` is an ordinary identifier. What separates the two is ADJACENCY: prose writes
+      // `Don't` with the quote against the word, and code always writes a space. Measured, not
+      // reasoned: without the adjacency test six files under `src/` lose their import specifiers.
+      //
+      // The keywords that CAN touch a quote (`case'x'`, `return'x'`) are the ones that clear
+      // `endsValue`, so they are already on the other side of this test and open their string.
+      //
+      // WHAT ADJACENCY DOES NOT REACH, WRITTEN DOWN RATHER THAN IMPLIED. A quote SEPARATED from the
+      // word — `<p>He said "hi {…} bye" now</p>` — still opens a string. Dropping the adjacency test
+      // would cover it, and then the only collisions left are the contextual keywords that are not in
+      // `KEYWORD_BEFORE_VALUE`: `from` and `import`, which precede a string with a space in every
+      // import in the tree. That is a list this repo cannot test, since nothing in `src/` writes a
+      // spaced quote in JSX prose — so the rule stops where the measurement stops. The whole-tree
+      // probe is what would catch it going wrong: the first draft of this test, without adjacency,
+      // reported six files ending inside a string.
+      if ((c === '"' || c === "'") && endsValue && /[\w$]/.test(before(i, 1))) {
+        i++;
+        continue;
+      }
       if (c === '"' || c === "'") {
         i = quoted(i);
         endsValue = true;

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -17,41 +17,83 @@
 
 type Scanned = {
   text: string;
-  // What was still open when the file ended. A misread regex announces itself here.
-  open: "string" | "template" | "block-comment" | null;
+  // What was still open when the file ended. A misread `/` or `<` announces itself here.
+  open: "string" | "template" | "block-comment" | "jsx" | null;
 };
 
 type Options = {
-  // Whether the CONTENTS of string and template literals go too. Comments always do.
+  // Whether the CONTENTS of string, template and JSX-text literals go too. Comments always do.
   strings: boolean;
 };
 
-// Where a `/` opens a regex literal rather than dividing. Shape alone cannot tell the two apart, and
-// erring toward division is the expensive half: an unrecognised `/"/g` opens a string that swallows
-// the code after it, and swallowed code is a site the sweep stops counting without a word. `src/`
-// carries a dozen such regexes today (`/^["'`]+|["'`]+$/g` in `graph/nudge.ts`, `/[\\']/g` in the
-// Drive toolpack, `/"/g` in four more), so this branch is load-bearing rather than defensive.
+// ONE FACT DECIDES BOTH AMBIGUITIES, which is why it is a variable and not two heuristics.
 //
-// The rule is the standard one: a `/` divides only when what precedes it can END a value. Anything
-// else — an operator, a comma, an opening bracket, `return`, `typeof`, the start of the file — opens a
-// regex. The known miss is `if (x) /re/.test(y)`, where `)` closes a condition rather than a value;
-// the test beside this file pins that `src/` has none.
-const KEYWORD_BEFORE_REGEX =
-  /\b(?:return|typeof|instanceof|in|of|new|delete|void|case|do|else|yield|await)$/;
-// Enough to clear the widest indentation in the tree; a `/` further than this from the token before it
-// would have to sit under 64 columns of blank, which the formatter does not produce.
-const LOOKBEHIND = 64;
+// `/` is a regex when a value cannot precede it and a division when one can; `<` opens a JSX element
+// under exactly the same condition and is a comparison otherwise. Both are answered by "can the token
+// just consumed END a value", tracked as the scan goes.
+//
+// Reading either one wrong in the permissive direction is the expensive half. An unrecognised `/"/g`
+// opens a string that swallows the code after it; a `"a" / 2` read as a regex opener swallows to the
+// end of the line, taking the `// comment` on it back out of view and counting it as code — the very
+// failure this module exists to stop, inverted. Both were found by review on the PR that added this.
+//
+// The token, not the character: `"a" / 2`, `` `x` / 2 ``, `i++ / 2` and `f() / 2` all end in a value
+// whose last character is not a word character.
+const KEYWORD_BEFORE_VALUE =
+  /^(?:return|typeof|instanceof|in|of|new|delete|void|case|do|else|yield|await)$/;
 
-function opensRegex(source: string, at: number): boolean {
-  const before = source
-    .slice(Math.max(0, at - LOOKBEHIND), at)
-    .replace(/\s+$/, "");
-  if (before === "") return true;
-  if (KEYWORD_BEFORE_REGEX.test(before)) return true;
-  // An identifier, a number or a closing bracket ends a value, so a `/` after one divides. This also
-  // answers `this`, `true` and `null` without naming them: they end in a letter, so the test below
-  // already calls them values. A mutation run proved the explicit list they had was dead code.
-  return !/[A-Za-z0-9_$)\]]/.test(before[before.length - 1] as string);
+// `<K extends keyof C>(k: K) => …` sits in exactly the position a JSX element does, and TypeScript
+// itself cannot always tell them apart — which is why the `<T,>` spelling exists at all. Three signals:
+//
+//   1. it closes on `>(`, which a JSX element followed by anything else does not;
+//   2. it holds no backtick or `{` — a tag with an expression attribute does, a type argument list
+//      effectively never does;
+//   3. it declares a parameter — ` extends ` or a trailing `,`, the two spellings TypeScript accepts
+//      in a `.tsx` file.
+//
+// The third was added after review: on 1 and 2 alone, `<div>(x)</div>` reads as a type argument list,
+// because the `>` that closes the tag is followed by the text's own parenthesis.
+//
+// NOTE: 3 turns out to decide every case in this tree on its own — a mutation run that dropped the
+// `>(` requirement broke nothing. It stays because it is the specific signal and 3 is the textual
+// one: a tag whose last attribute ends in a bare comma would satisfy 3 and is caught only by 1. That
+// is a hypothesis about code nobody has written, so it is written down as one rather than claimed as
+// a necessity the mutation run refuted.
+//
+// UNBOUNDED ON PURPOSE. An earlier version stopped after 200 characters so a stray `<` could not walk
+// the file; measured over `src/`, the whole scan takes 80 ms with that bound and 77 ms without, so the
+// bound was buying nothing and a mechanism with no measured behaviour behind it is debt.
+//
+// QUOTES ARE SKIPPED, NOT REFUSED, and that is the third round's finding. Refusing them recognised
+// `<div title="a > b">` correctly by accident and broke `<T extends "a" | "b",>(x: T) => …`, which is
+// an ordinary generic carrying a string-literal type. Skipping the string answers both: the `>` inside
+// it stops counting toward the depth, and the type parameters around it are still read.
+function typeArgumentList(source: string, from: number): boolean {
+  let depth = 0;
+  for (let j = from; j < source.length; j++) {
+    const ch = source[j] as string;
+    if (ch === '"' || ch === "'") {
+      const q = ch;
+      j++;
+      while (j < source.length && source[j] !== q && source[j] !== "\n") {
+        j += source[j] === "\\" ? 2 : 1;
+      }
+      continue;
+    }
+    if (ch === "`" || ch === "{") return false;
+    if (ch === "<") depth++;
+    else if (ch === ">") {
+      depth--;
+      if (depth === 0) {
+        let k = j + 1;
+        while (k < source.length && /\s/.test(source[k] as string)) k++;
+        if (source[k] !== "(") return false;
+        const inner = source.slice(from + 1, j);
+        return / extends /.test(inner) || /,\s*$/.test(inner);
+      }
+    }
+  }
+  return false;
 }
 
 function scan(source: string, { strings }: Options): Scanned {
@@ -61,14 +103,132 @@ function scan(source: string, { strings }: Options): Scanned {
     for (let i = from; i < to; i++) if (out[i] !== "\n") out[i] = " ";
   };
 
-  // Consumes code from `from`. With `stopAtBrace` it is inside a `${…}` and returns the index of the
-  // `}` that closes it, counting the braces opened in between so an object literal does not end it
-  // early; otherwise it runs to the end of the file.
-  function code(from: number, stopAtBrace: boolean): number {
+  // From an opening quote; returns the index just past the closing one.
+  function quoted(from: number): number {
+    const q = source[from];
+    let j = from + 1;
+    while (j < source.length && source[j] !== q && source[j] !== "\n") {
+      j += source[j] === "\\" ? 2 : 1;
+    }
+    if (j >= source.length || source[j] === "\n") open = "string";
+    // The quotes themselves stay, so an emptied literal is still a literal: a sweep can tell `f("")`
+    // from `f()`, and a pattern that requires an argument does not stop matching because the argument
+    // was prose.
+    if (strings) blank(from + 1, j);
+    return j + 1;
+  }
+
+  // From just past an opening backtick; returns the index just past the closing one. Literal runs are
+  // blanked and every `${…}` goes back through `code`, because an interpolation holds real code and a
+  // cut written in one is a real cut.
+  function template(from: number): number {
     let i = from;
-    let depth = 0;
+    let start = i;
     while (i < source.length) {
       const c = source[i];
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === "`") {
+        if (strings) blank(start, i);
+        return i + 1;
+      }
+      if (c === "$" && source[i + 1] === "{") {
+        if (strings) blank(start, i);
+        i = code(i + 2, "brace") + 1;
+        start = i;
+        continue;
+      }
+      i++;
+    }
+    if (strings) blank(start, source.length);
+    open = "template";
+    return source.length;
+  }
+
+  // From the `<` of an opening element; returns the index just past the element. JSX TEXT IS A
+  // LITERAL and nothing else in this file would treat it as one: `<p>s.slice(0, 1)</p>` is a phantom
+  // cut to every sweep here, and an ordinary `<p>Don't retry</p>` opens a string on the apostrophe
+  // that runs on until the next quote, swallowing whatever code is in between.
+  function jsx(from: number): number {
+    let i = from + 1;
+    let selfClosing = false;
+    // The tag: attribute values are literals, `{…}` in an attribute is code.
+    while (i < source.length) {
+      const c = source[i];
+      // A comment inside the tag is ordinary JS and this file is full of them. Missed on the first
+      // pass, and the apostrophe in `// the tabs' own border` opened a string that ran on.
+      if (c === "/" && source[i + 1] === "/") {
+        const nl = source.indexOf("\n", i);
+        const to = nl === -1 ? source.length : nl;
+        blank(i, to);
+        i = to;
+        continue;
+      }
+      if (c === "/" && source[i + 1] === "*") {
+        const end = source.indexOf("*/", i + 2);
+        const to = end === -1 ? source.length : end + 2;
+        blank(i, to);
+        i = to;
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        i = quoted(i);
+        continue;
+      }
+      if (c === "{") {
+        i = code(i + 1, "brace") + 1;
+        continue;
+      }
+      if (c === "/" && source[i + 1] === ">") {
+        selfClosing = true;
+        i += 2;
+        break;
+      }
+      if (c === ">") {
+        i++;
+        break;
+      }
+      i++;
+    }
+    if (selfClosing) return i;
+    // The children.
+    let start = i;
+    while (i < source.length) {
+      const c = source[i];
+      if (c === "{") {
+        if (strings) blank(start, i);
+        i = code(i + 1, "brace") + 1;
+        start = i;
+        continue;
+      }
+      if (c === "<") {
+        if (strings) blank(start, i);
+        if (source[i + 1] === "/") {
+          const gt = source.indexOf(">", i);
+          return gt === -1 ? source.length : gt + 1;
+        }
+        i = jsx(i);
+        start = i;
+        continue;
+      }
+      i++;
+    }
+    if (strings) blank(start, source.length);
+    open = "jsx";
+    return source.length;
+  }
+
+  // Consumes code from `from`. With `stop === "brace"` it is inside a `${…}` or a JSX `{…}` and
+  // returns the index of the `}` that closes it, counting the braces opened in between so an object
+  // literal does not end it early; otherwise it runs to the end of the file.
+  function code(from: number, stop: "brace" | "eof"): number {
+    let i = from;
+    let depth = 0;
+    let endsValue = false;
+    while (i < source.length) {
+      const c = source[i] as string;
       const d = source[i + 1];
 
       if (c === "/" && d === "/") {
@@ -86,9 +246,9 @@ function scan(source: string, { strings }: Options): Scanned {
         i = to;
         continue;
       }
-      if (c === "/" && opensRegex(source, i)) {
-        // Consumed and never blanked: a regex is code. Skipping it is exactly what keeps the quotes
-        // inside it from being read as the start of a string.
+      if (c === "/" && !endsValue) {
+        // Consumed and never blanked: a regex is code. Skipping it is what keeps the quotes inside it
+        // from being read as the start of a string.
         let j = i + 1;
         let inClass = false;
         while (j < source.length) {
@@ -107,70 +267,76 @@ function scan(source: string, { strings }: Options): Scanned {
           j++;
         }
         i = j;
+        endsValue = true;
         continue;
       }
       if (c === '"' || c === "'") {
-        let j = i + 1;
-        while (j < source.length && source[j] !== c && source[j] !== "\n") {
-          j += source[j] === "\\" ? 2 : 1;
-        }
-        if (j >= source.length || source[j] === "\n") open = "string";
-        // The quotes themselves stay, so an emptied literal is still a literal: a sweep can tell
-        // `f("")` from `f()`, and a pattern that requires an argument does not stop matching because
-        // the argument was prose. (Not for the sake of a pattern that READS the literal — that is
-        // `withoutComments`, which blanks nothing.)
-        if (strings) blank(i + 1, j);
-        i = j + 1;
+        i = quoted(i);
+        endsValue = true;
         continue;
       }
       if (c === "`") {
         i = template(i + 1);
+        endsValue = true;
         continue;
       }
-      if (stopAtBrace) {
+      if (
+        c === "<" &&
+        !endsValue &&
+        /[A-Za-z>]/.test(d ?? "") &&
+        !typeArgumentList(source, i)
+      ) {
+        i = jsx(i);
+        endsValue = true;
+        continue;
+      }
+      if (/[A-Za-z_$]/.test(c)) {
+        let j = i;
+        while (j < source.length && /[A-Za-z0-9_$]/.test(source[j] as string))
+          j++;
+        // A keyword cannot end a value, and that is what lets `return /re/` and `case "x"` through.
+        endsValue = !KEYWORD_BEFORE_VALUE.test(source.slice(i, j));
+        i = j;
+        continue;
+      }
+      if (/[0-9]/.test(c)) {
+        while (
+          i < source.length &&
+          /[0-9.eExXa-fA-F_]/.test(source[i] as string)
+        )
+          i++;
+        endsValue = true;
+        continue;
+      }
+      if (c === " " || c === "\n" || c === "\t" || c === "\r") {
+        // Whitespace is not a token, so it cannot change what the last one was. Letting it through to
+        // the reset below was the first version's bug: `"a" / 2` recovered `endsValue` on the quote
+        // and lost it again on the space, which is every real occurrence of the shape.
+        i++;
+        continue;
+      }
+      if ((c === "+" || c === "-") && d === c) {
+        // `i++ / 2`: the increment leaves the value it was applied to, so the `/` still divides.
+        i += 2;
+        continue;
+      }
+      if (stop === "brace") {
         if (c === "{") depth++;
         else if (c === "}") {
           if (depth === 0) return i;
           depth--;
         }
       }
+      // NOTE: `}` reads as the end of a BLOCK, never of an object literal, so `({}) / 2` is misread
+      // as a regex. Telling the two apart needs a real parser, and a block is the overwhelmingly
+      // common case; the whole-tree probe beside this file is what says the tree has no instance.
+      endsValue = c === ")" || c === "]";
       i++;
     }
-    // NOTE: an unclosed `${…}` needs no flag here — reaching the end returns to `template`, which is
-    // where the open template is recorded. A mutation run proved a second one dead.
     return i;
   }
 
-  // Consumes from just past an opening backtick and returns the index just past the closing one. The
-  // literal runs are blanked; every `${…}` goes back through `code`, because an interpolation holds
-  // real code and a cut written in one is a real cut.
-  function template(from: number): number {
-    let i = from;
-    let start = i;
-    while (i < source.length) {
-      const c = source[i];
-      if (c === "\\") {
-        i += 2;
-        continue;
-      }
-      if (c === "`") {
-        if (strings) blank(start, i);
-        return i + 1;
-      }
-      if (c === "$" && source[i + 1] === "{") {
-        if (strings) blank(start, i);
-        i = code(i + 2, true) + 1;
-        start = i;
-        continue;
-      }
-      i++;
-    }
-    if (strings) blank(start, source.length);
-    open = "template";
-    return source.length;
-  }
-
-  code(0, false);
+  code(0, "eof");
   return { text: out.join(""), open };
 }
 
@@ -180,15 +346,16 @@ export function withoutComments(source: string): string {
   return scan(source, { strings: false }).text;
 }
 
-// Comments out AND string contents out. For a sweep counting a code SHAPE, where a literal spelling
+// Comments out AND literal contents out. For a sweep counting a code SHAPE, where a literal spelling
 // that shape is prose by another name.
 export function codeOnly(source: string): string {
   return scan(source, { strings: true }).text;
 }
 
-// What the scan still had open when the file ended, or `null`. This is the self-check a misread regex
-// trips: it opens a literal that never closes and swallows every site after it. Cheap enough to assert
-// over the whole tree, and the only check available that does not need a second parser to agree with.
+// What the scan still had open when the file ended, or `null`. This is the self-check a misread `/` or
+// `<` trips: it opens a literal that never closes and swallows every site after it. Cheap enough to
+// assert over the whole tree, and the only check available that does not need a second parser to
+// agree with.
 export function unterminatedLiteral(source: string): Scanned["open"] {
   return scan(source, { strings: true }).open;
 }

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -1,0 +1,207 @@
+// The scanner every source sweep counts through, and the phantom site it exists to stop.
+//
+// A sweep that counts a code shape in `src/` reads the file as text, so prose that NAMES the shape is
+// counted as if it were the shape. Measured on #424: a comment citing `REFUSAL_SECTIONS.slice(0, 1)`
+// to explain a mutation put a file with no cut in it into the astral-cap ledger. The easy way out is
+// worse than the failure it fixes — adding the entry ARMS A WAIVER over a file that has nothing to
+// waive, and the day that file grows a real cut the count already matches and the sweep says nothing.
+//
+// It had already happened once. `tests/graph/refused-turn-callsites.test.ts` carries the same strip
+// written inline, and its comment records the two phantom sites that bought it. Two sites, one
+// invariant, and nothing obliging the third — so the strip lives here, and `countInSrc` exists so the
+// raw-text spelling is not the convenient one.
+//
+// OFFSETS AND LINE NUMBERS SURVIVE. Every removed character becomes a space and every newline is
+// kept, so `source.slice(0, m.index)` still names the same position and `.split("\n").length` still
+// names the same line. A sweep can strip and keep reporting where it found things.
+
+type Scanned = {
+  text: string;
+  // What was still open when the file ended. A misread regex announces itself here.
+  open: "string" | "template" | "block-comment" | null;
+};
+
+type Options = {
+  // Whether the CONTENTS of string and template literals go too. Comments always do.
+  strings: boolean;
+};
+
+// Where a `/` opens a regex literal rather than dividing. Shape alone cannot tell the two apart, and
+// erring toward division is the expensive half: an unrecognised `/"/g` opens a string that swallows
+// the code after it, and swallowed code is a site the sweep stops counting without a word. `src/`
+// carries a dozen such regexes today (`/^["'`]+|["'`]+$/g` in `graph/nudge.ts`, `/[\\']/g` in the
+// Drive toolpack, `/"/g` in four more), so this branch is load-bearing rather than defensive.
+//
+// The rule is the standard one: a `/` divides only when what precedes it can END a value. Anything
+// else — an operator, a comma, an opening bracket, `return`, `typeof`, the start of the file — opens a
+// regex. The known miss is `if (x) /re/.test(y)`, where `)` closes a condition rather than a value;
+// the test beside this file pins that `src/` has none.
+const KEYWORD_BEFORE_REGEX =
+  /\b(?:return|typeof|instanceof|in|of|new|delete|void|case|do|else|yield|await)$/;
+// Enough to clear the widest indentation in the tree; a `/` further than this from the token before it
+// would have to sit under 64 columns of blank, which the formatter does not produce.
+const LOOKBEHIND = 64;
+
+function opensRegex(source: string, at: number): boolean {
+  const before = source
+    .slice(Math.max(0, at - LOOKBEHIND), at)
+    .replace(/\s+$/, "");
+  if (before === "") return true;
+  if (KEYWORD_BEFORE_REGEX.test(before)) return true;
+  // An identifier, a number or a closing bracket ends a value, so a `/` after one divides. This also
+  // answers `this`, `true` and `null` without naming them: they end in a letter, so the test below
+  // already calls them values. A mutation run proved the explicit list they had was dead code.
+  return !/[A-Za-z0-9_$)\]]/.test(before[before.length - 1] as string);
+}
+
+function scan(source: string, { strings }: Options): Scanned {
+  const out = source.split("");
+  let open: Scanned["open"] = null;
+  const blank = (from: number, to: number) => {
+    for (let i = from; i < to; i++) if (out[i] !== "\n") out[i] = " ";
+  };
+
+  // Consumes code from `from`. With `stopAtBrace` it is inside a `${…}` and returns the index of the
+  // `}` that closes it, counting the braces opened in between so an object literal does not end it
+  // early; otherwise it runs to the end of the file.
+  function code(from: number, stopAtBrace: boolean): number {
+    let i = from;
+    let depth = 0;
+    while (i < source.length) {
+      const c = source[i];
+      const d = source[i + 1];
+
+      if (c === "/" && d === "/") {
+        const nl = source.indexOf("\n", i);
+        const to = nl === -1 ? source.length : nl;
+        blank(i, to);
+        i = to;
+        continue;
+      }
+      if (c === "/" && d === "*") {
+        const end = source.indexOf("*/", i + 2);
+        if (end === -1) open = "block-comment";
+        const to = end === -1 ? source.length : end + 2;
+        blank(i, to);
+        i = to;
+        continue;
+      }
+      if (c === "/" && opensRegex(source, i)) {
+        // Consumed and never blanked: a regex is code. Skipping it is exactly what keeps the quotes
+        // inside it from being read as the start of a string.
+        let j = i + 1;
+        let inClass = false;
+        while (j < source.length) {
+          const r = source[j];
+          if (r === "\\") {
+            j += 2;
+            continue;
+          }
+          if (r === "\n") break;
+          if (r === "[") inClass = true;
+          else if (r === "]") inClass = false;
+          else if (r === "/" && !inClass) {
+            j++;
+            break;
+          }
+          j++;
+        }
+        i = j;
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        let j = i + 1;
+        while (j < source.length && source[j] !== c && source[j] !== "\n") {
+          j += source[j] === "\\" ? 2 : 1;
+        }
+        if (j >= source.length || source[j] === "\n") open = "string";
+        // The quotes themselves stay, so an emptied literal is still a literal: a sweep can tell
+        // `f("")` from `f()`, and a pattern that requires an argument does not stop matching because
+        // the argument was prose. (Not for the sake of a pattern that READS the literal — that is
+        // `withoutComments`, which blanks nothing.)
+        if (strings) blank(i + 1, j);
+        i = j + 1;
+        continue;
+      }
+      if (c === "`") {
+        i = template(i + 1);
+        continue;
+      }
+      if (stopAtBrace) {
+        if (c === "{") depth++;
+        else if (c === "}") {
+          if (depth === 0) return i;
+          depth--;
+        }
+      }
+      i++;
+    }
+    // NOTE: an unclosed `${…}` needs no flag here — reaching the end returns to `template`, which is
+    // where the open template is recorded. A mutation run proved a second one dead.
+    return i;
+  }
+
+  // Consumes from just past an opening backtick and returns the index just past the closing one. The
+  // literal runs are blanked; every `${…}` goes back through `code`, because an interpolation holds
+  // real code and a cut written in one is a real cut.
+  function template(from: number): number {
+    let i = from;
+    let start = i;
+    while (i < source.length) {
+      const c = source[i];
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === "`") {
+        if (strings) blank(start, i);
+        return i + 1;
+      }
+      if (c === "$" && source[i + 1] === "{") {
+        if (strings) blank(start, i);
+        i = code(i + 2, true) + 1;
+        start = i;
+        continue;
+      }
+      i++;
+    }
+    if (strings) blank(start, source.length);
+    open = "template";
+    return source.length;
+  }
+
+  code(0, false);
+  return { text: out.join(""), open };
+}
+
+// Comments out, string contents kept. For a sweep whose pattern READS a literal: the refusal spelling
+// `refuse("stale")`, an error key, a route path.
+export function withoutComments(source: string): string {
+  return scan(source, { strings: false }).text;
+}
+
+// Comments out AND string contents out. For a sweep counting a code SHAPE, where a literal spelling
+// that shape is prose by another name.
+export function codeOnly(source: string): string {
+  return scan(source, { strings: true }).text;
+}
+
+// What the scan still had open when the file ended, or `null`. This is the self-check a misread regex
+// trips: it opens a literal that never closes and swallows every site after it. Cheap enough to assert
+// over the whole tree, and the only check available that does not need a second parser to agree with.
+export function unterminatedLiteral(source: string): Scanned["open"] {
+  return scan(source, { strings: true }).open;
+}
+
+// The one way a sweep counts a shape across `src/`, so that the raw-text spelling has to be written on
+// purpose rather than reached by copying the file next door.
+export async function countInSrc(re: RegExp): Promise<Record<string, number>> {
+  const { Glob } = await import("bun");
+  const found: Record<string, number> = {};
+  for await (const rel of new Glob("**/*.{ts,tsx}").scan("src")) {
+    const n = (codeOnly(await Bun.file(`src/${rel}`).text()).match(re) ?? [])
+      .length;
+    if (n > 0) found[`src/${rel}`] = n;
+  }
+  return found;
+}


### PR DESCRIPTION
A source sweep reads `src/` as text, so prose that NAMES the shape it counts is counted as if it were
the shape. `#424` measured one instance; the fix is the invariant, because the tree has five.

## What breaks

A comment explaining a cut puts the file it is written in into the astral-cap ledger, and the file has
no cut in it. Two lines of ordinary prose — the kind any PR writes, one of them a `// NOTE:` warning
*against* a shape — take five assertions red at once. Measured by appending them to `src/lib/ssrf.ts`
and `src/modules/split/service.ts` and running the three suites on `origin/main`:

```
(fail) every bare cut left in src/ is accounted for > the file list and the per-file counts still match
(fail) every line that names an error column is accounted for > the file list and the per-file counts still match
(fail) every line that names an error column is accounted for > the guard is still called everywhere it was
(fail) no zod record can put a caller's key in a refusal > no file under src declares one
(fail) a zod parse of caller input goes through parseInput > no service file parses caller input outside it
 77 pass, 5 fail
```

The same two lines on this branch: **82 pass, 0 fail.**

## Why it is not a chore

The cheapest way to unblock a red ledger is to add the entry. That **arms a waiver over a file with no
offender in it**, and the day that file grows a real one the count already matches and the sweep says
nothing — the failure `.codex-review-waived`'s own comment describes as sitting "armed over rewritten
code until the day it silences a real defect". The workaround in the reporting PR was to reword the
comment, which is right for that PR and is not the fix.

The second measured case is worse in the same direction: a `// NOTE: never write a bare
schema.parse(input) here` is reported as a bare `schema.parse(input)`. The warning against the shape
becomes the accusation that the shape is there.

## What the issue got right, and what it undercounted

Right: the mechanism, the cost, and that a strip of `//` and `/* */` fixes the case measured.

Undercounted: the issue frames one sweep, and `refused-turn-callsites.test.ts` **already carried the
same strip written inline**, with a comment recording the two phantom sites that bought it. Two sites
of one invariant, and nothing obliging the third — which is what makes this a shared unit rather than
a `replace` in one file. Counting found three more assertions in two more files.

Also undercounted: string literals. The issue calls them "the case that follows"; they are the same
case (`const doc = "z.record(z.string(), z.string())"` is a declaration to every sweep here), and they
cost nothing extra once the scan exists.

## The scan

`tests/utils/source-text.ts` — a character scanner, not a regex, and the reason is the expensive half
of the failure. Reading LESS than the file is cheap: a phantom site, red CI, someone annoyed. Reading
MORE is a swallowed region, which is a site the sweep silently stops counting — the same false waiver
reached from the other side. So:

- **Regex literals are recognised.** `src/` carries a dozen holding a quote or a backtick
  (`/^["'`]+|["'`]+$/g` in `graph/nudge.ts`, `/[\\']/g`, `/"/g` in four more). A `/` read as division
  opens a string on the quote inside it that never closes, swallowing the rest of the file. The
  standard heuristic decides it, and the one shape it gets wrong — `if (x) /re/.test(y)` — is asserted
  absent from `src/` rather than assumed absent.
- **Offsets and line numbers survive.** Removed characters become spaces, newlines are kept, so
  `source.slice(0, m.index)` still names the same position. `refused-turn-callsites` finds its anchor
  in the stripped text and slices it at that index; without this it could not.
- **Two exports, because the sweeps want different things.** `withoutComments` for a pattern that
  READS a literal (`refuse("stale")`); `codeOnly` for one counting a code SHAPE. Getting this backwards
  blinds the sweep instead of sharpening it, so it is a table row rather than a flag.
- **`countInSrc`** is the one way to count a shape across `src/`, so the raw-text spelling has to be
  chosen on purpose rather than reached by copying the file next door.

## Two findings the adoption produced

**`refused-turn-callsites` sought its anchor in raw text.** `source.indexOf("const refuse = async (")`
against the unstripped file: a comment naming the closure starts the scan above the real one and drags
every pre-invoke refusal into range — the exact thing that offset exists to exclude. Both call sites
now go through one `refuseSection`, which also removes the duplicated anchor.

**An exemption marker lives in a comment, so the strip cannot be applied blindly.** `unmarkedServiceParse`
reads `// not-caller-input:` to waive a call site. Stripping before reading it would turn every waived
site into an offender. The call is now looked for in the stripped line and the marker in the raw one,
lined up by index — which is what positional transparency is for.

## The fence, and what it does not reach

A test that walks `src/` with a Glob and reads it as text must count through the scan. **Ten sweeps
adopt it** across nine files; the fence fails if an eleventh arrives without one. `caller-id-spelling`
is the one exemption and it is EXECUTED rather than listed: a test drives that file's own predicate
with prose and requires zero, because it blanks non-code itself and uses the argument TEXT as its
ledger key, so pre-stripping would rewrite every key.

**Not reached, and the number is why this is written down instead of widened:** 53 call sites in
`tests/` read a NAMED source file as text, and most are doing something a strip would break (a
migration's SQL, a handler body counted as prose and code together). `refused-turn-callsites` is one of
those 53 and adopts the scan by judgement, not because the fence obliges it. Widening to all 53 would
flag dozens of readers that are correct today.

The fence's own first run flagged `agent-settings-mcp-parity`, which globs the same tree to `import`
each module and probe it with a Proxy and never reads a character of source. Narrowed rather than
waived.

## Validation scope

**Proven by test.**

- The A/B above: 5 red on `origin/main`, 0 here, same two lines of prose.
- **Acceptance check, and the reason this is safe to land:** all three existing ledgers count
  **byte-identically** through raw text and through the scan on the current tree. The strip changes no
  number today; it only changes what happens when prose arrives.
- Whole-tree structural probe over 602 files under `src/`: length preserved, line count preserved,
  every changed character is a space, and **no file ends inside an open literal** — the assertion that
  catches the regex heuristic guessing wrong. Asserted as a test, not just run once.
- The scan is not a no-op: it removes 42.2% of the non-space characters in `src/` as comments, 54.7%
  with string contents.
- **114 tests on the scanner, and every rule held by a mutation.** Three were only killable by tests
  written for them: a `countInSrc` reading raw text breaks nothing (every ledger agrees today), so the
  discriminator is a pattern that matches PROSE — `/\bthe\b/g` is 37,394 hits raw and 0 through the
  scan.
- **Mutations that survived were deletions, not gaps, and the code went.** An explicit `this|true|null`
  list in the regex heuristic and a duplicate `open = "template"` early on. Later rounds cut a
  four-keyword block rule to `else` alone, five URL schemes to `https?`, a character-class walk in the
  known-miss probe to `includes("/")`, and two redundant `endsValue` tests out of the
  function-expression rule — each removed by a mutation without a red row, and each removal explained
  where it was made.
- **Two survivors are documented instead of tested, both unreachable by construction.** The `\b` in the
  `else` rule (an identifier ending in those letters sets `endsValue` and short-circuits) and
  `endsValue = false` on the regex back-out (a `/` that backs out is never followed by another `/` on
  its line, or the regex would have closed on it).
- `bun check` full: 7993 pass, 0 fail, 524 files.

**Not validated live, and it does not apply.** §2.1 asks for an exercise against the real external
system when the fix touches one. This one touches no runtime code at all — the diff is entirely under
`tests/`, and the system under test IS the suite. The A/B against `origin/main` is the equivalent, and
it is above.

## What eleven review rounds changed

The scan shipped in round 1 already made every number above true; what the rounds bought was the
scanner being right about TypeScript it had not been shown. Nine rounds found 29 defects, every one a
misread that either invented a call site or swallowed a real one, and each fix is red-first against the
commit before it. The ones worth naming because they changed the MODEL rather than a condition:

- **The JSX mode was deleted.** Recognising elements cost a dry run, a memo, tag-depth balancing and
  multi-line attribute handling — and with all of it removed the three ledgers still count identically
  and the whole-tree probe still reports zero. 94 insertions against 190 deletions.
- **A regex reading that cannot close on its line is BACKED OUT, not applied.** Review asked for the
  case to be reported; reporting turned out to be the smaller half. The same signal disambiguates the
  JSX slash with no JSX state — `/>` closing a tag never finds its closing slash, while
  `.replace(/>/g, "&gt;")` finds it two characters later. Both spellings are in `src/`, and the tag was
  being read as a regex in 135 files.
- **That change invalidated four of this PR's own test rows**, and only a mutation run said so: with
  the back-out, a misread `/` costs nothing unless a later slash on the line closes it, so four rows
  from earlier rounds were measuring the back-out instead of the rule they were named for.

**Not covered, and counted rather than assumed.** The 53 named-path source readers listed above. Three
residues in the scan, each zero in `src/` today and each written down where the rule stops: a bare
non-http `ws://` in JSX text (the five non-http schemes in the tree are all inside comments, none in a
`.tsx`); a quote SEPARATED by a space from the word before it in JSX prose (covering it needs a list
holding `from` and `import` that nothing in `src/` exercises); and `a</b>/`, which `bun format`
rewrites to `a < /b>/` and the scan then reads correctly, so `bun check` is what holds it out.

The known-miss probe reports two divisions sharing a line as a suspect. That is the same ambiguity it
documents rather than resolves, so it is pinned in a row rather than left as a surprise.

Fixes #424

