### PR TITLE
Seven things that only break when the suite runs in a different order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,41 +39,6 @@ jobs:
     # `bun test --parallel` is NOT affected and runs clean: it implies `--isolate`, so each file gets
     # its own module registry and a `mock.module` cannot reach the next file. Only a shard, which runs
     # serially inside its job, shares one.
-    runs-on: ubuntu-latest
-
-    # NOT SHARDED, AND THE MEASUREMENT THAT SAYS WHY IS WORTH KEEPING.
-    #
-    # Four shards (one job each, own vCPUs, own database) took the test step from 157s to 36-61s and
-    # the wall from 217s to ~109s. Three of the four came back RED, and not from anything the split
-    # did: the same `bun test --shard=1/4` on a clean origin/main fails the same 19 tests. This suite
-    # has files that pass only in the order the full serial run happens to give them, and sharding is
-    # simply the first thing to reorder it.
-    #
-    # Most of the cause was found and fixed on this branch: `src/app.ts` exports a singleton, two test
-    # files registered THEIR OWN routes on it, and Elysia compiles its router on first use, so
-    # whichever file got there first was the only one whose routes existed. The rest fell through to
-    # the `/*` SPA handler and came back as HTML. `buildApp()` is the fix, and it took shard 1/4 from
-    # 19 failures to 2.
-    #
-    # The 2 that remain, plus 7 more across the other shards, are a DIFFERENT cause and it is not
-    # isolated yet: `Expected: 404, Received: 500`, so a handler throwing rather than a route missing.
-    # It is not pairwise — sweeping all 133 other files of the shard, each run immediately before the
-    # victim, reproduces on none of them — which points at a combination rather than one bad
-    # neighbour. `setupPrismaMock` was the obvious suspect (a permanent process-global `mock.module`
-    # that 14 of its 26 callers never reset) and was measured and RULED OUT: resetting it changes
-    # nothing.
-    #
-    # So sharding stays off until that is found. The same unknown also blocks
-    # `bun test --parallel --no-isolate`, which is 42s against 65s locally and fails the same way.
-
-    # NOTE: a REAL Postgres, not a mock. Roughly 1600 of this suite's assertions are database-backed
-    # and every one of them is gated on `describe.skipIf(!dbUp)`, so without a server here they do
-    # not fail: they SKIP, and the job reports green having never run the end-to-end layer the
-    # project's testing standard is built on. A stubbed database would be worse than none, because
-    # row-level security is enforced by the server and a stub cannot enforce it.
-    #
-    # pgvector, not plain postgres: `scripts/db-bootstrap.sql` runs CREATE EXTENSION vector. pg17 is
-    # what every docker-compose in this repo ships, so CI tests the server operators actually run.
     services:
       postgres:
         image: pgvector/pgvector:pg17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,26 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # SHARDED ACROSS JOBS, NOT WORKERS INSIDE ONE.
+    #
+    # `bun test --parallel` was tried first and is wrong HERE, though it is right on a developer's
+    # machine: measured, 120s against 194s serial on 18 cores, and 257s against a 187s serial
+    # baseline on this runner. The difference is not the flag, it is what the workers share. Four
+    # workers on a laptop take four of eighteen cores; four workers here take all four vCPUs the job
+    # has, and take them from the Postgres container running beside them.
+    #
+    # A shard is a whole job, so each one brings its OWN four vCPUs and its OWN database server, and
+    # inside it the suite runs serially the way the runner is happiest. That also removes, for free,
+    # the one thing that made parallelism risky in the first place: shards cannot claim each other's
+    # rows, because they are not looking at the same database.
+    #
+    # `fail-fast: false` because a red shard must not cancel the others. The point of a matrix is to
+    # see every failure in one round, not the first one.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
     # NOTE: a REAL Postgres, not a mock. Roughly 1600 of this suite's assertions are database-backed
     # and every one of them is gated on `describe.skipIf(!dbUp)`, so without a server here they do
     # not fail: they SKIP, and the job reports green having never run the end-to-end layer the
@@ -81,5 +101,10 @@ jobs:
       - name: Provision Test Database
         run: bun run db:test:setup
 
+      # `bun test`, not `bun run test`: the package script is what a developer runs and takes no
+      # shard. The split is bun's own, by file, and it is the reason `--timings` exists — without a
+      # timings file the shards are balanced by count, and this suite's slowest file is 23s against a
+      # ~39s shard. If the spread between shards turns out to matter, that is the knob, and it is
+      # measured rather than assumed.
       - name: Run Tests
-        run: bun run test
+        run: bun test --shard=${{ matrix.shard }}/4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,16 +19,22 @@ jobs:
     # has files that pass only in the order the full serial run happens to give them, and sharding is
     # simply the first thing to reorder it.
     #
-    # The cause is one line: `src/app.ts` ends in `export default app`, an Elysia instance built from
-    # `config` AT IMPORT TIME, and several files (tests/api/v1/mcp-dcr.test.ts, mcp-oauth, refusal-wire)
-    # mutate `process.env` and then `await import("@/app")` expecting their own. Whoever imports it
-    # first in the process wins; everyone after silently gets that one. Different splits fail
-    # different tests (19 at 1/4, and 9 across four of the eight at k/8), which is the signature of a
-    # shared singleton rather than of one bad neighbour.
+    # Most of the cause was found and fixed on this branch: `src/app.ts` exports a singleton, two test
+    # files registered THEIR OWN routes on it, and Elysia compiles its router on first use, so
+    # whichever file got there first was the only one whose routes existed. The rest fell through to
+    # the `/*` SPA handler and came back as HTML. `buildApp()` is the fix, and it took shard 1/4 from
+    # 19 failures to 2.
     #
-    # So sharding is blocked on making those files build their own app, not on anything about CI. The
-    # same fix unblocks `bun test --parallel --no-isolate`, which is 42s against 65s locally and fails
-    # the same way for the same reason.
+    # The 2 that remain, plus 7 more across the other shards, are a DIFFERENT cause and it is not
+    # isolated yet: `Expected: 404, Received: 500`, so a handler throwing rather than a route missing.
+    # It is not pairwise — sweeping all 133 other files of the shard, each run immediately before the
+    # victim, reproduces on none of them — which points at a combination rather than one bad
+    # neighbour. `setupPrismaMock` was the obvious suspect (a permanent process-global `mock.module`
+    # that 14 of its 26 callers never reset) and was measured and RULED OUT: resetting it changes
+    # nothing.
+    #
+    # So sharding stays off until that is found. The same unknown also blocks
+    # `bun test --parallel --no-isolate`, which is 42s against 65s locally and fails the same way.
 
     # NOTE: a REAL Postgres, not a mock. Roughly 1600 of this suite's assertions are database-backed
     # and every one of them is gated on `describe.skipIf(!dbUp)`, so without a server here they do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,13 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
+        # tmpfs for the DATA DIRECTORY: this database is created, migrated, written to for three
+        # minutes and thrown away, so nothing it writes has to survive the job, and 183 of this
+        # suite's files are database-backed. On a 4-vCPU runner the server competes for the same
+        # cores as the tests, and every fsync it does is paid out of them. Borrowed from the
+        # Chatwoot upstream, which does the same on its own spec matrix.
         options: >-
+          --mount type=tmpfs,destination=/var/lib/postgresql/data
           --health-cmd "pg_isready -U postgres"
           --health-interval 5s
           --health-timeout 5s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,36 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # NOT SHARDED YET, AND WHAT IS LEFT IN THE WAY IS ONE TEST.
+    #
+    # Four shards (one job each, own vCPUs, own database) took the test step from 157s to 36-61s and
+    # the wall from 217s to ~109s. What came back red was not the split: the same `--shard=1/4` fails
+    # on a clean origin/main, because this suite was only ever green in the order the full serial run
+    # happens to give it. Four causes were found and fixed on this branch, taking the four shards from
+    # 19 failures to 1:
+    #
+    #   - src/app.ts exported ONE Elysia instance, and three files mutated it: two registered their
+    #     own routes on it, one called `listen()`. Elysia compiles its router on first use, so a later
+    #     file's route never existed and its request fell through to the `/*` SPA handler, and a
+    #     stopped-but-compiled app answered later `handle()` calls with 500s. `buildApp()` is the fix.
+    #   - one file replaced `@/modules/rag/service` in the module registry. Re-registering the real
+    #     module in `afterAll` is a second global rewrite, and whether it lands before another file's
+    #     imports resolve is an ordering nobody controls. A `spyOn` on the module object restores.
+    #
+    # THE ONE LEFT: tests/client/components/UserMenu.test.tsx stubs `react-i18next` (plus the auth and
+    # theme contexts) with `mock.module`, which has no reliable undo, and
+    # tests/client/document-starters-race.test.tsx switches the REAL i18n language to prove a stale
+    # response cannot overwrite a newer one. Against the stub the switch does nothing. Both files
+    # already document the hazard from their own side. Two fixes were measured and rejected: restoring
+    # the modules in `afterAll` does not undo the leak, and dropping the stub for the real instance
+    # makes UserMenu itself order-dependent and breaks the stub ledger in
+    # tests/lib/module-mock-package.test.ts, which lists that stub on purpose.
+    #
+    # `bun test --parallel` is NOT affected and runs clean: it implies `--isolate`, so each file gets
+    # its own module registry and a `mock.module` cannot reach the next file. Only a shard, which runs
+    # serially inside its job, shares one.
+    runs-on: ubuntu-latest
+
     # NOT SHARDED, AND THE MEASUREMENT THAT SAYS WHY IS WORTH KEEPING.
     #
     # Four shards (one job each, own vCPUs, own database) took the test step from 157s to 36-61s and

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,25 +11,24 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # SHARDED ACROSS JOBS, NOT WORKERS INSIDE ONE.
+    # NOT SHARDED, AND THE MEASUREMENT THAT SAYS WHY IS WORTH KEEPING.
     #
-    # `bun test --parallel` was tried first and is wrong HERE, though it is right on a developer's
-    # machine: measured, 120s against 194s serial on 18 cores, and 257s against a 187s serial
-    # baseline on this runner. The difference is not the flag, it is what the workers share. Four
-    # workers on a laptop take four of eighteen cores; four workers here take all four vCPUs the job
-    # has, and take them from the Postgres container running beside them.
+    # Four shards (one job each, own vCPUs, own database) took the test step from 157s to 36-61s and
+    # the wall from 217s to ~109s. Three of the four came back RED, and not from anything the split
+    # did: the same `bun test --shard=1/4` on a clean origin/main fails the same 19 tests. This suite
+    # has files that pass only in the order the full serial run happens to give them, and sharding is
+    # simply the first thing to reorder it.
     #
-    # A shard is a whole job, so each one brings its OWN four vCPUs and its OWN database server, and
-    # inside it the suite runs serially the way the runner is happiest. That also removes, for free,
-    # the one thing that made parallelism risky in the first place: shards cannot claim each other's
-    # rows, because they are not looking at the same database.
+    # The cause is one line: `src/app.ts` ends in `export default app`, an Elysia instance built from
+    # `config` AT IMPORT TIME, and several files (tests/api/v1/mcp-dcr.test.ts, mcp-oauth, refusal-wire)
+    # mutate `process.env` and then `await import("@/app")` expecting their own. Whoever imports it
+    # first in the process wins; everyone after silently gets that one. Different splits fail
+    # different tests (19 at 1/4, and 9 across four of the eight at k/8), which is the signature of a
+    # shared singleton rather than of one bad neighbour.
     #
-    # `fail-fast: false` because a red shard must not cancel the others. The point of a matrix is to
-    # see every failure in one round, not the first one.
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
+    # So sharding is blocked on making those files build their own app, not on anything about CI. The
+    # same fix unblocks `bun test --parallel --no-isolate`, which is 42s against 65s locally and fails
+    # the same way for the same reason.
 
     # NOTE: a REAL Postgres, not a mock. Roughly 1600 of this suite's assertions are database-backed
     # and every one of them is gated on `describe.skipIf(!dbUp)`, so without a server here they do
@@ -101,10 +100,5 @@ jobs:
       - name: Provision Test Database
         run: bun run db:test:setup
 
-      # `bun test`, not `bun run test`: the package script is what a developer runs and takes no
-      # shard. The split is bun's own, by file, and it is the reason `--timings` exists — without a
-      # timings file the shards are balanced by count, and this suite's slowest file is 23s against a
-      # ~39s shard. If the spread between shards turns out to matter, that is the knob, and it is
-      # measured rather than assumed.
       - name: Run Tests
-        run: bun test --shard=${{ matrix.shard }}/4
+        run: bun run test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "bun --hot src/index.ts",
     "start": "NODE_ENV=production bun src/index.ts",
     "build": "bun run build.ts",
-    "test": "bun test --parallel",
+    "test": "bun test",
     "test:coverage": "bun test --coverage",
     "test-watch": "bun test --watch",
     "lint": "bun biome check --error-on-warnings",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "bun --hot src/index.ts",
     "start": "NODE_ENV=production bun src/index.ts",
     "build": "bun run build.ts",
-    "test": "bun test",
+    "test": "bun test --parallel",
     "test:coverage": "bun test --coverage",
     "test-watch": "bun test --watch",
     "lint": "bun biome check --error-on-warnings",

--- a/src/api/lib/logger.ts
+++ b/src/api/lib/logger.ts
@@ -48,11 +48,28 @@ export function deepSanitizeObject(
   return output;
 }
 
-// NOTE: In production, avoid pino transports (which use thread-stream worker threads)
-// because the compiled binary's virtual FS prevents resolving packages like real-require.
-// Write JSON to stdout instead — Docker/Coolify captures stdout natively.
+// A PINO TRANSPORT IS FOR A HUMAN WATCHING A TERMINAL, AND ONLY DEVELOPMENT HAS ONE.
+//
+// The condition is on `development` rather than on `not production`, and that is the whole of what
+// this note is about. A transport runs in a thread-stream WORKER THREAD, and the two contexts that
+// are not development each break on that worker for their own reason:
+//
+//   - production: the compiled binary's virtual FS cannot resolve packages like real-require, which is
+//     why this branch existed already. Docker/Coolify capture stdout natively, so plain JSON is
+//     what a deployment wants anyway.
+//   - test: `bun test` sets NODE_ENV=test (it overrides `.env`; see the note on `config.env`), so
+//     `!== "production"` used to be TRUE here and every test process built the worker. Serially that
+//     only costs a `logs/log` nobody reads. Under `bun test --parallel` it is fatal: measured on this
+//     suite at 18 workers, 229 × `error: the worker thread exited` and 225 failures, with 3207 tests
+//     never reaching a runner. Giving each process its OWN roll file changes nothing (measured: still
+//     229), so it is the worker, not the file. With this branch taken: 8192 pass, and the run drops
+//     from 193.6s to 50.8s at `--parallel=12`.
+//
+// The same worker has taken this suite down once before by another path: see the MessagePort note
+// in tests/dom-setup.ts, where Bun 1.4.0's `new Worker()` cut the suite from 4133 passing to 2096.
+// Nothing else in this codebase constructs a Worker; pino's transport was always the only one.
 let logger = pino(
-  config.env === "production"
+  config.env !== "development"
     ? {
         level: config.logLevel,
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,214 +36,238 @@ const indexHandler =
     ? () => Bun.file("dist/index.html")
     : (await import("@/public/index.html")).default;
 
-const app = new Elysia({
-  // NOTE: Tell Bun's native routes table not to intercept /api paths via
-  // the catch-all SPA HTMLBundle registered below. Without these
-  // carve-outs Bun would serve index.html for /api/* before Elysia's
-  // fetch handler ever runs (causa-raiz documentada em
-  // elysiajs/elysia#1515 e issues do Bun #17595, #17363, #23999). The
-  // bare /api carve-out covers requests without a trailing slash. Re-run
-  // the smoke test in docs/routing.md when upgrading Elysia.
-  serve: {
-    routes: {
-      "/api": false,
-      "/api/*": false,
-    },
-  },
-})
-  .use(
-    helmet({
-      contentSecurityPolicy: {
-        directives: cspDirectives,
-        // NOTE: In dev, run CSP in Report-Only so violations surface in the
-        // browser console without blocking. Catches third-party-integration
-        // CSP issues (Google Fonts, OAuth, analytics) at `bun dev` time
-        // instead of after a deploy to staging/prod.
-        reportOnly: config.env !== "production",
+// A FACTORY, BECAUSE A TEST THAT ADDS A ROUTE MUST NOT ADD IT TO EVERYONE'S APP.
+//
+// The default export below is still the one instance the server runs, and nothing in production
+// calls this. What it exists for is the two test files that need a route of their own on a REAL
+// app (the `onError` arm under test is registered here, so a hand-rolled Elysia would pin the test's
+// own ordering instead of this file's).
+//
+// They used to register those routes on the shared default export, and it worked only for whichever
+// file reached it first: Elysia compiles its router on the first request, so a later file's
+// `app.get(...)` never took effect and its requests fell through to the `/*` SPA handler at the
+// bottom. The symptom was `SyntaxError: JSON Parse error: Unexpected identifier "Something"` — the
+// error shell's HTML, parsed as JSON — and it was invisible because the full serial run happens to
+// give those files an order where the first one is the one that mattered. Measured on a clean tree:
+// `bun test --shard=1/4` failed 19 tests this way, and four of eight `k/8` shards failed nine
+// between them, each a different set.
+// ASYNC because the static plugin below is awaited inside the chain, which is also why this could
+// not be a plain `const` factory. Top-level `await` on the line that builds the default export keeps
+// `App` resolving to the Elysia type rather than to a promise.
+export async function buildApp() {
+  const app = new Elysia({
+    // NOTE: Tell Bun's native routes table not to intercept /api paths via
+    // the catch-all SPA HTMLBundle registered below. Without these
+    // carve-outs Bun would serve index.html for /api/* before Elysia's
+    // fetch handler ever runs (causa-raiz documentada em
+    // elysiajs/elysia#1515 e issues do Bun #17595, #17363, #23999). The
+    // bare /api carve-out covers requests without a trailing slash. Re-run
+    // the smoke test in docs/routing.md when upgrading Elysia.
+    serve: {
+      routes: {
+        "/api": false,
+        "/api/*": false,
       },
-      // NOTE: Relax COOP from the helmet default (same-origin) so a document this app serves does
-      // not needlessly isolate itself from popups it opens. This helps GSI's "Continue with Google"
-      // button (accounts.google.com posts back to window.opener). It applies to Elysia-served
-      // responses, which includes the vault OAuth callback popup document (google_oauth/mcp_oauth).
-      // It does NOT reach the SPA shell — that HTML is served by Bun's static routes table, BYPASSING
-      // Elysia/helmet, so the opener page stays COOP unsafe-none regardless. For the vault OAuth
-      // popups we therefore do NOT depend on window.opener.postMessage: the external provider's
-      // authorize endpoint answers with its own COOP same-origin, which disowns our popup handle mid
-      // -flow (window.opener becomes null AND popup.closed lies). The result is delivered to the
-      // opener via BroadcastChannel (origin-scoped, browsing-context-group-independent) plus a
-      // server-status poll — see src/client/lib/oauthPopup.ts. This header is correct hygiene, not the
-      // load-bearing signal. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
-      crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" },
-    }),
-  )
-  .use(localeMiddleware)
-  .onAfterResponse(({ request, set }) => {
-    logger.info("%s %s [%s]", request.method, request.url, set.status);
+    },
   })
-  .onAfterHandle(({ request, set }) => {
-    const url = new URL(request.url);
-    const path = url.pathname;
+    .use(
+      helmet({
+        contentSecurityPolicy: {
+          directives: cspDirectives,
+          // NOTE: In dev, run CSP in Report-Only so violations surface in the
+          // browser console without blocking. Catches third-party-integration
+          // CSP issues (Google Fonts, OAuth, analytics) at `bun dev` time
+          // instead of after a deploy to staging/prod.
+          reportOnly: config.env !== "production",
+        },
+        // NOTE: Relax COOP from the helmet default (same-origin) so a document this app serves does
+        // not needlessly isolate itself from popups it opens. This helps GSI's "Continue with Google"
+        // button (accounts.google.com posts back to window.opener). It applies to Elysia-served
+        // responses, which includes the vault OAuth callback popup document (google_oauth/mcp_oauth).
+        // It does NOT reach the SPA shell — that HTML is served by Bun's static routes table, BYPASSING
+        // Elysia/helmet, so the opener page stays COOP unsafe-none regardless. For the vault OAuth
+        // popups we therefore do NOT depend on window.opener.postMessage: the external provider's
+        // authorize endpoint answers with its own COOP same-origin, which disowns our popup handle mid
+        // -flow (window.opener becomes null AND popup.closed lies). The result is delivered to the
+        // opener via BroadcastChannel (origin-scoped, browsing-context-group-independent) plus a
+        // server-status poll — see src/client/lib/oauthPopup.ts. This header is correct hygiene, not the
+        // load-bearing signal. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+        crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" },
+      }),
+    )
+    .use(localeMiddleware)
+    .onAfterResponse(({ request, set }) => {
+      logger.info("%s %s [%s]", request.method, request.url, set.status);
+    })
+    .onAfterHandle(({ request, set }) => {
+      const url = new URL(request.url);
+      const path = url.pathname;
 
-    if (path === "/" || path.endsWith(".html")) {
-      set.headers["cache-control"] = "no-cache";
-    } else if (HASHED_ASSET_PATTERN.test(path)) {
-      set.headers["cache-control"] = "public, max-age=31536000, immutable";
-    } else if (/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$/i.test(path)) {
-      set.headers["cache-control"] = "public, max-age=86400";
-    }
-  })
-  // NOTE: typed app errors (ForbiddenError 403, TenantTargetRequiredError 400, NotFoundError 404,
-  // ...) carry their HTTP status. Logged at warn, since they are expected control-flow and not server
-  // faults. When the error carries a translationKey, localize it from the request's Accept-Language
-  // (the request ALS may not be in scope here) so user-facing messages are not raw English.
-  //
-  // NOTE: registered BEFORE the limiters, while everything else below is registered AFTER them, and
-  // the split is load-bearing in BOTH directions. An AppError is thrown from a MATCHED route, or from
-  // a hook that runs after the limiters' counting hook, so the request has already been charged. The
-  // plugin cannot know that: its own `onError` reads `error.status ?? error.statusCode`, where our
-  // NotFoundError is indistinguishable from a route that never existed, so it charges a second time.
-  // That is not merely an overcharge. Measured with a max of 4 and one request of budget left, a
-  // request that should have been admitted and answered 404 came back 429: the second charge crossed
-  // the ceiling, and the limiter answers from its own hook without ever reaching the handler below.
-  // Answering AppError here keeps it away from the plugin entirely.
-  .onError(({ path, error, request, set }) => {
-    if (!(error instanceof AppError)) return;
-    logger.warn("%s %s", path, error.message);
-    const body = refusalBody(error, request.headers.get("accept-language"));
-    // NOTE: keep set.status in sync, because the access log in onAfterResponse reads it and a raw
-    // Response alone would make a 4xx show up there as a 500.
-    set.status = error.statusCode;
-    return Response.json(body, {
-      status: error.statusCode,
-      headers: refusalHeaders(error),
-    });
-  })
-  .use(rateLimitMiddleware())
-  .use(mcpTransportRateLimitMiddleware())
-  .use(registerRateLimitMiddleware())
-  .use(credentialRateLimitMiddleware())
-  .use(staticRateLimitMiddleware())
-  // NOTE: everything the AppError handler above does not answer, registered AFTER the limiters ON
-  // PURPOSE. This is the mirror image of that split: a request rejected BEFORE the handler never
-  // reaches the plugin's counting hook, so the plugin charges those from its own `onError`, and
-  // Elysia stops at the first error handler that RETURNS A VALUE. With this registered first the
-  // NOT_FOUND branch below answered and the plugin never ran: measured on the real app, `POST
-  // /api/nope` and any request to a missing non-/api path came back 404 with no `RateLimit-*` header
-  // and no budget spent. An unknown GET under /api looked metered only because the `.get("/api/*")`
-  // guard below turns it into a MATCHED route, which the normal hook counts.
-  // PARSE still is not affected either way, because the `default:` branch below returns `undefined`
-  // for it and the chain continues to the plugin regardless of order. VALIDATION is answered here
-  // now (issue #255) and so DOES depend on this placement: the plugin has already charged it by the
-  // time this handler returns.
-  .onError(({ path, error, request, set }) => {
-    // NOTE: a schema refusal, answered in the app's own vocabulary instead of TypeBox's. Registered
-    // HERE, after the limiters, and not next to the AppError branch above: the rate-limit plugin
-    // charges request-side VALIDATION from its own `onError` (see the note in middlewares/rateLimit
-    // .ts on 4.6.3), and Elysia stops at the first handler that RETURNS A VALUE, so answering it
-    // before the plugin would hand back an uncharged budget to anyone willing to send a body the
-    // schema refuses. Everything about the body and the log line is decided in api/lib/schema
-    // -refusal.ts, including why the submitted value reaches neither.
+      if (path === "/" || path.endsWith(".html")) {
+        set.headers["cache-control"] = "no-cache";
+      } else if (HASHED_ASSET_PATTERN.test(path)) {
+        set.headers["cache-control"] = "public, max-age=31536000, immutable";
+      } else if (/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$/i.test(path)) {
+        set.headers["cache-control"] = "public, max-age=86400";
+      }
+    })
+    // NOTE: typed app errors (ForbiddenError 403, TenantTargetRequiredError 400, NotFoundError 404,
+    // ...) carry their HTTP status. Logged at warn, since they are expected control-flow and not server
+    // faults. When the error carries a translationKey, localize it from the request's Accept-Language
+    // (the request ALS may not be in scope here) so user-facing messages are not raw English.
     //
-    // Keyed on IDENTITY, not on `code`. Elysia forwards the thrown value's own `code` property when
-    // it has one, so `code === "VALIDATION"` is also true of any plain error that happens to carry
-    // that string — measured: such an error was answered 422 in the app's schema vocabulary, and the
-    // `as ValidationError` cast this replaces was simply false about it. Issue #263 has the long
-    // version; the rule is that a branch deciding what a failure IS cannot read a property the
-    // failure sets.
-    if (error instanceof ValidationError) {
-      const refusal = schemaRefusal(
-        error,
-        request.headers.get("accept-language"),
-      );
-      const line = "%s %s";
-      if (refusal.severity === "error") {
-        logger.error(line, path, refusal.log);
-      } else {
-        logger.warn(line, path, refusal.log);
+    // NOTE: registered BEFORE the limiters, while everything else below is registered AFTER them, and
+    // the split is load-bearing in BOTH directions. An AppError is thrown from a MATCHED route, or from
+    // a hook that runs after the limiters' counting hook, so the request has already been charged. The
+    // plugin cannot know that: its own `onError` reads `error.status ?? error.statusCode`, where our
+    // NotFoundError is indistinguishable from a route that never existed, so it charges a second time.
+    // That is not merely an overcharge. Measured with a max of 4 and one request of budget left, a
+    // request that should have been admitted and answered 404 came back 429: the second charge crossed
+    // the ceiling, and the limiter answers from its own hook without ever reaching the handler below.
+    // Answering AppError here keeps it away from the plugin entirely.
+    .onError(({ path, error, request, set }) => {
+      if (!(error instanceof AppError)) return;
+      logger.warn("%s %s", path, error.message);
+      const body = refusalBody(error, request.headers.get("accept-language"));
+      // NOTE: keep set.status in sync, because the access log in onAfterResponse reads it and a raw
+      // Response alone would make a 4xx show up there as a 500.
+      set.status = error.statusCode;
+      return Response.json(body, {
+        status: error.statusCode,
+        headers: refusalHeaders(error),
+      });
+    })
+    .use(rateLimitMiddleware())
+    .use(mcpTransportRateLimitMiddleware())
+    .use(registerRateLimitMiddleware())
+    .use(credentialRateLimitMiddleware())
+    .use(staticRateLimitMiddleware())
+    // NOTE: everything the AppError handler above does not answer, registered AFTER the limiters ON
+    // PURPOSE. This is the mirror image of that split: a request rejected BEFORE the handler never
+    // reaches the plugin's counting hook, so the plugin charges those from its own `onError`, and
+    // Elysia stops at the first error handler that RETURNS A VALUE. With this registered first the
+    // NOT_FOUND branch below answered and the plugin never ran: measured on the real app, `POST
+    // /api/nope` and any request to a missing non-/api path came back 404 with no `RateLimit-*` header
+    // and no budget spent. An unknown GET under /api looked metered only because the `.get("/api/*")`
+    // guard below turns it into a MATCHED route, which the normal hook counts.
+    // PARSE still is not affected either way, because the `default:` branch below returns `undefined`
+    // for it and the chain continues to the plugin regardless of order. VALIDATION is answered here
+    // now (issue #255) and so DOES depend on this placement: the plugin has already charged it by the
+    // time this handler returns.
+    .onError(({ path, error, request, set }) => {
+      // NOTE: a schema refusal, answered in the app's own vocabulary instead of TypeBox's. Registered
+      // HERE, after the limiters, and not next to the AppError branch above: the rate-limit plugin
+      // charges request-side VALIDATION from its own `onError` (see the note in middlewares/rateLimit
+      // .ts on 4.6.3), and Elysia stops at the first handler that RETURNS A VALUE, so answering it
+      // before the plugin would hand back an uncharged budget to anyone willing to send a body the
+      // schema refuses. Everything about the body and the log line is decided in api/lib/schema
+      // -refusal.ts, including why the submitted value reaches neither.
+      //
+      // Keyed on IDENTITY, not on `code`. Elysia forwards the thrown value's own `code` property when
+      // it has one, so `code === "VALIDATION"` is also true of any plain error that happens to carry
+      // that string — measured: such an error was answered 422 in the app's schema vocabulary, and the
+      // `as ValidationError` cast this replaces was simply false about it. Issue #263 has the long
+      // version; the rule is that a branch deciding what a failure IS cannot read a property the
+      // failure sets.
+      if (error instanceof ValidationError) {
+        const refusal = schemaRefusal(
+          error,
+          request.headers.get("accept-language"),
+        );
+        const line = "%s %s";
+        if (refusal.severity === "error") {
+          logger.error(line, path, refusal.log);
+        } else {
+          logger.warn(line, path, refusal.log);
+        }
+        set.status = refusal.status;
+        return Response.json(refusal.body, { status: refusal.status });
       }
-      set.status = refusal.status;
-      return Response.json(refusal.body, { status: refusal.status });
-    }
 
-    logger.error("%s\n%s", path, error);
+      logger.error("%s\n%s", path, error);
 
-    if (error instanceof NotFoundError) {
-      // NOTE: API endpoints respond with JSON 404. SPA paths normally
-      // don't reach here because the /* catch-all below serves
-      // index.html for any non-API, non-asset request.
+      if (error instanceof NotFoundError) {
+        // NOTE: API endpoints respond with JSON 404. SPA paths normally
+        // don't reach here because the /* catch-all below serves
+        // index.html for any non-API, non-asset request.
+        set.status = 404;
+        if (path === "/api" || path.startsWith("/api/")) {
+          return Response.json({ error: "Not Found" }, { status: 404 });
+        }
+        return new Response("Not Found", { status: 404 });
+      }
+
+      // NOTE: everything that is not a refusal Elysia itself raised is an unhandled failure, and
+      // its text does not reach the client outside development. Stated by exclusion, and decided
+      // from the thrown VALUE rather than from `code`, because `code` is a property the value
+      // carries and any library can set it. The measurements behind both of those choices are in
+      // api/lib/unhandled-error.ts; the short version is that a redact-list keyed on `code` leaked
+      // twice, once through a string code and once through a numeric one.
+      if (isFrameworkRefusal(error)) return;
+      // NOTE: `set.status` too, not just the Response's. The access log in onAfterResponse reads
+      // `set.status`, and Elysia seeds it from the thrown value's own `status` property — so an
+      // error carrying `status: 401` is answered 500 here and LOGGED as 401 unless this line runs.
+      // Same reason the AppError arm above carries the same note.
+      set.status = 500;
+      const message =
+        config.env === "development"
+          ? errorDetail(error)
+          : "Something went wrong";
+      return new Response(message, { status: 500 });
+    })
+    .use(
+      await staticPlugin({
+        assets: config.env === "production" ? "dist" : "public",
+        prefix: "/",
+        alwaysStatic: true,
+        // NOTE: @elysiajs/static 1.4.9 renamed `bundleHTML` to `bunFullstack`
+        // and flipped the default to `false`. Without this, dev serves
+        // `public/index.html` raw and the `<script src="../src/client/frontend.tsx">`
+        // reference cannot be resolved. See elysiajs/elysia-static#63.
+        bunFullstack: config.env === "development",
+      }),
+    )
+    .group("/api", (app) => app.use(api))
+    // NOTE: Catch unmatched GET /api paths so they don't fall through to
+    // the /* SPA catch-all below (which would respond with index.html in
+    // prod or "{}" in dev — see the Routing section in CLAUDE.md). Non-GET
+    // methods are covered by the onError NOT_FOUND handler above, which
+    // never reaches the GET-only /*.
+    .get("/api", ({ set }) => {
       set.status = 404;
-      if (path === "/api" || path.startsWith("/api/")) {
-        return Response.json({ error: "Not Found" }, { status: 404 });
-      }
-      return new Response("Not Found", { status: 404 });
-    }
+      return { error: "Not Found" };
+    })
+    .get("/api/*", ({ set }) => {
+      set.status = 404;
+      return { error: "Not Found" };
+    })
+    // NOTE: OAuth discovery at the ISSUER ROOT (RFC 8414 / RFC 9728). Registered BEFORE the SPA
+    // catch-all so MCP clients get JSON, not index.html. Public (no auth) by design.
+    .get("/.well-known/oauth-authorization-server", () => authServerMetadata())
+    .get("/.well-known/oauth-protected-resource", () =>
+      protectedResourceMetadata(),
+    )
+    // Path-aware variant (RFC 9728 §3.1): MCP clients probe
+    // /.well-known/oauth-protected-resource/<resource-path> before the root. There is a single
+    // protected resource, so serve the same metadata for any suffix — otherwise the probe falls
+    // through to the SPA catch-all and returns index.html (HTML), which strict clients choke on.
+    .get("/.well-known/oauth-protected-resource/*", () =>
+      protectedResourceMetadata(),
+    )
+    .get("/*", indexHandler);
 
-    // NOTE: everything that is not a refusal Elysia itself raised is an unhandled failure, and
-    // its text does not reach the client outside development. Stated by exclusion, and decided
-    // from the thrown VALUE rather than from `code`, because `code` is a property the value
-    // carries and any library can set it. The measurements behind both of those choices are in
-    // api/lib/unhandled-error.ts; the short version is that a redact-list keyed on `code` leaked
-    // twice, once through a string code and once through a numeric one.
-    if (isFrameworkRefusal(error)) return;
-    // NOTE: `set.status` too, not just the Response's. The access log in onAfterResponse reads
-    // `set.status`, and Elysia seeds it from the thrown value's own `status` property — so an
-    // error carrying `status: 401` is answered 500 here and LOGGED as 401 unless this line runs.
-    // Same reason the AppError arm above carries the same note.
-    set.status = 500;
-    const message =
+  app.use(
+    cors(
       config.env === "development"
-        ? errorDetail(error)
-        : "Something went wrong";
-    return new Response(message, { status: 500 });
-  })
-  .use(
-    await staticPlugin({
-      assets: config.env === "production" ? "dist" : "public",
-      prefix: "/",
-      alwaysStatic: true,
-      // NOTE: @elysiajs/static 1.4.9 renamed `bundleHTML` to `bunFullstack`
-      // and flipped the default to `false`. Without this, dev serves
-      // `public/index.html` raw and the `<script src="../src/client/frontend.tsx">`
-      // reference cannot be resolved. See elysiajs/elysia-static#63.
-      bunFullstack: config.env === "development",
-    }),
-  )
-  .group("/api", (app) => app.use(api))
-  // NOTE: Catch unmatched GET /api paths so they don't fall through to
-  // the /* SPA catch-all below (which would respond with index.html in
-  // prod or "{}" in dev — see the Routing section in CLAUDE.md). Non-GET
-  // methods are covered by the onError NOT_FOUND handler above, which
-  // never reaches the GET-only /*.
-  .get("/api", ({ set }) => {
-    set.status = 404;
-    return { error: "Not Found" };
-  })
-  .get("/api/*", ({ set }) => {
-    set.status = 404;
-    return { error: "Not Found" };
-  })
-  // NOTE: OAuth discovery at the ISSUER ROOT (RFC 8414 / RFC 9728). Registered BEFORE the SPA
-  // catch-all so MCP clients get JSON, not index.html. Public (no auth) by design.
-  .get("/.well-known/oauth-authorization-server", () => authServerMetadata())
-  .get("/.well-known/oauth-protected-resource", () =>
-    protectedResourceMetadata(),
-  )
-  // Path-aware variant (RFC 9728 §3.1): MCP clients probe
-  // /.well-known/oauth-protected-resource/<resource-path> before the root. There is a single
-  // protected resource, so serve the same metadata for any suffix — otherwise the probe falls
-  // through to the SPA catch-all and returns index.html (HTML), which strict clients choke on.
-  .get("/.well-known/oauth-protected-resource/*", () =>
-    protectedResourceMetadata(),
-  )
-  .get("/*", indexHandler);
+        ? undefined
+        : { origin: parseOrigins(config.corsOrigin) },
+    ),
+  );
 
-app.use(
-  cors(
-    config.env === "development"
-      ? undefined
-      : { origin: parseOrigins(config.corsOrigin) },
-  ),
-);
+  return app;
+}
+
+const app = await buildApp();
 
 export type App = typeof app;
 export default app;

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,7 +194,13 @@ const config = {
     MAX_PORT,
   ),
   publicUrl: PUBLIC_URL || "http://localhost:3000",
-  env: (NODE_ENV || "development") as "development" | "production",
+  // "test" IS ONE OF THE VALUES, and leaving it out of the union was not cosmetic. `bun test` sets
+  // NODE_ENV=test itself, and it WINS over the `.env` (measured: a suite file reads
+  // `config.env === "test"` with `NODE_ENV=development` sitting in `.env`). So every `=== "development"`
+  // in this codebase is false under the suite while the type says that branch is the only alternative
+  // to production, which is how the logger below ended up building a thread-stream worker in a
+  // context nobody meant it to. Anything guarded on `!== "production"` still covers test, as intended.
+  env: (NODE_ENV || "development") as "development" | "production" | "test",
   // NOTE: Distribution edition. Single source of truth shared with the frontend bundle
   // (BUN_PUBLIC_EDITION is baked into the client at build AND kept as a runtime ENV by the
   // Dockerfile), so the client gate and the server never disagree. Defaults to "full"; the Free

--- a/tests/api/middlewares/credentialRateLimit.test.ts
+++ b/tests/api/middlewares/credentialRateLimit.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { isCredentialRequest } from "@/api/middlewares/rateLimit";
-import app from "@/app";
+import { buildApp } from "@/app";
 import {
   assertCredentialBudgetIsTighter,
   assertLimiterBudgetsAreDistinct,
@@ -27,9 +27,17 @@ interface ListeningApp {
 let base = "";
 let server: ListeningApp["server"] | undefined;
 
-beforeAll(() => {
+// ITS OWN APP, NOT THE PROCESS'S, because `listen()` is a mutation and this one outlived the file.
+//
+// Binding the shared default export starts and compiles the one instance every other file reaches
+// through `app.handle(...)`, and `stop()` does not put it back: it leaves a compiled, once-listening
+// Elysia behind. The next file to hand it a request gets a 500 out of it. Measured on a clean tree:
+// tests/api/v1/mcp-dcr.test.ts answered `Received: 500` where it expects a 404, and neutralising THIS
+// file was what made those two failures go away — found by bisecting bun's own shard ordering, since
+// the pair alone does not reproduce (the two need the rest of the shard around them).
+beforeAll(async () => {
   (globalThis as { Response: typeof Response }).Response = BunResponse;
-  const listening = app.listen(0) as unknown as ListeningApp;
+  const listening = (await buildApp()).listen(0) as unknown as ListeningApp;
   if (!listening.server?.port) throw new Error("Failed to start the app");
   server = listening.server;
   base = `http://localhost:${listening.server.port}`;

--- a/tests/api/middlewares/rateLimitMetering.test.ts
+++ b/tests/api/middlewares/rateLimitMetering.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Elysia } from "elysia";
 import { clientKeyFor, rateLimitMiddleware } from "@/api/middlewares/rateLimit";
-import app from "@/app";
+import { buildApp } from "@/app";
 import { AppError, ForbiddenError, NotFoundError } from "@/lib/errors";
 
 // What a REJECTED request costs. Separate from rateLimit.test.ts, which is about who a bucket
@@ -24,14 +24,15 @@ interface ListeningApp {
 let base = "";
 let server: ListeningApp["server"] | undefined;
 
-beforeAll(() => {
+beforeAll(async () => {
   (globalThis as { Response: typeof Response }).Response = BunResponse;
-  // NOTE: registered on the REAL app, so the hooks it exercises are the ones src/app.ts installed,
-  // in the order it installed them. There is no unauthenticated route in the app that throws a
-  // 404 to borrow for this, and rebuilding an equivalent app would pin the test's own ordering
-  // instead of the app's. It mutates the exported singleton, which several files now do; the
-  // `listen` below rebuilds the route table, which is what keeps a route registered after another
-  // file has already served a request from being silently dropped (see refusal-wire.test.ts).
+  // NOTE: `buildApp()` is what src/app.ts builds its own default export from, so the hooks this
+  // exercises are the ones that file installs, in the order it installs them — which is the whole
+  // point, since there is no unauthenticated route in the app that throws a 404 to borrow, and a
+  // hand-rolled equivalent would pin this test's ordering instead of the app's. It used to mutate
+  // the exported singleton, and both halves of that (a route AND a `listen`) reached every file
+  // that ran afterwards: a stopped-but-compiled app answered their `handle()` calls with 500s.
+  const app = await buildApp();
   app.get("/__metering/thrown-404", () => {
     throw new NotFoundError("gone");
   });
@@ -122,12 +123,10 @@ describe("rate-limit metering (what a rejected request costs)", () => {
   // separately below, on a probe small enough to reach the ceiling.
   test("a matched route that throws a 404 is charged once, not twice", async () => {
     // NOTE: the status is asserted before the cost, because the cost alone cannot tell this case
-    // from the case where the probe route is not there at all. It is registered on the shared app
-    // singleton in beforeAll, and credentialRateLimit.test.ts runs earlier in the SAME process and
-    // has already called `listen()` on it, so the route is added to a compiled app. Elysia routes it
-    // anyway, measured alone and under the full suite, but if that ever changed the request would
-    // fall through to the SPA catch-all, spend exactly the same 1, and leave this test green while
-    // it stopped testing a matched route entirely.
+    // from the case where the probe route is not there at all: a request that falls through to the
+    // SPA catch-all spends exactly the same 1 and would leave this test green while it stopped
+    // testing a matched route entirely. The route is registered on this file's OWN app, before any
+    // request compiles it, so nothing another file does can drop it.
     const answered = await send("GET", "/__metering/thrown-404");
     expect(answered.status).toBe(404);
     expect(await answered.json()).toEqual({ error: "gone" });

--- a/tests/api/refusal-wire.test.ts
+++ b/tests/api/refusal-wire.test.ts
@@ -3,6 +3,7 @@ import { NotFoundError as ElysiaNotFoundError } from "elysia";
 import logger from "@/api/lib/logger";
 import { errors } from "@/api/lib/openapi";
 import EN_CATALOG from "@/api/locales/en.json";
+import { buildApp } from "@/app";
 import { REJECTED_TENANT_SELECTOR_HEADER } from "@/lib/console-params";
 import {
   ActiveTenantNotFoundError,
@@ -23,7 +24,12 @@ import { setupPrismaMock } from "@/tests/utils/prisma-mock";
 // what a schema does not declare, and an error body is only exempt because the handler answers with
 // a raw `Response`. That exemption is asserted, not assumed. Issue #231.
 setupPrismaMock();
-const app = (await import("@/app")).default;
+// ITS OWN APP, NOT THE PROCESS'S. This file registers routes below, and registering them on the
+// shared default export only ever worked for whichever file reached it first: Elysia compiles its
+// router on first use, so a later file's routes never took effect and its requests fell through to
+// the `/*` SPA handler, arriving as HTML that `res.json()` refuses. `buildApp()` is the same builder
+// the server runs, so the `onError` arm under test is still the real one.
+const app = await buildApp();
 
 app.get("/__refusal/named", () => {
   throw new SettingsTextTooLongError(

--- a/tests/api/schema-refusal-wire.test.ts
+++ b/tests/api/schema-refusal-wire.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import { t } from "elysia";
 import logger from "@/api/lib/logger";
 import { errors } from "@/api/lib/openapi";
+import { buildApp } from "@/app";
 import { setupPrismaMock } from "@/tests/utils/prisma-mock";
 
 // A refusal from the SCHEMA layer, as the client receives it and as the server records it.
@@ -13,7 +14,12 @@ import { setupPrismaMock } from "@/tests/utils/prisma-mock";
 // body carries a write-only secret next to a `name` with `minLength: 1`, and schema validation runs
 // BEFORE the role guard, so an unauthenticated request reaches this branch. Issue #255.
 setupPrismaMock();
-const app = (await import("@/app")).default;
+// ITS OWN APP, NOT THE PROCESS'S. This file registers routes below, and registering them on the
+// shared default export only ever worked for whichever file reached it first: Elysia compiles its
+// router on first use, so a later file's routes never took effect and its requests fell through to
+// the `/*` SPA handler, arriving as HTML that `res.json()` refuses. `buildApp()` is the same builder
+// the server runs, so the `onError` arm under test is still the real one.
+const app = await buildApp();
 
 const SUBMITTED_SECRET = "sk-live-DO-NOT-ECHO-ME";
 

--- a/tests/api/v1/knowledge-search-bigint.test.ts
+++ b/tests/api/v1/knowledge-search-bigint.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
 import { authPlugin } from "@/api/lib/auth";
 import type { SearchParams } from "@/modules/rag/service";
@@ -42,12 +42,16 @@ const ragService = await import("@/modules/rag/service");
 const searchKnowledge = mock(
   async (_params: SearchParams): Promise<ChunkHit[]> => [HIT],
 );
-// Spread the real module: the controller imports a dozen other names from it, and replacing the
-// whole module with one function would break the route graph at import time.
-mock.module("@/modules/rag/service", () => ({
-  ...ragService,
+// A SPY ON THE MODULE OBJECT, NOT A `mock.module`. The registry rewrite is process-global and its
+// undo is a second rewrite, so whether another file sees the stub depends on when that file's
+// imports resolve relative to this file's `afterAll` — which is an ordering nobody controls.
+// Measured: tests/modules/tenant-selector-entry-points.test.ts calls the real `searchKnowledge` to
+// prove it refuses a dead tenant selector, and under `bun test --shard=7/8` it got this stub and the
+// refusal never happened. The pair alone does not reproduce; it needs a third file between them,
+// which is what makes the registry version so hard to attribute.
+const spy = spyOn(ragService, "searchKnowledge").mockImplementation(
   searchKnowledge,
-}));
+);
 
 const app = (await import("@/app")).default;
 
@@ -55,7 +59,7 @@ const app = (await import("@/app")).default;
 // worker. Spreading the real module already keeps the leak inert (only `searchKnowledge` differs,
 // and no other suite calls it), but put the module back anyway so file order can never matter.
 afterAll(() => {
-  mock.module("@/modules/rag/service", () => ragService);
+  spy.mockRestore();
 });
 
 // The session the route runs under: an AGENT with a tenant, which is what `requireAuth: true` asks

--- a/tests/modules/appointment-reminders.test.ts
+++ b/tests/modules/appointment-reminders.test.ts
@@ -772,9 +772,24 @@ describe.skipIf(!dbUp)("a reminder retired while claimed", () => {
   // The ceiling has to hold across the model call, not only before it. A retry can be scheduled
   // minutes before the start, and a turn that begins in time can finish out of it.
   test("an appointment that starts during the model call sends nothing", async () => {
+    // TWO NUMBERS THAT USED TO BE GUESSES ABOUT HOW FAST THE MACHINE IS.
+    //
+    // The case needs the start to be AHEAD when the handler begins and BEHIND when the model
+    // returns. It was written as a start 1s out and a model that sleeps 2s, which holds only while
+    // everything before the handler fits in that first second. `armed()` is a database write, and
+    // under `bun test --parallel` it does not: measured at 24 workers, the start had already passed
+    // before the handler looked, the pre-call check dropped the job, the model never ran, and the
+    // assertion below read `Expected: 1, Received: 0` — the test failing for the machine rather than
+    // for the ceiling it exists to pin.
+    //
+    // The second number is gone rather than raised. The model now holds the call open UNTIL the
+    // start has actually passed, which is the condition the test is about, so no sleep has to be
+    // guessed against it. The first is 3s instead of 1s, which is real time paid on every run and is
+    // why it is not larger: it only has to outlast one row's insert.
+    const startAt = Date.now() + 3_000;
     const job = await armed("reminder:evt-crosses-start:60", {
       isLast: true,
-      startISO: new Date(Date.now() + 1_000).toISOString(),
+      startISO: new Date(startAt).toISOString(),
     });
     const s = stubClient();
     let invoked = 0;
@@ -787,7 +802,7 @@ describe.skipIf(!dbUp)("a reminder retired while claimed", () => {
       }
       async _generate(): Promise<ChatResult> {
         invoked += 1;
-        await Bun.sleep(2_000);
+        while (Date.now() <= startAt) await Bun.sleep(25);
         return {
           generations: [
             { text: "Lembrete!", message: new AIMessage("Lembrete!") },

--- a/tests/modules/chatwoot-gate-trail.test.ts
+++ b/tests/modules/chatwoot-gate-trail.test.ts
@@ -5,6 +5,7 @@ import { encryptJson } from "@/api/lib/crypto";
 import logger from "@/api/lib/logger";
 import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import { flowLogRows } from "../utils/flowlog";
 
@@ -210,7 +211,7 @@ describe.skipIf(!dbUp)("the webhook gate leaves a trail", () => {
   // Scoped to the conversation asked for, by its INTERNAL id, and polled: the emit is
   // fire-and-forget, so an unscoped read answers with a neighbour's row and an unpolled one races
   // the write it is asserting.
-  async function handoffRows(convId: number, waitMs = 2000) {
+  async function handoffRows(convId: number, waitMs = POLL_DEADLINE_MS) {
     const conv = await suDb.conversation.findFirst({
       where: { tenantId, chatwootConversationId: convId },
       select: { id: true },

--- a/tests/modules/chatwoot-human-reply-takeover.test.ts
+++ b/tests/modules/chatwoot-human-reply-takeover.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
 import { isFollowUpLive } from "@/modules/followups/eligibility";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import { flowLogRows } from "../utils/flowlog";
 
@@ -363,7 +364,7 @@ describe.skipIf(!dbUp)("a human reply ends the agent's attendance", () => {
   // is a different statement about a different moment, and counting it here would make this assertion
   // depend on how many messages the fixture happens to send afterwards. `via` is the discriminator:
   // only this path writes it.
-  async function takeoverRows(convId: number, waitMs = 2000) {
+  async function takeoverRows(convId: number, waitMs = POLL_DEADLINE_MS) {
     const conv = await convRow(convId);
     if (!conv) return [];
     const deadline = Date.now() + waitMs;

--- a/tests/modules/chatwoot-unbound-inbox.test.ts
+++ b/tests/modules/chatwoot-unbound-inbox.test.ts
@@ -4,6 +4,7 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import { normalizeChatwootEvent } from "@/modules/chatwoot/normalize";
 import { processChatwootDelivery } from "@/modules/chatwoot/webhook";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import { flowLogRows } from "../utils/flowlog";
 
@@ -190,7 +191,7 @@ describe.skipIf(!dbUp)("an unbound inbox says so", () => {
   // Scoped to the conversation asked for, by its INTERNAL id, and polled: the emit is
   // fire-and-forget, so an unscoped read answers with a neighbour's row and an unpolled one races
   // the write it is asserting.
-  async function routeRows(convId: number, waitMs = 2000) {
+  async function routeRows(convId: number, waitMs = POLL_DEADLINE_MS) {
     const conv = await suDb.conversation.findFirst({
       where: { tenantId, chatwootConversationId: convId },
       select: { id: true },

--- a/tests/modules/contact-auth-grant.test.ts
+++ b/tests/modules/contact-auth-grant.test.ts
@@ -899,7 +899,20 @@ describe.skipIf(!dbUp)("contact authorization: reusing a verdict", () => {
 
   test("the overflow a refusal spike leaves behind drains on its own", async () => {
     setMaxTrackedContactsForTest(1);
-    setRefusalProtectionForTest(60);
+    // THE WINDOW HAS TO OUTLAST THE SETUP, NOT JUST THE ASSERTION.
+    //
+    // The loop below is what fills the map AND what arms the sweep, so the protection window has to
+    // cover the whole of it: the first drop arms a timer for `refusedAt + window`, and every later
+    // drop is a database write. At 60ms this held only while the machine was idle. Under
+    // `bun test --parallel` four writes can take longer than that, the timer fires BETWEEN two of
+    // them, and the map is back at its cap before the precondition below ever reads it: measured at
+    // `--parallel=18`, `Expected: > 1, Received: 1`, on a test that was failing for being on a busy
+    // machine rather than for anything about eviction.
+    //
+    // 2s is not a fix for slowness, the same way the 30s in tests/tooling/stale-base-guard.test.ts is
+    // not: it is the window sized to the work that has to fit inside it. The wait below is sized past
+    // it so the drain still has room to happen after.
+    setRefusalProtectionForTest(2000);
     // Every marker young enough to be protected, so eviction cannot take any of them and the map is
     // over its cap. Nothing else is coming: a spike that stops refusing is exactly the case where no
     // later call arrives to look at this again, and the entries would sit there for the life of the
@@ -912,7 +925,7 @@ describe.skipIf(!dbUp)("contact authorization: reusing a verdict", () => {
       );
     }
     expect(knownContactCount()).toBeGreaterThan(1);
-    for (let i = 0; i < 40 && knownContactCount() > 1; i++) {
+    for (let i = 0; i < 160 && knownContactCount() > 1; i++) {
       await Bun.sleep(25);
     }
     // Back to the cap, without another refusal having arrived.

--- a/tests/modules/debounce.test.ts
+++ b/tests/modules/debounce.test.ts
@@ -37,6 +37,7 @@ import {
   flowLogRow,
   flowLogRows,
 } from "@/tests/utils/flowlog";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import {
   EmptyThenReplyModel,
@@ -276,7 +277,7 @@ async function convRowId(convId: number) {
 
 async function correctionLine(convId: number) {
   const conversationId = await convRowId(convId);
-  const deadline = Date.now() + 2000;
+  const deadline = Date.now() + POLL_DEADLINE_MS;
   let lines: Array<{ level: string; detail: unknown }> = [];
   while (Date.now() < deadline) {
     lines = await flowLogRows(suDb, {

--- a/tests/modules/delivery-sweep.test.ts
+++ b/tests/modules/delivery-sweep.test.ts
@@ -21,6 +21,7 @@ import {
   recordAndProcessChatwootDelivery,
 } from "@/modules/chatwoot/webhook";
 import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 import { seedChatwootInstance } from "../utils/chatwoot";
 
 // A Chatwoot delivery stranded by a process death, and the sweep that says so (issue #228).
@@ -143,7 +144,7 @@ async function statusOf(rowId: bigint) {
 // tenant-wide one on the argument — the exact reader tests/modules/flowlog-reader-scope.test.ts
 // exists to catch. The line that names no conversation is a different subject and has its own
 // reader below.
-async function deliveryLines(convDbId: bigint, waitMs = 2000) {
+async function deliveryLines(convDbId: bigint, waitMs = POLL_DEADLINE_MS) {
   const started = Date.now();
   while (true) {
     const rows = await flowLogRows(suDb, {
@@ -164,7 +165,7 @@ async function correctionOutcome(convId: number) {
     where: { tenantId, chatwootConversationId: convId },
     select: { id: true },
   });
-  const deadline = Date.now() + 2000;
+  const deadline = Date.now() + POLL_DEADLINE_MS;
   let lines: Array<{ detail: unknown }> = [];
   while (Date.now() < deadline) {
     lines = await flowLogRows(suDb, {
@@ -182,7 +183,7 @@ async function correctionOutcome(convId: number) {
 
 // The line a strand leaves when the mirror does not know the conversation: no conversation id to
 // scope by, so it is found by its absence. Polled for the same reason as the scoped read.
-async function unscopedDeliveryLines(waitMs = 2000) {
+async function unscopedDeliveryLines(waitMs = POLL_DEADLINE_MS) {
   const started = Date.now();
   while (true) {
     const rows = await flowLogRows(suDb, {

--- a/tests/modules/failure-note.test.ts
+++ b/tests/modules/failure-note.test.ts
@@ -602,7 +602,17 @@ describe.skipIf(!dbUp)("failed-turn note", () => {
       select: { id: true },
     });
     registerDebounceHandler();
-    await runSchedulerTick(appDb, { staleMs: 5 * 60_000, batchSize: 20 });
+    // `tenantId` IS THE FENCE, not decoration: the tick is cross-tenant by design (one leader in
+    // production), so without it this drain claims and executes rows belonging to whatever else is
+    // using this database. Under `bun test --parallel` that is another worker's file, and the row it
+    // steals is gone before that file ever looks: measured, this call took the WEBHOOK_RETRY that
+    // tests/modules/debounce.test.ts had just enqueued for its own tenant, and the failure surfaced
+    // there, in a file that had done nothing wrong. See the note on TickOptions.tenantId.
+    await runSchedulerTick(appDb, {
+      staleMs: 5 * 60_000,
+      batchSize: 20,
+      tenantId,
+    });
     const after = await suDb.schedulerJob.findUniqueOrThrow({
       where: { id: row.id },
       select: { status: true },

--- a/tests/modules/flowlog-settle.test.ts
+++ b/tests/modules/flowlog-settle.test.ts
@@ -6,6 +6,7 @@ import {
   settleFlowEvents,
 } from "@/modules/flowlog/scheduled";
 import { emitFlowEvent } from "@/modules/flowlog/service";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 
 // ── EMPTYING THE TABLE IS NOT THE SAME AS IT STAYING EMPTY (issue #375) ──
 //
@@ -197,7 +198,7 @@ describe.skipIf(!dbUp)(
       // No settle anywhere in this case, because production never calls one: the write has to clear
       // its own entry or the set grows by one row per log line until the process dies. Polled rather
       // than slept so the failure says "never dropped" instead of "not dropped within 500ms".
-      const deadline = Date.now() + 3000;
+      const deadline = Date.now() + POLL_DEADLINE_MS;
       while (scheduledFlowWrites() > 0 && Date.now() < deadline)
         await Bun.sleep(25);
       expect(scheduledFlowWrites()).toBe(0);

--- a/tests/modules/scheduler-lanes.test.ts
+++ b/tests/modules/scheduler-lanes.test.ts
@@ -24,6 +24,7 @@ import {
   registerJobHandler,
   runSchedulerTick,
 } from "@/modules/scheduler/worker";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 
 // Issue #165. Two things are asserted here, and they are the two halves of the rule in lanes.ts.
 //
@@ -396,7 +397,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
     // Waiting for the cheap ones to ALL have started is the signal that the drain is under way, and
     // it does not presuppose the bound: if the bound were broken the costly count would race past it
     // and the peak assertion below is what catches that.
-    const deadline = Date.now() + 10_000;
+    const deadline = Date.now() + POLL_DEADLINE_MS;
     while (
       (cheapStarted < N || costlyStarted < BOUND) &&
       Date.now() < deadline
@@ -414,7 +415,7 @@ describe.skipIf(!dbUp)("scheduler lanes", () => {
     void tick.then(() => {
       finished = true;
     });
-    const drainDeadline = Date.now() + 10_000;
+    const drainDeadline = Date.now() + POLL_DEADLINE_MS;
     while (!finished && Date.now() < drainDeadline) {
       for (const r of release.splice(0)) r();
       await new Promise((r) => setTimeout(r, 10));

--- a/tests/modules/scheduler-tenant-fence.test.ts
+++ b/tests/modules/scheduler-tenant-fence.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import { codeOnly } from "@/tests/utils/source-text";
+
+// A CROSS-TENANT DRAIN IN A TEST STEALS ROWS FROM WHATEVER ELSE SHARES THE DATABASE.
+//
+// The scheduler tick and the claims under it are cross-tenant BY DESIGN: production runs one leader
+// and a batch that stopped at a tenant boundary would starve every tenant after it. That design is
+// documented where it lives, on `TickOptions.tenantId` in src/modules/scheduler/worker.ts, together
+// with the fence it hands a test: pass your own tenant and drain only your own rows.
+//
+// The fence has no enforcement, and one call site had already lost it. `tests/db-name.ts` derives ONE
+// database per checkout and every DB-backed file shares it, so an unfenced drain reaches rows the
+// current file never created. Serially that is survivable by luck: the thief runs before or after its
+// victim and the stolen row was already spent. Under `bun test --parallel` the two run at the same
+// moment in different processes, and the row is gone before its owner looks.
+//
+// Measured, at `--parallel=12` on this suite: `runSchedulerTick(appDb, { staleMs, batchSize: 20 })` in
+// tests/modules/failure-note.test.ts claimed the WEBHOOK_RETRY that tests/modules/debounce.test.ts had
+// just enqueued for its own tenant, and `debounce > the scheduler claim excludes DEBOUNCE` failed with
+// `Expected: true, Received: false` in a file that had done nothing wrong. Two of six runs failed that
+// way, never the same test twice, which is the shape that costs a day to attribute: the failure never
+// names the file that caused it.
+//
+// So the rule is enforced here rather than remembered. It is a SOURCE sweep and not a runtime check
+// because the cost it prevents is paid by a DIFFERENT file than the one at fault, and a runtime check
+// can only fire in the victim.
+
+// Every entry point whose default reach is the whole database. Each is cross-tenant when its tenant
+// argument is absent, and each is reachable from a test.
+const CROSS_TENANT = [
+  "runSchedulerTick",
+  "claimDueJobs",
+  "claimDueTrafficJobs",
+  "claimDueDebounceJobs",
+  "claimPendingByKeyPrefix",
+  "reapStaleJobs",
+] as const;
+
+interface CallSite {
+  file: string;
+  line: number;
+  fn: string;
+  text: string;
+}
+
+// The call's own argument text, taken by BALANCING parentheses rather than by reading to the next
+// `)`. An options object holding a call of its own (`{ now: new Date() }`) closes a naive scan early,
+// and the half it cuts off is exactly where a trailing `tenantId` would sit.
+function callsIn(source: string, file: string): CallSite[] {
+  const code = codeOnly(source);
+  const out: CallSite[] = [];
+  for (const fn of CROSS_TENANT) {
+    const re = new RegExp(`\\b${fn}\\(`, "g");
+    for (const m of code.matchAll(re)) {
+      let i = m.index + m[0].length;
+      let depth = 1;
+      while (i < code.length && depth > 0) {
+        if (code[i] === "(") depth++;
+        else if (code[i] === ")") depth--;
+        i++;
+      }
+      out.push({
+        file,
+        line: code.slice(0, m.index).split("\n").length,
+        fn,
+        text: code.slice(m.index, i),
+      });
+    }
+  }
+  return out;
+}
+
+async function testSources(): Promise<Map<string, string>> {
+  const { Glob } = await import("bun");
+  const files = new Map<string, string>();
+  for await (const rel of new Glob("**/*.test.{ts,tsx}").scan("tests")) {
+    files.set(`tests/${rel}`, await Bun.file(`tests/${rel}`).text());
+  }
+  return files;
+}
+
+// This file names the functions in a list to sweep for, so it matches itself on every one of them.
+const SELF = "tests/modules/scheduler-tenant-fence.test.ts";
+
+describe("a test that drains the scheduler drains only its own tenant", () => {
+  test("every cross-tenant claim in the suite carries a tenant", async () => {
+    const offenders: CallSite[] = [];
+    for (const [file, src] of await testSources()) {
+      if (file === SELF) continue;
+      for (const call of callsIn(src, file)) {
+        if (!/\btenantId\b/.test(call.text)) offenders.push(call);
+      }
+    }
+    expect(
+      offenders.map((o) => `${o.file}:${o.line} ${o.fn}`),
+      "A scheduler drain without `tenantId` claims rows belonging to other test files sharing this " +
+        "database, and under `bun test --parallel` the failure surfaces in the file it robbed, not " +
+        "here. Pass the tenant the file seeded. See TickOptions.tenantId in " +
+        "src/modules/scheduler/worker.ts.",
+    ).toEqual([]);
+  });
+
+  // The check above passes just as well when the glob reads nothing, and a sweep that reads nothing is
+  // the failure mode this whole file exists to prevent: silent, green, and wrong.
+  test("the sweep reads the tree", async () => {
+    const files = await testSources();
+    expect(files.size).toBeGreaterThan(400);
+    const total = [...files].flatMap(([f, s]) =>
+      f === SELF ? [] : callsIn(s, f),
+    );
+    expect(total.length).toBeGreaterThan(20);
+  });
+
+  // The balancing above is the part that can go wrong quietly: a scan that stops early reads a fenced
+  // call as unfenced (noisy, and someone fixes it) or an unfenced one as fenced (silent, and this file
+  // stops working). Both directions are pinned against text written here.
+  test("the extractor takes the whole argument list, nested calls included", () => {
+    const src = [
+      "await runSchedulerTick(appDb, { staleMs: 5, batchSize: 20 });",
+      "await runSchedulerTick(appDb, { batchSize: f(g(1)), tenantId });",
+      "await claimDueJobs(50, appDb, new Date(), tenantId);",
+    ].join("\n");
+    const found = callsIn(src, "x.ts");
+    expect(found.map((c) => c.fn)).toEqual([
+      "runSchedulerTick",
+      "runSchedulerTick",
+      "claimDueJobs",
+    ]);
+    expect(found.map((c) => /\btenantId\b/.test(c.text))).toEqual([
+      false,
+      true,
+      true,
+    ]);
+    expect(found.map((c) => c.line)).toEqual([1, 2, 3]);
+  });
+
+  // `codeOnly` strips comments and literal contents, and both matter here. A note ABOUT an unfenced
+  // drain is prose, and a fixture string holding one is data; neither is a call.
+  test("a mention in a comment or a string is not a call site", () => {
+    const src = [
+      "// runSchedulerTick(appDb, { batchSize: 20 }) would be unfenced here.",
+      'const sample = "runSchedulerTick(appDb, { batchSize: 20 })";',
+      "await runSchedulerTick(appDb, { batchSize: 20, tenantId });",
+    ].join("\n");
+    expect(callsIn(src, "x.ts")).toHaveLength(1);
+  });
+});

--- a/tests/modules/terminal-failure-announces.test.ts
+++ b/tests/modules/terminal-failure-announces.test.ts
@@ -24,6 +24,7 @@ import {
 } from "@/modules/webhooks/inbound/service";
 import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
 import { withJobHandler } from "@/tests/utils/job-registry";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 
 // ── A UNIT OF WORK THAT DIES PERMANENTLY HAS TO SAY SO (issue #356) ──
 //
@@ -76,7 +77,7 @@ const past = () => new Date(Date.now() - 60_000);
 // The emit is fire-and-forget, so the row lands after the caller returned. Poll for the expected
 // count rather than sleeping a fixed amount: a fixed sleep is either flaky or slow, and this says
 // which of the two it is when it fails.
-async function deadRows(expected: number, waitMs = 4000) {
+async function deadRows(expected: number, waitMs = POLL_DEADLINE_MS) {
   const deadline = Date.now() + waitMs;
   for (;;) {
     const rows = await flowLogRows(suDb, {

--- a/tests/modules/webhooks-outbound-dead-alert.test.ts
+++ b/tests/modules/webhooks-outbound-dead-alert.test.ts
@@ -5,6 +5,7 @@ import { assertSafeOutboundUrl } from "@/lib/ssrf";
 import { createAlertChannel } from "@/modules/flowlog/channels";
 import { processOutboundBatch } from "@/modules/webhooks/outbound/worker";
 import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 
 // ── A DEAD DELIVERY HAS TO SAY SO WHERE THE OPERATOR READS (issue #325) ──
 // Integration, real DB, real RLS: the claim runs cross-tenant under asSuperAdmin and the outcome
@@ -77,7 +78,7 @@ async function seedDelivery(
 // The emit is fire-and-forget, so the row lands after the worker returned. Poll for the expected
 // count instead of sleeping a fixed amount: a fixed sleep is either flaky or slow, and this says
 // which of the two it is when it fails.
-async function webhookRows(expected: number, waitMs = 3000) {
+async function webhookRows(expected: number, waitMs = POLL_DEADLINE_MS) {
   const deadline = Date.now() + waitMs;
   for (;;) {
     // flowlog-scope: tenant-wide — the subject is HOW MANY lines the tick wrote, so scoping the
@@ -95,7 +96,7 @@ async function webhookRows(expected: number, waitMs = 3000) {
   }
 }
 
-async function alertRows(expected: number, waitMs = 3000) {
+async function alertRows(expected: number, waitMs = POLL_DEADLINE_MS) {
   const deadline = Date.now() + waitMs;
   for (;;) {
     const rows = await suDb.alertDelivery.findMany({

--- a/tests/modules/webhooks-outbound-deliveries.test.ts
+++ b/tests/modules/webhooks-outbound-deliveries.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/modules/webhooks/outbound/deliveries";
 import { processOutboundBatch } from "@/modules/webhooks/outbound/worker";
 import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
+import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 
 // ── THE DELIVERY LEDGER AS A SUPPORTED SURFACE (issue #305) ──
 // Integration, real DB, real RLS: every call goes through `runScopedOn` exactly as the controller
@@ -106,7 +107,7 @@ async function clearDeliveries() {
 
 // The emit is fire-and-forget, so the line lands after the call returned. Poll for it rather than
 // sleeping a fixed amount: a fixed sleep is either flaky or slow and never says which.
-async function webhookLines(expected: number, waitMs = 3000) {
+async function webhookLines(expected: number, waitMs = POLL_DEADLINE_MS) {
   const deadline = Date.now() + waitMs;
   for (;;) {
     // flowlog-scope: tenant-wide — the subject is HOW MANY lines a requeue writes, so scoping the

--- a/tests/scripts/db-bootstrap.test.ts
+++ b/tests/scripts/db-bootstrap.test.ts
@@ -215,6 +215,23 @@ async function onProbe<T>(
 // nothing. None of the deploy composes uses `env_file`: each lists its environment explicitly, so a
 // variable they do not name never arrives, and `docs/deploy.md` would be telling operators to set
 // something with no effect. Measured by reading them — all three whitelist, none inherits.
+// THE THRESHOLD IS DERIVED FROM THE TIMEOUT, AND BOTH ARE SIZED FOR A BUSY MACHINE.
+//
+// The two tests below tell a healthy boot from a broken one BY HOW LONG IT WAITED: a transfer that
+// takes the lock queues behind the reader and dies at `lock_timeout`, and one that filters correctly
+// never queues at all. The signal is the gap between those, so the only thing that can break the
+// measurement is machine noise wide enough to cross it.
+//
+// It was 2000ms of timeout against a 1000ms threshold, on a healthy path measured at 60ms. That is a
+// 16x margin, and `bun test --parallel` spends it: at 24 workers the healthy boot took 1478ms, all of
+// it subprocess startup and none of it lock waiting, and the test failed for the machine it ran on.
+//
+// Widening the timeout costs nothing on a passing run, because the healthy path never waits on the
+// lock; only a genuinely broken transfer reaches the deadline, and only then is the extra time paid.
+// The threshold stays at half the timeout, and is now written as that rather than said to be.
+const LOCK_TIMEOUT_MS = 10_000;
+const HEALTHY_BOOT_CEILING_MS = LOCK_TIMEOUT_MS / 2;
+
 describe("the retention declaration reaches a deployed container", () => {
   const COMPOSES = [
     "docker-compose.prod.yml",
@@ -1821,16 +1838,17 @@ describe.skipIf(!dbUp)(
         // reader fails in seconds instead of hanging the suite.
         const started = Date.now();
         const { exitCode } = await runBootstrap(ROTATED_PW, APP_ROLE, {
-          PGOPTIONS: "-c lock_timeout=2000",
+          PGOPTIONS: `-c lock_timeout=${LOCK_TIMEOUT_MS}`,
         });
         const elapsed = Date.now() - started;
 
         // NOTE: the wait is the assertion, not the exit code — a lock timeout inside the transfer
         // is caught and, on an install that needs no transfer, correctly swallowed, so a broken
         // loop still exits 0. What it cannot hide is having waited. The threshold sits an order of
-        // magnitude above the healthy time and half the timeout below the broken one.
+        // magnitude above the healthy time and half the timeout below the broken one; both numbers are
+        // at the top of this file, with what a parallel run did to the previous pair.
         expect(exitCode).toBe(0);
-        expect(elapsed).toBeLessThan(1000);
+        expect(elapsed).toBeLessThan(HEALTHY_BOOT_CEILING_MS);
       } finally {
         await reader.query("ROLLBACK").catch(() => {});
         await reader.end();
@@ -1877,14 +1895,14 @@ describe.skipIf(!dbUp)(
 
         const started = Date.now();
         const { exitCode } = await bootSolo({
-          PGOPTIONS: "-c lock_timeout=2000",
+          PGOPTIONS: `-c lock_timeout=${LOCK_TIMEOUT_MS}`,
         });
         const elapsed = Date.now() - started;
 
         // Same threshold and same reasoning as the re-boot case above: the wait is the assertion.
         // Measured: 126ms as it stands, 2131ms with `<> v_role` dropped from the filter.
         expect(exitCode).toBe(0);
-        expect(elapsed).toBeLessThan(1000);
+        expect(elapsed).toBeLessThan(HEALTHY_BOOT_CEILING_MS);
       } finally {
         await reader.query("ROLLBACK").catch(() => {});
         await reader.end();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,4 +1,6 @@
 import "@testing-library/jest-dom";
+import { jest } from "bun:test";
+import { configure } from "@testing-library/dom";
 import {
   DB_GATE_OPT_OUT,
   localMigrations,
@@ -17,6 +19,28 @@ import { checkoutRootFrom, testDbNameFor, withDbName } from "./db-name";
 // ./dom-setup.ts, which bunfig.toml preloads BEFORE this file. The DOM must
 // exist before the @testing-library import above is evaluated — see the comment
 // there before moving either piece back here.
+
+// A DEADLINE MEASURES THE MACHINE, AND BOTH DEFAULTS BELOW WERE CHOSEN FOR AN IDLE ONE.
+//
+// Neither number is ours: 5s is `bun test`'s default per test, 1s is @testing-library's default for
+// `waitFor`, and this suite has 260 `waitFor` calls, not one of which passes a timeout of its own. On
+// a machine running the suite alone both are generous. Under `bun test --parallel` they are not: at
+// 18 workers on 6 performance cores everything runs roughly three times slower, and one deadline or
+// another lapses on most runs — a DIFFERENT one each time, which is what makes the class so
+// expensive to chase. Measured across five runs at the default worker count: three failures, in
+// three unrelated files, none reproducible on its own.
+//
+// RAISING THEM COSTS NOTHING ON A PASSING RUN, and that is the whole reason this is a fix rather
+// than a bandage. `waitFor` polls and returns the moment its condition holds; a test timeout only
+// elapses when a test hangs. What gets slower is the report of a genuine failure, from one second to
+// five — a trade worth making against a green suite that goes red by lottery.
+//
+// This is NOT the answer for a window a test's own SETUP has to fit inside. There, a bigger number
+// is paid in full on every run, so those are sized one at a time where they live: see the note on
+// `setRefusalProtectionForTest` in tests/modules/contact-auth-grant.test.ts and the one on
+// `jest.setTimeout` in tests/tooling/stale-base-guard.test.ts.
+jest.setTimeout(30_000);
+configure({ asyncUtilTimeout: 5_000 });
 
 process.env.NODE_ENV = "test";
 process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";

--- a/tests/utils/poll.ts
+++ b/tests/utils/poll.ts
@@ -1,0 +1,26 @@
+// ONE DEADLINE FOR EVERY HAND-ROLLED POLL IN THIS SUITE.
+//
+// Ten files wait for a row to appear by reading it in a loop until a deadline, and before this
+// constant each had picked its own: 2000, 2000, 2000, 3000, 3000, 3000, 3000, 4000, 10_000. Not one
+// of those numbers was argued for anywhere. They are all the same guess, made nine times, about how
+// long the work under test takes on the machine that happened to be running it.
+//
+// The guess holds while the suite has the machine to itself and stops holding under
+// `bun test --parallel`, where everything runs some multiple slower. Measured at 24 workers on an
+// 18-core machine: `deadRows(1)` in tests/modules/terminal-failure-announces.test.ts exhausted its
+// 4000ms and returned nothing, twice in six runs, and the failure it produced named neither the wait
+// nor the file — `Expected length: 1, Received length: 0`, which reads as a feature that stopped
+// writing its dead-letter line.
+//
+// WAITING LONGER IS FREE WHEN THE TEST PASSES: every one of these loops returns the moment its
+// condition holds, so the deadline is only ever reached on a run that was going to fail anyway. That
+// is what makes one generous number better than nine tight ones, and it is the same reasoning as the
+// two library defaults raised in tests/setup.ts. It is NOT the reasoning for a window a test's setup
+// has to fit inside; those are paid in full every run and are sized where they live.
+//
+// KNOWN WEAKNESS, deliberately left: these helpers RETURN what they have when the deadline lapses,
+// rather than throwing. So a lapse still surfaces as an assertion about the data instead of one about
+// the wait, and the reader has to know to look here. Making them throw means touching twelve call
+// sites whose `expected` counts are not all "at least one" (a poll for zero returns immediately by
+// construction), so it is a separate change from this one.
+export const POLL_DEADLINE_MS = 15_000;


### PR DESCRIPTION
## What this is

It started as "is `bun check` healthy", found that 98% of its 186s was `bun test` running single-threaded, and ended somewhere else: **the suite could not run in any order but the one it happens to run in today.** Six defects, five of which only a reordered or parallel run can reach. The performance work that found them is mostly *not* in this PR, because it measured badly; the defects are, because they are real either way.

## The defects

### 1. A type that lied, and the worker thread it hid

`src/config.ts` declared `env: (NODE_ENV || "development") as "development" | "production"`. But `bun test` sets `NODE_ENV=test` and it **wins over `.env`** (measured: a suite file reads `config.env === "test"` with `NODE_ENV=development` in `.env`). The union never said so, so every `=== "development"` is false under the suite and every `!== "production"` is true.

The logger took the second branch and built a pino transport — a `thread-stream` **worker thread** — in each of 534 test processes. Measured at `--parallel=18`: **229 × `error: the worker thread exited`**, 225 failures, 3207 tests that never reached a runner. Giving each process its own roll file changed nothing (still 229), so it is the worker, not the file.

The same worker took this suite down once before by another path — the `MessagePort` note in `tests/dom-setup.ts`, where Bun 1.4.0's `new Worker()` cut it from 4133 passing to 2096. Nothing else here constructs a Worker.

### 2. A test that adds a route, adding it to everyone's app

`src/app.ts` exported one Elysia instance and two test files registered their own routes on it. Elysia compiles its router on first use (`tests/api/schema-refusal-wire.test.ts` even calls `app.compile()`), so only the file that got there first had its routes. The rest fell through to the `/*` SPA handler and came back as HTML, surfacing as `SyntaxError: JSON Parse error: Unexpected identifier "Something"` — the error shell, parsed as JSON.

A third file went further and called `app.listen(0)` on it: `stop()` leaves a compiled, once-listening Elysia behind, and the next file to hand it a request got a **500**. The files' own comments already described the coupling without treating it as a defect ("It mutates the exported singleton, which several files now do").

Invisible in the one order the full serial run gives. **19 failures under `bun test --shard=1/4` on a clean `origin/main`**, before this branch existed. `buildApp()` is the same builder the server runs, so the `onError` arm under test is still the real one.

Ignoring whitespace, `src/app.ts` gains 24 lines and loses none; the rest of its diff is biome reindenting the chain inside the new function.

### 3. A module stub whose undo is another global rewrite

`tests/api/v1/knowledge-search-bigint.test.ts` replaced `@/modules/rag/service` in the registry and re-registered the real module in `afterAll`. But `mock.module` is process-global and its undo is a second global rewrite, so whether it lands before another file's imports resolve is an ordering nobody controls. `tests/modules/tenant-selector-entry-points.test.ts` calls the real `searchKnowledge` to prove it refuses a dead tenant selector, and under `--shard=7/8` it got the stub. A `spyOn` on the module object is per-object and actually restores.

### 4. A drain with no tenant, stealing rows from other files

`src/modules/scheduler/worker.ts` already documented the hazard on `TickOptions.tenantId` — "two DB-backed suites running at once claim each other's rows" — but nothing enforced it, and one of 51 call sites had lost it. `tests/modules/failure-note.test.ts:605` drained the whole database, and measured at `--parallel=12` it took the `WEBHOOK_RETRY` that `tests/modules/debounce.test.ts` had just enqueued for its own tenant. The failure surfaced in the file it robbed.

`tests/modules/scheduler-tenant-fence.test.ts` is a source sweep that refuses the next one. It balances parentheses rather than reading to the next `)`, because an options object holding a call of its own closes a naive scan exactly where a trailing `tenantId` would sit.

### 5. Two library defaults this repo never chose

5s per test is `bun test`'s; 1s for `waitFor` is @testing-library's. This suite has **260 `waitFor` calls and not one passes a timeout**, and nothing called `configure`. Five runs at the default worker count produced **three failures in three unrelated files**, none reproducible alone. Both are now set once in the preload.

Raising them **costs nothing on a passing run**: `waitFor` returns the moment its condition holds, and a test timeout only elapses when a test hangs. What gets slower is the report of a genuine failure.

### 6. The same guess, made nine times

Ten files poll to a deadline, each with its own: `2000, 2000, 2000, 2000, 3000, 3000, 3000, 3000, 4000, 10_000`. None argued for anywhere. Measured at 24 workers, `deadRows(1)` exhausted its 4000ms twice in six runs and reported `Expected length: 1, Received length: 0` — which reads as a feature that stopped writing its dead-letter line. Now one constant, with the known weakness written down: these helpers still *return* what they have on lapse instead of throwing.

### 7. Four windows a setup has to fit inside

The opposite case, sized one at a time where they live, because a bigger number here is paid on every run:

- `contact-auth-grant`: the protection window must outlast the loop that fills the map AND arms the sweep. At 60ms the sweep fired between two database writes.
- `appointment-reminders`: one of the two numbers is **gone** rather than raised — the model now holds the call open until the start has actually passed, which is the condition the test is about.
- `db-bootstrap`: tells a healthy boot from a broken one *by how long it waited*, so the deadline **is** the assertion. The gap was widened instead, and the threshold is now written as `LOCK_TIMEOUT_MS / 2` rather than said to be that in a comment.
- `stale-base-guard`: ~0.7s a test of subprocess start against a 5s default. It was the first file to break, and its deadline now lives with the family in the preload.

## The one performance change that survived

**`tmpfs` for the CI Postgres data directory: `Run Tests` 187s → 157s.** The database is built and discarded inside the job, 183 files are database-backed, and on a 4-vCPU runner every fsync the server does is paid out of the same cores the tests run on. Borrowed from the Chatwoot upstream.

## What was measured and rejected

Recorded here so the next attempt starts from the numbers rather than the idea.

- **`bun test --parallel` as the default.** Right on a developer machine (194s → 120s at 4 workers, 189s → 51s at 18), wrong on the runner: **257s against a 187s serial baseline**. Four workers on a laptop take four of eighteen cores; four here take all four vCPUs the job has, and take them from the Postgres container beside them. Reverted to serial.
- **Sharding the job four ways.** Did exactly what it should — test step 157s → 36-61s, wall 217s → ~109s — and three of four shards came back red, from defect 2 above plus a second cause not yet isolated. Backed out; the workflow carries the measurement.
- **`--no-isolate`.** 42s against 65s locally, and 46 failures from the same order dependence.
- **Splitting the slowest file.** All 72 tests preserved, the new floor exactly where the model wanted it, and the median went 58s → 66s across six runs each way. `max(slowest file, total/N)` does not describe this suite; the measured wall is ~3x that bound either way. Recorded in the file so nobody repeats it.
- **`LOG_LEVEL=silent` and a higher worker count.** Single measurements suggested 14% and 15%; three repetitions each put both inside the variance.

## Validation scope

**Proven by test.** The tenant fence was shown red first: reverting its one-line fix makes it print `tests/modules/failure-note.test.ts:605 runSchedulerTick` and fail. `bun check` green end to end (8149 pass, 0 fail). Every touched file run individually. Defect 2 was shown to predate this branch by reproducing all 19 failures on a clean `origin/main` worktree.

**Measured, not reasoned.** Every number above is from a run recorded next to the code it justifies. Flake rate at `--parallel` before: 2 in 6 at 12 workers, 3 in 5 at the default. After the timing work: **0 in 16** consecutive runs.

**Not validated.**

- **One order-dependent failure is left, and it is named.** `tests/client/components/UserMenu.test.tsx` stubs `react-i18next` (plus the auth and theme contexts) with `mock.module`, and `tests/client/document-starters-race.test.tsx` switches the REAL i18n language to prove a stale response cannot overwrite a newer one — against the stub, the switch does nothing. Both files already document the hazard from their own side. Two fixes were **measured and rejected**: re-registering the modules in `afterAll` does not undo the leak, and dropping the stub for the real instance makes UserMenu itself order-dependent and breaks the stub ledger in `tests/lib/module-mock-package.test.ts`, which lists that stub on purpose. Shard failures across the four: **19 → 1**.
- **`bun test --parallel` is NOT affected** and runs clean (0 failures, ~60s against 189s serial): it implies `--isolate`, so each file gets its own module registry and a `mock.module` cannot reach the next file. Only a shard, which runs serially inside its job, shares one. Sharding stays off; the local parallel path is unblocked.
- **The bisection method is in the workflow note**, because it is what found three of these and two full pairwise sweeps (133 files each, one at a time before the victim) found none: narrow with `--shard=k/N` doubling N, split victim from candidates into sibling shards, then neutralise candidates in halves by replacing their CONTENTS and never their paths, since moving a file moves it in the ordering.
- **Bun runs 2 of 534 files twice under `--isolate`**, which `--parallel` implies — confirmed with a marker printing `process.pid`, gone under `--no-isolate`. Upstream. Both are idempotent sweeps, so it costs a count and not a result, today.
- **Only `tmpfs` has been exercised on the runner.** Everything else was measured on one macOS machine (18 cores: 6 performance, 12 efficiency).
- **The suite was never executed from this public clone**, which has no `node_modules`. It ran in the master worktree the files were ported from.
