### PR TITLE
feat(rag): support OpenAI-compatible embedding endpoints

### DIFF
--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -14,7 +14,7 @@ import { emitDeadLetter } from "@/modules/flowlog/dead-letter";
 import { cancelPendingJob, enqueueJob } from "@/modules/scheduler/service";
 import { type JobResult, registerJobHandler } from "@/modules/scheduler/worker";
 import { readEmbeddingSettings } from "@/modules/tenant-settings/service";
-import { resolveVaultRefState } from "@/modules/vault/service";
+import { resolveVaultEntryState } from "@/modules/vault/service";
 import { chunkText } from "./chunk";
 import { type EmbeddingConfig, embedTexts } from "./embeddings";
 import { toVectorLiteral } from "./sql";
@@ -52,7 +52,7 @@ export async function resolveEmbeddingStatus(
   // sends them looking for a row that is not there, so it falls back to the reason a workspace that
   // never configured one gets. An ACTIVE row holding a blank secret is neither — it is `empty`, and
   // that only stays distinguishable because the state and the value came from the same query.
-  const resolved = await resolveVaultRefState<
+  const resolved = await resolveVaultEntryState<
     string | { apiKey: string; baseURL?: string }
   >(db, settings.credentialRef);
   if (resolved.state === "not_found")
@@ -63,7 +63,7 @@ export async function resolveEmbeddingStatus(
       reason: "credential_pending",
       credentialRef: settings.credentialRef,
     };
-  const raw = resolved.value;
+  const raw = resolved.entry.secret;
   const { apiKey, baseURL: secretBaseURL } =
     typeof raw === "string" || !raw
       ? { apiKey: typeof raw === "string" ? raw : "", baseURL: undefined }
@@ -76,7 +76,11 @@ export async function resolveEmbeddingStatus(
     };
   return {
     ok: true,
-    config: { model, apiKey, baseURL: settings.baseURL ?? secretBaseURL },
+    config: {
+      model,
+      apiKey,
+      baseURL: settings.baseURL ?? resolved.entry.baseUrl ?? secretBaseURL,
+    },
   };
 }
 

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -47,7 +47,7 @@ export async function resolveEmbeddingStatus(
 ): Promise<EmbeddingStatus> {
   const settings = await readEmbeddingSettings(db, tenantId);
   if (!settings.credentialRef) return { ok: false, reason: "not_configured" };
-  // NOTE: The three failures are distinguished from ONE read (see resolveVaultRefState). A ref whose
+  // NOTE: The three failures are distinguished from ONE read (see resolveVaultEntryState). A ref whose
   // row is gone is not "pending": telling the operator to fill a credential that no longer exists
   // sends them looking for a row that is not there, so it falls back to the reason a workspace that
   // never configured one gets. An ACTIVE row holding a blank secret is neither — it is `empty`, and
@@ -79,7 +79,18 @@ export async function resolveEmbeddingStatus(
     config: {
       model,
       apiKey,
-      baseURL: settings.baseURL ?? resolved.entry.baseUrl ?? secretBaseURL,
+      // The entry's baseUrl is honored ONLY for `openai_compatible`. `updateEmbeddingSettings`
+      // validates that this ref resolves and NOT what kind it is, while three other kinds require a
+      // baseUrl of their own (chatwoot_api_token, mcp_oauth, langfuse) and any kind at all may carry
+      // one. Without the kind test, an operator who picks the Chatwoot credential here does not get
+      // a 401 from OpenAI any more — they get every chunk of their knowledge base POSTed at the
+      // Chatwoot host.
+      baseURL:
+        settings.baseURL ??
+        (resolved.entry.kind === "openai_compatible"
+          ? resolved.entry.baseUrl
+          : null) ??
+        secretBaseURL,
     },
   };
 }

--- a/src/modules/rag/embeddings.ts
+++ b/src/modules/rag/embeddings.ts
@@ -145,17 +145,42 @@ async function embedCompatibleBatch(
   });
   if (!res.ok) throw await providerResponseError(res);
   // A 2xx whose body is not JSON is a response that ARRIVED and cannot be used, and it has to be
-  // said here: `res.json()` rejects with a statusless SyntaxError, which is indistinguishable from a
-  // connection reset and would be sent the same batch twice more on the ingest path.
-  let json: { data?: Array<{ index?: number; embedding?: unknown }> };
+  // said here: `res.json()` rejects with a statusless SyntaxError, indistinguishable from a
+  // connection reset, and the ingest's policy would send the same batch twice more.
+  //
+  // ONLY a syntax failure, though. Reading a body is still transport: the connection can reset or
+  // the deadline can fire between the headers and the last byte, and both reject out of this same
+  // call. Swallowing those into "unusable" would skip the retry they deserve and make one
+  // interruption a terminally FAILED document.
+  let json: unknown;
   try {
-    json = (await res.json()) as typeof json;
-  } catch {
+    json = await res.json();
+  } catch (err) {
+    if (!(err instanceof SyntaxError)) throw err;
     throw new UnusableResponseError(
       "embedding provider returned a body that is not JSON",
     );
   }
-  const items = [...(json.data ?? [])];
+  // The SHAPE is checked before anything is read off it, for the same reason. Valid JSON whose root
+  // is `null`, or whose `data` is an object, throws a statusless TypeError on the property access
+  // and the spread — which the ingest would then read as transport and pay for twice more, against a
+  // provider that already gave its deterministic answer.
+  const data =
+    typeof json === "object" && json !== null
+      ? (json as { data?: unknown }).data
+      : undefined;
+  if (
+    json === null ||
+    typeof json !== "object" ||
+    (data !== undefined && !Array.isArray(data))
+  ) {
+    throw new UnusableResponseError(
+      "embedding provider returned an unusable response shape",
+    );
+  }
+  const items = [
+    ...((data ?? []) as Array<{ index?: number; embedding?: unknown }>),
+  ];
   if (items.length !== texts.length) {
     throw new UnusableResponseError(
       "embedding provider returned the wrong vector count",
@@ -198,17 +223,16 @@ async function embedCompatibleBatch(
   });
 }
 
-async function embedCompatible(
-  texts: string[],
-  cfg: EmbeddingConfig & { baseURL: string },
+// Where the compatible request is aimed, resolved once for the whole document rather than per batch.
+async function compatibleTarget(
+  baseURL: string,
   deps: EmbeddingDeps,
-  retryStatusless: boolean,
-): Promise<number[][]> {
+): Promise<string> {
   // Through `URL`, not concatenation: the vault accepts any http(s) URL, and Azure's own spelling
   // carries a query (`…/v1?api-version=2024-02-01`). Appending to that string puts the path INSIDE
   // the query and the POST lands on `/v1`, which a compatible server answers with something that
   // parses far enough to be confusing.
-  const endpoint = compatibleEndpoint(cfg.baseURL);
+  const endpoint = compatibleEndpoint(baseURL);
   // SSRF guard on the URL the OPERATOR configured, immediately before the fetch, exactly as the
   // openai-compatible branch of `listProviderModels` does. The vault validates `baseUrl` as http(s)
   // syntax and nothing more, so without this a tenant admin turns knowledge ingestion into a POST at
@@ -217,17 +241,13 @@ async function embedCompatible(
   const safeUrl = await (deps.assertSafe ?? assertSafeOutboundUrl)(endpoint, {
     allowHttp: true,
   });
-  const url = safeUrl.toString();
-  const fetchImpl = deps.fetchImpl ?? fetch;
-  const out: number[][] = [];
+  return safeUrl.toString();
+}
+
+function batchesOf(texts: string[]): string[][] {
+  const out: string[][] = [];
   for (let i = 0; i < texts.length; i += COMPATIBLE_BATCH_SIZE) {
-    const batch = texts.slice(i, i + COMPATIBLE_BATCH_SIZE);
-    out.push(
-      ...(await withTransientRetry(
-        () => embedCompatibleBatch(batch, cfg, url, fetchImpl),
-        retryStatusless,
-      )),
-    );
+    out.push(texts.slice(i, i + COMPATIBLE_BATCH_SIZE));
   }
   return out;
 }
@@ -291,12 +311,31 @@ export async function embedTexts(
   deps: EmbeddingDeps = {},
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
-  const vectors = await throughProvider(() =>
-    cfg.baseURL
-      ? embedCompatible(texts, { ...cfg, baseURL: cfg.baseURL }, deps, true)
-      : client(cfg, deps).embedDocuments(texts),
-  );
-  return vectors.map((v) => assertWidth(v, cfg));
+  const baseURL = cfg.baseURL;
+  if (!baseURL) {
+    const vectors = await throughProvider(() =>
+      client(cfg, deps).embedDocuments(texts),
+    );
+    return vectors.map((v) => assertWidth(v, cfg));
+  }
+  const url = await throughProvider(() => compatibleTarget(baseURL, deps));
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const out: number[][] = [];
+  // The loop lives HERE rather than inside one `throughProvider`, so the width is asserted after
+  // EACH batch: a document past 512 chunks whose first response already proves the endpoint serves a
+  // 768-wide model stops there instead of paying for the rest of it. It also keeps `assertWidth`
+  // outside the boundary, where its own sentence survives instead of being reduced to the closed
+  // vocabulary — which is the whole reason it is not left to `toVectorLiteral`.
+  for (const batch of batchesOf(texts)) {
+    const vectors = await throughProvider(() =>
+      withTransientRetry(
+        () => embedCompatibleBatch(batch, cfg, url, fetchImpl),
+        true,
+      ),
+    );
+    for (const v of vectors) out.push(assertWidth(v, cfg));
+  }
+  return out;
 }
 
 export async function embedQuery(
@@ -304,12 +343,12 @@ export async function embedQuery(
   cfg: EmbeddingConfig,
   deps: EmbeddingDeps = {},
 ): Promise<number[]> {
+  const baseURL = cfg.baseURL;
   const vector = await throughProvider(async () => {
-    if (cfg.baseURL) {
-      const vectors = await embedCompatible(
-        [text],
-        { ...cfg, baseURL: cfg.baseURL },
-        deps,
+    if (baseURL) {
+      const url = await compatibleTarget(baseURL, deps);
+      const vectors = await withTransientRetry(
+        () => embedCompatibleBatch([text], cfg, url, deps.fetchImpl ?? fetch),
         false,
       );
       return vectors[0] as number[];

--- a/src/modules/rag/embeddings.ts
+++ b/src/modules/rag/embeddings.ts
@@ -13,7 +13,10 @@ export interface EmbeddingConfig {
   model: string;
   apiKey: string;
   baseURL?: string;
+  fetchImpl?: typeof fetch;
 }
+
+const EMBEDDING_TIMEOUT_MS = 60_000;
 
 function client(cfg: EmbeddingConfig): OpenAIEmbeddings {
   return new OpenAIEmbeddings({
@@ -23,17 +26,66 @@ function client(cfg: EmbeddingConfig): OpenAIEmbeddings {
   });
 }
 
+async function embedCompatible(
+  texts: string[],
+  cfg: EmbeddingConfig & { baseURL: string },
+): Promise<number[][]> {
+  const base = cfg.baseURL.replace(/\/+$/, "");
+  const res = await (cfg.fetchImpl ?? fetch)(`${base}/embeddings`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: ["Bea", "rer ", cfg.apiKey].join(""),
+    },
+    body: JSON.stringify({ model: cfg.model, input: texts }),
+    redirect: "error",
+    signal: AbortSignal.timeout(EMBEDDING_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`embedding provider failed with ${res.status}`);
+  const json = (await res.json()) as {
+    data?: Array<{ index?: number; embedding?: unknown }>;
+  };
+  const ordered = [...(json.data ?? [])].sort(
+    (a, b) => (a.index ?? 0) - (b.index ?? 0),
+  );
+  if (ordered.length !== texts.length) {
+    throw new Error("embedding provider returned the wrong vector count");
+  }
+  return ordered.map((item) => {
+    if (
+      !Array.isArray(item.embedding) ||
+      !item.embedding.every((value) => typeof value === "number")
+    ) {
+      throw new Error("embedding provider returned an invalid vector");
+    }
+    return item.embedding as number[];
+  });
+}
+
 export async function embedTexts(
   texts: string[],
   cfg: EmbeddingConfig,
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
-  return throughProvider(() => client(cfg).embedDocuments(texts));
+  return throughProvider(() =>
+    cfg.baseURL
+      ? embedCompatible(texts, { ...cfg, baseURL: cfg.baseURL })
+      : client(cfg).embedDocuments(texts),
+  );
 }
 
 export async function embedQuery(
   text: string,
   cfg: EmbeddingConfig,
 ): Promise<number[]> {
-  return throughProvider(() => client(cfg).embedQuery(text));
+  return throughProvider(async () => {
+    if (cfg.baseURL) {
+      const vectors = await embedCompatible([text], {
+        ...cfg,
+        baseURL: cfg.baseURL,
+      });
+      return vectors[0] as number[];
+    }
+    return client(cfg).embedQuery(text);
+  });
 }

--- a/src/modules/rag/embeddings.ts
+++ b/src/modules/rag/embeddings.ts
@@ -5,7 +5,7 @@ import {
   statusOf,
   throughProvider,
 } from "@/lib/provider-failure";
-import { assertSafeOutboundUrl } from "@/lib/ssrf";
+import { assertSafeOutboundUrl, SsrfError } from "@/lib/ssrf";
 import { clipText } from "@/lib/text";
 
 // Embedding wrapper. OpenAI-compatible by default (text-embedding-3-small → 1536 dims, matching
@@ -73,6 +73,13 @@ const COMPATIBLE_RETRY_DELAYS_MS = [500, 2000];
 // retried on either: the endpoint answered, and it will answer the same way again.
 function isTransient(err: unknown, retryStatusless: boolean): boolean {
   if (err instanceof UnusableResponseError) return false;
+  // NO clause for the guard's own refusal, which now runs on every attempt and so lands in here.
+  // `SsrfError` extends `AppError` and carries status 400, which `statusOf` already reads and
+  // `isTransientProviderStatus` already rejects — a second copy is a branch no input can reach, and
+  // mutation found it dead exactly as `provider-failure` records for its own. The outcome is the one
+  // we want and it is worth naming: a block is deterministic, and the one case where a second answer
+  // WOULD differ is the rebinding this re-check exists to catch, where asking again is asking to be
+  // let through on the second reply.
   if (providerFailure(err) === "timeout") return true;
   const status = statusOf(err);
   if (status === null) return retryStatusless;
@@ -129,10 +136,20 @@ async function providerResponseError(res: Response): Promise<Error> {
 
 async function embedCompatibleBatch(
   texts: string[],
-  cfg: EmbeddingConfig,
-  url: string,
-  fetchImpl: typeof fetch,
+  cfg: EmbeddingConfig & { baseURL: string },
+  deps: EmbeddingDeps,
 ): Promise<number[][]> {
+  // BEFORE EVERY FETCH, not once per document. `assertSafeOutboundUrl` resolves the hostname, and a
+  // tenant-controlled name can answer publicly for the check and privately a moment later; a
+  // document is many batches and a batch may be retried twice, so a URL vetted once and reused hands
+  // the key and the chunks to whatever the name resolves to by then. Same rule as the custom HTTP
+  // tool, which re-asserts on the FINAL url immediately before its own fetch (`graph/tools/http.ts`).
+  //
+  // It narrows the window rather than closing it: `fetch` resolves the name again, so the check and
+  // the connection are still two lookups. Pinning the vetted address is the only thing that closes
+  // it, and it is not what any other outbound path here does.
+  const url = await compatibleTarget(cfg.baseURL, deps);
+  const fetchImpl = deps.fetchImpl ?? fetch;
   const res = await fetchImpl(url, {
     method: "POST",
     headers: {
@@ -179,7 +196,7 @@ async function embedCompatibleBatch(
     );
   }
   const items = [
-    ...((data ?? []) as Array<{ index?: number; embedding?: unknown }>),
+    ...((data ?? []) as Array<{ index?: unknown; embedding?: unknown } | null>),
   ];
   if (items.length !== texts.length) {
     throw new UnusableResponseError(
@@ -196,23 +213,37 @@ async function embedCompatibleBatch(
   // permutation (a duplicate, a 1.5, a 9 among two inputs) sorts into SOMETHING and sails past the
   // count check above. Neither leaves an order to recover, so both are refused rather than guessed —
   // the cost of guessing is a document published with every vector against the wrong chunk.
-  const indexed = items.filter((i) => typeof i.index === "number").length;
-  if (indexed > 0) {
-    const indexes = items.map((i) => i.index as number);
+  // ABSENT is the only thing that licenses positional order, and `"1"` or `null` is not absent — it
+  // is the provider stating an order in a spelling we cannot read. Testing `typeof === "number"`
+  // conflated the two and fell back to position, which publishes the vectors swapped whenever such a
+  // response is also out of order.
+  const present = items.filter((i) => i?.index !== undefined);
+  if (present.length > 0) {
+    const indexes = present.map((i) => i?.index);
     const usable =
-      indexed === items.length &&
-      new Set(indexes).size === indexes.length &&
-      indexes.every((n) => Number.isInteger(n) && n >= 0 && n < items.length);
+      present.length === items.length &&
+      indexes.every(
+        (n) =>
+          typeof n === "number" &&
+          Number.isInteger(n) &&
+          n >= 0 &&
+          n < items.length,
+      ) &&
+      new Set(indexes).size === indexes.length;
     if (!usable) {
       throw new UnusableResponseError(
         "embedding provider returned an unusable index set",
       );
     }
-    items.sort((a, b) => (a.index as number) - (b.index as number));
+    items.sort((a, b) => (a?.index as number) - (b?.index as number));
   }
+  // Optional chaining throughout, and no separate clause for a `null` ITEM inside `data`: every read
+  // above is `i?.`, so a null never reaches a property access, and it arrives here with no
+  // `embedding` and is refused by this check. A clause of its own changed only which of two
+  // sentences the process log got, and mutation found it dead.
   return items.map((item) => {
     if (
-      !Array.isArray(item.embedding) ||
+      !Array.isArray(item?.embedding) ||
       !item.embedding.every((value) => typeof value === "number")
     ) {
       throw new UnusableResponseError(
@@ -305,6 +336,18 @@ function assertWidth(vec: number[], cfg: EmbeddingConfig): number[] {
   return vec;
 }
 
+// An SSRF refusal is OURS: nothing was sent, and the operator has a configuration to fix. Left to
+// the boundary it is dressed as `HTTP 400` — `SsrfError` extends `AppError`, which carries that
+// status, and `providerFailure` reads exactly that field — which tells the operator the endpoint
+// answered. Unwrapped from `cause`, where `asProviderFailure` parks the original, so the guard's own
+// sentence and its i18n code survive. Same principle as `assertWidth`: what WE concluded is not
+// reduced to the vocabulary reserved for what a server wrote.
+function unwrapOurOwn(err: unknown): never {
+  const cause = (err as { cause?: unknown })?.cause;
+  if (cause instanceof SsrfError) throw cause;
+  throw err;
+}
+
 export async function embedTexts(
   texts: string[],
   cfg: EmbeddingConfig,
@@ -318,8 +361,6 @@ export async function embedTexts(
     );
     return vectors.map((v) => assertWidth(v, cfg));
   }
-  const url = await throughProvider(() => compatibleTarget(baseURL, deps));
-  const fetchImpl = deps.fetchImpl ?? fetch;
   const out: number[][] = [];
   // The loop lives HERE rather than inside one `throughProvider`, so the width is asserted after
   // EACH batch: a document past 512 chunks whose first response already proves the endpoint serves a
@@ -329,10 +370,10 @@ export async function embedTexts(
   for (const batch of batchesOf(texts)) {
     const vectors = await throughProvider(() =>
       withTransientRetry(
-        () => embedCompatibleBatch(batch, cfg, url, fetchImpl),
+        () => embedCompatibleBatch(batch, { ...cfg, baseURL }, deps),
         true,
       ),
-    );
+    ).catch(unwrapOurOwn);
     for (const v of vectors) out.push(assertWidth(v, cfg));
   }
   return out;
@@ -346,14 +387,13 @@ export async function embedQuery(
   const baseURL = cfg.baseURL;
   const vector = await throughProvider(async () => {
     if (baseURL) {
-      const url = await compatibleTarget(baseURL, deps);
       const vectors = await withTransientRetry(
-        () => embedCompatibleBatch([text], cfg, url, deps.fetchImpl ?? fetch),
+        () => embedCompatibleBatch([text], { ...cfg, baseURL }, deps),
         false,
       );
       return vectors[0] as number[];
     }
     return client(cfg, deps).embedQuery(text);
-  });
+  }).catch(unwrapOurOwn);
   return assertWidth(vector, cfg);
 }

--- a/src/modules/rag/embeddings.ts
+++ b/src/modules/rag/embeddings.ts
@@ -1,57 +1,113 @@
 import { OpenAIEmbeddings } from "@langchain/openai";
 import { throughProvider } from "@/lib/provider-failure";
+import { assertSafeOutboundUrl } from "@/lib/ssrf";
 
 // Embedding wrapper. OpenAI-compatible by default (text-embedding-3-small → 1536 dims, matching
 // the knowledge_chunks vector(1536) column). The API key is resolved from the vault by the
 // caller (never inlined/logged). Embedding is network I/O and MUST run outside any transaction.
 
 // The vector column width. A model producing a different dimensionality needs a schema migration;
-// we guard at insert time rather than silently corrupting the index.
+// we guard at insert time rather than silently corrupting the index — and, since a configurable
+// endpoint can answer with any model at all, at the network boundary too (`assertWidth`).
 export const EMBEDDING_DIM = 1536;
 
 export interface EmbeddingConfig {
   model: string;
   apiKey: string;
   baseURL?: string;
+}
+
+// Injectables, trailing and defaulted, rather than fields on `EmbeddingConfig`: that config is built
+// from a vault row in `resolveEmbeddingStatus` and has no business carrying a function. Same shape
+// `listProviderModels` uses for the same pair, and the SSRF assertion in particular MUST be
+// stubbable — it resolves DNS, so a hermetic test cannot reach the real one.
+export interface EmbeddingDeps {
   fetchImpl?: typeof fetch;
+  assertSafe?: typeof assertSafeOutboundUrl;
 }
 
 const EMBEDDING_TIMEOUT_MS = 60_000;
 
-function client(cfg: EmbeddingConfig): OpenAIEmbeddings {
+// The same bound `@langchain/openai` applies on the SDK path (`batchSize = 512`). It is here because
+// `embedTexts` is handed EVERY chunk of a document at once (`documents.ts`), which has no size cap:
+// one unbounded POST is a 400/413 on a self-hosted server, which is precisely the deployment this
+// path exists to serve. Sequential rather than langchain's `Promise.all`, for the same reason —
+// a single-GPU endpoint is not helped by twenty simultaneous requests.
+const COMPATIBLE_BATCH_SIZE = 512;
+
+function client(cfg: EmbeddingConfig, deps: EmbeddingDeps): OpenAIEmbeddings {
+  const configuration = {
+    ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}),
+    // Only when injected: undefined here would still be a key the SDK sees, and the point is that
+    // production keeps the global fetch. It exists so a test can assert what this path SENDS —
+    // which is the reason the compatible path below exists at all: with no `encoding_format` of its
+    // own the SDK adds `base64`, and a good many self-hosted servers answer that with a 400.
+    ...(deps.fetchImpl ? { fetch: deps.fetchImpl } : {}),
+  };
   return new OpenAIEmbeddings({
     model: cfg.model,
     apiKey: cfg.apiKey,
-    ...(cfg.baseURL ? { configuration: { baseURL: cfg.baseURL } } : {}),
+    ...(Object.keys(configuration).length ? { configuration } : {}),
   });
 }
 
-async function embedCompatible(
+// The error a non-2xx compatible response becomes, shaped so that BOTH halves of the boundary keep
+// working. `providerFailure` takes the status from a numeric `status`/`statusCode` property and
+// never parses the message, so a status baked into the text alone is thrown away and every 401, 404
+// and 429 reaches the operator as the opaque "provider error". And `asProviderFailure` keeps this
+// error as `cause` for the process log, which is where the vendor's own words are RELOCATED to
+// rather than deleted (`provider-failure.ts`, `docs/logs.md`) — so the body has to be in here, or a
+// wrong model id and a malformed request are undiagnosable anywhere. The SDK path builds its
+// message out of the response body for exactly this reason; this one has to do it by hand.
+//
+// The body may quote what was embedded, which is the customer's question or their document. That is
+// precisely why it lives on this error and never on the one that replaces it: the message the four
+// operator-facing stores read is "HTTP <status>", authored here.
+async function providerResponseError(res: Response): Promise<Error> {
+  let body = "";
+  try {
+    body = (await res.text()).slice(0, 2000);
+  } catch {
+    // A body that cannot be read costs the log its detail, never the status.
+  }
+  const message = body
+    ? `${res.status} ${body}`
+    : `embedding provider failed with ${res.status}`;
+  return Object.assign(new Error(message), { status: res.status });
+}
+
+async function embedCompatibleBatch(
   texts: string[],
-  cfg: EmbeddingConfig & { baseURL: string },
+  cfg: EmbeddingConfig,
+  url: string,
+  fetchImpl: typeof fetch,
 ): Promise<number[][]> {
-  const base = cfg.baseURL.replace(/\/+$/, "");
-  const res = await (cfg.fetchImpl ?? fetch)(`${base}/embeddings`, {
+  const res = await fetchImpl(url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      authorization: ["Bea", "rer ", cfg.apiKey].join(""),
+      authorization: `Bearer ${cfg.apiKey}`,
     },
     body: JSON.stringify({ model: cfg.model, input: texts }),
     redirect: "error",
     signal: AbortSignal.timeout(EMBEDDING_TIMEOUT_MS),
   });
-  if (!res.ok) throw new Error(`embedding provider failed with ${res.status}`);
+  if (!res.ok) throw await providerResponseError(res);
   const json = (await res.json()) as {
     data?: Array<{ index?: number; embedding?: unknown }>;
   };
-  const ordered = [...(json.data ?? [])].sort(
-    (a, b) => (a.index ?? 0) - (b.index ?? 0),
-  );
-  if (ordered.length !== texts.length) {
+  const items = [...(json.data ?? [])];
+  // Sort by `index` only when EVERY item carries one. The SDK path reads the array positionally, so
+  // response order is the fallback that has always been in use; treating a missing index as 0 would
+  // instead collapse every item onto the same key and make the order depend on the sort's tie
+  // handling, which is a worse answer than the one we already trusted.
+  if (items.every((i) => typeof i.index === "number")) {
+    items.sort((a, b) => (a.index as number) - (b.index as number));
+  }
+  if (items.length !== texts.length) {
     throw new Error("embedding provider returned the wrong vector count");
   }
-  return ordered.map((item) => {
+  return items.map((item) => {
     if (
       !Array.isArray(item.embedding) ||
       !item.embedding.every((value) => typeof value === "number")
@@ -62,30 +118,85 @@ async function embedCompatible(
   });
 }
 
+async function embedCompatible(
+  texts: string[],
+  cfg: EmbeddingConfig & { baseURL: string },
+  deps: EmbeddingDeps,
+): Promise<number[][]> {
+  const base = cfg.baseURL.replace(/\/+$/, "");
+  // SSRF guard on the URL the OPERATOR configured, immediately before the fetch, exactly as the
+  // openai-compatible branch of `listProviderModels` does. The vault validates `baseUrl` as http(s)
+  // syntax and nothing more, so without this a tenant admin turns knowledge ingestion into a POST at
+  // any loopback, RFC1918 or metadata address. `allowHttp` for the same reason the models listing
+  // allows it: these endpoints are self-hosted and routinely plain http on a private network.
+  const safeUrl = await (deps.assertSafe ?? assertSafeOutboundUrl)(
+    `${base}/embeddings`,
+    { allowHttp: true },
+  );
+  const url = safeUrl.toString();
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const out: number[][] = [];
+  for (let i = 0; i < texts.length; i += COMPATIBLE_BATCH_SIZE) {
+    const batch = texts.slice(i, i + COMPATIBLE_BATCH_SIZE);
+    out.push(...(await embedCompatibleBatch(batch, cfg, url, fetchImpl)));
+  }
+  return out;
+}
+
+// WHY THIS IS CHECKED HERE AND NOT ONLY AT INSERT TIME.
+//
+// `updateEmbeddingSettings` pins provider, model and baseURL to EMBEDDING_DEFAULTS and honors only
+// the credential, because the column is `vector(1536)` and nothing records which model produced a
+// stored vector. Carrying the vault entry's `baseUrl` moves the endpoint choice into the one field
+// that survives that lock, and the endpoint is what decides which model actually answers. So the
+// width stops being guaranteed by construction and has to be asserted.
+//
+// Outside `throughProvider` on purpose: this is OUR reading of the response, not something the
+// server wrote, so it is not reduced to the closed vocabulary. `toVectorLiteral` catches the same
+// thing, but only once ingestion is already inside the publish transaction, and it cannot say that
+// an endpoint is the reason.
+//
+// It does NOT close the case of a different model at the SAME width (text-embedding-ada-002 is also
+// 1536): nothing in the response identifies the model reliably — llama.cpp answers with the loaded
+// file's path — so a same-width swap silently degrades retrieval until flexible embeddings ships.
+function assertWidth(vec: number[], cfg: EmbeddingConfig): number[] {
+  if (vec.length !== EMBEDDING_DIM) {
+    throw new Error(
+      `embedding endpoint returned ${vec.length} dimensions for model "${cfg.model}", but the index column is ${EMBEDDING_DIM} wide`,
+    );
+  }
+  return vec;
+}
+
 export async function embedTexts(
   texts: string[],
   cfg: EmbeddingConfig,
+  deps: EmbeddingDeps = {},
 ): Promise<number[][]> {
   if (texts.length === 0) return [];
-  return throughProvider(() =>
+  const vectors = await throughProvider(() =>
     cfg.baseURL
-      ? embedCompatible(texts, { ...cfg, baseURL: cfg.baseURL })
-      : client(cfg).embedDocuments(texts),
+      ? embedCompatible(texts, { ...cfg, baseURL: cfg.baseURL }, deps)
+      : client(cfg, deps).embedDocuments(texts),
   );
+  return vectors.map((v) => assertWidth(v, cfg));
 }
 
 export async function embedQuery(
   text: string,
   cfg: EmbeddingConfig,
+  deps: EmbeddingDeps = {},
 ): Promise<number[]> {
-  return throughProvider(async () => {
+  const vector = await throughProvider(async () => {
     if (cfg.baseURL) {
-      const vectors = await embedCompatible([text], {
-        ...cfg,
-        baseURL: cfg.baseURL,
-      });
+      const vectors = await embedCompatible(
+        [text],
+        { ...cfg, baseURL: cfg.baseURL },
+        deps,
+      );
       return vectors[0] as number[];
     }
-    return client(cfg).embedQuery(text);
+    return client(cfg, deps).embedQuery(text);
   });
+  return assertWidth(vector, cfg);
 }

--- a/src/modules/rag/embeddings.ts
+++ b/src/modules/rag/embeddings.ts
@@ -1,6 +1,12 @@
 import { OpenAIEmbeddings } from "@langchain/openai";
-import { throughProvider } from "@/lib/provider-failure";
+import {
+  isTransientProviderStatus,
+  providerFailure,
+  statusOf,
+  throughProvider,
+} from "@/lib/provider-failure";
 import { assertSafeOutboundUrl } from "@/lib/ssrf";
+import { clipText } from "@/lib/text";
 
 // Embedding wrapper. OpenAI-compatible by default (text-embedding-3-small → 1536 dims, matching
 // the knowledge_chunks vector(1536) column). The API key is resolved from the vault by the
@@ -35,6 +41,27 @@ const EMBEDDING_TIMEOUT_MS = 60_000;
 // a single-GPU endpoint is not helped by twenty simultaneous requests.
 const COMPATIBLE_BATCH_SIZE = 512;
 
+// WHAT THE SDK PATH WAS ALREADY DOING, AND WHY DROPPING IT COSTS MORE HERE THAN ELSEWHERE.
+//
+// `@langchain/openai` sets the OpenAI client's own `maxRetries` to 0 and wraps every call in
+// `AsyncCaller`, whose default is SIX retries — so this path started out with none where the one it
+// replaces had six. And an ingest failure is terminal: the document lands in FAILED and only a
+// manual reindex moves it, which is a worse outcome than any single 503 deserves.
+//
+// Three attempts rather than six, because the same function serves `embedQuery` inside a live turn,
+// where every extra attempt is a customer waiting; three with these delays is still strictly more
+// patient than the zero this path shipped with, and strictly less than the six a 600s-default SDK
+// timeout could stretch out on main today. Only the ENDPOINT's momentary state is retried — the
+// predicate is `provider-failure`'s, so a 401 or a 404 answers the same way every time and is not
+// asked twice.
+const COMPATIBLE_RETRY_DELAYS_MS = [500, 2000];
+
+function isTransient(err: unknown): boolean {
+  if (providerFailure(err) === "timeout") return true;
+  const status = statusOf(err);
+  return status !== null && isTransientProviderStatus(status);
+}
+
 function client(cfg: EmbeddingConfig, deps: EmbeddingDeps): OpenAIEmbeddings {
   const configuration = {
     ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}),
@@ -66,7 +93,10 @@ function client(cfg: EmbeddingConfig, deps: EmbeddingDeps): OpenAIEmbeddings {
 async function providerResponseError(res: Response): Promise<Error> {
   let body = "";
   try {
-    body = (await res.text()).slice(0, 2000);
+    // `clipText`, not a bare slice: this is arbitrary text an arbitrary server wrote, and a cut
+    // landing between the halves of a surrogate pair leaves a lone surrogate in a value bound for
+    // the process log (`tests/lib/astral-cap-sweep.test.ts`).
+    body = clipText(await res.text(), 2000);
   } catch {
     // A body that cannot be read costs the log its detail, never the status.
   }
@@ -123,24 +153,56 @@ async function embedCompatible(
   cfg: EmbeddingConfig & { baseURL: string },
   deps: EmbeddingDeps,
 ): Promise<number[][]> {
-  const base = cfg.baseURL.replace(/\/+$/, "");
+  // Through `URL`, not concatenation: the vault accepts any http(s) URL, and Azure's own spelling
+  // carries a query (`…/v1?api-version=2024-02-01`). Appending to that string puts the path INSIDE
+  // the query and the POST lands on `/v1`, which a compatible server answers with something that
+  // parses far enough to be confusing.
+  const endpoint = compatibleEndpoint(cfg.baseURL);
   // SSRF guard on the URL the OPERATOR configured, immediately before the fetch, exactly as the
   // openai-compatible branch of `listProviderModels` does. The vault validates `baseUrl` as http(s)
   // syntax and nothing more, so without this a tenant admin turns knowledge ingestion into a POST at
   // any loopback, RFC1918 or metadata address. `allowHttp` for the same reason the models listing
   // allows it: these endpoints are self-hosted and routinely plain http on a private network.
-  const safeUrl = await (deps.assertSafe ?? assertSafeOutboundUrl)(
-    `${base}/embeddings`,
-    { allowHttp: true },
-  );
+  const safeUrl = await (deps.assertSafe ?? assertSafeOutboundUrl)(endpoint, {
+    allowHttp: true,
+  });
   const url = safeUrl.toString();
   const fetchImpl = deps.fetchImpl ?? fetch;
   const out: number[][] = [];
   for (let i = 0; i < texts.length; i += COMPATIBLE_BATCH_SIZE) {
     const batch = texts.slice(i, i + COMPATIBLE_BATCH_SIZE);
-    out.push(...(await embedCompatibleBatch(batch, cfg, url, fetchImpl)));
+    out.push(
+      ...(await withTransientRetry(() =>
+        embedCompatibleBatch(batch, cfg, url, fetchImpl),
+      )),
+    );
   }
   return out;
+}
+
+// The `/embeddings` sibling of whatever path the operator configured, with the query and fragment
+// carried over. A base URL that does not parse is handed to the SSRF guard as it stands, so the
+// refusal is the guard's own "invalid URL" rather than a TypeError reduced to "provider error".
+function compatibleEndpoint(baseURL: string): string {
+  try {
+    const u = new URL(baseURL);
+    u.pathname = `${u.pathname.replace(/\/+$/, "")}/embeddings`;
+    return u.toString();
+  } catch {
+    return baseURL;
+  }
+}
+
+async function withTransientRetry<T>(call: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await call();
+    } catch (err) {
+      const delay = COMPATIBLE_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined || !isTransient(err)) throw err;
+      await Bun.sleep(delay);
+    }
+  }
 }
 
 // WHY THIS IS CHECKED HERE AND NOT ONLY AT INSERT TIME.

--- a/src/modules/rag/embeddings.ts
+++ b/src/modules/rag/embeddings.ts
@@ -51,16 +51,37 @@ const COMPATIBLE_BATCH_SIZE = 512;
 // Three attempts rather than six, because the same function serves `embedQuery` inside a live turn,
 // where every extra attempt is a customer waiting; three with these delays is still strictly more
 // patient than the zero this path shipped with, and strictly less than the six a 600s-default SDK
-// timeout could stretch out on main today. Only the ENDPOINT's momentary state is retried — the
-// predicate is `provider-failure`'s, so a 401 or a 404 answers the same way every time and is not
-// asked twice.
+// timeout could stretch out on main today.
 const COMPATIBLE_RETRY_DELAYS_MS = [500, 2000];
 
-function isTransient(err: unknown): boolean {
+// WHAT COUNTS AS WORTH ASKING AGAIN, and it is not one answer for both callers — the same split
+// `provider-failure` describes, where the set of transient STATUSES is shared and the policy over it
+// belongs to the call site.
+//
+// A failure with no status at all is the case that divides them. `AsyncCaller` retried it (its
+// `STATUS_NO_RETRY` list is statuses, so a connection reset falls through to a retry), and it is
+// just as often a base URL that will never resolve. `modules/vision/retry` excludes it deliberately,
+// because a customer is waiting on that turn and the operator needs a bad endpoint to fail on the
+// first attempt. Both readings are right, for different callers:
+//
+//   embedTexts — the INGEST. Nobody is waiting, and the failure is terminal: the document lands in
+//   FAILED and only a manual reindex moves it. A reset costs the document, so it is asked again.
+//   embedQuery — a live TURN, where the retry is time a customer spends waiting for a search that
+//   the turn can proceed without.
+//
+// A response we could not use (wrong count, unusable indexes, a vector that is not numbers) is never
+// retried on either: the endpoint answered, and it will answer the same way again.
+function isTransient(err: unknown, retryStatusless: boolean): boolean {
+  if (err instanceof UnusableResponseError) return false;
   if (providerFailure(err) === "timeout") return true;
   const status = statusOf(err);
-  return status !== null && isTransientProviderStatus(status);
+  if (status === null) return retryStatusless;
+  return isTransientProviderStatus(status);
 }
+
+// A response that arrived and cannot be used. Its own class so the retry policy can tell it from a
+// transport failure, which otherwise looks identical: neither carries a status.
+class UnusableResponseError extends Error {}
 
 function client(cfg: EmbeddingConfig, deps: EmbeddingDeps): OpenAIEmbeddings {
   const configuration = {
@@ -127,22 +148,38 @@ async function embedCompatibleBatch(
     data?: Array<{ index?: number; embedding?: unknown }>;
   };
   const items = [...(json.data ?? [])];
-  // Sort by `index` only when EVERY item carries one. The SDK path reads the array positionally, so
-  // response order is the fallback that has always been in use; treating a missing index as 0 would
-  // instead collapse every item onto the same key and make the order depend on the sort's tie
-  // handling, which is a worse answer than the one we already trusted.
-  if (items.every((i) => typeof i.index === "number")) {
-    items.sort((a, b) => (a.index as number) - (b.index as number));
-  }
   if (items.length !== texts.length) {
-    throw new Error("embedding provider returned the wrong vector count");
+    throw new UnusableResponseError(
+      "embedding provider returned the wrong vector count",
+    );
+  }
+  // Reorder by `index` only when EVERY item carries one AND they form exactly 0..n-1. The SDK path
+  // reads the array positionally, so response order is the fallback that has always been in use;
+  // treating a missing index as 0 would collapse every item onto one key and hand the order to the
+  // sort's tie handling instead. And a set that is numeric but not a permutation — a duplicate, a
+  // 1.5, a 9 among two inputs — sorts into SOMETHING and passes the count check above, which is how
+  // a document gets published with each vector attached to the wrong chunk. There is no order to
+  // recover there, so it is refused rather than guessed.
+  if (items.every((i) => typeof i.index === "number")) {
+    const indexes = items.map((i) => i.index as number);
+    const permutation =
+      new Set(indexes).size === indexes.length &&
+      indexes.every((n) => Number.isInteger(n) && n >= 0 && n < items.length);
+    if (!permutation) {
+      throw new UnusableResponseError(
+        "embedding provider returned an unusable index set",
+      );
+    }
+    items.sort((a, b) => (a.index as number) - (b.index as number));
   }
   return items.map((item) => {
     if (
       !Array.isArray(item.embedding) ||
       !item.embedding.every((value) => typeof value === "number")
     ) {
-      throw new Error("embedding provider returned an invalid vector");
+      throw new UnusableResponseError(
+        "embedding provider returned an invalid vector",
+      );
     }
     return item.embedding as number[];
   });
@@ -152,6 +189,7 @@ async function embedCompatible(
   texts: string[],
   cfg: EmbeddingConfig & { baseURL: string },
   deps: EmbeddingDeps,
+  retryStatusless: boolean,
 ): Promise<number[][]> {
   // Through `URL`, not concatenation: the vault accepts any http(s) URL, and Azure's own spelling
   // carries a query (`…/v1?api-version=2024-02-01`). Appending to that string puts the path INSIDE
@@ -172,8 +210,9 @@ async function embedCompatible(
   for (let i = 0; i < texts.length; i += COMPATIBLE_BATCH_SIZE) {
     const batch = texts.slice(i, i + COMPATIBLE_BATCH_SIZE);
     out.push(
-      ...(await withTransientRetry(() =>
-        embedCompatibleBatch(batch, cfg, url, fetchImpl),
+      ...(await withTransientRetry(
+        () => embedCompatibleBatch(batch, cfg, url, fetchImpl),
+        retryStatusless,
       )),
     );
   }
@@ -193,13 +232,16 @@ function compatibleEndpoint(baseURL: string): string {
   }
 }
 
-async function withTransientRetry<T>(call: () => Promise<T>): Promise<T> {
+async function withTransientRetry<T>(
+  call: () => Promise<T>,
+  retryStatusless: boolean,
+): Promise<T> {
   for (let attempt = 0; ; attempt++) {
     try {
       return await call();
     } catch (err) {
       const delay = COMPATIBLE_RETRY_DELAYS_MS[attempt];
-      if (delay === undefined || !isTransient(err)) throw err;
+      if (delay === undefined || !isTransient(err, retryStatusless)) throw err;
       await Bun.sleep(delay);
     }
   }
@@ -238,7 +280,7 @@ export async function embedTexts(
   if (texts.length === 0) return [];
   const vectors = await throughProvider(() =>
     cfg.baseURL
-      ? embedCompatible(texts, { ...cfg, baseURL: cfg.baseURL }, deps)
+      ? embedCompatible(texts, { ...cfg, baseURL: cfg.baseURL }, deps, true)
       : client(cfg, deps).embedDocuments(texts),
   );
   return vectors.map((v) => assertWidth(v, cfg));
@@ -255,6 +297,7 @@ export async function embedQuery(
         [text],
         { ...cfg, baseURL: cfg.baseURL },
         deps,
+        false,
       );
       return vectors[0] as number[];
     }

--- a/src/modules/rag/embeddings.ts
+++ b/src/modules/rag/embeddings.ts
@@ -144,28 +144,41 @@ async function embedCompatibleBatch(
     signal: AbortSignal.timeout(EMBEDDING_TIMEOUT_MS),
   });
   if (!res.ok) throw await providerResponseError(res);
-  const json = (await res.json()) as {
-    data?: Array<{ index?: number; embedding?: unknown }>;
-  };
+  // A 2xx whose body is not JSON is a response that ARRIVED and cannot be used, and it has to be
+  // said here: `res.json()` rejects with a statusless SyntaxError, which is indistinguishable from a
+  // connection reset and would be sent the same batch twice more on the ingest path.
+  let json: { data?: Array<{ index?: number; embedding?: unknown }> };
+  try {
+    json = (await res.json()) as typeof json;
+  } catch {
+    throw new UnusableResponseError(
+      "embedding provider returned a body that is not JSON",
+    );
+  }
   const items = [...(json.data ?? [])];
   if (items.length !== texts.length) {
     throw new UnusableResponseError(
       "embedding provider returned the wrong vector count",
     );
   }
-  // Reorder by `index` only when EVERY item carries one AND they form exactly 0..n-1. The SDK path
-  // reads the array positionally, so response order is the fallback that has always been in use;
-  // treating a missing index as 0 would collapse every item onto one key and hand the order to the
-  // sort's tie handling instead. And a set that is numeric but not a permutation — a duplicate, a
-  // 1.5, a 9 among two inputs — sorts into SOMETHING and passes the count check above, which is how
-  // a document gets published with each vector attached to the wrong chunk. There is no order to
-  // recover there, so it is refused rather than guessed.
-  if (items.every((i) => typeof i.index === "number")) {
+  // Two acceptable shapes and nothing between them: NO item carries an index, or every one does and
+  // they form exactly 0..n-1.
+  //
+  // The empty case is the SDK path's own assumption — it reads the array positionally — so response
+  // order is the fallback that has always been in use here. A PARTIAL set is not that: one item
+  // saying `index: 1` is the provider stating that position is not the order, and reading the array
+  // positionally anyway publishes `[b, a]` for `[{index:1,b},{a}]`. And a full set that is not a
+  // permutation (a duplicate, a 1.5, a 9 among two inputs) sorts into SOMETHING and sails past the
+  // count check above. Neither leaves an order to recover, so both are refused rather than guessed —
+  // the cost of guessing is a document published with every vector against the wrong chunk.
+  const indexed = items.filter((i) => typeof i.index === "number").length;
+  if (indexed > 0) {
     const indexes = items.map((i) => i.index as number);
-    const permutation =
+    const usable =
+      indexed === items.length &&
       new Set(indexes).size === indexes.length &&
       indexes.every((n) => Number.isInteger(n) && n >= 0 && n < items.length);
-    if (!permutation) {
+    if (!usable) {
       throw new UnusableResponseError(
         "embedding provider returned an unusable index set",
       );

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -185,6 +185,43 @@ export interface ResolvedVaultEntry<T = unknown> {
   name: string;
 }
 
+export type VaultEntryResolution<T> =
+  | { state: "filled"; entry: ResolvedVaultEntry<T> }
+  | { state: "pending" }
+  | { state: "not_found" };
+
+// State-aware variant for callers that need both operator-facing pending/not-found diagnostics and
+// active-entry metadata such as baseUrl. Keeping this separate avoids changing the generic
+// resolveVaultRefState value contract used by existing secret-only consumers.
+export async function resolveVaultEntryState<T = unknown>(
+  db: ScopedDb,
+  ref: string,
+): Promise<VaultEntryResolution<T>> {
+  const entry = await db.vaultEntry.findFirst({
+    where: vaultRefWhere(ref),
+    select: {
+      secret: true,
+      kind: true,
+      baseUrl: true,
+      paramName: true,
+      name: true,
+      status: true,
+    },
+  });
+  if (!entry) return { state: "not_found" };
+  if (entry.status === "pending") return { state: "pending" };
+  return {
+    state: "filled",
+    entry: {
+      secret: decryptJson<T>(entry.secret),
+      kind: entry.kind,
+      baseUrl: entry.baseUrl,
+      paramName: entry.paramName,
+      name: entry.name,
+    },
+  };
+}
+
 export async function resolveVaultEntry<T = unknown>(
   db: ScopedDb,
   ref: string,

--- a/tests/modules/rag-embeddings-failure.test.ts
+++ b/tests/modules/rag-embeddings-failure.test.ts
@@ -64,10 +64,20 @@ describe("an embedding failure carries no part of what was embedded", () => {
     baseURL,
   });
 
+  // The SSRF guard is ON here (`tests/setup.ts` sets NODE_ENV=test, so `allowPrivateTargets` is
+  // false) and the fixture below is a loopback server, which the guard refuses — correctly, and in
+  // production too, where reaching a private endpoint is an explicit SSRF_ALLOW_PRIVATE_TARGETS
+  // opt-in. The subject here is what a provider's REJECTION is allowed to say, so the guard is
+  // stubbed out of the way rather than tested twice; `rag-embeddings.test.ts` owns the assertion
+  // that it runs at all, and before any fetch.
+  const deps = () => ({ assertSafe: async (u: string) => new URL(u) });
+
   // Both entry points, because they leak into different stores and a rule applied to one of two
   // callers is the shape this whole change exists to stop repeating.
   test("the query path reports the status, not the question", async () => {
-    const err = (await embedQuery(MARKER, cfg()).catch((e) => e)) as Error;
+    const err = (await embedQuery(MARKER, cfg(), deps()).catch(
+      (e) => e,
+    )) as Error;
     expect(err).toBeInstanceOf(Error);
     expect(err.message).not.toContain(MARKER);
     expect(err.message).toBe("HTTP 400");
@@ -75,7 +85,9 @@ describe("an embedding failure carries no part of what was embedded", () => {
   });
 
   test("the document path reports the status, not the text", async () => {
-    const err = (await embedTexts([MARKER], cfg()).catch((e) => e)) as Error;
+    const err = (await embedTexts([MARKER], cfg(), deps()).catch(
+      (e) => e,
+    )) as Error;
     expect(err).toBeInstanceOf(Error);
     expect(err.message).not.toContain(MARKER);
     expect(err.message).toBe("HTTP 400");
@@ -90,7 +102,7 @@ describe("an embedding failure carries no part of what was embedded", () => {
       seen.push(args[0]);
     };
     try {
-      await embedQuery(MARKER, cfg()).catch(() => undefined);
+      await embedQuery(MARKER, cfg(), deps()).catch(() => undefined);
     } finally {
       (logger as { warn: unknown }).warn = realWarn;
     }
@@ -103,6 +115,6 @@ describe("an embedding failure carries no part of what was embedded", () => {
   // The early return is not a way past the boundary: an empty batch never calls the provider, so
   // there is nothing to reduce and nothing to leak.
   test("an empty batch never reaches the provider", async () => {
-    expect(await embedTexts([], cfg())).toEqual([]);
+    expect(await embedTexts([], cfg(), deps())).toEqual([]);
   });
 });

--- a/tests/modules/rag-embeddings.test.ts
+++ b/tests/modules/rag-embeddings.test.ts
@@ -240,6 +240,69 @@ describe("OpenAI-compatible embeddings", () => {
     );
   });
 
+  // AsyncCaller's no-retry list is STATUSES, so a connection reset fell through to a retry on the
+  // path this replaced. The ingest is where that matters: nobody is waiting and the document lands
+  // terminally FAILED.
+  test("the ingest asks again after a transport failure with no status", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls === 1) throw new TypeError("fetch failed");
+      return json({ data: [{ index: 0, embedding: vec(4) }] });
+    }) as unknown as typeof fetch;
+    expect(
+      await embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).toEqual([vec(4)]);
+    expect(calls).toBe(2);
+  });
+
+  // The other half of that split: a live turn, where the retry is time a customer spends and a base
+  // URL that will never resolve has to fail on the first attempt (`modules/vision/retry`).
+  test("the query path does not, and fails on the first attempt", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+    await expect(
+      embedQuery("q", config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
+    expect(calls).toBe(1);
+  });
+
+  // A response that arrived and cannot be used is never asked again: the endpoint answered, and it
+  // will answer the same way next time.
+  test("an unusable response is not retried", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return json({ data: [] });
+    }) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
+    expect(calls).toBe(1);
+  });
+
+  // Numeric but not a permutation of 0..n-1: it sorts into SOMETHING and passes the count check, so
+  // without this the document publishes with each vector attached to the wrong chunk.
+  test.each([
+    ["a duplicate index", [0, 0]],
+    ["an index past the batch", [0, 9]],
+    ["a non-integer index", [0, 1.5]],
+  ])("refuses %s", async (_label, indexes) => {
+    const fetchImpl = (async () =>
+      json({
+        data: (indexes as number[]).map((index, i) => ({
+          index,
+          embedding: vec(i),
+        })),
+      })) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a", "b"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
+  });
+
   test("the query path refuses the same mismatch", async () => {
     const fetchImpl = (async () =>
       json({

--- a/tests/modules/rag-embeddings.test.ts
+++ b/tests/modules/rag-embeddings.test.ts
@@ -284,6 +284,36 @@ describe("OpenAI-compatible embeddings", () => {
     expect(calls).toBe(1);
   });
 
+  // One item saying `index: 1` is the provider stating that position is not the order. Reading the
+  // array positionally anyway publishes the pair swapped.
+  test("refuses a response only some of whose items are indexed", async () => {
+    const fetchImpl = (async () =>
+      json({
+        data: [{ index: 1, embedding: vec(1) }, { embedding: vec(0) }],
+      })) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a", "b"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
+  });
+
+  // A 2xx whose body is not JSON arrived and cannot be used: `res.json()` rejects with a statusless
+  // SyntaxError, which the ingest's own policy would otherwise read as a transport failure and send
+  // the same batch twice more.
+  test("a 2xx that is not JSON is refused once, not asked again", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return new BunResponse("<html>gateway</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    }) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
+    expect(calls).toBe(1);
+  });
+
   // Numeric but not a permutation of 0..n-1: it sorts into SOMETHING and passes the count check, so
   // without this the document publishes with each vector attached to the wrong chunk.
   test.each([

--- a/tests/modules/rag-embeddings.test.ts
+++ b/tests/modules/rag-embeddings.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { embedQuery, embedTexts } from "@/modules/rag/embeddings";
+
+function config(fetchImpl: typeof fetch) {
+  return {
+    model: "text-embedding-3-small",
+    apiKey: ["unit", "value"].join("-"),
+    baseURL: "https://embedding.internal/v1/",
+    fetchImpl,
+  };
+}
+
+describe("OpenAI-compatible embeddings", () => {
+  test("preserves provider vectors and restores response order", async () => {
+    let requestBody: { input?: string[] } = {};
+    const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+      expect(String(url)).toBe("https://embedding.internal/v1/embeddings");
+      requestBody = JSON.parse(init?.body as string);
+      return new Response(
+        JSON.stringify({
+          data: [
+            { index: 1, embedding: [0, 1, 0] },
+            { index: 0, embedding: [1, 0, 0] },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const vectors = await embedTexts(
+      ["primeiro", "segundo"],
+      config(fetchImpl),
+    );
+    expect(requestBody.input).toEqual(["primeiro", "segundo"]);
+    expect(vectors).toEqual([
+      [1, 0, 0],
+      [0, 1, 0],
+    ]);
+  });
+
+  test("uses the same compatible path for query embeddings", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({ data: [{ index: 0, embedding: [0.5, 0.5] }] }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      )) as unknown as typeof fetch;
+    expect(await embedQuery("consulta", config(fetchImpl))).toEqual([0.5, 0.5]);
+  });
+
+  test("rejects a response with the wrong vector count", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    await expect(embedTexts(["consulta"], config(fetchImpl))).rejects.toThrow(
+      "provider error",
+    );
+  });
+});

--- a/tests/modules/rag-embeddings.test.ts
+++ b/tests/modules/rag-embeddings.test.ts
@@ -314,6 +314,69 @@ describe("OpenAI-compatible embeddings", () => {
     expect(calls).toBe(1);
   });
 
+  // Reading a body is still transport: the connection can reset between the headers and the last
+  // byte, and it rejects out of the same call a syntax error does.
+  test("a body that dies mid-read is transport, and is asked again", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new TypeError(
+              "The socket connection was closed unexpectedly",
+            );
+          },
+        } as unknown as Response;
+      }
+      return json({ data: [{ index: 0, embedding: vec(5) }] });
+    }) as unknown as typeof fetch;
+    expect(
+      await embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).toEqual([vec(5)]);
+    expect(calls).toBe(2);
+  });
+
+  // Valid JSON, unusable shape: reading `data` off a null root, or spreading an object, throws a
+  // statusless TypeError the ingest would otherwise pay for twice more.
+  test.each([
+    ["a null root", null],
+    ["a data that is not an array", { data: { 0: "nope" } }],
+  ])("refuses %s without asking again", async (_label, body) => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return json(body);
+    }) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
+    expect(calls).toBe(1);
+  });
+
+  // A first response that already proves the endpoint serves another model stops the document there
+  // instead of paying for every remaining batch.
+  test("stops at the first batch whose width is wrong", async () => {
+    let calls = 0;
+    const fetchImpl = (async (_u: unknown, init?: RequestInit) => {
+      calls += 1;
+      const body = JSON.parse(init?.body as string) as { input: string[] };
+      return json({
+        data: body.input.map((_t, i) => ({ index: i, embedding: vec(0, 768) })),
+      });
+    }) as unknown as typeof fetch;
+    await expect(
+      embedTexts(
+        Array.from({ length: 600 }, (_, i) => String(i)),
+        config(),
+        { fetchImpl, assertSafe: passThrough },
+      ),
+    ).rejects.toThrow(/returned 768 dimensions/);
+    expect(calls).toBe(1);
+  });
+
   // Numeric but not a permutation of 0..n-1: it sorts into SOMETHING and passes the count check, so
   // without this the document publishes with each vector attached to the wrong chunk.
   test.each([

--- a/tests/modules/rag-embeddings.test.ts
+++ b/tests/modules/rag-embeddings.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { SsrfError } from "@/lib/ssrf";
 import {
   EMBEDDING_DIM,
   type EmbeddingDeps,
@@ -102,15 +103,41 @@ describe("OpenAI-compatible embeddings", () => {
     const seen: Array<[string, unknown]> = [];
     const assertSafe: EmbeddingDeps["assertSafe"] = async (u, opts) => {
       seen.push([u, opts]);
-      throw new Error("Blocked outbound URL: 169.254.169.254 is blocked");
+      throw new SsrfError("address 169.254.169.254 is in a blocked range");
     };
     await expect(
       embedTexts(["a"], config(), { fetchImpl, assertSafe }),
-    ).rejects.toThrow("provider error");
+      // The guard's own sentence, not `HTTP 400`: nothing was sent, and dressing our refusal as the
+      // endpoint's status sends the operator to look at a server that never heard from us.
+    ).rejects.toThrow("169.254.169.254");
     expect(fetched).toBe(false);
+    // Exactly once: a refusal by the guard is deterministic, and the one case where a second answer
+    // would differ is the rebinding the per-fetch check exists to catch.
     expect(seen).toEqual([
       ["https://embedding.internal/v1/embeddings", { allowHttp: true }],
     ]);
+  });
+
+  // The guard runs before EVERY fetch, not once per document: a name can answer publicly for the
+  // check and privately a moment later, and a document is many batches.
+  test("vets the URL again for every batch", async () => {
+    let asserts = 0;
+    const assertSafe: EmbeddingDeps["assertSafe"] = async (u) => {
+      asserts += 1;
+      return new URL(u);
+    };
+    const fetchImpl = (async (_u: unknown, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string) as { input: string[] };
+      return json({
+        data: body.input.map((_t, i) => ({ index: i, embedding: vec(0) })),
+      });
+    }) as unknown as typeof fetch;
+    await embedTexts(
+      Array.from({ length: 600 }, (_, i) => String(i)),
+      config(),
+      { fetchImpl, assertSafe },
+    );
+    expect(asserts).toBe(2);
   });
 
   // `documents.ts` hands over EVERY chunk of a document at once and nothing caps a document's size,
@@ -354,6 +381,24 @@ describe("OpenAI-compatible embeddings", () => {
       embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
     ).rejects.toThrow("provider error");
     expect(calls).toBe(1);
+  });
+
+  // `"1"` and `null` are not ABSENT: they are the provider stating an order in a spelling we cannot
+  // read. Counting them as absent falls back to position and publishes this response swapped.
+  test.each([
+    ["indexes that are strings", ["1", "0"]],
+    ["indexes that are null", [null, null]],
+  ])("refuses %s rather than reading position", async (_label, indexes) => {
+    const fetchImpl = (async () =>
+      json({
+        data: (indexes as unknown[]).map((index, i) => ({
+          index,
+          embedding: vec(i === 0 ? 1 : 0),
+        })),
+      })) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a", "b"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
   });
 
   // A first response that already proves the endpoint serves another model stops the document there

--- a/tests/modules/rag-embeddings.test.ts
+++ b/tests/modules/rag-embeddings.test.ts
@@ -1,63 +1,237 @@
 import { describe, expect, test } from "bun:test";
-import { embedQuery, embedTexts } from "@/modules/rag/embeddings";
+import {
+  EMBEDDING_DIM,
+  type EmbeddingDeps,
+  embedQuery,
+  embedTexts,
+} from "@/modules/rag/embeddings";
 
-function config(fetchImpl: typeof fetch) {
+const nativeGlobals = globalThis as unknown as { BunResponse: typeof Response };
+const BunResponse = nativeGlobals.BunResponse;
+
+// A vector of the width the `knowledge_chunks` column actually is. Anything narrower is a different
+// model answering, which is the case `assertWidth` exists for and is asserted on its own below.
+function vec(seed: number, dim = EMBEDDING_DIM): number[] {
+  return Array.from({ length: dim }, (_, i) => (i === seed ? 1 : 0));
+}
+
+function config() {
   return {
     model: "text-embedding-3-small",
-    apiKey: ["unit", "value"].join("-"),
+    apiKey: "sk-probe",
     baseURL: "https://embedding.internal/v1/",
-    fetchImpl,
   };
+}
+
+// The SSRF assertion resolves DNS, so a hermetic test cannot reach the real one; `embedding.internal`
+// does not exist. Its own wiring is asserted separately.
+const passThrough: EmbeddingDeps["assertSafe"] = async (u) => new URL(u);
+
+function json(body: unknown, status = 200): Response {
+  return new BunResponse(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 describe("OpenAI-compatible embeddings", () => {
   test("preserves provider vectors and restores response order", async () => {
-    let requestBody: { input?: string[] } = {};
+    let requestBody: { input?: string[]; model?: string } = {};
+    let seenUrl = "";
+    let seenAuth = "";
     const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
-      expect(String(url)).toBe("https://embedding.internal/v1/embeddings");
-      requestBody = JSON.parse(init?.body as string);
-      return new Response(
-        JSON.stringify({
-          data: [
-            { index: 1, embedding: [0, 1, 0] },
-            { index: 0, embedding: [1, 0, 0] },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
+      seenUrl = String(url);
+      seenAuth = String(
+        (init?.headers as Record<string, string> | undefined)?.authorization,
       );
-    }) as typeof fetch;
+      requestBody = JSON.parse(init?.body as string);
+      return json({
+        data: [
+          { index: 1, embedding: vec(1) },
+          { index: 0, embedding: vec(0) },
+        ],
+      });
+    }) as unknown as typeof fetch;
 
-    const vectors = await embedTexts(
-      ["primeiro", "segundo"],
-      config(fetchImpl),
-    );
+    const vectors = await embedTexts(["primeiro", "segundo"], config(), {
+      fetchImpl,
+      assertSafe: passThrough,
+    });
+    expect(seenUrl).toBe("https://embedding.internal/v1/embeddings");
+    expect(seenAuth).toBe("Bearer sk-probe");
     expect(requestBody.input).toEqual(["primeiro", "segundo"]);
-    expect(vectors).toEqual([
-      [1, 0, 0],
-      [0, 1, 0],
-    ]);
+    // The pinned model travels on the wire: the endpoint may move, the model may not.
+    expect(requestBody.model).toBe("text-embedding-3-small");
+    expect(vectors).toEqual([vec(0), vec(1)]);
+  });
+
+  test("keeps response order when the provider sends no index at all", async () => {
+    const fetchImpl = (async () =>
+      json({
+        data: [{ embedding: vec(0) }, { embedding: vec(1) }],
+      })) as unknown as typeof fetch;
+    expect(
+      await embedTexts(["a", "b"], config(), {
+        fetchImpl,
+        assertSafe: passThrough,
+      }),
+    ).toEqual([vec(0), vec(1)]);
   });
 
   test("uses the same compatible path for query embeddings", async () => {
     const fetchImpl = (async () =>
-      new Response(
-        JSON.stringify({ data: [{ index: 0, embedding: [0.5, 0.5] }] }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      )) as unknown as typeof fetch;
-    expect(await embedQuery("consulta", config(fetchImpl))).toEqual([0.5, 0.5]);
+      json({
+        data: [{ index: 0, embedding: vec(7) }],
+      })) as unknown as typeof fetch;
+    expect(
+      await embedQuery("consulta", config(), {
+        fetchImpl,
+        assertSafe: passThrough,
+      }),
+    ).toEqual(vec(7));
+  });
+
+  // The guard the vault does not apply: `baseUrl` is persisted after an http(s) SYNTAX check only,
+  // so without this a tenant admin turns ingestion into a POST at a loopback or metadata address.
+  test("asserts the outbound URL before any fetch, and refuses on a block", async () => {
+    let fetched = false;
+    const fetchImpl = (async () => {
+      fetched = true;
+      return json({ data: [] });
+    }) as unknown as typeof fetch;
+    const seen: Array<[string, unknown]> = [];
+    const assertSafe: EmbeddingDeps["assertSafe"] = async (u, opts) => {
+      seen.push([u, opts]);
+      throw new Error("Blocked outbound URL: 169.254.169.254 is blocked");
+    };
+    await expect(
+      embedTexts(["a"], config(), { fetchImpl, assertSafe }),
+    ).rejects.toThrow("provider error");
+    expect(fetched).toBe(false);
+    expect(seen).toEqual([
+      ["https://embedding.internal/v1/embeddings", { allowHttp: true }],
+    ]);
+  });
+
+  // `documents.ts` hands over EVERY chunk of a document at once and nothing caps a document's size,
+  // so an unbatched call is a 400/413 on the self-hosted servers this path exists to serve.
+  test("splits a large document into bounded batches, in order", async () => {
+    const sizes: number[] = [];
+    const fetchImpl = (async (_u: unknown, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string) as { input: string[] };
+      sizes.push(body.input.length);
+      return json({
+        data: body.input.map((t, i) => ({
+          index: i,
+          embedding: vec(Number(t)),
+        })),
+      });
+    }) as unknown as typeof fetch;
+
+    const texts = Array.from({ length: 600 }, (_, i) =>
+      String(i % EMBEDDING_DIM),
+    );
+    const vectors = await embedTexts(texts, config(), {
+      fetchImpl,
+      assertSafe: passThrough,
+    });
+    expect(sizes).toEqual([512, 88]);
+    expect(vectors).toHaveLength(600);
+    expect(vectors[0]).toEqual(vec(0));
+    expect(vectors[511]).toEqual(vec(511));
+    expect(vectors[512]).toEqual(vec(512));
+    expect(vectors[599]).toEqual(vec(599));
+  });
+
+  // `providerFailure` reads the status off a numeric property and never parses the message, so a
+  // status that lives only in the text reaches the operator as the opaque "provider error".
+  test("reports the provider's status, and keeps its words for the log", async () => {
+    const fetchImpl = (async () =>
+      new BunResponse('{"error":{"message":"invalid api key"}}', {
+        status: 401,
+      })) as unknown as typeof fetch;
+    const err = (await embedTexts(["a"], config(), {
+      fetchImpl,
+      assertSafe: passThrough,
+    }).catch((e) => e)) as Error;
+    expect(err.message).toBe("HTTP 401");
+    expect(String((err.cause as Error).message)).toContain("invalid api key");
   });
 
   test("rejects a response with the wrong vector count", async () => {
     const fetchImpl = (async () =>
-      new Response(JSON.stringify({ data: [] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
+      json({ data: [] })) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["consulta"], config(), {
+        fetchImpl,
+        assertSafe: passThrough,
+      }),
+    ).rejects.toThrow("provider error");
+  });
+
+  test("rejects a vector that is not all numbers", async () => {
+    const fetchImpl = (async () =>
+      json({
+        data: [{ index: 0, embedding: ["nope"] }],
       })) as unknown as typeof fetch;
-    await expect(embedTexts(["consulta"], config(fetchImpl))).rejects.toThrow(
-      "provider error",
+    await expect(
+      embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("provider error");
+  });
+
+  // The column is `vector(1536)` and `updateEmbeddingSettings` pins the model precisely because
+  // nothing records which model produced a stored vector. Once the endpoint is configurable, the
+  // width is no longer guaranteed by construction — and it has to fail by NAME, not as the closed
+  // "provider error", or the operator cannot tell a wrong endpoint from a dead one.
+  test("refuses an endpoint answering with a different dimensionality", async () => {
+    const fetchImpl = (async () =>
+      json({
+        data: [{ index: 0, embedding: vec(0, 768) }],
+      })) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow(/returned 768 dimensions .* is 1536 wide/);
+  });
+
+  test("the query path refuses the same mismatch", async () => {
+    const fetchImpl = (async () =>
+      json({
+        data: [{ index: 0, embedding: vec(0, 1024) }],
+      })) as unknown as typeof fetch;
+    await expect(
+      embedQuery("q", config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow(/returned 1024 dimensions/);
+  });
+});
+
+// The other half of the routing, and the reason the compatible path is worth its own code: with no
+// `encoding_format` of its own the OpenAI SDK adds `base64`, which a good many OpenAI-compatible
+// servers reject outright.
+describe("no configured base URL keeps the OpenAI SDK path", () => {
+  test("goes to OpenAI, and lets the SDK pick the wire format", async () => {
+    let seenUrl = "";
+    let body: { encoding_format?: string } = {};
+    const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+      seenUrl = String(url);
+      body = JSON.parse(init?.body as string);
+      const floats = new Float32Array(vec(3));
+      return json({
+        data: [
+          {
+            index: 0,
+            embedding: Buffer.from(floats.buffer).toString("base64"),
+          },
+        ],
+      });
+    }) as unknown as typeof fetch;
+
+    const out = await embedQuery(
+      "consulta",
+      { model: "text-embedding-3-small", apiKey: "sk-probe" },
+      { fetchImpl },
     );
+    expect(seenUrl).toBe("https://api.openai.com/v1/embeddings");
+    expect(body.encoding_format).toBe("base64");
+    expect(out).toEqual(vec(3));
   });
 });

--- a/tests/modules/rag-embeddings.test.ts
+++ b/tests/modules/rag-embeddings.test.ts
@@ -193,6 +193,53 @@ describe("OpenAI-compatible embeddings", () => {
     ).rejects.toThrow(/returned 768 dimensions .* is 1536 wide/);
   });
 
+  // `@langchain/openai` pins the OpenAI client to `maxRetries: 0` and wraps the call in AsyncCaller,
+  // which retries six times; this path shipped with none, and an ingest failure is terminal (the
+  // document lands in FAILED and only a manual reindex moves it).
+  test("asks again after a transient failure, and only then", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return calls === 1
+        ? new BunResponse("upstream busy", { status: 503 })
+        : json({ data: [{ index: 0, embedding: vec(2) }] });
+    }) as unknown as typeof fetch;
+    expect(
+      await embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).toEqual([vec(2)]);
+    expect(calls).toBe(2);
+  });
+
+  test("does not ask again about what we sent", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return new BunResponse("bad key", { status: 401 });
+    }) as unknown as typeof fetch;
+    await expect(
+      embedTexts(["a"], config(), { fetchImpl, assertSafe: passThrough }),
+    ).rejects.toThrow("HTTP 401");
+    expect(calls).toBe(1);
+  });
+
+  // Azure's own spelling of a compatible base carries a query; concatenating puts `/embeddings`
+  // inside it and the POST lands on the base path instead.
+  test("keeps a query on the base URL out of the path", async () => {
+    let seenUrl = "";
+    const fetchImpl = (async (url: string | URL) => {
+      seenUrl = String(url);
+      return json({ data: [{ index: 0, embedding: vec(1) }] });
+    }) as unknown as typeof fetch;
+    await embedTexts(
+      ["a"],
+      { ...config(), baseURL: "https://azure.example/openai/v1?api-version=x" },
+      { fetchImpl, assertSafe: passThrough },
+    );
+    expect(seenUrl).toBe(
+      "https://azure.example/openai/v1/embeddings?api-version=x",
+    );
+  });
+
   test("the query path refuses the same mismatch", async () => {
     const fetchImpl = (async () =>
       json({

--- a/tests/modules/rag-ingest-block.test.ts
+++ b/tests/modules/rag-ingest-block.test.ts
@@ -282,6 +282,35 @@ describe.skipIf(!dbUp)(
       expect(config.model).toBe("text-embedding-3-small");
     });
 
+    // `updateEmbeddingSettings` validates that the ref RESOLVES and nothing else, and four other
+    // kinds persist a baseUrl of their own. Honouring it for any kind means the operator who picks
+    // the Chatwoot credential here POSTs every chunk of their knowledge base at the Chatwoot host,
+    // with a request that looks entirely plausible on the way out.
+    test("a base URL belonging to another service never becomes the embedding endpoint", async () => {
+      const { id } = await seedTenant("embed-wrong-kind");
+      const entry = await createVaultEntry(
+        ctx(id),
+        {
+          name: "chatwoot-of-this-tenant",
+          value: "internal-test-value",
+          kind: "chatwoot_api_token",
+          baseUrl: "https://chatwoot.internal.example",
+        },
+        undefined,
+        undefined,
+        appDb,
+      );
+      await updateEmbeddingSettings(
+        ctx(id),
+        { credentialRef: entry.ref },
+        appDb,
+      );
+      const config = await runScopedOn(appDb, ctx(id), (db) =>
+        resolveEmbeddingConfig(db, id, "text-embedding-3-small"),
+      );
+      expect(config.baseURL).toBeUndefined();
+    });
+
     // Review finding, round 4: this shape also rides on the documents list, which any authenticated
     // role can read, while the reindex endpoint that needs the deeplink is TENANT_ADMIN. The ref is
     // still resolved here — the controller is what drops it — so the split has to stay visible.

--- a/tests/modules/rag-ingest-block.test.ts
+++ b/tests/modules/rag-ingest-block.test.ts
@@ -256,6 +256,32 @@ describe.skipIf(!dbUp)(
       expect((await readDoc(id, doc.id))?.status).toBe("UNINDEXED");
     });
 
+    test("an active OpenAI-compatible credential preserves its base URL for RAG", async () => {
+      const { id } = await seedTenant("embed-base-url");
+      const entry = await createVaultEntry(
+        ctx(id),
+        {
+          name: "embed-compatible",
+          value: "internal-test-value",
+          kind: "openai_compatible",
+          baseUrl: "https://embedding.internal.example/v1",
+        },
+        undefined,
+        undefined,
+        appDb,
+      );
+      await updateEmbeddingSettings(
+        ctx(id),
+        { credentialRef: entry.ref },
+        appDb,
+      );
+      const config = await runScopedOn(appDb, ctx(id), (db) =>
+        resolveEmbeddingConfig(db, id, "text-embedding-3-small"),
+      );
+      expect(config.baseURL).toBe("https://embedding.internal.example/v1");
+      expect(config.model).toBe("text-embedding-3-small");
+    });
+
     // Review finding, round 4: this shape also rides on the documents list, which any authenticated
     // role can read, while the reindex endpoint that needs the deeplink is TENANT_ADMIN. The ref is
     // still resolved here — the controller is what drops it — so the split has to stay visible.

--- a/tests/modules/rag-ingest-stale-publish.test.ts
+++ b/tests/modules/rag-ingest-stale-publish.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
+import config from "@/config";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import {
   createDocument,
@@ -118,8 +119,17 @@ function toBase64(vec: number[]): string {
   );
 }
 
+let savedAllowPrivate = false;
+
 beforeAll(() => {
   if (!dbUp) return;
+  // The fixture below is a loopback embedding endpoint reached through the REAL ingest path, and
+  // `embedCompatible` now runs the SSRF guard on the operator-configured URL before fetching — which
+  // refuses 127.0.0.1 under NODE_ENV=test, exactly as it would in production. Same save/restore the
+  // mcp-oauth suite uses for its own loopback fixture; reaching a private endpoint for real is the
+  // operator's explicit SSRF_ALLOW_PRIVATE_TARGETS opt-in, and it is not what this suite is about.
+  savedAllowPrivate = config.ssrf.allowPrivateTargets;
+  config.ssrf.allowPrivateTargets = true;
   embedServer = Bun.serve({
     port: 0,
     async fetch(req) {
@@ -246,6 +256,7 @@ async function readChunks(tenantId: bigint, id: bigint): Promise<string[]> {
 }
 
 afterAll(async () => {
+  config.ssrf.allowPrivateTargets = savedAllowPrivate;
   embedServer?.stop(true);
   if (!dbUp) return;
   for (const id of tenants) {


### PR DESCRIPTION
# feat(rag): support OpenAI-compatible embedding endpoints

## Summary

- preserve an active compatible credential's `baseUrl` through Vault resolution;
- call the standard `/embeddings` endpoint when a custom base URL is configured;
- support document and query embeddings;
- restore provider vectors by response index;
- reject invalid vectors and wrong vector counts;
- preserve the existing OpenAI SDK path when no compatible URL is configured.

## Motivation

Private and self-hosted OpenAI-compatible embedding endpoints cannot currently be configured reliably because the Vault entry URL is lost before ingestion/query embedding.

## Tests

```bash
bun test tests/modules/rag-embeddings.test.ts tests/modules/rag-ingest-block.test.ts
```

Result: targeted non-DB tests pass; DB tests are skipped when test database variables are absent.

## Full check status

`bun check` reaches the full suite. One pre-existing UI test times out independently:

```text
KnowledgeApprovals — a suggestion reviewed elsewhere meanwhile leaves the queue...
```

The timeout reproduces on `main`/in isolation and is unrelated to this RAG change.

## Local source

- branch: `feat/rag-openai-compatible-embeddings`
- commit: `5711756`

## Checklist

- [x] focused feature
- [x] tests included
- [x] no secrets
- [x] no customer-specific values
- [x] tenant-scoped Vault resolution preserved
- [x] Conventional Commit
- [ ] GitHub fork remote configured
- [ ] PR submitted
- [ ] CLA acknowledged at submission
