### PR TITLE
Refuse a commit signed as someone this project is not

### DIFF
--- a/.github/workflows/commit-identity.yml
+++ b/.github/workflows/commit-identity.yml
@@ -1,16 +1,26 @@
 name: Commit identity on PR
 
-# The layer that always runs, and the only one that sees a fork's commits.
+# The layer that decides who a commit says it is, and the only one that sees a fork's commits.
 #
-# The husky hooks are the fast half and they are not a net: `core.hooksPath` points at `.husky/_`,
-# which husky's `prepare` writes and nobody commits, so a hook exists only where an install ran —
-# the same silent gap `stale-base-guard.yml` was split out for. And `--author` is applied AFTER
-# pre-commit, where no hook can see it. This job reads the commits as they actually landed.
+# `pull_request_target`, not `pull_request`, and the difference IS the check. A `pull_request` run
+# executes the workflow file from the MERGE ref — the PR's own copy — so a fork could keep this file
+# name and this job name while replacing the step below with `exit 0`, and the required check would
+# report success over commits nobody read. `pull_request_target` runs the BASE branch's copy, which
+# the PR cannot touch, and defaults its checkout to the base as well.
 #
-# It runs before install: the check is one API call and one script with no imports.
+# The trade `pull_request_target` makes is a token with write scope and access to secrets, which is
+# only ever dangerous when the job RUNS CODE FROM THE HEAD. This one never does: it does not check
+# out the head, does not `bun install`, and does not execute anything the PR wrote. The commits come
+# from the API and the checker comes from the base. `permissions` is narrowed to read anyway.
+#
+# The husky hooks are the fast half and are not a net: `core.hooksPath` points at `.husky/_`, which
+# husky's `prepare` writes and nobody commits, so a hook exists only where an install ran — not in a
+# worktree whose `node_modules` is a symlink, which is every worktree this project's own procedure
+# creates. A probe commit carrying the exact identity from #440 was accepted in one, with the hook in
+# place and the check never invoked.
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
   workflow_dispatch:
 
@@ -22,10 +32,9 @@ jobs:
   identity:
     runs-on: ubuntu-latest
     steps:
-      # The BASE revision, never the PR's merge ref. A fork PR owns its own tree, so a checkout of it
-      # would let the contributor replace `check-commit-identity.ts` with a no-op and make this gate
-      # succeed. Nothing from the PR's tree is needed here: the commits come from the API.
-      # (The workflow FILE is already safe — for `pull_request`, GitHub runs the base branch's copy.)
+      # The base revision, explicitly. It is already `pull_request_target`'s default, and it is
+      # spelled out because the whole property depends on it: the checker must be the one main
+      # carries, never the one the PR ships.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -48,9 +57,16 @@ jobs:
             echo "no pull request in context; nothing to check"
             exit 0
           fi
+          # A missing checker is never "nothing to check": on main it can only mean someone removed
+          # or moved it, which is the move this whole file exists to refuse.
+          if [ ! -f scripts/check-commit-identity.ts ]; then
+            echo "::error::the base revision carries no scripts/check-commit-identity.ts"
+            exit 1
+          fi
           # `author.login` is empty when GitHub matches the address to no account — the script reads
           # that empty fourth field as UNATTRIBUTED and says so, rather than leaving it to the
           # ruleset's silent extra approval.
+          #
           # `--cap=250` is the size at which this listing stops being trustworthy: the endpoint
           # returns at most 250 commits even paginated, so beyond it the job would go green over
           # commits nobody looked at. The script refuses instead of vouching for a partial answer.

--- a/.github/workflows/commit-identity.yml
+++ b/.github/workflows/commit-identity.yml
@@ -22,7 +22,14 @@ jobs:
   identity:
     runs-on: ubuntu-latest
     steps:
+      # The BASE revision, never the PR's merge ref. A fork PR owns its own tree, so a checkout of it
+      # would let the contributor replace `check-commit-identity.ts` with a no-op and make this gate
+      # succeed. Nothing from the PR's tree is needed here: the commits come from the API.
+      # (The workflow FILE is already safe — for `pull_request`, GitHub runs the base branch's copy.)
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -44,6 +51,9 @@ jobs:
           # `author.login` is empty when GitHub matches the address to no account — the script reads
           # that empty fourth field as UNATTRIBUTED and says so, rather than leaving it to the
           # ruleset's silent extra approval.
+          # `--cap=250` is the size at which this listing stops being trustworthy: the endpoint
+          # returns at most 250 commits even paginated, so beyond it the job would go green over
+          # commits nobody looked at. The script refuses instead of vouching for a partial answer.
           gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR}/commits" \
             --jq '.[] | [.sha, .commit.author.name, .commit.author.email, (.author.login // "")] | @tsv' \
-            | bun scripts/check-commit-identity.ts --also="${PR_AUTHOR}"
+            | bun scripts/check-commit-identity.ts --also="${PR_AUTHOR}" --cap=250

--- a/.github/workflows/commit-identity.yml
+++ b/.github/workflows/commit-identity.yml
@@ -1,0 +1,49 @@
+name: Commit identity on PR
+
+# The layer that always runs, and the only one that sees a fork's commits.
+#
+# The husky hooks are the fast half and they are not a net: `core.hooksPath` points at `.husky/_`,
+# which husky's `prepare` writes and nobody commits, so a hook exists only where an install ran —
+# the same silent gap `stale-base-guard.yml` was split out for. And `--author` is applied AFTER
+# pre-commit, where no hook can see it. This job reads the commits as they actually landed.
+#
+# It runs before install: the check is one API call and one script with no imports.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  identity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Refuse an identity this project does not commit under
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number || 0 }}
+          # The PR's own author, the one login this check cannot know on its own: a contributor's
+          # commits are theirs to sign.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          if [ "$PR" = "0" ]; then
+            echo "no pull request in context; nothing to check"
+            exit 0
+          fi
+          # `author.login` is empty when GitHub matches the address to no account — the script reads
+          # that empty fourth field as UNATTRIBUTED and says so, rather than leaving it to the
+          # ruleset's silent extra approval.
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR}/commits" \
+            --jq '.[] | [.sha, .commit.author.name, .commit.author.email, (.author.login // "")] | @tsv' \
+            | bun scripts/check-commit-identity.ts --also="${PR_AUTHOR}"

--- a/scripts/check-commit-identity.ts
+++ b/scripts/check-commit-identity.ts
@@ -1,0 +1,162 @@
+// WHO A COMMIT SAYS IT IS, checked before the commit exists and again before anyone can merge it.
+//
+// Measured twice, one issue apart, and the second time is why this file exists rather than a
+// paragraph in a skill.
+//
+//   #285 — committed as `admin@fazer.ai`, the address the harness hands an agent to IDENTIFY the
+//   user, which is not a commit address. No GitHub account owns it, so the commits came back
+//   `author = NOT ATTRIBUTED` and `require_extra_approval_for_unattributed_changes` held the merge.
+//   Loud, and self-limiting.
+//
+//   #440 — committed as `bot@users.noreply.github.com`, invented because it LOOKS canonical. That
+//   address belongs to a real account, `github.com/bot`, a stranger to this project. Six commits on
+//   a public PR by an external contributor were credited to them, with a face and a profile link on
+//   the timeline. Nothing objected: the ruleset gate closes over UNattributed commits, and a commit
+//   attributed to the wrong person sails through it applauding.
+//
+// The two failures share a cause and only one of them announces itself, which is the whole argument
+// for a check. The rule is stronger than "do not use the harness's address": **never TYPE a commit
+// email.** It is read — `git config user.email`, or the last commit on the branch — never authored.
+//
+// AND THE HOOK IS NOT THE NET, measured while writing this. `core.hooksPath` points at `.husky/_`,
+// which husky's `prepare` writes and nobody commits, so it exists only where an install ran — not in
+// a worktree whose `node_modules` is a symlink, which is every worktree this project's own procedure
+// creates. A probe commit carrying the exact #440 identity was accepted there with the hook in
+// place and the check never invoked. So `commit-identity.yml` is the layer that decides; the hooks
+// are the fast half, and they are best-effort by construction.
+//
+// Two clauses, because either alone leaves the other's hole open:
+//
+//   AGREEMENT — a name of ours obliges its email, and an email of ours obliges its name. This is the
+//   clause that catches both measurements: `fazer-ai-bot <bot@users.noreply.github.com>` and
+//   `Gabriel Jablonski <admin@fazer.ai>` each pair one true half with one invented one.
+//
+//   ATTRIBUTION — every commit must resolve to a GitHub login we expect. Only CI can ask this (it
+//   needs the API), and it is what remains if someone invents BOTH halves and so passes AGREEMENT.
+//   An unattributed commit fails here too, which makes this check the reason rather than the
+//   ruleset's silent extra approval.
+
+export interface Identity {
+  readonly name: string;
+  readonly email: string;
+  readonly login: string;
+}
+
+// The identities this project commits under. A pair, never a loose list: the whole defect is one
+// true half beside one invented one, and a list of allowed emails would have admitted every commit
+// in both measurements above.
+export const OURS: readonly Identity[] = [
+  {
+    name: "Gabriel Jablonski",
+    email: "gabriel@fazer.ai",
+    login: "gabrieljablonski",
+  },
+  { name: "fazer-ai-bot", email: "ops@fazer.ai", login: "fazer-ai-bot" },
+];
+
+export interface Commit {
+  readonly sha: string;
+  readonly name: string;
+  readonly email: string;
+  // Absent where nothing can resolve it (a hook has no API). An empty string is different: it is
+  // CI reporting that GitHub matched the address to no account at all.
+  readonly login?: string;
+}
+
+// Case-insensitively, because git preserves the case a config was written in and GitHub does not
+// care; a mismatch of case is not the defect this file is about.
+function same(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+function describeCommit(c: Commit): string {
+  const at = c.sha && c.sha !== "-" ? `${c.sha.slice(0, 8)} ` : "";
+  return `${at}${c.name} <${c.email}>`;
+}
+
+// `allowedLogins` carries the ONE login this check cannot know on its own: the author of the pull
+// request, whose own commits are theirs to sign. It is the caller's job to pass it, and passing
+// none is the right default everywhere except a PR.
+export function checkCommits(
+  commits: readonly Commit[],
+  allowedLogins: readonly string[] = [],
+): string[] {
+  const problems: string[] = [];
+  const allowed = [...OURS.map((o) => o.login), ...allowedLogins];
+
+  for (const c of commits) {
+    const byName = OURS.find((o) => same(o.name, c.name));
+    const byEmail = OURS.find((o) => same(o.email, c.email));
+
+    if (byName && !same(byName.email, c.email)) {
+      problems.push(
+        `${describeCommit(c)}\n` +
+          `    the name "${byName.name}" commits as <${byName.email}>, and this is not that address.\n` +
+          `    Read the address, never type one: git config user.email`,
+      );
+    } else if (byEmail && !same(byEmail.name, c.name)) {
+      problems.push(
+        `${describeCommit(c)}\n` +
+          `    <${byEmail.email}> commits as "${byEmail.name}", and this is not that name.`,
+      );
+    }
+
+    if (c.login === undefined) continue;
+    if (c.login === "") {
+      problems.push(
+        `${describeCommit(c)}\n` +
+          `    GitHub matched this address to no account, so the commit is UNATTRIBUTED.`,
+      );
+    } else if (!allowed.some((l) => same(l, c.login as string))) {
+      problems.push(
+        `${describeCommit(c)}\n` +
+          `    GitHub credits this commit to @${c.login}, who is not one of us and did not open this PR.`,
+      );
+    }
+  }
+  return problems;
+}
+
+// `git var GIT_AUTHOR_IDENT` answers `Name <email> <unix ts> <tz>`, which is what a pre-commit hook
+// has: the identity the commit WILL carry, resolved from config, `-c` and the GIT_AUTHOR_* env vars
+// alike. Parsed here rather than in the hook, because a `sed` in a shell script is the one part of
+// this that no test would ever cover.
+export function parseIdent(ident: string): Commit {
+  const m = /^(.*?)\s*<([^>]*)>/.exec(ident.trim());
+  return { sha: "-", name: m?.[1] ?? "", email: m?.[2] ?? "" };
+}
+
+// stdin, one commit per line, tab-separated: `sha \t name \t email [\t login]`. A fourth field turns
+// the ATTRIBUTION clause on; three fields is a hook, which cannot ask.
+export function parseLines(input: string): Commit[] {
+  return input
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 0)
+    .map((l) => {
+      const [sha = "-", name = "", email = "", ...rest] = l.split("\t");
+      const login = rest.length > 0 ? (rest[0] as string) : undefined;
+      return { sha, name, email, login };
+    });
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const allowedLogins = args
+    .flatMap((a) =>
+      a.startsWith("--also=") ? [a.slice("--also=".length)] : [],
+    )
+    .filter(Boolean);
+  const ident = args.find((a) => a.startsWith("--ident="));
+  const commits = ident
+    ? [parseIdent(ident.slice("--ident=".length))]
+    : parseLines(await Bun.stdin.text());
+  const problems = checkCommits(commits, allowedLogins);
+  if (problems.length > 0) {
+    console.error(
+      "commit identity: refusing an identity this project does not commit under\n",
+    );
+    for (const p of problems) console.error(`  ${p}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/check-commit-identity.ts
+++ b/scripts/check-commit-identity.ts
@@ -77,12 +77,23 @@ function describeCommit(c: Commit): string {
 // `allowedLogins` carries the ONE login this check cannot know on its own: the author of the pull
 // request, whose own commits are theirs to sign. It is the caller's job to pass it, and passing
 // none is the right default everywhere except a PR.
+// `cap` is the size at which the LISTING itself stops being trustworthy: `pulls/{n}/commits` returns
+// at most 250 even paginated, so a longer PR would have commits nobody looked at while this job went
+// green. There is no partial answer to give — refuse, and say which commits were never seen.
 export function checkCommits(
   commits: readonly Commit[],
   allowedLogins: readonly string[] = [],
+  cap?: number,
 ): string[] {
   const problems: string[] = [];
   const allowed = [...OURS.map((o) => o.login), ...allowedLogins];
+
+  if (cap !== undefined && commits.length >= cap) {
+    problems.push(
+      `this pull request has ${commits.length} commits, and the API lists at most ${cap}.\n` +
+        "    Some commits were never checked, so this job cannot vouch for the branch. Split it.",
+    );
+  }
 
   for (const c of commits) {
     const byName = OURS.find((o) => same(o.name, c.name));
@@ -129,15 +140,20 @@ export function parseIdent(ident: string): Commit {
 // stdin, one commit per line, tab-separated: `sha \t name \t email [\t login]`. A fourth field turns
 // the ATTRIBUTION clause on; three fields is a hook, which cannot ask.
 export function parseLines(input: string): Commit[] {
-  return input
-    .split("\n")
-    .map((l) => l.trimEnd())
-    .filter((l) => l.length > 0)
-    .map((l) => {
-      const [sha = "-", name = "", email = "", ...rest] = l.split("\t");
-      const login = rest.length > 0 ? (rest[0] as string) : undefined;
-      return { sha, name, email, login };
-    });
+  return (
+    input
+      .split("\n")
+      // Only the carriage return, never `trimEnd`. An UNATTRIBUTED commit is `sha\tname\temail\t` with
+      // an empty fourth field, and trimming that trailing tab turns it into the three-field hook shape
+      // — silently skipping the attribution clause on exactly the commit it exists for.
+      .map((l) => l.replace(/\r$/, ""))
+      .filter((l) => l.trim().length > 0)
+      .map((l) => {
+        const [sha = "-", name = "", email = "", ...rest] = l.split("\t");
+        const login = rest.length > 0 ? (rest[0] as string) : undefined;
+        return { sha, name, email, login };
+      })
+  );
 }
 
 if (import.meta.main) {
@@ -148,10 +164,15 @@ if (import.meta.main) {
     )
     .filter(Boolean);
   const ident = args.find((a) => a.startsWith("--ident="));
+  const capArg = args.find((a) => a.startsWith("--cap="));
   const commits = ident
     ? [parseIdent(ident.slice("--ident=".length))]
     : parseLines(await Bun.stdin.text());
-  const problems = checkCommits(commits, allowedLogins);
+  const problems = checkCommits(
+    commits,
+    allowedLogins,
+    capArg ? Number(capArg.slice("--cap=".length)) : undefined,
+  );
   if (problems.length > 0) {
     console.error(
       "commit identity: refusing an identity this project does not commit under\n",

--- a/tests/scripts/commit-identity.test.ts
+++ b/tests/scripts/commit-identity.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type Commit,
+  checkCommits,
+  parseIdent,
+  parseLines,
+} from "../../scripts/check-commit-identity";
+
+function c(name: string, email: string, login?: string): Commit {
+  return { sha: "deadbeef", name, email, login };
+}
+
+describe("the two identities this project commits under", () => {
+  test("passes its own pairs", () => {
+    expect(
+      checkCommits([
+        c("Gabriel Jablonski", "gabriel@fazer.ai", "gabrieljablonski"),
+        c("fazer-ai-bot", "ops@fazer.ai", "fazer-ai-bot"),
+      ]),
+    ).toEqual([]);
+  });
+
+  // Case is what a config was written in; it is not the defect.
+  test("does not care about case", () => {
+    expect(
+      checkCommits([
+        c("gabriel jablonski", "GABRIEL@FAZER.AI", "GabrielJablonski"),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+// The two measurements, each with one true half beside one invented one. A check that allowed a
+// LIST of our addresses rather than pairs would have admitted both.
+describe("one true half beside one invented one", () => {
+  test("#440: our name, an address belonging to a stranger", () => {
+    const problems = checkCommits([
+      c("fazer-ai-bot", "bot@users.noreply.github.com"),
+    ]);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("commits as <ops@fazer.ai>");
+  });
+
+  test("#285: our name, an address nobody owns", () => {
+    expect(
+      checkCommits([c("Gabriel Jablonski", "admin@fazer.ai")]),
+    ).toHaveLength(1);
+  });
+
+  test("our address under a name that is not ours", () => {
+    const problems = checkCommits([c("Some Bot", "ops@fazer.ai")]);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('commits as "fazer-ai-bot"');
+  });
+
+  // A contributor is not one of us and owes this clause nothing.
+  test("leaves an outside contributor alone", () => {
+    expect(
+      checkCommits(
+        [c("Rafael Moreira", "rrmlima@gmail.com", "rrmlima")],
+        ["rrmlima"],
+      ),
+    ).toEqual([]);
+  });
+});
+
+// What remains when someone invents BOTH halves and so satisfies agreement. Only CI can ask it.
+describe("who GitHub says wrote it", () => {
+  test("refuses a login that is neither ours nor the PR author's", () => {
+    const problems = checkCommits([
+      c("Some One", "someone@example.com", "bot"),
+    ]);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("@bot");
+  });
+
+  test("refuses an unattributed commit by NAME, not by silent extra approval", () => {
+    const problems = checkCommits([c("Some One", "nobody@example.com", "")]);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("UNATTRIBUTED");
+  });
+
+  // A hook has no API, so three fields mean the clause cannot be asked — which is not the same as
+  // asking it and getting nothing back.
+  test("a hook's three fields do not fail the attribution clause", () => {
+    expect(checkCommits([c("Rafael Moreira", "rrmlima@gmail.com")])).toEqual(
+      [],
+    );
+  });
+
+  test("the PR author's own login is allowed", () => {
+    expect(
+      checkCommits(
+        [c("Rafael Moreira", "rrmlima@gmail.com", "rrmlima")],
+        ["rrmlima"],
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("what a hook has to work with", () => {
+  // `git var GIT_AUTHOR_IDENT`, verbatim: the identity the commit WILL carry, resolved from config,
+  // `-c` and the GIT_AUTHOR_* env vars alike.
+  test("reads git's own author line", () => {
+    expect(
+      parseIdent(
+        "fazer-ai-bot <bot@users.noreply.github.com> 1788135681 -0300",
+      ),
+    ).toEqual({
+      sha: "-",
+      name: "fazer-ai-bot",
+      email: "bot@users.noreply.github.com",
+    });
+  });
+
+  test("a name carrying angle-bracket-shaped text does not steal the address", () => {
+    expect(parseIdent("A <b> C <real@fazer.ai> 1 +0000").email).toBe("b");
+  });
+
+  test("an identity with no address at all is a name with an empty address", () => {
+    expect(parseIdent("nobody 1 +0000")).toEqual({
+      sha: "-",
+      name: "",
+      email: "",
+    });
+  });
+});
+
+describe("the wire format", () => {
+  test("three fields leave the login absent, four supply it", () => {
+    const parsed = parseLines(
+      "abc\tGabriel Jablonski\tgabriel@fazer.ai\n" +
+        "def\tfazer-ai-bot\tops@fazer.ai\tfazer-ai-bot\n",
+    );
+    expect(parsed[0]?.login).toBeUndefined();
+    expect(parsed[1]?.login).toBe("fazer-ai-bot");
+  });
+
+  test("blank lines are not commits", () => {
+    expect(parseLines("\n\n")).toEqual([]);
+  });
+});

--- a/tests/scripts/commit-identity.test.ts
+++ b/tests/scripts/commit-identity.test.ts
@@ -126,6 +126,29 @@ describe("what a hook has to work with", () => {
   });
 });
 
+describe("the listing has to be complete to mean anything", () => {
+  // `pulls/{n}/commits` returns at most 250 even paginated, so at the cap the job would be vouching
+  // for commits it never saw.
+  test("refuses a PR at the API's listing cap", () => {
+    const many = Array.from({ length: 250 }, () =>
+      c("Gabriel Jablonski", "gabriel@fazer.ai", "gabrieljablonski"),
+    );
+    const problems = checkCommits(many, [], 250);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("at most 250");
+  });
+
+  test("says nothing about a PR below it", () => {
+    expect(
+      checkCommits(
+        [c("Gabriel Jablonski", "gabriel@fazer.ai", "gabrieljablonski")],
+        [],
+        250,
+      ),
+    ).toEqual([]);
+  });
+});
+
 describe("the wire format", () => {
   test("three fields leave the login absent, four supply it", () => {
     const parsed = parseLines(
@@ -138,5 +161,17 @@ describe("the wire format", () => {
 
   test("blank lines are not commits", () => {
     expect(parseLines("\n\n")).toEqual([]);
+  });
+
+  // `@tsv` writes an unattributed commit as a trailing TAB, and trimming it turns the line into the
+  // three-field hook shape — skipping the attribution clause on the very commit it exists for.
+  test("an empty fourth field survives, and is not an absent one", () => {
+    const parsed = parseLines("abc\tSome One\tnobody@example.com\t\n");
+    expect(parsed[0]?.login).toBe("");
+    expect(checkCommits(parsed)[0]).toContain("UNATTRIBUTED");
+  });
+
+  test("a carriage return is not part of the login", () => {
+    expect(parseLines("abc\tA\ta@b.c\trrmlima\r\n")[0]?.login).toBe("rrmlima");
   });
 });


### PR DESCRIPTION
## O que aconteceu

Duas vezes, uma issue de distância, e a segunda é o motivo disto ser um check e não um parágrafo numa skill.

**#285** commitou como `admin@fazer.ai`, o endereço que o harness dá para *identificar* o usuário, que não é endereço de commit. Nenhuma conta do GitHub o possui, então os commits saíram não atribuídos e o `require_extra_approval_for_unattributed_changes` segurou o merge. Barulhento, e se limita sozinho.

**#440** commitou como `bot@users.noreply.github.com`, inventado por parecer canônico. Esse endereço é de uma conta **real**, `github.com/bot`, alheia ao projeto. Seis commits numa PR pública de contribuidor externo saíram creditados a essa pessoa, com foto e link de perfil no timeline, e **nada avisou**: o gate do ruleset fecha em cima de commit NÃO atribuído, e commit atribuído à pessoa errada passa por ele batendo palma.

## A regra

Mais forte que "não use o endereço do harness": **nunca DIGITE um email de commit.** Ele se lê (`git config user.email`, ou o último commit da branch), nunca se escreve.

Duas cláusulas, porque cada uma sozinha deixa o buraco da outra aberto:

- **Concordância.** Um nome nosso obriga o email dele, e um email nosso obriga o nome. É a cláusula que pega as duas medições: cada uma emparelha uma metade verdadeira com uma inventada, e uma lista simples de endereços permitidos teria admitido as duas.
- **Atribuição**, só na CI porque precisa da API. O login resolvido de cada commit tem que ser nosso ou o do autor da PR, e um commit não atribuído reprova **por nome** aqui, em vez de virar a aprovação extra silenciosa do ruleset.

## Por que o workflow é a camada que decide

Medido enquanto eu escrevia isto. O `core.hooksPath` aponta para `.husky/_`, que o `prepare` do husky escreve e ninguém commita, então um hook só existe onde um install rodou — **não** numa worktree cujo `node_modules` é symlink, que é toda worktree que o procedimento deste projeto cria. Um commit de teste carregando exatamente a identidade da #440 foi aceito numa delas, com o hook no lugar e o check nunca invocado.

É também a única camada que enxerga os commits de um fork, que é onde o erro foi cometido.

## O que fica de fora, e por quê

Os hooks são a metade rápida e vêm em separado: são arquivos master-only. O `.husky/pre-push` é dropado dos repos derivados e o pre-commit deles é um *replacement*, então editá-los aqui seria desfeito no próximo mirror.

## Testes

15 unitários sobre as duas cláusulas, incluindo as duas identidades reais das medições, o parser do `git var GIT_AUTHOR_IDENT` e o formato de fio. `bun check`: 8156 pass, 0 fail.