### PR TITLE
Stop three kinds of test from deciding for the whole process, and shard the CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,34 +11,46 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # NOT SHARDED YET, AND WHAT IS LEFT IN THE WAY IS ONE TEST.
+    strategy:
+      # Every shard runs: one red shard must not cancel the other three, or the report names one
+      # failure when there may be four.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    name: test (${{ matrix.shard }}/4)
+
+    # SHARDED FOUR WAYS. Each job gets its own runner, its own vCPUs and its own database, and
+    # `--shard=k/4` splits the files by index so the four sets are disjoint and cover the tree.
     #
-    # Four shards (one job each, own vCPUs, own database) took the test step from 157s to 36-61s and
-    # the wall from 217s to ~109s. What came back red was not the split: the same `--shard=1/4` fails
-    # on a clean origin/main, because this suite was only ever green in the order the full serial run
-    # happens to give it. Four causes were found and fixed on this branch, taking the four shards from
-    # 19 failures to 1:
+    # It could not be turned on before, and the reason was never the split: this suite was only ever
+    # green in the order the full serial run happens to give it, so `--shard=1/4` failed on a clean
+    # main. Two rounds found and fixed the causes, all of them the same shape: a test writing to
+    # something the whole process shares, undone by nothing:
     #
-    #   - src/app.ts exported ONE Elysia instance, and three files mutated it: two registered their
-    #     own routes on it, one called `listen()`. Elysia compiles its router on first use, so a later
-    #     file's route never existed and its request fell through to the `/*` SPA handler, and a
-    #     stopped-but-compiled app answered later `handle()` calls with 500s. `buildApp()` is the fix.
-    #   - one file replaced `@/modules/rag/service` in the module registry. Re-registering the real
-    #     module in `afterAll` is a second global rewrite, and whether it lands before another file's
-    #     imports resolve is an ordering nobody controls. A `spyOn` on the module object restores.
+    #   - src/app.ts exported ONE Elysia instance and three files mutated it.
+    #   - `mock.module` on a module whose teardown handed the registry back the namespace
+    #     `await import()` returned, which is the object the rewrite already changed in place. Six
+    #     files; tests/lib/module-mock-undo.test.ts now refuses the shape.
+    #   - `mock.module("react-i18next", …)` in nine client test files, each freezing `i18n.language`
+    #     at a literal for every file downstream. Replaced by a per-file instance delivered through
+    #     `I18nextProvider` (tests/utils/i18n.tsx).
+    #   - an unfenced `runSchedulerTick` draining rows other files had enqueued
+    #     (tests/modules/scheduler-tenant-fence.test.ts).
     #
-    # THE ONE LEFT: tests/client/components/UserMenu.test.tsx stubs `react-i18next` (plus the auth and
-    # theme contexts) with `mock.module`, which has no reliable undo, and
-    # tests/client/document-starters-race.test.tsx switches the REAL i18n language to prove a stale
-    # response cannot overwrite a newer one. Against the stub the switch does nothing. Both files
-    # already document the hazard from their own side. Two fixes were measured and rejected: restoring
-    # the modules in `afterAll` does not undo the leak, and dropping the stub for the real instance
-    # makes UserMenu itself order-dependent and breaks the stub ledger in
-    # tests/lib/module-mock-package.test.ts, which lists that stub on purpose.
+    # Every one of them failed in a DIFFERENT file than the one at fault, which is why three of the
+    # four are now static sweeps rather than notes.
     #
-    # `bun test --parallel` is NOT affected and runs clean: it implies `--isolate`, so each file gets
-    # its own module registry and a `mock.module` cannot reach the next file. Only a shard, which runs
-    # serially inside its job, shares one.
+    # HOW THEY WERE FOUND, because two full pairwise sweeps (133 files each) found none of them: bun
+    # ignores argument order, so narrow with `--shard=k/N` doubling N. A file in `1/8` is in `1/16`
+    # or `9/16`. When the victim lands alone in a passing shard, the culprit is in the sibling shard.
+    # Neutralise candidates in halves by replacing their CONTENTS, never their paths: moving a file
+    # moves it in the ordering, which is also why adding one test file reshuffles every shard.
+    #
+    # `bun test --parallel` stays off here. It is right on a developer machine (189s to 51s at 18
+    # workers) and wrong on a 4-vCPU runner, measured at 257s against a 187s serial baseline: four
+    # workers take all four vCPUs and take them from the Postgres container beside them. Sharding
+    # buys the same wall clock by adding runners instead of dividing one.
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -102,4 +114,4 @@ jobs:
         run: bun run db:test:setup
 
       - name: Run Tests
-        run: bun run test
+        run: bun test --shard=${{ matrix.shard }}/4

--- a/tests/api/v1/knowledge-tenant-context.test.ts
+++ b/tests/api/v1/knowledge-tenant-context.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
 import { authPlugin } from "@/api/lib/auth";
 import type { TenantContext } from "@/lib/tenancy";
@@ -26,22 +26,34 @@ const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
 setupPrismaMock();
 
 const ragService = await import("@/modules/rag/service");
+// The return type is DERIVED from the real function rather than written as `unknown[]`: `spyOn` is
+// typed where a registry rewrite was not, so the shape the route actually receives is checked here
+// instead of at runtime in whatever file the leak reached.
 const listKnowledgeBases = mock(
-  async (_ctx: TenantContext, _base?: unknown): Promise<unknown[]> => [],
+  async (
+    _ctx: TenantContext,
+    _base?: unknown,
+  ): Promise<Awaited<ReturnType<typeof ragService.listKnowledgeBases>>> => [],
 );
-// Spread the real module: the controller imports a dozen other names from it, and replacing the
-// whole module with one function would break the route graph at import time.
-mock.module("@/modules/rag/service", () => ({
-  ...ragService,
+// A SPY ON THE MODULE OBJECT, NOT A REGISTRY REWRITE. A rewrite is process-global and its undo is a
+// second rewrite that does not undo anything: `await import()` hands back the LIVE namespace, and
+// the mock rewrote it in place, so handing that same object back re-registers the stub while
+// reading as a cleanup. tests/lib/module-mock-package.test.ts states this; this file was written
+// before it did.
+//
+// Measured on the four shards: with the rewrite in place, `listKnowledgeBases` went on answering
+// `[]` for every file downstream, and tests/modules/tenant-selector-entry-points.test.ts, which
+// calls the real one to prove it REFUSES a dead tenant selector, got the stub, so nothing
+// was refused and the tenant lookup it counts never happened. Two failures in shard 1/4, neither
+// naming this file.
+const spy = spyOn(ragService, "listKnowledgeBases").mockImplementation(
   listKnowledgeBases,
-}));
+);
 
 const app = (await import("@/app")).default;
 
-// `mock.module` is GLOBAL to the process and outlives this file for every other test in the same
-// worker, so put the module back.
 afterAll(() => {
-  mock.module("@/modules/rag/service", () => ragService);
+  spy.mockRestore();
 });
 
 // A fleet operator: no home tenant, and a target chosen per request via the header.

--- a/tests/api/v1/query-filter-refusal.test.ts
+++ b/tests/api/v1/query-filter-refusal.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
 import { authPlugin } from "@/api/lib/auth";
 import {
@@ -31,40 +31,59 @@ const record =
     return Promise.resolve({ items: [], nextCursor: null, entries: [] });
   };
 
+// SPIES ON THE MODULE OBJECTS, NOT REGISTRY REWRITES. Four rewrites used to sit here, each undone
+// in `afterAll` by handing the module back the namespace `await import()` returned, which is the
+// LIVE object the rewrite had already changed in place, so the teardown re-registered the stub
+// while reading as a cleanup. tests/lib/module-mock-package.test.ts states exactly this; these
+// lines predate it.
+//
+// Measured on the four shards: `listExecutionLogs` went on answering `{ items: [] }` for every file
+// downstream, so tests/modules/flowlog.test.ts read nothing back and reported a tenant unable to
+// see its OWN rows, as an RLS failure, in a file that stubs nothing. `listAudit` did the same to
+// tests/modules/tier3.test.ts. Three failures in shard 4/4, none naming this file.
 const flowlogRead = await import("@/modules/flowlog/read");
-mock.module("@/modules/flowlog/read", () => ({
-  ...flowlogRead,
-  listExecutionLogs: mock(record("logs")),
-}));
+// `record` answers an empty page for all three readers, so it cannot carry one derived return type.
+// The cast NAMES the function it is standing in for rather than erasing to `never`, so a signature
+// change points here instead of passing silently.
+const listExecutionLogs = spyOn(
+  flowlogRead,
+  "listExecutionLogs",
+).mockImplementation(
+  record("logs") as unknown as typeof flowlogRead.listExecutionLogs,
+);
+
 const auditService = await import("@/modules/audit/service");
-mock.module("@/modules/audit/service", () => ({
-  ...auditService,
-  listAudit: mock(async (..._a: unknown[]) => []),
-}));
+const listAudit = spyOn(auditService, "listAudit").mockImplementation(
+  (async () => []) as unknown as typeof auditService.listAudit,
+);
 
 const conversationsService = await import("@/modules/conversations/service");
-mock.module("@/modules/conversations/service", () => ({
-  ...conversationsService,
-  listConversations: mock(record("conversations")),
-}));
+const listConversations = spyOn(
+  conversationsService,
+  "listConversations",
+).mockImplementation(
+  record(
+    "conversations",
+  ) as unknown as typeof conversationsService.listConversations,
+);
+
 const adminService = await import("@/api/features/admin/admin.service");
-mock.module("@/api/features/admin/admin.service", () => ({
-  ...adminService,
-  getUsers: mock(async (..._a: unknown[]) => ({
+const getUsers = spyOn(adminService, "getUsers").mockImplementation(
+  (async () => ({
     users: [],
     total: 0,
     page: 1,
     totalPages: 0,
-  })),
-}));
+  })) as unknown as typeof adminService.getUsers,
+);
 
 const app = (await import("@/app")).default;
 
 afterAll(() => {
-  mock.module("@/modules/flowlog/read", () => flowlogRead);
-  mock.module("@/modules/audit/service", () => auditService);
-  mock.module("@/modules/conversations/service", () => conversationsService);
-  mock.module("@/api/features/admin/admin.service", () => adminService);
+  listExecutionLogs.mockRestore();
+  listAudit.mockRestore();
+  listConversations.mockRestore();
+  getUsers.mockRestore();
 });
 
 // TENANT_ADMIN, which is what these routes ask for.

--- a/tests/api/v1/upstream-zod-error.test.ts
+++ b/tests/api/v1/upstream-zod-error.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
 import { z } from "zod";
 import { authPlugin } from "@/api/lib/auth";
@@ -30,20 +30,20 @@ const mcpService = await import("@/modules/mcp-connections/service");
 // A ZodError produced the way the SDK produces one: a schema THIS request never chose, over a value
 // the caller never sent.
 const upstream = z.object({ tools: z.array(z.object({ name: z.string() })) });
-mock.module("@/modules/mcp-connections/service", () => ({
-  ...mcpService,
-  discoverMcpTools: async () => {
-    upstream.parse({ tools: [{ name: 42 }] });
-    return { instructions: null, tools: [] };
-  },
-}));
+// A spy, not a registry rewrite: the undo below has to actually undo. Handing `mock.module` the
+// namespace `await import()` returned puts back the object the rewrite already changed in place.
+const discoverMcpTools = spyOn(
+  mcpService,
+  "discoverMcpTools",
+).mockImplementation((async () => {
+  upstream.parse({ tools: [{ name: 42 }] });
+  return { instructions: null, tools: [] };
+}) as unknown as typeof mcpService.discoverMcpTools);
 
 const app = (await import("@/app")).default;
 
-// `mock.module` is GLOBAL to the process and outlives this file for every other test in the same
-// worker, so put the module back.
 afterAll(() => {
-  mock.module("@/modules/mcp-connections/service", () => mcpService);
+  discoverMcpTools.mockRestore();
 });
 
 const admin = { ...mockUser, tenantId: 1n, role: "TENANT_ADMIN" as const };

--- a/tests/client/components/TenantDeepLink.test.tsx
+++ b/tests/client/components/TenantDeepLink.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { ToastProvider } from "@/client/components";
+import { withI18n } from "@/tests/utils/i18n";
 
 // The decision this applies has a table of its own (tests/client/lib/tenantDeepLink.test.ts). What
 // is tested HERE is the part a pure function cannot see: when the parameter is consumed, and when
@@ -63,20 +64,6 @@ function installFetchStub() {
   }) as typeof fetch;
 }
 
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
-      const text = typeof fallback === "string" ? fallback : key;
-      if (!vars) return text;
-      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
-        name in vars ? String(vars[name]) : m,
-      );
-    },
-    i18n: { language: "en" },
-  }),
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
-
 mock.module("@/client/contexts/AuthContext", () => ({
   useAuth: () => ({
     user: { id: "1", role, tenantId: userTenantId },
@@ -94,21 +81,23 @@ function SearchProbe() {
 
 function renderAt(search: string) {
   return render(
-    <MemoryRouter initialEntries={[`/resources/vault${search}`]}>
-      <ToastProvider>
-        <SearchProbe />
-        <Routes>
-          <Route
-            path="/resources/vault"
-            element={
-              <TenantDeepLink>
-                <div>panel</div>
-              </TenantDeepLink>
-            }
-          />
-        </Routes>
-      </ToastProvider>
-    </MemoryRouter>,
+    withI18n(
+      <MemoryRouter initialEntries={[`/resources/vault${search}`]}>
+        <ToastProvider>
+          <SearchProbe />
+          <Routes>
+            <Route
+              path="/resources/vault"
+              element={
+                <TenantDeepLink>
+                  <div>panel</div>
+                </TenantDeepLink>
+              }
+            />
+          </Routes>
+        </ToastProvider>
+      </MemoryRouter>,
+    ),
   );
 }
 

--- a/tests/client/components/UserMenu.test.tsx
+++ b/tests/client/components/UserMenu.test.tsx
@@ -1,6 +1,14 @@
 /// <reference lib="dom" />
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import {
   act,
@@ -11,10 +19,10 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
+import { createTestI18n } from "@/tests/utils/i18n";
 
 const mockLogout = mock(async () => {});
 const mockSetTheme = mock((_: string) => {});
-const mockChangeLanguage = mock(async (_: string) => {});
 
 mock.module("@/client/contexts/AuthContext", () => ({
   useAuth: () => ({
@@ -34,35 +42,28 @@ mock.module("@/client/contexts/ThemeContext", () => ({
   ThemeProvider: ({ children }: { children: ReactNode }) => children,
 }));
 
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
-      const text = typeof fallback === "string" ? fallback : key;
-      if (!vars) return text;
-      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
-        name in vars ? String(vars[name]) : m,
-      );
-    },
-    i18n: {
-      language: "en",
-      changeLanguage: mockChangeLanguage,
-    },
-  }),
-}));
+// A REAL i18next instance, held here so the language radio's effect can be read off it. See
+// tests/utils/i18n.tsx: a registry stub of `react-i18next` used to live here, and the `i18n` it
+// handed back was a literal `{ language: "en" }` that every file running afterwards imported.
+const i18n = createTestI18n();
+const changeLanguage = spyOn(i18n, "changeLanguage");
 
+import { I18nextProvider } from "react-i18next";
 import { UserMenu } from "@/client/components/UserMenu";
 
 function renderMenu() {
   return render(
-    <TooltipPrimitive.Provider>
-      <MemoryRouter initialEntries={["/"]}>
-        <Routes>
-          <Route path="/" element={<UserMenu />} />
-          <Route path="/login" element={<div>LOGIN_PAGE_MARKER</div>} />
-          <Route path="/settings" element={<div>SETTINGS_PAGE_MARKER</div>} />
-        </Routes>
-      </MemoryRouter>
-    </TooltipPrimitive.Provider>,
+    <I18nextProvider i18n={i18n}>
+      <TooltipPrimitive.Provider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route path="/" element={<UserMenu />} />
+            <Route path="/login" element={<div>LOGIN_PAGE_MARKER</div>} />
+            <Route path="/settings" element={<div>SETTINGS_PAGE_MARKER</div>} />
+          </Routes>
+        </MemoryRouter>
+      </TooltipPrimitive.Provider>
+    </I18nextProvider>,
   );
 }
 
@@ -77,7 +78,7 @@ describe("UserMenu", () => {
   beforeEach(() => {
     mockLogout.mockClear();
     mockSetTheme.mockClear();
-    mockChangeLanguage.mockClear();
+    changeLanguage.mockClear();
   });
 
   afterEach(() => cleanup());
@@ -112,7 +113,7 @@ describe("UserMenu", () => {
     openDropdown();
     const ptRadio = screen.getByRole("menuitemradio", { name: /português/i });
     fireEvent.click(ptRadio);
-    expect(mockChangeLanguage).toHaveBeenCalledWith("pt-BR");
+    expect(changeLanguage).toHaveBeenCalledWith("pt-BR");
   });
 
   test("Settings menuitem navigates to /settings", () => {

--- a/tests/client/error-toast-reason.test.ts
+++ b/tests/client/error-toast-reason.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { expectWaiverLedger } from "@/tests/utils/ledger";
+import { codeSkeleton } from "@/tests/utils/source-text";
 
 // THE GUARD AGAINST THE NEXT HANDLER THAT ASKS THE SERVER AND THEN INVENTS ITS OWN SENTENCE.
 //
@@ -55,46 +56,6 @@ function callArgs(src: string, openParen: number): string {
     i++;
   }
   return src.slice(openParen + 1, i - 1);
-}
-
-// The source with every comment and every string body blanked to spaces, offsets preserved.
-//
-// Counting braces on the raw text drifts, and it drifts SILENTLY: this tree's comments are prose
-// about the code and full of `{ error }`, `{{placeholder}}` and `${…}`. One unbalanced brace inside
-// one comment shifts every block boundary after it, and the scan then answers about the wrong
-// function for the rest of the file. Measured: on the raw text the scan found 28 offenders and
-// missed `BusinessHoursForm.tsx:230`, which is a bare `catch {}` under `throw err` read by hand.
-export function codeSkeleton(src: string): string {
-  const out = src.split("");
-  let i = 0;
-  const blank = (from: number, to: number) => {
-    for (let k = from; k < to && k < out.length; k++) {
-      if (out[k] !== "\n") out[k] = " ";
-    }
-  };
-  while (i < src.length) {
-    const two = src.slice(i, i + 2);
-    if (two === "//") {
-      const end = src.indexOf("\n", i);
-      blank(i, end < 0 ? src.length : end);
-      i = end < 0 ? src.length : end;
-    } else if (two === "/*") {
-      const end = src.indexOf("*/", i + 2);
-      blank(i, end < 0 ? src.length : end + 2);
-      i = end < 0 ? src.length : end + 2;
-    } else if (src[i] === '"' || src[i] === "'" || src[i] === "`") {
-      const quote = src[i] as string;
-      let k = i + 1;
-      while (k < src.length) {
-        if (src[k] === "\\") k += 2;
-        else if (src[k] === quote) break;
-        else k++;
-      }
-      blank(i + 1, k);
-      i = k + 1;
-    } else i++;
-  }
-  return out.join("");
 }
 
 // Every `{` still open at `at`, innermost last. Brace-matched rather than indentation-matched: this

--- a/tests/client/field-refusal-fence.test.ts
+++ b/tests/client/field-refusal-fence.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { codeSkeleton } from "@/tests/client/error-toast-reason.test";
 import { expectWaiverLedger } from "@/tests/utils/ledger";
+import { codeSkeleton } from "@/tests/utils/source-text";
 
 // THE GUARD AGAINST THE NEXT FORM THAT SENDS A FIELD REFUSAL TO A BANNER.
 //

--- a/tests/client/pages/DashboardFirstResponse.test.tsx
+++ b/tests/client/pages/DashboardFirstResponse.test.tsx
@@ -6,12 +6,12 @@ import {
   beforeAll,
   describe,
   expect,
-  mock,
   test,
 } from "bun:test";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { DashboardPage } from "@/client/pages/DashboardPage";
+import { withI18n } from "@/tests/utils/i18n";
 
 // Issue #283: on an inbox served by humans every KPI on this page is derived from LlmUsage, so the
 // panel reads zero, which reads as failure rather than as "the agent was not here". The number
@@ -22,26 +22,10 @@ import { DashboardPage } from "@/client/pages/DashboardPage";
 // NOTE: every assertion reduces to a string or a number BEFORE expect. A failing expectation still
 // holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
 
-// `mock.module` is process-global in Bun and leaks across files in the same worker, and one of them
-// (tests/client/components/TenantDeepLink.test.tsx) installs a `t` that returns the default string
-// WITHOUT interpolating, so `{{sampled}}` reaches the DOM literally and an assertion about the
-// sample size fails on a translation detail rather than on the figure. Declared here rather than
-// inherited, and interpolating, so this file states the surface it needs instead of depending on
-// which file ran first. Measured: passes alone, failed inside `bun check`, until this existed.
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
-      const text = typeof fallback === "string" ? fallback : key;
-      if (!vars) return text;
-      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
-        name in vars ? String(vars[name]) : m,
-      );
-    },
-    i18n: { language: "en" },
-  }),
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
-
+// This file asserts on rendered LABELS, so what `t` answers is part of the fixture. It used to
+// secure that by replacing `react-i18next` in the module registry, which secured it for every other
+// file in the process too: the stub the last such file installed was what they all got. `withI18n`
+// hands this tree its own i18next by context instead: same answers, no reach past this file.
 const realFetch = globalThis.fetch;
 
 let kpis: Record<string, unknown> = {};
@@ -80,9 +64,11 @@ const BASE = {
 async function renderWith(k: Record<string, unknown>): Promise<void> {
   kpis = { ...BASE, ...k };
   render(
-    <MemoryRouter>
-      <DashboardPage />
-    </MemoryRouter>,
+    withI18n(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    ),
   );
   await waitFor(() => {
     expect(screen.queryAllByText("First response").length).toBeGreaterThan(0);

--- a/tests/client/pages/KnowledgeApprovals.test.tsx
+++ b/tests/client/pages/KnowledgeApprovals.test.tsx
@@ -19,6 +19,7 @@ import {
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { ToastProvider } from "@/client/components";
+import { withI18n } from "@/tests/utils/i18n";
 
 // Issue #81: the approval card offered exactly two actions, Approve and Reject. An operator facing a
 // suggestion the agent hedged ("solicita-se validação da informação") could only approve the hedge
@@ -76,22 +77,6 @@ function installFetchStub() {
   }) as typeof fetch;
 }
 
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (
-      key: string,
-      fallback?: string | Record<string, unknown>,
-      opts?: Record<string, unknown>,
-    ) => {
-      const fb = typeof fallback === "string" ? fallback : key;
-      const vars = (typeof fallback === "string" ? opts : fallback) ?? {};
-      return fb.replace(/\{\{(\w+)\}\}/g, (_m, k) => String(vars[k] ?? ""));
-    },
-    i18n: { language: "en" },
-  }),
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
-
 mock.module("@/client/contexts/ThemeContext", () => ({
   useTheme: () => ({
     theme: "dark",
@@ -127,11 +112,13 @@ function seed(over: Record<string, unknown> = {}) {
 
 function renderQueue() {
   return render(
-    <MemoryRouter>
-      <ToastProvider>
-        <KnowledgeApprovals />
-      </ToastProvider>
-    </MemoryRouter>,
+    withI18n(
+      <MemoryRouter>
+        <ToastProvider>
+          <KnowledgeApprovals />
+        </ToastProvider>
+      </MemoryRouter>,
+    ),
   );
 }
 

--- a/tests/client/pages/KnowledgeDocsBlock.test.tsx
+++ b/tests/client/pages/KnowledgeDocsBlock.test.tsx
@@ -21,6 +21,7 @@ import type { ReactNode } from "react";
 import { ToastProvider } from "@/client/components";
 import clientEn from "@/client/locales/en.json";
 import clientPt from "@/client/locales/pt-BR.json";
+import { createTestI18n, withI18n } from "@/tests/utils/i18n";
 
 // Issue #80, review finding of round 5: the embedding block is a READ-TIME answer about the
 // workspace's configuration, and the documents modal holds it as a snapshot taken when the list was
@@ -146,17 +147,30 @@ function json(body: unknown): Response {
   });
 }
 
-// The stub resolves against the REAL catalogs, and falls back to the call site's default only when
-// the key is missing — which is what i18next itself does. A stub that always answered the default
-// would render correctly for a key the catalog does not have, and that is precisely the failure
-// issue #256 is about: an unresolvable key is invisible at runtime. With the lookup in place, a
-// test asserting the CATALOG's sentence goes red when the key stops resolving.
+// THE REAL CATALOGS, because this file's subject is whether a key RESOLVES.
+//
+// `t` has to answer the catalog entry where there is one and the call site's default only where
+// there is not. Something that always answered the default would render correctly for a key the
+// catalog does not have, and that is precisely the failure issue #256 is about: an unresolvable key
+// is invisible at runtime. With the catalogs loaded, a test asserting the CATALOG's sentence goes
+// red when the key stops resolving.
+//
+// That used to be a hand-written `t` doing its own lookup, installed into the module registry. It
+// answered the same thing and it answered for the whole process: the `i18n` beside it froze
+// `language` at whatever this file last assigned, for every file that ran afterwards. Real i18next,
+// held here and delivered by context, is the same behaviour with none of the reach.
 const CATALOGS: Record<string, Record<string, unknown>> = {
   en: clientEn as Record<string, unknown>,
   "pt-BR": clientPt as Record<string, unknown>,
 };
-// The locale the mounted tree renders in; a test flips it to read the other language.
-let uiLanguage = "en";
+// The locale the mounted tree renders in; a test flips it with `setLanguage` below.
+const i18n = createTestI18n("en", {
+  en: { translation: clientEn },
+  "pt-BR": { translation: clientPt },
+});
+function setLanguage(locale: string) {
+  i18n.changeLanguage(locale);
+}
 
 function lookup(locale: string, key: string): string | undefined {
   let node: unknown = CATALOGS[locale];
@@ -166,25 +180,6 @@ function lookup(locale: string, key: string): string | undefined {
   }
   return typeof node === "string" ? node : undefined;
 }
-
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (
-      key: string,
-      fallback?: string | Record<string, unknown>,
-      opts?: Record<string, unknown>,
-    ) => {
-      const fb = typeof fallback === "string" ? fallback : key;
-      const vars = (typeof fallback === "string" ? opts : fallback) ?? {};
-      const template = lookup(uiLanguage, key) ?? fb;
-      return template.replace(/\{\{(\w+)\}\}/g, (_m, k) =>
-        String(vars[k] ?? ""),
-      );
-    },
-    i18n: { language: uiLanguage },
-  }),
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
 
 mock.module("@/client/contexts/ThemeContext", () => ({
   useTheme: () => ({
@@ -239,11 +234,14 @@ async function openModal(firstDocTitle = "Doc") {
   render(
     // The blocked badge is wrapped in a <Tooltip>, which is a Radix consumer: without the provider
     // the App normally supplies, rendering the row throws.
-    <TooltipProvider>
-      <ToastProvider>
-        <Harness />
-      </ToastProvider>
-    </TooltipProvider>,
+    withI18n(
+      <TooltipProvider>
+        <ToastProvider>
+          <Harness />
+        </ToastProvider>
+      </TooltipProvider>,
+      i18n,
+    ),
   );
   fireEvent.click(screen.getByRole("button", { name: "open" }));
   await screen.findByText(firstDocTitle);
@@ -821,13 +819,13 @@ describe("a failed document's reason, rendered", () => {
     gatedDocsCalls = [];
     docsReleasers.clear();
     addDocResponse = null;
-    uiLanguage = "en";
+    setLanguage("en");
     installFetchStub();
   });
 
   afterEach(() => {
     cleanup();
-    uiLanguage = "en";
+    setLanguage("en");
   });
 
   // The three tokens the ingest job stores, next to the sentence each catalog answers with. Read
@@ -850,7 +848,7 @@ describe("a failed document's reason, rendered", () => {
   for (const [token, catalogKey] of CASES) {
     for (const locale of ["en", "pt-BR"] as const) {
       test(`${token} renders the ${locale} sentence`, async () => {
-        uiLanguage = locale;
+        setLanguage(locale);
         docsQueue = [
           {
             documents: [doc({ status: "FAILED", error: token })],
@@ -883,7 +881,7 @@ describe("a failed document's reason, rendered", () => {
     async (token, catalogKey) => {
       const seen: string[] = [];
       for (const locale of ["en", "pt-BR"] as const) {
-        uiLanguage = locale;
+        setLanguage(locale);
         docsQueue = [
           {
             documents: [doc({ status: "FAILED", error: token })],
@@ -910,7 +908,7 @@ describe("a failed document's reason, rendered", () => {
   test("the two languages are not the same sentence on screen", async () => {
     const seen: string[] = [];
     for (const locale of ["en", "pt-BR"] as const) {
-      uiLanguage = locale;
+      setLanguage(locale);
       docsQueue = [
         {
           documents: [
@@ -937,7 +935,7 @@ describe("a failed document's reason, rendered", () => {
   // The stored column, in the shape a row written before issue #256 carries. Same render path, same
   // tooltip — the alias only matters if it survives to the screen.
   test("a row written before the rename renders the pt-BR sentence too", async () => {
-    uiLanguage = "pt-BR";
+    setLanguage("pt-BR");
     docsQueue = [
       {
         documents: [
@@ -970,7 +968,7 @@ describe("a failed document's reason, rendered", () => {
   // An unknown token is NOT localized: it is the worker's raw diagnostic, and showing it verbatim is
   // the point (a translated "unknown error" would replace the only information there is).
   test("a diagnostic the map does not know is shown verbatim", async () => {
-    uiLanguage = "pt-BR";
+    setLanguage("pt-BR");
     docsQueue = [
       {
         documents: [

--- a/tests/client/pages/LogsGroupTitle.test.tsx
+++ b/tests/client/pages/LogsGroupTitle.test.tsx
@@ -6,7 +6,6 @@ import {
   beforeAll,
   describe,
   expect,
-  mock,
   test,
 } from "bun:test";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
@@ -14,6 +13,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { ToastProvider } from "@/client/components";
 import { LogsPage } from "@/client/pages/LogsPage";
+import { withI18n } from "@/tests/utils/i18n";
 
 // Issue #357: a Logs group whose rows have no conversation announces itself as "Turn", and the one
 // stage that can NEVER be a turn (`webhook`: an outbound delivery on a worker tick, long after
@@ -24,24 +24,10 @@ import { LogsPage } from "@/client/pages/LogsPage";
 // NOTE: every assertion reduces to a string or a boolean BEFORE expect. A failing expectation still
 // holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
 
-// `mock.module` is process-global in Bun and leaks across files in the same worker; another file's
-// `t` returns the key rather than the default string, which would make an assertion about the
-// rendered label fail on a translation detail instead of on the label. Declared here, interpolating,
-// so this file states the surface it needs instead of depending on which file ran first.
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
-      const text = typeof fallback === "string" ? fallback : key;
-      if (!vars) return text;
-      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
-        name in vars ? String(vars[name]) : m,
-      );
-    },
-    i18n: { language: "en" },
-  }),
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
-
+// This file asserts on rendered LABELS, so what `t` answers is part of the fixture. It used to
+// secure that by replacing `react-i18next` in the module registry, which secured it for every other
+// file in the process too: the stub the last such file installed was what they all got. `withI18n`
+// hands this tree its own i18next by context instead: same answers, no reach past this file.
 const realFetch = globalThis.fetch;
 
 interface Row {
@@ -94,13 +80,15 @@ const stubFetch = (async (input: unknown) => {
 async function titles(rows: Row[]): Promise<string[]> {
   items = rows.map(row);
   render(
-    <MemoryRouter>
-      <TooltipPrimitive.Provider>
-        <ToastProvider>
-          <LogsPage />
-        </ToastProvider>
-      </TooltipPrimitive.Provider>
-    </MemoryRouter>,
+    withI18n(
+      <MemoryRouter>
+        <TooltipPrimitive.Provider>
+          <ToastProvider>
+            <LogsPage />
+          </ToastProvider>
+        </TooltipPrimitive.Provider>
+      </MemoryRouter>,
+    ),
   );
   return await waitFor(() => {
     const found = screen

--- a/tests/client/pages/LogsScopeChip.test.tsx
+++ b/tests/client/pages/LogsScopeChip.test.tsx
@@ -6,7 +6,6 @@ import {
   beforeAll,
   describe,
   expect,
-  mock,
   test,
 } from "bun:test";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
@@ -14,6 +13,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { ToastProvider } from "@/client/components";
 import { LogsPage } from "@/client/pages/LogsPage";
+import { withI18n } from "@/tests/utils/i18n";
 
 // THE OTHER PLACE THE PAGE NAMES A GROUP, AND IT WAS NAMING IT SOMETHING ELSE.
 //
@@ -29,22 +29,10 @@ import { LogsPage } from "@/client/pages/LogsPage";
 // NOTE: every assertion reduces to a string or a boolean BEFORE expect. A failing expectation still
 // holding a DOM node serializes a cyclic happy-dom tree and stalls the runner.
 
-// `mock.module` is process-global in Bun and leaks across files in the same worker, so this file
-// states the i18n surface it needs rather than depending on which file ran first.
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
-      const text = typeof fallback === "string" ? fallback : key;
-      if (!vars) return text;
-      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
-        name in vars ? String(vars[name]) : m,
-      );
-    },
-    i18n: { language: "en" },
-  }),
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
-
+// This file asserts on rendered LABELS, so what `t` answers is part of the fixture. It used to
+// secure that by replacing `react-i18next` in the module registry, which secured it for every other
+// file in the process too: the stub the last such file installed was what they all got. `withI18n`
+// hands this tree its own i18next by context instead: same answers, no reach past this file.
 const realFetch = globalThis.fetch;
 
 interface Row {
@@ -100,13 +88,15 @@ async function labels(
 ): Promise<{ chip: string; card: string | null }> {
   items = rows.map(row);
   const { container } = render(
-    <MemoryRouter initialEntries={[`/logs?turnId=${scopeTurnId}`]}>
-      <TooltipPrimitive.Provider>
-        <ToastProvider>
-          <LogsPage />
-        </ToastProvider>
-      </TooltipPrimitive.Provider>
-    </MemoryRouter>,
+    withI18n(
+      <MemoryRouter initialEntries={[`/logs?turnId=${scopeTurnId}`]}>
+        <TooltipPrimitive.Provider>
+          <ToastProvider>
+            <LogsPage />
+          </ToastProvider>
+        </TooltipPrimitive.Provider>
+      </MemoryRouter>,
+    ),
   );
   return await waitFor(() => {
     const chipEl = [...container.querySelectorAll("span")].find((s) =>

--- a/tests/client/pages/SetupPage.test.tsx
+++ b/tests/client/pages/SetupPage.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { withI18n } from "@/tests/utils/i18n";
 
 const mockLogin = mock((_: unknown) => {});
 const mockRefresh = mock(async () => {});
@@ -39,26 +40,6 @@ mock.module("@/client/contexts/ThemeContext", () => ({
   ThemeProvider: ({ children }: { children: ReactNode }) => children,
 }));
 
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
-      const text = typeof fallback === "string" ? fallback : key;
-      if (!vars) return text;
-      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
-        name in vars ? String(vars[name]) : m,
-      );
-    },
-    i18n: { language: "en" },
-  }),
-  // NOTE: `SetupPage` imports from the `@/client/components` barrel, which
-  // transitively pulls `@/client/lib/i18n.ts` and its top-level
-  // `i18n.use(initReactI18next).init(...)`. Without this stub the file fails
-  // to load on CI (different module-eval ordering than the dev box) with
-  // `SyntaxError: Export named 'initReactI18next' not found`. Shape matches
-  // the real export: `{ type: "3rdParty", init }`.
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
-
 const { SetupPage } = await import("@/client/pages/SetupPage");
 const { ToastProvider } = await import("@/client/components/Toast");
 
@@ -72,21 +53,23 @@ function LocationProbe() {
 // its promise that exactly one channel fires. The app mounts every route inside one.
 function renderAt(path: string) {
   return render(
-    <ToastProvider>
-      <MemoryRouter initialEntries={[path]}>
-        <Routes>
-          <Route
-            path="/setup"
-            element={
-              <>
-                <SetupPage />
-                <LocationProbe />
-              </>
-            }
-          />
-        </Routes>
-      </MemoryRouter>
-    </ToastProvider>,
+    withI18n(
+      <ToastProvider>
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route
+              path="/setup"
+              element={
+                <>
+                  <SetupPage />
+                  <LocationProbe />
+                </>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>,
+    ),
   );
 }
 

--- a/tests/client/pages/VaultFillDeepLink.test.tsx
+++ b/tests/client/pages/VaultFillDeepLink.test.tsx
@@ -13,6 +13,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { ToastProvider } from "@/client/components";
+import { withI18n } from "@/tests/utils/i18n";
 
 // Issue #151: `credential_create` answers with a `fillAt` link so the operator can put the secret in
 // out of band. The vault panel looked the id up in the tenant the browser happened to have selected
@@ -53,20 +54,6 @@ function installFetchStub() {
   }) as typeof fetch;
 }
 
-mock.module("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string, fallback?: string, vars?: Record<string, unknown>) => {
-      const text = typeof fallback === "string" ? fallback : key;
-      if (!vars) return text;
-      return text.replace(/\{\{(\w+)\}\}/g, (m, name) =>
-        name in vars ? String(vars[name]) : m,
-      );
-    },
-    i18n: { language: "en" },
-  }),
-  initReactI18next: { type: "3rdParty", init: () => {} },
-}));
-
 mock.module("@/client/contexts/ThemeContext", () => ({
   useTheme: () => ({
     theme: "dark",
@@ -88,14 +75,16 @@ function SearchProbe() {
 
 function renderPanel(search: string) {
   return render(
-    <MemoryRouter initialEntries={[`/resources/vault${search}`]}>
-      <ToastProvider>
-        <SearchProbe />
-        <Routes>
-          <Route path="/resources/vault" element={<VaultPanel />} />
-        </Routes>
-      </ToastProvider>
-    </MemoryRouter>,
+    withI18n(
+      <MemoryRouter initialEntries={[`/resources/vault${search}`]}>
+        <ToastProvider>
+          <SearchProbe />
+          <Routes>
+            <Route path="/resources/vault" element={<VaultPanel />} />
+          </Routes>
+        </ToastProvider>
+      </MemoryRouter>,
+    ),
   );
 }
 

--- a/tests/lib/module-mock-package.test.ts
+++ b/tests/lib/module-mock-package.test.ts
@@ -40,17 +40,6 @@ const PACKAGE_MOCK = () => /mock\.module\(\s*"(?![./]|@\/)([^"]+)"/g;
 const PACKAGE_MOCKS_WAIVED: Record<string, string> = {
   "api/features/auth/google.service.test.ts → jose":
     "the stub DELEGATES to the real `jwtVerify` unless a test overrides it for its own call, so the leaked function still verifies real tokens for every file downstream. Asserted there by a round trip that runs after `beforeEach`, which is what fails if the delegation or the `mockClear` is taken away.",
-  "client/components/TenantDeepLink.test.tsx → react-i18next":
-    "predates this ledger, and the argument it used to carry — that a leaked stub only ever meets another stub — was measured false on 2026-08-29 (#435): a new page test renders a translated component WITHOUT stubbing, four of these stubs dropped the vars argument, and the label came out holding a literal `{{ref}}`. Green locally, red on CI, because the answer is whichever file ran last. What keeps it harmless now is the sweep below, not the coincidence: every one of these returns the fallback AND interpolates, which is this ledger's rule applied to `t` — the leak is permanent either way, so it has to carry correct behaviour.",
-  "client/components/UserMenu.test.tsx → react-i18next": "same as above.",
-  "client/pages/DashboardFirstResponse.test.tsx → react-i18next":
-    "same as above.",
-  "client/pages/KnowledgeApprovals.test.tsx → react-i18next": "same as above.",
-  "client/pages/KnowledgeDocsBlock.test.tsx → react-i18next": "same as above.",
-  "client/pages/LogsGroupTitle.test.tsx → react-i18next": "same as above.",
-  "client/pages/LogsScopeChip.test.tsx → react-i18next": "same as above.",
-  "client/pages/SetupPage.test.tsx → react-i18next": "same as above.",
-  "client/pages/VaultFillDeepLink.test.tsx → react-i18next": "same as above.",
 };
 
 // This file's own `mock.module(…)` occurrences are FIXTURES for the decision table below, not calls.
@@ -141,7 +130,7 @@ describe("every third-party module stub is argued for", () => {
   });
 
   test("the ledger may only shrink", () => {
-    expectWaiverLedger("PACKAGE_MOCKS_WAIVED", PACKAGE_MOCKS_WAIVED, 10);
+    expectWaiverLedger("PACKAGE_MOCKS_WAIVED", PACKAGE_MOCKS_WAIVED, 1);
   });
 
   // What the sweep READS, asserted separately from what it decides. No helper stubs a package
@@ -290,14 +279,29 @@ describe("a leaked `t` still interpolates", () => {
       "`mock.module` has no file scope, so this `t` is what every file that runs afterwards gets — " +
         "including files that never asked for a stub and whose labels DO interpolate. A `t` that " +
         "returns the fallback unexpanded renders `{{ref}}` on screen, and the file that fails is not " +
-        "this one. Expand `{{name}}` from the vars argument, the way " +
-        "tests/client/pages/LogsGroupTitle.test.tsx does.",
+        "this one. Do not write one: `withI18n` in tests/utils/i18n.tsx hands the tree a real i18next " +
+        "instance by context, and real interpolation comes with it.",
     ).toEqual([]);
   });
 
-  // The sweep is worth nothing if it stops finding the stubs it is meant to police.
-  test("and the sweep still finds them", async () => {
-    expect(i18nStubFiles(await scanTree()).length).toBeGreaterThan(0);
+  // THE TREE NO LONGER HOLDS ONE, AND THAT IS THE POINT, SO THIS SELF-CHECK IS INVERTED.
+  //
+  // It used to read `toBeGreaterThan(0)`, on the rule that a sweep finding nothing has stopped
+  // being evidence. Nine files stubbed the package then; none does now, because a per-file i18next
+  // instance handed down through `I18nextProvider` answers the same `t` without writing anything to
+  // the module registry (tests/utils/i18n.tsx). So the honest assertion is the stronger one: zero.
+  //
+  // What covers the function now that the tree cannot exercise it is the fixture table below, which
+  // is the same answer this file already gives for its own `SELF` exclusion. And the sweep above is
+  // what keeps the zero true: an unwaived `mock.module("react-i18next", …)` fails there first.
+  test("nothing stubs react-i18next any more", async () => {
+    expect(
+      i18nStubFiles(await scanTree()),
+      "Stubbing this package replaces it for the whole process, and the `i18n` a hand-written stub " +
+        "hands back freezes `language` at a literal, which is what made " +
+        "tests/client/document-starters-race.test.tsx stop racing. Use `withI18n` from " +
+        "tests/utils/i18n.tsx instead: a real instance, per file, delivered by context.",
+    ).toEqual([]);
   });
 
   describe("the decision, over files it is handed", () => {

--- a/tests/lib/module-mock-undo.test.ts
+++ b/tests/lib/module-mock-undo.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import { Glob } from "bun";
+import { codeOnly } from "@/tests/utils/source-text";
+
+// A TEARDOWN THAT HANDS BACK THE NAMESPACE `await import()` RETURNED PUTS NOTHING BACK.
+//
+// `mock.module(spec, factory)` rewrites the module registry for the WHOLE process, and it rewrites
+// the live namespace object in place. So a file that saves the namespace first and re-registers it
+// afterwards is handing the registry the object the rewrite already changed:
+//
+//     const service = await import("@/modules/rag/service");
+//     mock.module("@/modules/rag/service", () => ({ ...service, listX: stub }));
+//     afterAll(() => mock.module("@/modules/rag/service", () => service));   // <- undoes nothing
+//
+// It reads as a cleanup, it is what a reviewer expects to see, and the stub survives it for every
+// file that runs afterwards. tests/lib/module-mock-package.test.ts already says this in prose. This
+// is the same sentence, enforced.
+//
+// Measured on 2026-08-30, over `bun test --shard=k/4` against a clean main: six files were carrying
+// this shape and two of them were reachable in the order the shards give.
+//
+//   - tests/api/v1/knowledge-tenant-context.test.ts stubbed `listKnowledgeBases` to answer `[]`, and
+//     tests/modules/tenant-selector-entry-points.test.ts, which calls the real one to prove it
+//     REFUSES a dead tenant selector, got the stub. Nothing was refused. Two failures in shard 1/4.
+//   - tests/api/v1/query-filter-refusal.test.ts stubbed `listExecutionLogs` and `listAudit` the same
+//     way, and tests/modules/flowlog.test.ts then read none of its own rows back, reported as a
+//     tenant unable to see its own data, which is the shape of an RLS defect. Three failures in
+//     shard 4/4, across two files, neither of which stubs anything.
+//
+// None of the five failures named the file at fault, which is why this is a source sweep and not a
+// runtime check: the cost is paid somewhere else, so only the source can name the cause.
+//
+// WHAT IS NOT FLAGGED, and the distinction is the whole decision: a factory returning an object
+// LITERAL is fine, because `{ ...service }` taken before the rewrite is a copy and the copy still
+// holds the original functions. What is flagged is a factory returning a bare identifier that this
+// file bound from `await import(...)`. The two are indistinguishable at the call site, so the sweep
+// resolves the binding instead of reading the call.
+//
+// THE FIX IS NEVER A BETTER TEARDOWN. `spyOn(namespaceObject, "name")` keeps the original value and
+// `mockRestore()` puts that value back, per property, without touching the registry at all. Every
+// file named above now does that.
+
+const NAMESPACE_BINDING =
+  /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+import\s*\(/g;
+// A factory that is an arrow returning a bare identifier and nothing else. The specifier is left
+// unnamed in this sentence on purpose: the package sweep next door reads raw source, so spelling a
+// quoted bare specifier inside a `mock.module(` here would be counted as a stub of a package by
+// that name. The
+// specifier is matched as `"[^"]*"` rather than `"[^"]+"` because this runs over `codeOnly` output,
+// where a string body is blanked and an EMPTY pair of quotes is what a real specifier looks like.
+const UNDO_BY_IDENT =
+  /mock\.module\(\s*"[^"]*"\s*,\s*\(\s*\)\s*=>\s*([A-Za-z_$][\w$]*)\s*\)/g;
+
+export interface ScannedFile {
+  rel: string;
+  source: string;
+}
+
+export function undoByLiveNamespace(files: readonly ScannedFile[]): string[] {
+  const out: string[] = [];
+  for (const { rel, source } of files) {
+    // `codeOnly` decides WHERE, the raw source says WHAT. It blanks string BODIES, so the specifier
+    // reaches the match as spaces; every removed character becomes one, so the offsets still name the
+    // same position in `source` and the name can be read back from there.
+    const code = codeOnly(source);
+    const namespaces = new Set(
+      [...code.matchAll(NAMESPACE_BINDING)].map((m) => m[1] as string),
+    );
+    if (namespaces.size === 0) continue;
+    for (const m of code.matchAll(UNDO_BY_IDENT)) {
+      if (!namespaces.has(m[1] as string)) continue;
+      const spec = /"([^"]*)"/.exec(
+        source.slice(m.index, m.index + m[0].length),
+      )?.[1];
+      out.push(`${rel} → ${spec ?? "?"}`);
+    }
+  }
+  return [...new Set(out)].sort();
+}
+
+async function testSources(): Promise<ScannedFile[]> {
+  const out: ScannedFile[] = [];
+  for await (const rel of new Glob("**/*.{ts,tsx}").scan("tests")) {
+    out.push({ rel, source: await Bun.file(`tests/${rel}`).text() });
+  }
+  return out;
+}
+
+// This file spells the shape in its own fixtures, so it answers for itself the way every sweep here
+// does: `codeOnly` covers the prose, and the table below covers what prose cannot.
+const SELF = "lib/module-mock-undo.test.ts";
+
+describe("a module stub is undone by restoring, not by re-registering", () => {
+  test("no teardown hands the registry a live namespace", async () => {
+    expect(
+      undoByLiveNamespace((await testSources()).filter((f) => f.rel !== SELF)),
+      "`mock.module` rewrites this namespace object IN PLACE, so handing it back registers the stub " +
+        "a second time. The file reads as if it cleaned up and every file that runs afterwards still " +
+        "gets the stub, and fails somewhere else, naming its own assertion. Use " +
+        '`spyOn(namespace, "name")` and `mockRestore()`, which keeps the original value.',
+    ).toEqual([]);
+  });
+
+  // A sweep that reads nothing passes, and passing on an empty read is the failure this file exists
+  // to prevent. The tree no longer holds the shape, so what has to be non-empty is the INPUT.
+  test("the sweep reads the tree", async () => {
+    const files = await testSources();
+    expect(files.length).toBeGreaterThan(400);
+    expect(
+      files.some((f) => /await\s+import\s*\(/.test(f.source)),
+      "no file binds a namespace at all, so the sweep could not flag one either way",
+    ).toBe(true);
+  });
+
+  describe("the decision, over files it is handed", () => {
+    const scan = (source: string) =>
+      undoByLiveNamespace([{ rel: "a.ts", source }]);
+
+    test("re-registering a bound namespace is flagged", () => {
+      expect(
+        scan(
+          'const svc = await import("@/m");\nmock.module("@/m", () => ({ ...svc, f: stub }));\nafterAll(() => {\n  mock.module("@/m", () => svc);\n});\n',
+        ),
+      ).toEqual(["a.ts → @/m"]);
+    });
+
+    // The copy is the whole point of the distinction: `{ ...svc }` evaluated BEFORE the rewrite holds
+    // the original functions, so re-registering it does restore them.
+    test("re-registering a copy taken beforehand is not", () => {
+      expect(
+        scan(
+          'const svc = await import("@/m");\nconst real = { ...svc };\nmock.module("@/m", () => ({ ...svc, f: stub }));\nafterAll(() => {\n  mock.module("@/m", () => real);\n});\n',
+        ),
+      ).toEqual([]);
+    });
+
+    test("an object literal factory is not a re-registration", () => {
+      expect(
+        scan(
+          'const cfg = await import("@/config");\nmock.module("@/config", () => ({ default: cfg.default }));\n',
+        ),
+      ).toEqual([]);
+    });
+
+    test("a file that binds no namespace is out of scope", () => {
+      expect(scan('mock.module("@/m", () => real);\n')).toEqual([]);
+    });
+
+    // Prose describing the shape is not the shape, which is the phantom-site failure `codeOnly`
+    // exists for and which this file's own header would otherwise trip.
+    test("the shape written in a comment is not a call site", () => {
+      expect(
+        scan(
+          'const svc = await import("@/m");\n// mock.module("@/m", () => svc) would undo nothing.\n',
+        ),
+      ).toEqual([]);
+    });
+
+    test("two spellings of the same pair are reported once", () => {
+      expect(
+        scan(
+          'const svc = await import("@/m");\nmock.module("@/m", () => svc);\nmock.module("@/m", () => svc);\n',
+        ),
+      ).toEqual(["a.ts → @/m"]);
+    });
+  });
+});

--- a/tests/utils/i18n.tsx
+++ b/tests/utils/i18n.tsx
@@ -1,0 +1,64 @@
+/// <reference lib="dom" />
+
+import { createInstance, type i18n as I18n, type Resource } from "i18next";
+import type { ReactElement, ReactNode } from "react";
+import { I18nextProvider } from "react-i18next";
+
+// A REAL i18next, PER FILE, INSTEAD OF A STUB IN THE PROCESS REGISTRY.
+//
+// Nine test files used to open by stubbing this package in the module registry, handing back a
+// hand-written `useTranslation`. That call has no file scope and no teardown, so the stub the LAST
+// of them installed is what every file afterwards imported, and the `i18n` inside it was a literal
+// `{ language: "en" }`. A file downstream reading the language for real therefore read a constant.
+//
+// Measured: tests/client/document-starters-race.test.tsx switches the language to prove a stale
+// starter list cannot overwrite a newer one, and `DocumentsPanel` picks its locale with
+// `i18n.language.startsWith("pt")`. Against the frozen stub the switch changed nothing, both loads
+// asked for the same locale, and the race the test exists to lose stopped happening, silently,
+// because the assertions still found the English list they were handed.
+//
+// What replaces it is not a better stub. `t(key, fallback)` is i18next's own `defaultValue`
+// signature, so an instance with EMPTY resources answers exactly what those stubs answered:
+//
+//     t("theme.label", "Theme")            -> "Theme"        (the fallback)
+//     t("theme.light")                     -> "theme.light"  (the key, no fallback given)
+//     t("x", "hi {{ref}}", { ref: "Z" })   -> "hi Z"         (real interpolation)
+//
+// The third line is the #435 defect the stub ledger describes: four hand-written `t`s dropped the
+// vars argument and a label reached the DOM holding a literal `{{ref}}`. It cannot recur here,
+// because nobody is writing `t` any more.
+//
+// And the instance travels by CONTEXT, through `I18nextProvider`, which is what makes this per-file:
+// `useTranslation` reads the context first and only falls back to the global instance when there is
+// none. Nothing is written to the module registry, so there is nothing to leak and nothing to undo.
+//
+// `useSuspense: false` because these tests render without a Suspense boundary; the default would
+// suspend on the first render and the tree would never appear.
+//
+// `resources` is for the one test file that asserts against the REAL catalogs: pass them and `t`
+// answers the catalog entry where there is one and the fallback where there is not, which is what a
+// hand-written lookup in that file used to do by hand.
+export function createTestI18n(lng = "en", resources?: Resource): I18n {
+  const instance = createInstance();
+  instance.init({
+    lng,
+    resources: resources ?? {
+      en: { translation: {} },
+      "pt-BR": { translation: {} },
+    },
+    fallbackLng: false,
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  });
+  return instance;
+}
+
+// Wraps a tree in a fresh instance. Use the two-argument form when the test needs to hold the
+// instance to read `language` off it or to switch it mid-test.
+export function withI18n(children: ReactNode, instance?: I18n): ReactElement {
+  return (
+    <I18nextProvider i18n={instance ?? createTestI18n()}>
+      {children}
+    </I18nextProvider>
+  );
+}

--- a/tests/utils/source-text.ts
+++ b/tests/utils/source-text.ts
@@ -501,3 +501,63 @@ export async function countInSrc(re: RegExp): Promise<Record<string, number>> {
   }
   return found;
 }
+
+// A SECOND, SIMPLER SCRUBBER, AND WHY BOTH EXIST.
+//
+// It lived in tests/client/error-toast-reason.test.ts until another test file imported it from
+// there, which is what a helper in a `.test.ts` invites. That import cost something measurable:
+// under `bun test --shard=k/4` the two files land in different processes, so the exporting file's
+// 47 tests registered TWICE across the fleet and the shard totals stopped matching the serial run.
+// Nothing failed, and the arithmetic of a gate that no longer adds up is exactly what a gate is for.
+//
+// ONE SUCH IMPORT IS LEFT, DELIBERATELY. tests/lib/source-text.test.ts takes `bigIntArgs` from
+// tests/lib/caller-id-spelling.test.ts, and moving that one was tried and reverted: it drags
+// `blankNonCode`, `startsRegex` and `KEYWORDS_BEFORE_REGEX` behind it, and relocating those call
+// sites moves `BigInt(` occurrences into a different file, which is the key the waiver ledger in
+// caller-id-spelling is written against. Two tests went red for that reason alone. The cost of
+// leaving it is 12 test registrations repeated across four shards; the cost of moving it is
+// rewriting a ledger to buy them back.
+//
+// It is NOT merged into `codeOnly` above. That one answers regex bodies and URL schemes and carries
+// five rounds of measurement behind those answers; this one does not, and its callers count braces
+// rather than positions. Merging them is a change to what those sweeps decide, so it is a separate
+// piece of work from moving a function out of a test file.
+// The source with every comment and every string body blanked to spaces, offsets preserved.
+//
+// Counting braces on the raw text drifts, and it drifts SILENTLY: this tree's comments are prose
+// about the code and full of `{ error }`, `{{placeholder}}` and `${…}`. One unbalanced brace inside
+// one comment shifts every block boundary after it, and the scan then answers about the wrong
+// function for the rest of the file. Measured: on the raw text the scan found 28 offenders and
+// missed `BusinessHoursForm.tsx:230`, which is a bare `catch {}` under `throw err` read by hand.
+export function codeSkeleton(src: string): string {
+  const out = src.split("");
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== "\n") out[k] = " ";
+    }
+  };
+  while (i < src.length) {
+    const two = src.slice(i, i + 2);
+    if (two === "//") {
+      const end = src.indexOf("\n", i);
+      blank(i, end < 0 ? src.length : end);
+      i = end < 0 ? src.length : end;
+    } else if (two === "/*") {
+      const end = src.indexOf("*/", i + 2);
+      blank(i, end < 0 ? src.length : end + 2);
+      i = end < 0 ? src.length : end + 2;
+    } else if (src[i] === '"' || src[i] === "'" || src[i] === "`") {
+      const quote = src[i] as string;
+      let k = i + 1;
+      while (k < src.length) {
+        if (src[k] === "\\") k += 2;
+        else if (src[k] === quote) break;
+        else k++;
+      }
+      blank(i + 1, k);
+      i = k + 1;
+    } else i++;
+  }
+  return out.join("");
+}


### PR DESCRIPTION
## What this is

A follow-up to #446, which fixed four order dependencies and named one it could not. Measuring the
four shards against a clean `main` found **six** failures, not one, and they turned out to be three
causes rather than three families. All are now fixed, and the CI job is sharded four ways, which is
what the whole exercise was for.

Every defect here has one shape: **a test file writes to something the whole process shares, and
nothing puts it back.** The cost is paid by a different file, so the failure names its own
assertion and never the cause. That is also why two of the three fixes are static sweeps rather
than notes.

## The defects

### 1. Nine files replaced `react-i18next` for everyone

Each opened with `mock.module("react-i18next", …)` handing back a hand-written `useTranslation`.
That call has no file scope and no teardown, so the stub the LAST of them installed is what every
file afterwards imported.

The stub ledger in `tests/lib/module-mock-package.test.ts` already argued this exact shape for `t`:
the leak is permanent either way, so it has to carry correct behaviour. Nobody applied the same
reasoning to `i18n`, and that is the half that broke. All nine froze `i18n.language` at a literal.

`tests/client/document-starters-race.test.tsx` switches the language to prove a stale starter list
cannot overwrite a newer one, and `DocumentsPanel` picks its locale with
`i18n.language.startsWith("pt")`. Against a frozen literal both loads asked for the same locale and
the race the test exists to lose stopped happening, silently, because the assertions still found
the English list they were handed.

**The replacement is not a better stub.** `t(key, fallback)` is i18next's own `defaultValue`
signature, so an instance with EMPTY resources answers exactly what those stubs answered:

| call | stub | real instance, no resources |
| --- | --- | --- |
| `t("theme.label", "Theme")` | `"Theme"` | `"Theme"` |
| `t("theme.light")` | `"theme.light"` | `"theme.light"` |
| `t("x", "hi {{ref}}", {ref:"Z"})` | `"hi Z"` | `"hi Z"` |

The third row is the #435 defect the ledger describes, where four hand-written `t`s dropped the
vars argument and a label reached the DOM holding a literal `{{ref}}`. It cannot recur, because
nobody is writing `t` any more. The instance travels by CONTEXT through `I18nextProvider`, which
`useTranslation` reads before falling back to the global one, so nothing is written to the registry.

Also gone: the `initReactI18next: { type: "3rdParty", init: () => {} }` every stub carried.
`SetupPage`'s own comment recorded why it was there, that the real `@/client/lib/i18n.ts` could not
load while the package was stubbed. It was a patch on the leak.

The ledger drops from 10 entries to 1, and the interpolation sweep's self-check is **inverted**: it
asserted `toBeGreaterThan(0)` on the rule that a sweep finding nothing has stopped being evidence,
and now asserts zero, because zero is the state and the package sweep above is what holds it.

### 2. Six teardowns that put nothing back

```ts
const service = await import("@/modules/rag/service");
mock.module("@/modules/rag/service", () => ({ ...service, listX: stub }));
afterAll(() => mock.module("@/modules/rag/service", () => service));   // undoes nothing
```

`mock.module` rewrites the live namespace in place, so the teardown hands the registry the object
the rewrite already changed. The ledger says this in prose, and said it while these six lines sat in
the tree. What was missing was anything that made the sentence cost something.

Two were reachable in the order the shards give:

- `knowledge-tenant-context` stubbed `listKnowledgeBases` to answer `[]`, and
  `tenant-selector-entry-points`, which calls the real one to prove it REFUSES a dead tenant
  selector, got the stub. Nothing was refused. **2 failures in shard 1/4.**
- `query-filter-refusal` stubbed `listExecutionLogs` and `listAudit`, so `flowlog` read none of its
  own rows back and reported a tenant unable to see its OWN data, which is the shape of an RLS
  defect, and `tier3`'s audit round trip came back empty. **3 failures in shard 4/4, across two
  files, neither of which stubs anything.**
- `upstream-zod-error` carried the same shape on `discoverMcpTools`. Nothing reached it in the four
  orders measured, which is luck rather than a difference.

All three now use `spyOn(namespace, "name")`, which keeps the original value and restores per
property. #446 applied this same fix to `searchKnowledge` in the file next door: it fixed the
instance and left the class.

`tests/lib/module-mock-undo.test.ts` is what makes it stay fixed. It **resolves the binding** rather
than reading the call, because `() => real` where `real = { ...ns }` is a copy taken before the
rewrite and does restore, while `() => ns` does not, and the two are identical at the call site.
Four files in the tree take the copy and are correctly silent.

A side effect worth naming: `spyOn` is typed where a registry rewrite was not. The conversion made
`tsc` check the real signatures, and one stub was declared `Promise<unknown[]>` for a route that
expects a specific row shape.

### 3. A helper exported from a `.test.ts`

`field-refusal-fence` imported `codeSkeleton` from `error-toast-reason.test.ts`. In serial the two
share one module cache and the exporter's tests register once; in different shards they are
different processes and register twice. **This is what #446 recorded as a bun `--isolate` defect,
measured with `process.pid` markers.** The diagnosis was wrong: it is a test file importing a test
file, and `--isolate` was incidental.

`codeSkeleton` moves to `tests/utils/source-text.ts`. One such import is left, deliberately, with
the reason written where the function lives (see Not validated).

## The sharding

Four jobs, one runner and one database each, `fail-fast: false`.

**On the runner, wall clock 252s to 113s.** The four jobs took 98s, 107s, 108s and 109s; the serial
baseline is the `Run Tests on PR` run on `main` at `9a76a35f`. Locally the slowest shard is 76s
against a 186s serial test step. The runner gains more than the laptop because the four jobs also
stop competing for the same four vCPUs, which is what made `--parallel` slower there than serial
(257s against a 187s baseline, measured in #446).

The workflow's note now carries the bisection method instead of the blocker: bun ignores argument
order, so narrow with `--shard=k/N` doubling N, and neutralise candidates by replacing their
CONTENTS rather than their paths, since moving a file moves it in the ordering. Two full pairwise
sweeps (133 files each) had found none of these.

## Validation scope

**Proven by test.** Each of the six failures was reproduced on a clean `main` under `--shard=k/4`
and each file was confirmed to pass alone first, so all six are order-dependent by construction.
After the fixes: four shards at **0 fail**, `bun check` green.

**Measured on two different shard compositions.** The base moved mid-round and brought seven new
test files, which reshuffles every shard because the split is by file index. Re-run on the new base:
serial 8332 pass / 0 fail across 544 files, four shards 0 fail, slowest 76s. A green run on one
composition would have said much less.

**The gate's coverage was measured, not assumed.** Comparing the junit output of the serial run
against the union of the four shards: **no test runs in serial that does not run in some shard.**
The reverse is not exact, and the 12 tests that repeat are the deliberate exception below.

**Not validated.**

- **Twelve test registrations still repeat across the four shards.** `tests/lib/source-text.test.ts`
  imports `bigIntArgs` from `tests/lib/caller-id-spelling.test.ts`. Moving it was tried and
  reverted: it drags `blankNonCode`, `startsRegex` and `KEYWORDS_BEFORE_REGEX` behind it, and
  relocating those call sites moves `BigInt(` occurrences into a different file, which is the key
  the waiver ledger in that file is written against. Two tests went red for that reason alone. The
  cost of leaving it is twelve repeated registrations; the cost of moving it is rewriting a ledger.
- **Three source scrubbers now sit in one file** (`codeOnly`, `codeSkeleton`, and `blankNonCode`
  where it already was). They answer the same question and each carries its own measured
  exceptions, so merging them changes what their sweeps decide. Written down, not done.
- **`bun test --parallel` was not re-measured** here. It implies `--isolate`, so a registry rewrite
  cannot reach the next file and none of these defects were visible under it.
- **The runner numbers above are from this PR's own CI run**, so the sharding is exercised where it
  will live. What is still local-only is the six-failure baseline: reproducing it needs a run of
  `--shard=k/4` against an unfixed tree, which no CI run here has.
