### PR TITLE
Ask whether the caller holds a transaction, not whether one exists

### DIFF
--- a/tests/graph/pool-inversion.test.ts
+++ b/tests/graph/pool-inversion.test.ts
@@ -49,19 +49,19 @@ let instanceId = 0n;
 
 // A checkpointer that samples the transaction counter on every call the ingestion makes.
 class SamplingSaver extends MemorySaver {
-  readonly samples: Array<{ call: string; open: number }> = [];
-  constructor(private readonly openTx: () => number) {
+  readonly samples: Array<{ call: string; held: boolean }> = [];
+  constructor(private readonly heldTx: () => boolean) {
     super();
   }
   // biome-ignore lint/suspicious/noExplicitAny: matching the saver's own signatures
   override async getTuple(...args: any[]): Promise<any> {
-    this.samples.push({ call: "getTuple", open: this.openTx() });
+    this.samples.push({ call: "getTuple", held: this.heldTx() });
     // biome-ignore lint/suspicious/noExplicitAny: same
     return (MemorySaver.prototype.getTuple as any).apply(this, args);
   }
   // biome-ignore lint/suspicious/noExplicitAny: same
   override async put(...args: any[]): Promise<any> {
-    this.samples.push({ call: "put", open: this.openTx() });
+    this.samples.push({ call: "put", held: this.heldTx() });
     // biome-ignore lint/suspicious/noExplicitAny: same
     return (MemorySaver.prototype.put as any).apply(this, args);
   }
@@ -105,7 +105,7 @@ describe.skipIf(!dbUp)("no Prisma transaction spans the checkpointer", () => {
       contactInboxId,
     );
     const counting = countingBase(appDb);
-    const saver = new SamplingSaver(counting.open);
+    const saver = new SamplingSaver(counting.heldHere);
 
     // Two messages on one thread: the first opens the attendance (divider + marker), the second goes
     // through the dedupe read. Between them they exercise every checkpointer call the section makes.
@@ -131,7 +131,7 @@ describe.skipIf(!dbUp)("no Prisma transaction spans the checkpointer", () => {
     // The section really did touch the checkpointer, or the assertion below would be vacuous.
     expect(saver.samples.length).toBeGreaterThan(0);
     expect(saver.samples.some((s) => s.call === "put")).toBe(true);
-    expect(saver.samples.filter((s) => s.open !== 0)).toEqual([]);
+    expect(saver.samples.filter((s) => s.held)).toEqual([]);
     // And it left nothing open behind it.
     expect(counting.open()).toBe(0);
   });

--- a/tests/lib/counting-base-context.test.ts
+++ b/tests/lib/counting-base-context.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { PrismaClient } from "@/../generated/prisma/client";
+import { countingBase } from "../utils/counting-base";
+
+// `countingBase` is the instrument two suites use to assert that a section holds no connection
+// across an await (`tests/graph/pool-inversion.test.ts`, `tests/modules/contact-auth-nudge.test.ts`).
+// Both used to read the raw COUNT, and the count answers a different question than either asks: the
+// client is shared with writes this run neither started nor awaits — `emitFlowEvent` is one by
+// design — so a detached INSERT still in flight made the count non-zero while the caller held
+// nothing. That was a real CI failure on a green branch, reproducible with
+// `PROBE_FLOWLOG_DELAY_MS=12`, and it is why `heldHere` is answered from the caller's own async
+// context rather than from a number.
+//
+// A fake client rather than a database: what is under test is the instrument's bookkeeping, and a
+// real transaction would only make the two answers harder to tell apart.
+function fakeClient(): PrismaClient {
+  const c = {
+    $extends: () => c,
+    $transaction: async (fn: (tx: unknown) => unknown) => fn({}),
+  };
+  return c as unknown as PrismaClient;
+}
+
+describe("countingBase tells 'the caller is inside one' from 'one exists'", () => {
+  test("heldHere is true inside the transaction and false outside it", async () => {
+    const c = countingBase(fakeClient());
+    expect(c.heldHere()).toBe(false);
+    await c.base.$transaction(async () => {
+      expect(c.heldHere()).toBe(true);
+    });
+    expect(c.heldHere()).toBe(false);
+  });
+
+  test("a detached transaction in flight does not make the caller look held", async () => {
+    const c = countingBase(fakeClient());
+    let release: (() => void) | undefined;
+    const blocked = new Promise<void>((r) => {
+      release = r;
+    });
+    // Started and NOT awaited, which is the shape of `emitFlowEvent`.
+    const detached = c.base.$transaction(async () => blocked);
+    await Bun.sleep(0);
+
+    // The count sees it, which is what the leak check is for and what used to be read here.
+    expect(c.open()).toBe(1);
+    // The caller does not, because it is not in that transaction's context.
+    expect(c.heldHere()).toBe(false);
+
+    release?.();
+    await detached;
+    expect(c.open()).toBe(0);
+  });
+
+  test("the mark does not leak into a transaction opened beside it", async () => {
+    const c = countingBase(fakeClient());
+    let seen: boolean | undefined;
+    await c.base.$transaction(async () => {
+      // A second transaction started from inside the first WOULD see the mark, so the case that
+      // matters is the sibling: opened after the first resolved, from the top level.
+      seen = c.heldHere();
+    });
+    expect(seen).toBe(true);
+    expect(c.heldHere()).toBe(false);
+  });
+
+  test("$extends keeps one watch rather than starting a second", async () => {
+    const c = countingBase(fakeClient());
+    const extended = c.base.$extends({}) as unknown as PrismaClient;
+    await extended.$transaction(async () => {
+      expect(c.heldHere()).toBe(true);
+    });
+    expect(c.total()).toBe(1);
+  });
+});

--- a/tests/modules/contact-auth-nudge.test.ts
+++ b/tests/modules/contact-auth-nudge.test.ts
@@ -262,14 +262,16 @@ describe.skipIf(!dbUp)("contact authorization on the proactive nudge", () => {
       wanted = false;
       return new Response('{"authorized":true}', { status: 200 });
     });
-    // Recorded per ask, and what is recorded is how many Prisma transactions are OPEN at that moment.
+    // Recorded per ask, and what is recorded is whether the ASK ITSELF is inside a Prisma
+    // transaction — not how many exist, which counts `emitFlowEvent`'s fire-and-forget write on the
+    // same client and fails whenever that INSERT is still in flight (`tests/utils/counting-base.ts`).
     // The ask made inside the thread claim used to have to arrive WITH a connection, because the
     // claim was one long advisory-lock transaction and a provider opening its own there asked a
     // pinned pool for a second one, which fails under `DB_POOL_MAX=1` — and jobRetired swallows a
     // failed read as "not retired", so the fence went quiet exactly where it mattered. The claim
     // holds no transaction any more (issue #225), so the invariant that replaces it is the stronger
     // one: the ask is free to open its own scope precisely because nothing is pinned.
-    const openTxAtAsk: number[] = [];
+    const heldAtAsk: boolean[] = [];
     const strictness: boolean[] = [];
     const counted = countingBase(appDb);
     const outcome = await runAgentNudge({
@@ -278,7 +280,7 @@ describe.skipIf(!dbUp)("contact authorization on the proactive nudge", () => {
       nudge: { source: "followup", kind: "inactivity" },
       postActions: { assignLabels: ["seguimento"] },
       stillWanted: async ({ strict }) => {
-        openTxAtAsk.push(counted.open());
+        heldAtAsk.push(counted.heldHere());
         strictness.push(strict);
         return wanted;
       },
@@ -296,8 +298,8 @@ describe.skipIf(!dbUp)("contact authorization on the proactive nudge", () => {
     expect(auth.calls).toHaveLength(1);
     // Asked at both moments it has to be: on entry, and again inside the thread claim, which is what
     // makes it exclusive with a /reset. And no ask, the claim's included, finds a transaction open.
-    expect(openTxAtAsk.length).toBeGreaterThanOrEqual(2);
-    expect(openTxAtAsk.filter((n) => n !== 0)).toEqual([]);
+    expect(heldAtAsk.length).toBeGreaterThanOrEqual(2);
+    expect(heldAtAsk.filter(Boolean)).toEqual([]);
     // EXACTLY ONE of them asks strictly, and it is not the entry one. The two want opposite answers
     // when the read itself fails: before the write an unreadable answer has to stop the run, and
     // around a send it must not, because throwing there abandons the bookkeeping of a message the

--- a/tests/utils/counting-base.ts
+++ b/tests/utils/counting-base.ts
@@ -1,20 +1,37 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { PrismaClient } from "@/../generated/prisma/client";
 
-// Counts Prisma transactions: `open` is how many are in flight right now, `total` how many were
-// ever opened through this client. Survives `$extends`, which `runScopedOn` calls before
-// `$transaction`, so the count follows the client the scoped helper actually uses.
+// Watches Prisma transactions opened through one client. Survives `$extends`, which `runScopedOn`
+// calls before `$transaction`, so the watch follows the client the scoped helper actually uses.
 //
-// The two answer different questions. `open` catches a transaction held across an await that should
-// not be; `total` catches work that was SPLIT across transactions which should have shared one — a
-// mutation and the audit row recording it, say, where two means the record can be lost without the
-// change being lost.
+// Three answers, and picking the wrong one is a flake rather than a wrong result:
+//
+// `heldHere` is for "is the CALLER inside a transaction right now" — a section that must not hold a
+// connection across an await. It is answered from the caller's own async context, which is the only
+// thing that makes it about the caller: the client is shared with work this run did not start and
+// does not await. `emitFlowEvent` is exactly that (`src/modules/flowlog/service.ts`) — fire-and-
+// forget by design, because a customer must not wait on a log line — and its transaction runs
+// through this same client. Counting it made this assertion fail whenever that INSERT happened to
+// still be in flight: measured on CI, and reproducible here with `PROBE_FLOWLOG_DELAY_MS=12`, which
+// lands the write on top of the ask.
+//
+// `open` is the raw count of transactions in flight ANYWHERE through this client, which is a leak
+// check ("it left nothing open behind it") and answers nothing about who is asking.
+//
+// `total` catches work that was SPLIT across transactions which should have shared one — a mutation
+// and the audit row recording it, say, where two means the record can be lost without the change
+// being lost.
 export function countingBase(client: PrismaClient): {
   base: PrismaClient;
+  heldHere: () => boolean;
   open: () => number;
   total: () => number;
 } {
   let open = 0;
   let total = 0;
+  // Entered for the length of the transaction, so only code running INSIDE it sees the mark. A
+  // detached write started elsewhere has its own context and never sets this one.
+  const inside = new AsyncLocalStorage<true>();
   // biome-ignore lint/suspicious/noExplicitAny: proxying Prisma's client surface
   const wrap = (target: any): any =>
     new Proxy(target, {
@@ -27,7 +44,7 @@ export function countingBase(client: PrismaClient): {
             open += 1;
             total += 1;
             try {
-              return await t.$transaction(fn, ...rest);
+              return await inside.run(true, () => t.$transaction(fn, ...rest));
             } finally {
               open -= 1;
             }
@@ -38,6 +55,7 @@ export function countingBase(client: PrismaClient): {
     });
   return {
     base: wrap(client) as PrismaClient,
+    heldHere: () => inside.getStore() === true,
     open: () => open,
     total: () => total,
   };


### PR DESCRIPTION
No issue: found while closing #399's round, in a file that PR does not touch.

`countingBase` (`tests/utils/counting-base.ts`) is the instrument two suites use to assert that a section holds no database connection across an await — `tests/graph/pool-inversion.test.ts` samples it at every checkpointer call, and `tests/modules/contact-auth-nudge.test.ts` samples it at every `stillWanted` ask. Both read the raw COUNT of transactions in flight through the client.

The count answers a different question than either asks. The client is shared with writes the run neither started nor awaits, and `emitFlowEvent` is one of them **by design** — `trackFlowWrite(writeFlowEvent(ctx, ev))`, no await, because a customer must not wait on a log line. Its transaction runs through the same client, so whenever that INSERT was still in flight at the moment of a sample, the count came back non-zero and the assertion failed on a section that was holding nothing.

## How it was found, and how to reproduce it

It failed CI once, on a branch that does not touch this path, and a re-run of the same commit went green. Reading the code pointed the wrong way: none of the fourteen `stillWanted` asks is lexically inside a transaction (checked by matching parentheses, not brace depth), and both lease-renewal `setInterval`s are 100s and 10s — far too long for a 43ms test.

Instrumenting `countingBase` to record a stack per open transaction, and to report when one opens while another is live, produced the answer on the first isolated run: `writeFlowEvent` with **no caller above it in the stack**, which is the signature of a detached promise.

`src/modules/flowlog/service.ts` already carries a probe hook for this, and it makes the failure deterministic:

```
PROBE_FLOWLOG_DELAY_MS=12 bun test tests/modules/contact-auth-nudge.test.ts
```

Same file, same line, same `[1]` against `[]` as CI. Other delays pass, which is the whole shape of the flake: the window is a single INSERT, so only load (or a 12ms nudge) puts it on top of a sample.

## The change

`heldHere()` answers from the caller's own async context — an `AsyncLocalStorage` entered for the length of the transaction — which is the only formulation that is about the caller rather than about the process. A detached write started elsewhere has its own context and never sets it.

`open()` stays as the raw count. One assertion does want it: `expect(counting.open()).toBe(0)` at the end of the pool-inversion test is a leak check, and a leak check is exactly the question a count answers.

Both sampling sites move to `heldHere()`. Neither had a reason to want the process-wide number.

## Validation

`tests/lib/counting-base-context.test.ts` (4) pins the distinction on a fake client, no database, because what is under test is the instrument's bookkeeping: `heldHere` true inside and false outside; a **detached transaction in flight leaving `open()` at 1 and `heldHere()` false**, which is the case that caused this; the mark not surviving the transaction; and `$extends` keeping one watch rather than starting a second.

Mutation battery, 3 mutations, 0 survivors:

| mutation | result |
| --- | --- |
| `heldHere` pinned false — the assertions become vacuous | 3 tests red |
| the `AsyncLocalStorage` scope never entered | 3 tests red |
| the claim's ask put back inside a `runScopedOn` (the #225 defect these assertions exist to catch) | the nudge test red |

The third is the one that matters: the fix does not buy stability by making the assertion vacuous.

Full suite green locally (8273), and the reproduction above now passes at every delay from 8ms to 60ms.

## Not fixed here, and not measured

The same overlap has a production-shaped question behind it: a detached flowlog write can ask the pool for a connection while a turn holds its own, and `DB_POOL_MAX=1` is a supported setting with four measurements in this repo of a nested transaction dying after 2047ms under it (`src/graph/thread-claim.ts`, `src/modules/chatwoot/webhook.ts`). That case is *concurrent* rather than *nested*, which is not the same shape, and I have not reproduced it. Recorded as a question to measure, not as a defect.
