### PR TITLE
Ask whether a credential can serve the field that names it, instead of only whether it resolves

### DIFF
--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -23,6 +23,8 @@
     "chatwootProfileFailed": "Chatwoot could not be reached with the URL and token provided.",
     "chatwootRebindFailed": "The bot could not be reconnected to Chatwoot.",
     "conversationNotFound": "Conversation not found.",
+    "credentialKindUnusableAsKey": "This field reads an API key and the \"{{kind}}\" credential type cannot supply one: it either holds several fields instead of a single secret, or it is one this product never sends to another service. Pick a different credential.",
+    "credentialKindUnusableOutbound": "The \"{{kind}}\" credential type is read inside this product and is never sent to another service, so it cannot authenticate a request. Pick a different credential.",
     "credentialNotUsable": "This credential did not provide an API key: it may be missing, empty, or of a type this provider cannot use.",
     "credentialPending": "The credential {{ref}} has not been filled yet",
     "credentialPendingUnsupportedKind": "This credential type is set up via a connect flow and cannot be created as a pending reference",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -23,6 +23,8 @@
     "chatwootProfileFailed": "Não foi possível acessar o Chatwoot com a URL e o token informados.",
     "chatwootRebindFailed": "Não foi possível reconectar o bot ao Chatwoot.",
     "conversationNotFound": "Conversa não encontrada.",
+    "credentialKindUnusableAsKey": "Este campo lê uma chave de API e o tipo de credencial \"{{kind}}\" não consegue fornecer uma: ou ele guarda vários campos em vez de um segredo único, ou é um tipo que este produto nunca envia para outro serviço. Escolha outra credencial.",
+    "credentialKindUnusableOutbound": "O tipo de credencial \"{{kind}}\" é lido dentro deste produto e nunca é enviado para outro serviço, então não consegue autenticar uma requisição. Escolha outra credencial.",
     "credentialNotUsable": "Esta credencial não forneceu uma chave de API: ela pode estar ausente, vazia ou de um tipo que este provedor não usa.",
     "credentialPending": "A credencial {{ref}} ainda não foi preenchida",
     "credentialPendingUnsupportedKind": "Este tipo de credencial é configurado por um fluxo de conexão e não pode ser criado como referência pendente",

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -26,6 +26,8 @@ import {
 // the defaults in sync with src/api/locales/*.json.
 // translate('errors.credentialPending', 'The credential {{ref}} has not been filled yet')
 // translate('errors.credentialPendingUnsupportedKind', 'This credential type is set up via a connect flow and cannot be created as a pending reference')
+// translate('errors.credentialKindUnusableAsKey', 'This field reads an API key and the "{{kind}}" credential type cannot supply one: it either holds several fields instead of a single secret, or it is one this product never sends to another service. Pick a different credential.')
+// translate('errors.credentialKindUnusableOutbound', 'The "{{kind}}" credential type is read inside this product and is never sent to another service, so it cannot authenticate a request. Pick a different credential.')
 // translate('errors.emptyVaultSecret', 'A vault secret must not be empty.')
 // translate('errors.invalidSecretType', 'That secret type is not valid.')
 // translate('errors.invalidVaultBaseUrl', 'Base URL must be a valid http(s) URL')

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -159,6 +159,10 @@ export function useVaultBaseUrls(): (ref: string) => string | null {
 export function useVaultRefs(): {
   known: Set<string> | null;
   pending: Set<string>;
+  // The KIND of every ref in `known`, keyed the same way, so a field can ask whether the entry it
+  // names can actually serve it — resolving and serving are different questions (issue #471). Null
+  // alongside `known` and for the same reason: an empty map would read as "no kind fits".
+  kinds: Map<string, string | null> | null;
   pendingEntries: VaultEntry[];
 } {
   const [entries, setEntries] = useState<VaultEntry[] | null>(null);
@@ -198,6 +202,13 @@ export function useVaultRefs(): {
     pending: useMemo(
       () => new Set(pendingEntries.map((e) => formatVaultRef(e.id))),
       [pendingEntries],
+    ),
+    kinds: useMemo(
+      () =>
+        entries
+          ? new Map(entries.map((e) => [formatVaultRef(e.id), e.kind]))
+          : null,
+      [entries],
     ),
     pendingEntries,
   };

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getActiveTenantId } from "@/client/lib/activeTenant";
 import { api } from "@/client/lib/api";
 import { canonicalVaultRef, formatVaultRef } from "@/client/lib/credentialRef";
+import type { VaultRefFacts } from "@/modules/agents/config-health";
 
 // Derived from the treaty response, never hand-mirrored (see docs/eden-treaty.md).
 export type VaultEntry = NonNullable<
@@ -159,10 +160,11 @@ export function useVaultBaseUrls(): (ref: string) => string | null {
 export function useVaultRefs(): {
   known: Set<string> | null;
   pending: Set<string>;
-  // The KIND of every ref in `known`, keyed the same way, so a field can ask whether the entry it
-  // names can actually serve it — resolving and serving are different questions (issue #471). Null
-  // alongside `known` and for the same reason: an empty map would read as "no kind fits".
-  kinds: Map<string, string | null> | null;
+  // What the vault says each ref in `known` IS, keyed the same way, so a field can ask whether the
+  // entry it names can actually serve it — resolving and serving are different questions (issue
+  // #471). The value's shape comes back as a boolean the server computed, never as the value. Null
+  // alongside `known` and for the same reason: an empty map would read as "nothing fits".
+  facts: Map<string, VaultRefFacts> | null;
   pendingEntries: VaultEntry[];
 } {
   const [entries, setEntries] = useState<VaultEntry[] | null>(null);
@@ -203,10 +205,15 @@ export function useVaultRefs(): {
       () => new Set(pendingEntries.map((e) => formatVaultRef(e.id))),
       [pendingEntries],
     ),
-    kinds: useMemo(
+    facts: useMemo(
       () =>
         entries
-          ? new Map(entries.map((e) => [formatVaultRef(e.id), e.kind]))
+          ? new Map(
+              entries.map((e) => [
+                formatVaultRef(e.id),
+                { kind: e.kind, valueFitsKind: e.valueFitsKind },
+              ]),
+            )
           : null,
       [entries],
     ),

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -836,6 +836,18 @@
       "ttsNormalize": "The speech-rewrite credential no longer exists, so replies are spoken without the rewrite.",
       "vision": "The image-reading credential no longer exists, so images and documents are not read."
     },
+    "configIssueWrongKind": {
+      "contactAuth": "The contact-authorization credential is a type this product never sends to another service, so the check fails and the agent stays silent. Pick a credential that can authenticate a request.",
+      "embedding": "A knowledge base needs indexing, but the embedding credential is a type that cannot be used as an API key. Pick a credential that holds a single key.",
+      "guardrails": "The guardrails credential is a type that cannot be used as an API key, so messages go out unscreened. Pick a credential that holds a single key.",
+      "memoryModel": "The summary-model credential is a type that cannot be used as an API key, so attendances that end are not summarized. Pick a credential that holds a single key.",
+      "model": "The model credential is a type that cannot be used as an API key, so the agent cannot reply. Pick a credential that holds a single key.",
+      "modelFallback": "The fallback-provider credential is a type that cannot be used as an API key, so the fallback cannot take a turn. Pick a credential that holds a single key.",
+      "stt": "The transcription credential is a type that cannot be used as an API key, so voice messages are not transcribed. Pick a credential that holds a single key.",
+      "tts": "The audio-reply credential is a type that cannot be used as an API key, so replies are sent as text. Pick a credential that holds a single key.",
+      "ttsNormalize": "The speech-rewrite credential is a type that cannot be used as an API key, so replies are spoken without the rewrite. Pick a credential that holds a single key.",
+      "vision": "The image-reading credential is a type that cannot be used as an API key, so images and documents are not read. Pick a credential that holds a single key."
+    },
     "conflictToast": "This agent was changed elsewhere. Reload, or save again to overwrite.",
     "contactAuth": "Contact authorization",
     "contactAuthCredential": "Credential",
@@ -1000,6 +1012,7 @@
     "identitySectionHint": "Name, system prompt and whether the agent is active.",
     "importWarning": {
       "credentialAmbiguous": "Credential \"{{name}}\" appears with more than one type in the export, so it was left unset.",
+      "credentialKindUnusable": "The credential wired to \"{{field}}\" is a \"{{kind}}\" credential, which that field cannot use. It was left wired so you can see it; pick another one there.",
       "credentialMissingMeta": "Credential \"{{name}}\" is missing from the export metadata, so it was left unset.",
       "credentialNotFound": "Credential \"{{name}}\" was not found here, so it was left unset.",
       "credentialPending": "Credential \"{{name}}\" was not found here, so a placeholder was created. Fill in its secret to activate it.",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -839,6 +839,18 @@
       "ttsNormalize": "A credencial da reescrita para fala não existe mais, então o áudio sai sem a reescrita.",
       "vision": "A credencial de leitura de imagens não existe mais, então imagens e documentos não são lidos."
     },
+    "configIssueWrongKind": {
+      "contactAuth": "A credencial da autorização do contato é de um tipo que este produto nunca envia para outro serviço, então a verificação falha e o agente fica em silêncio. Escolha uma credencial capaz de autenticar uma requisição.",
+      "embedding": "Uma base de conhecimento precisa ser indexada, mas a credencial de embedding é de um tipo que não pode ser usado como chave de API. Escolha uma credencial que guarde uma única chave.",
+      "guardrails": "A credencial dos guardrails é de um tipo que não pode ser usado como chave de API, então as mensagens saem sem triagem. Escolha uma credencial que guarde uma única chave.",
+      "memoryModel": "A credencial do modelo de resumo é de um tipo que não pode ser usado como chave de API, então os atendimentos encerrados não são resumidos. Escolha uma credencial que guarde uma única chave.",
+      "model": "A credencial do modelo é de um tipo que não pode ser usado como chave de API, então o agente não consegue responder. Escolha uma credencial que guarde uma única chave.",
+      "modelFallback": "A credencial do provedor reserva é de um tipo que não pode ser usado como chave de API, então o reserva não assume nenhum turno. Escolha uma credencial que guarde uma única chave.",
+      "stt": "A credencial da transcrição é de um tipo que não pode ser usado como chave de API, então as mensagens de voz não são transcritas. Escolha uma credencial que guarde uma única chave.",
+      "tts": "A credencial da resposta em áudio é de um tipo que não pode ser usado como chave de API, então as respostas saem em texto. Escolha uma credencial que guarde uma única chave.",
+      "ttsNormalize": "A credencial da reescrita para fala é de um tipo que não pode ser usado como chave de API, então as respostas são faladas sem a reescrita. Escolha uma credencial que guarde uma única chave.",
+      "vision": "A credencial da leitura de imagens é de um tipo que não pode ser usado como chave de API, então imagens e documentos não são lidos. Escolha uma credencial que guarde uma única chave."
+    },
     "conflictToast": "Este agente foi alterado em outro lugar. Recarregue, ou salve de novo para sobrescrever.",
     "contactAuth": "Autorização do contato",
     "contactAuthCredential": "Credencial",
@@ -1003,6 +1015,7 @@
     "identitySectionHint": "Nome, prompt do sistema e se o agente está ativo.",
     "importWarning": {
       "credentialAmbiguous": "A credencial \"{{name}}\" aparece com mais de um tipo no export, então ficou em branco.",
+      "credentialKindUnusable": "A credencial ligada a \"{{field}}\" é do tipo \"{{kind}}\", que aquele campo não consegue usar. Ela ficou ligada para você ver; escolha outra ali.",
       "credentialMissingMeta": "A credencial \"{{name}}\" não está nos metadados do export, então ficou em branco.",
       "credentialNotFound": "A credencial \"{{name}}\" não foi encontrada aqui, então ficou em branco.",
       "credentialPending": "A credencial \"{{name}}\" não foi encontrada aqui, então criamos um espaço reservado. Preencha o segredo para ativá-la.",

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1773,6 +1773,7 @@ function AgentEditor() {
   const {
     known: knownRefs,
     pending: pendingRefs,
+    kinds: refKinds,
     pendingEntries,
   } = useVaultRefs();
 
@@ -1909,6 +1910,23 @@ function AgentEditor() {
   // t('editor.configIssueUnresolved.modelFallback', 'The fallback-provider credential no longer exists, so the fallback cannot take a turn.')
   // t('editor.configIssueUnresolved.vision', 'The image-reading credential no longer exists, so images and documents are not read.')
   // t('editor.configIssueUnresolved.embedding', 'A knowledge base needs indexing, but the embedding credential no longer exists.')
+  // The fourth verdict: the entry is there and filled, and its TYPE cannot serve the field. Each
+  // sentence names the consequence its feature already owns, like the three families above, and ends
+  // in the one move that fixes it — which is neither "fill it in" nor "pick a new one because it is
+  // gone", but "this key belongs somewhere else". Issue #471.
+  // t('editor.configIssueWrongKind.model', 'The model credential is a type that cannot be used as an API key, so the agent cannot reply. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.stt', 'The transcription credential is a type that cannot be used as an API key, so voice messages are not transcribed. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.tts', 'The audio-reply credential is a type that cannot be used as an API key, so replies are sent as text. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.ttsNormalize', 'The speech-rewrite credential is a type that cannot be used as an API key, so replies are spoken without the rewrite. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.memoryModel', 'The summary-model credential is a type that cannot be used as an API key, so attendances that end are not summarized. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.modelFallback', 'The fallback-provider credential is a type that cannot be used as an API key, so the fallback cannot take a turn. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.vision', 'The image-reading credential is a type that cannot be used as an API key, so images and documents are not read. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.guardrails', 'The guardrails credential is a type that cannot be used as an API key, so messages go out unscreened. Pick a credential that holds a single key.')
+  // t('editor.configIssueWrongKind.embedding', 'A knowledge base needs indexing, but the embedding credential is a type that cannot be used as an API key. Pick a credential that holds a single key.')
+  // The contact-authorization gate is the one field here that accepts a connected account, so its
+  // sentence cannot say "a single key": what it refuses is the opposite case, a credential this
+  // product only ever reads internally and never sends to another service.
+  // t('editor.configIssueWrongKind.contactAuth', 'The contact-authorization credential is a type this product never sends to another service, so the check fails and the agent stays silent. Pick a credential that can authenticate a request.')
   // Knowledge bases this agent uses (its RAG grant) that still have documents awaiting indexing —
   // surfaced as a config warning so a freshly-imported agent flags "index me" right in the editor.
   const ragGrant = grants.find((g) => g.source === "RAG");
@@ -1984,6 +2002,7 @@ function AgentEditor() {
     guardrailsLastFailureAt: guardrailHealth?.lastAt,
     pendingRefs,
     knownRefs,
+    refKinds,
     knowledgeBasesNeedingIndex,
     embeddingCredentialRef,
     redirectEnabled: channelRedirect.enabled,
@@ -2105,6 +2124,15 @@ function AgentEditor() {
         return t(
           "editor.importWarning.credentialPending",
           'Credential "{{name}}" was not found here, so a placeholder was created. Fill in its secret to activate it.',
+          p,
+        );
+      // The entry was found and wired; what does not fit is the PAIRING. Named by field rather than
+      // by credential name, unlike the four around it: the same credential can be right on one field
+      // and wrong on the next, so the name alone would not say where to look. Issue #471.
+      case "credentialKindUnusable":
+        return t(
+          "editor.importWarning.credentialKindUnusable",
+          'The credential wired to "{{field}}" is a "{{kind}}" credential, which that field cannot use. It was left wired so you can see it; pick another one there.',
           p,
         );
       case "credentialMissingMeta":

--- a/src/client/pages/agents/AgentEditorPage.tsx
+++ b/src/client/pages/agents/AgentEditorPage.tsx
@@ -1773,7 +1773,7 @@ function AgentEditor() {
   const {
     known: knownRefs,
     pending: pendingRefs,
-    kinds: refKinds,
+    facts: refFacts,
     pendingEntries,
   } = useVaultRefs();
 
@@ -2002,7 +2002,7 @@ function AgentEditor() {
     guardrailsLastFailureAt: guardrailHealth?.lastAt,
     pendingRefs,
     knownRefs,
-    refKinds,
+    refFacts,
     knowledgeBasesNeedingIndex,
     embeddingCredentialRef,
     redirectEnabled: channelRedirect.enabled,

--- a/src/graph/prepare.ts
+++ b/src/graph/prepare.ts
@@ -89,7 +89,7 @@ import { llmNormalizeForSpeech } from "@/modules/tts/normalize";
 import { resolveNormalizeModel } from "@/modules/tts/normalize-model";
 import { readTtsConfig, type TtsConfig } from "@/modules/tts/settings";
 import { resolveInjectableCredential } from "@/modules/vault/injectable";
-import { tryResolveVaultEntry } from "@/modules/vault/service";
+import { tryResolveApiKeyEntry } from "@/modules/vault/service";
 import { chatwootThreadId, getCheckpointer } from "./checkpointer";
 import {
   type FallbackConfig,
@@ -367,15 +367,23 @@ export async function loadAgentConfig(
   let apiKey = "";
   let credentialBaseUrl: string | null = null;
   if (mc.credentialRef) {
-    const entry = await tryResolveVaultEntry<string>(db, mc.credentialRef);
-    if (!entry) {
+    const entry = await tryResolveApiKeyEntry(db, mc.credentialRef);
+    if (entry.state !== "ok") {
       // A credentialRef that no longer resolves (deleted / still-pending / a NAME passed where a
       // vault:<id> ref is required) otherwise makes the agent go silent with no trace — the turn just
       // returns null. Log it so the silent no-reply is diagnosable.
+      //
+      // `unusable` is the same silence for a different reason and gets its own sentence: the entry is
+      // there and filled, and its KIND cannot be an API key (a `google_oauth` pair, a managed blob, a
+      // secret the catalog says never leaves). Told apart because the fix is not the same — one is
+      // "fill or re-pick this credential", the other is "this credential belongs on another field".
       logger.warn(
-        "agent %s: model credentialRef %s did not resolve — the agent cannot reply until it is fixed",
+        entry.state === "unusable"
+          ? "agent %s: model credentialRef %s resolves to a %s credential, which cannot be used as an API key — the agent cannot reply until it is fixed"
+          : "agent %s: model credentialRef %s did not resolve — the agent cannot reply until it is fixed",
         String(args.agentId),
         mc.credentialRef,
+        entry.state === "unusable" ? entry.kind : "",
       );
       return null;
     }
@@ -389,18 +397,18 @@ export async function loadAgentConfig(
   let guardrailsApiKey = "";
   let guardrailsCredentialBaseUrl: string | null = null;
   if (guardrails.enabled && guardrails.credentialRef) {
-    const gEntry = await tryResolveVaultEntry<string>(
-      db,
-      guardrails.credentialRef,
-    );
-    if (gEntry) {
+    const gEntry = await tryResolveApiKeyEntry(db, guardrails.credentialRef);
+    if (gEntry.state === "ok") {
       guardrailsApiKey = gEntry.secret;
       guardrailsCredentialBaseUrl = gEntry.baseUrl;
     } else {
       logger.warn(
-        "agent %s: guardrails credentialRef %s did not resolve — guardrails analysis is skipped",
+        gEntry.state === "unusable"
+          ? "agent %s: guardrails credentialRef %s resolves to a %s credential, which cannot be used as an API key — guardrails analysis is skipped"
+          : "agent %s: guardrails credentialRef %s did not resolve — guardrails analysis is skipped",
         String(args.agentId),
         guardrails.credentialRef,
+        gEntry.state === "unusable" ? gEntry.kind : "",
       );
     }
   }
@@ -412,18 +420,21 @@ export async function loadAgentConfig(
   let ttsNormalizeApiKey = "";
   let ttsNormalizeCredentialBaseUrl: string | null = null;
   if (ttsCfg.normalize && ttsCfg.normalizeCredentialRef) {
-    const nEntry = await tryResolveVaultEntry<string>(
+    const nEntry = await tryResolveApiKeyEntry(
       db,
       ttsCfg.normalizeCredentialRef,
     );
-    if (nEntry) {
+    if (nEntry.state === "ok") {
       ttsNormalizeApiKey = nEntry.secret;
       ttsNormalizeCredentialBaseUrl = nEntry.baseUrl;
     } else {
       logger.warn(
-        "agent %s: tts normalize credentialRef %s did not resolve, so the speech rewrite is skipped",
+        nEntry.state === "unusable"
+          ? "agent %s: tts normalize credentialRef %s resolves to a %s credential, which cannot be used as an API key, so the speech rewrite is skipped"
+          : "agent %s: tts normalize credentialRef %s did not resolve, so the speech rewrite is skipped",
         String(args.agentId),
         ttsCfg.normalizeCredentialRef,
+        nEntry.state === "unusable" ? nEntry.kind : "",
       );
     }
   }
@@ -435,18 +446,18 @@ export async function loadAgentConfig(
   let modelFallbackApiKey = "";
   let modelFallbackCredentialBaseUrl: string | null = null;
   if (hasModelFallback(fallbackCfg) && fallbackCfg.credentialRef) {
-    const fEntry = await tryResolveVaultEntry<string>(
-      db,
-      fallbackCfg.credentialRef,
-    );
-    if (fEntry) {
+    const fEntry = await tryResolveApiKeyEntry(db, fallbackCfg.credentialRef);
+    if (fEntry.state === "ok") {
       modelFallbackApiKey = fEntry.secret;
       modelFallbackCredentialBaseUrl = fEntry.baseUrl;
     } else {
       logger.warn(
-        "agent %s: model fallback credentialRef %s did not resolve, so there is nothing behind the provider",
+        fEntry.state === "unusable"
+          ? "agent %s: model fallback credentialRef %s resolves to a %s credential, which cannot be used as an API key, so there is nothing behind the provider"
+          : "agent %s: model fallback credentialRef %s did not resolve, so there is nothing behind the provider",
         String(args.agentId),
         fallbackCfg.credentialRef,
+        fEntry.state === "unusable" ? fEntry.kind : "",
       );
     }
   }
@@ -459,18 +470,18 @@ export async function loadAgentConfig(
   let memoryCompactionApiKey = "";
   let memoryCompactionCredentialBaseUrl: string | null = null;
   if (memoryCfg.enabled && memoryCfg.credentialRef) {
-    const mEntry = await tryResolveVaultEntry<string>(
-      db,
-      memoryCfg.credentialRef,
-    );
-    if (mEntry) {
+    const mEntry = await tryResolveApiKeyEntry(db, memoryCfg.credentialRef);
+    if (mEntry.state === "ok") {
       memoryCompactionApiKey = mEntry.secret;
       memoryCompactionCredentialBaseUrl = mEntry.baseUrl;
     } else {
       logger.warn(
-        "agent %s: memory compaction credentialRef %s did not resolve, so the attendance summary is not written",
+        mEntry.state === "unusable"
+          ? "agent %s: memory compaction credentialRef %s resolves to a %s credential, which cannot be used as an API key, so the attendance summary is not written"
+          : "agent %s: memory compaction credentialRef %s did not resolve, so the attendance summary is not written",
         String(args.agentId),
         memoryCfg.credentialRef,
+        mEntry.state === "unusable" ? mEntry.kind : "",
       );
     }
   }

--- a/src/graph/tools/assemble.ts
+++ b/src/graph/tools/assemble.ts
@@ -305,10 +305,7 @@ export async function loadToolSelections(
         let credentialKind: string | null = null;
         let credentialParamName: string | null = null;
         if (conn.credentialRef) {
-          const entry = await tryResolveVaultEntry<unknown>(
-            db,
-            conn.credentialRef,
-          );
+          const entry = await tryResolveVaultEntry(db, conn.credentialRef);
           credentialKind = entry?.kind ?? null;
           credentialParamName = entry?.paramName ?? null;
           credentialBaseUrl = entry?.baseUrl ?? null;

--- a/src/modules/agents/config-health-message.ts
+++ b/src/modules/agents/config-health-message.ts
@@ -124,6 +124,15 @@ export function configIssueMessage(
       "This credential no longer exists. Pick another one.",
     );
   }
+  // The credential is there and filled, and its TYPE cannot serve this field. Worth its own sentence
+  // because the other three all end in "fill it in" or "it is gone", and the move here is neither:
+  // the entry is fine, it just belongs somewhere else. Issue #471.
+  if (issue.wrongKind) {
+    return t(
+      `editor.configIssueWrongKind.${issue.key}`,
+      "This credential's type cannot be used here. Pick one that holds a single API key.",
+    );
+  }
   return t(
     `editor.configIssue.${issue.key}`,
     "This feature is enabled but has no credential set.",

--- a/src/modules/agents/config-health-read.ts
+++ b/src/modules/agents/config-health-read.ts
@@ -139,10 +139,16 @@ export async function readAgentConfigHealth(
       .filter((e) => e.status === "pending")
       .map((e) => formatVaultRef(e.id)),
   );
-  // The fourth question over the same list: an entry that exists and is filled can still be the wrong
-  // TYPE for the field naming it (issue #471). Read from the same rows as the three above, so the
-  // four answers cannot disagree about which refs the vault holds.
-  const refKinds = new Map(vault.map((e) => [formatVaultRef(e.id), e.kind]));
+  // The fourth question over the same list: an entry that exists and is filled can still be unable to
+  // serve the field naming it, by its TYPE or by holding a value that type does not describe (issue
+  // #471). Read from the same rows as the three above, so the four answers cannot disagree about
+  // which refs the vault holds.
+  const refFacts = new Map(
+    vault.map((e) => [
+      formatVaultRef(e.id),
+      { kind: e.kind, valueFitsKind: e.valueFitsKind },
+    ]),
+  );
   const baseUrlByRef = new Map(
     vault.map((e) => [formatVaultRef(e.id), e.baseUrl]),
   );
@@ -264,7 +270,7 @@ export async function readAgentConfigHealth(
     guardrailsLastFailureAt: guardrailHealth?.lastAt,
     pendingRefs,
     knownRefs,
-    refKinds,
+    refFacts,
     knowledgeBasesNeedingIndex,
     embeddingCredentialRef: tenantSettings.embedding.credentialRef ?? "",
     redirectEnabled: redirect.enabled,

--- a/src/modules/agents/config-health-read.ts
+++ b/src/modules/agents/config-health-read.ts
@@ -66,6 +66,9 @@ export interface AgentConfigHealthIssue {
   // caller that created it.
   pending?: boolean;
   unresolved?: boolean;
+  // The credential exists and is filled, and its TYPE cannot serve this field. Its own state, not a
+  // third spelling of the two above: the fix is to pick a different credential.
+  wrongKind?: boolean;
   vaultId?: string;
   knowledgeBaseId?: string;
   knowledgeBaseName?: string;
@@ -136,6 +139,10 @@ export async function readAgentConfigHealth(
       .filter((e) => e.status === "pending")
       .map((e) => formatVaultRef(e.id)),
   );
+  // The fourth question over the same list: an entry that exists and is filled can still be the wrong
+  // TYPE for the field naming it (issue #471). Read from the same rows as the three above, so the
+  // four answers cannot disagree about which refs the vault holds.
+  const refKinds = new Map(vault.map((e) => [formatVaultRef(e.id), e.kind]));
   const baseUrlByRef = new Map(
     vault.map((e) => [formatVaultRef(e.id), e.baseUrl]),
   );
@@ -257,6 +264,7 @@ export async function readAgentConfigHealth(
     guardrailsLastFailureAt: guardrailHealth?.lastAt,
     pendingRefs,
     knownRefs,
+    refKinds,
     knowledgeBasesNeedingIndex,
     embeddingCredentialRef: tenantSettings.embedding.credentialRef ?? "",
     redirectEnabled: redirect.enabled,
@@ -289,6 +297,7 @@ export async function readAgentConfigHealth(
       ...(issue.sectionId ? { sectionId: issue.sectionId } : {}),
       ...(issue.pending ? { pending: true } : {}),
       ...(issue.unresolved ? { unresolved: true } : {}),
+      ...(issue.wrongKind ? { wrongKind: true } : {}),
       ...(issue.vaultId ? { vaultId: issue.vaultId } : {}),
       ...(issue.knowledgeBaseId
         ? { knowledgeBaseId: issue.knowledgeBaseId }

--- a/src/modules/agents/config-health.ts
+++ b/src/modules/agents/config-health.ts
@@ -20,7 +20,7 @@ import { readMemoryConfig } from "@/modules/memory/settings";
 import { resolveNormalizeModel } from "@/modules/tts/normalize-model";
 import {
   type CredentialUse,
-  secretTypeFits,
+  credentialServes,
 } from "@/modules/vault/secret-types";
 
 // What the vault answers about one ref beyond "it exists". Kept as a pair rather than two parallel
@@ -347,10 +347,7 @@ function credIssue(
   // for the same reason `unresolved` waits on `known`. Issue #471.
   if (canonical !== null && vault.facts) {
     const facts = vault.facts.get(canonical);
-    if (
-      facts !== undefined &&
-      (!secretTypeFits(facts.kind, use) || !facts.valueFitsKind)
-    ) {
+    if (facts !== undefined && !credentialServes(facts, use)) {
       return { kind: "wrongKind" };
     }
   }

--- a/src/modules/agents/config-health.ts
+++ b/src/modules/agents/config-health.ts
@@ -23,6 +23,16 @@ import {
   secretTypeFits,
 } from "@/modules/vault/secret-types";
 
+// What the vault answers about one ref beyond "it exists". Kept as a pair rather than two parallel
+// maps because the two are read together and a caller that had one and not the other would be
+// asking the half-question this module exists to stop asking.
+export interface VaultRefFacts {
+  kind: string | null;
+  // Whether the stored value is the shape `kind` declares (secretValueFitsKind, computed server-side
+  // so no secret crosses the wire). True for a pending entry, which has no value yet.
+  valueFitsKind: boolean;
+}
+
 // Live configuration-health checks for the agent editor (item 1): detect features that are turned on
 // but missing the credential they need to actually run. The common trigger is importing an agent —
 // the import never carries secrets, so every credential ref comes back unset. Each issue carries a
@@ -242,12 +252,12 @@ export interface ConfigHealthInput {
   // Under-reporting for a moment is the safe direction here; over-reporting trains the operator to
   // ignore the panel.
   knownRefs?: Set<string> | null;
-  // The KIND of each ref in `knownRefs`, keyed the same way. Resolving is not the same question as
-  // serving: an entry can exist, be filled, and still hold a shape the reading field cannot use
-  // (issue #471). `null`/absent has the same meaning it has for `knownRefs` — the vault has not
-  // answered yet — and for the same reason: reporting on an empty map would flag every credentialled
-  // field on the page for the first paint.
-  refKinds?: Map<string, string | null> | null;
+  // What each ref in `knownRefs` IS, keyed the same way. Resolving is not the same question as
+  // serving: an entry can exist, be filled, and still be unusable — by its type, or by holding a
+  // value that type does not describe (issue #471). `null`/absent has the same meaning it has for
+  // `knownRefs` — the vault has not answered yet — and for the same reason: reporting on an empty
+  // map would flag every credentialled field on the page for the first paint.
+  refFacts?: Map<string, VaultRefFacts> | null;
   // Knowledge bases this agent uses that still have documents awaiting indexing (status UNINDEXED),
   // e.g. right after an import that bundled the source text. Each becomes a "knowledge" issue — unless
   // the embedding prerequisite below is missing, in which case a single "embedding" issue is raised.
@@ -286,10 +296,12 @@ type CredVerdict =
 interface VaultView {
   pending: Set<string> | undefined;
   known: Set<string> | null | undefined;
-  // The kind of every ref in `known`, so a ref that resolves can still be told apart from one that
-  // can SERVE the field. Absent (not merely empty) until the vault answers, exactly like `known`:
-  // an empty map would read as "no kind fits" and flag every credential on the page for one paint.
-  kinds: Map<string, string | null> | null | undefined;
+  // What the vault knows about each ref in `known` beyond its existence: the kind it declares, and
+  // whether its stored value is the shape that kind describes. Both, because the runtime asks both
+  // and a panel that asks fewer calls an agent healthy on a configuration the turn refuses. Absent
+  // (not merely empty) until the vault answers, exactly like `known`: an empty map would read as
+  // "nothing fits" and flag every credential on the page for one paint.
+  facts: Map<string, VaultRefFacts> | null | undefined;
 }
 
 // For one credentialed feature, decides which issue (if any) to raise:
@@ -323,15 +335,22 @@ function credIssue(
   if (vault.known && (canonical === null || !vault.known.has(canonical))) {
     return { kind: "unresolved" };
   }
-  // Present, filled, and the wrong TYPE for this field: a multi-field or managed-blob entry where a
-  // plain API key is read, or one the catalog says never leaves in a request. The write boundary
-  // refuses this pairing now (requireVaultRefFor), so what reaches here is what was already stored —
-  // an import, or a row that predates the rule. Reported last of the four because the other three
-  // are about the entry itself and this one is about the pairing; and only once the kinds have
-  // arrived, for the same reason `unresolved` waits on `known`. Issue #471.
-  if (canonical !== null && vault.kinds) {
-    const kind = vault.kinds.get(canonical);
-    if (kind !== undefined && !secretTypeFits(kind, use)) {
+  // Present, filled, and unable to serve this field. Two ways, one verdict: the TYPE cannot supply
+  // what the field reads (a multi-field or managed-blob entry where a plain API key goes, or one the
+  // catalog says never leaves in a request), or the stored VALUE is not the shape its own type
+  // declares. Both are what `tryResolveApiKeyEntry` refuses at the turn, and asking one of the two
+  // here would put the panel back to calling an agent healthy on a configuration the runtime drops.
+  //
+  // The write boundary refuses both now, so what reaches here is what was already stored — an
+  // import, or a row that predates the rule. Reported last of the four because the other three are
+  // about the entry itself and this one is about the pairing; and only once the vault has answered,
+  // for the same reason `unresolved` waits on `known`. Issue #471.
+  if (canonical !== null && vault.facts) {
+    const facts = vault.facts.get(canonical);
+    if (
+      facts !== undefined &&
+      (!secretTypeFits(facts.kind, use) || !facts.valueFitsKind)
+    ) {
       return { kind: "wrongKind" };
     }
   }
@@ -403,7 +422,7 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   const vault: VaultView = {
     pending: input.pendingRefs,
     known: input.knownRefs,
-    kinds: input.refKinds,
+    facts: input.refFacts,
   };
   const push = (base: ConfigIssue, res: CredVerdict | null): void => {
     if (!res) return;
@@ -839,7 +858,10 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
     const embedding = credIssue(
       true,
       input.embeddingCredentialRef ?? "",
-      "apiKey",
+      // Not `apiKey`: this field's reader takes `{ apiKey, baseURL }` as well as the plain string,
+      // so holding its value to the kind here would put a warning on a working configuration. The
+      // KIND rule is the same one — a `google_oauth` entry is still flagged.
+      "embeddingKey",
       vault,
     );
     if (embedding) {

--- a/src/modules/agents/config-health.ts
+++ b/src/modules/agents/config-health.ts
@@ -18,6 +18,10 @@ import {
 } from "@/modules/business-hours/hours";
 import { readMemoryConfig } from "@/modules/memory/settings";
 import { resolveNormalizeModel } from "@/modules/tts/normalize-model";
+import {
+  type CredentialUse,
+  secretTypeFits,
+} from "@/modules/vault/secret-types";
 
 // Live configuration-health checks for the agent editor (item 1): detect features that are turned on
 // but missing the credential they need to actually run. The common trigger is importing an agent —
@@ -86,6 +90,11 @@ export interface ConfigIssue {
   // NAMES, which no resolver matches). There is nothing to fill in, so this deep-links to the field
   // like a missing credential does.
   unresolved?: boolean;
+  // When true, the credential exists and its secret is filled, and its TYPE cannot serve this field:
+  // a multi-field or managed-blob entry where a plain API key is read, or one the catalog says never
+  // travels outbound. The fix is a different credential, not filling this one in, so it deep-links to
+  // the field like a missing credential does rather than to the vault fill modal.
+  wrongKind?: boolean;
   // For "knowledge" issues: the base that has imported-but-unindexed documents (and its name), so the
   // editor can open that base's documents modal.
   knowledgeBaseId?: string;
@@ -233,6 +242,12 @@ export interface ConfigHealthInput {
   // Under-reporting for a moment is the safe direction here; over-reporting trains the operator to
   // ignore the panel.
   knownRefs?: Set<string> | null;
+  // The KIND of each ref in `knownRefs`, keyed the same way. Resolving is not the same question as
+  // serving: an entry can exist, be filled, and still hold a shape the reading field cannot use
+  // (issue #471). `null`/absent has the same meaning it has for `knownRefs` — the vault has not
+  // answered yet — and for the same reason: reporting on an empty map would flag every credentialled
+  // field on the page for the first paint.
+  refKinds?: Map<string, string | null> | null;
   // Knowledge bases this agent uses that still have documents awaiting indexing (status UNINDEXED),
   // e.g. right after an import that bundled the source text. Each becomes a "knowledge" issue — unless
   // the embedding prerequisite below is missing, in which case a single "embedding" issue is raised.
@@ -256,13 +271,26 @@ export interface ConfigHealthInput {
   savedSchedule?: Schedule | null;
 }
 
-// The three ways one credentialed feature can be unrunnable. Every credential ref on the agent goes
-// through this one function, all six of them: a rule that reaches half its fields is worse than no
+// The four ways one credentialed feature can be unrunnable. Every credential ref on the agent goes
+// through this one function, all ten of them: a rule that reaches half its fields is worse than no
 // rule, because the half it misses now reads as checked.
 type CredVerdict =
   | { kind: "missing" }
   | { kind: "pending"; vaultId: string }
-  | { kind: "unresolved" };
+  | { kind: "unresolved" }
+  | { kind: "wrongKind" };
+
+// What the vault has answered so far, as the three questions this module asks of a ref. Grouped
+// because they travel together and are read together: a ref is judged against all three or none, and
+// passing them one by one had already produced ten call sites of the same four arguments.
+interface VaultView {
+  pending: Set<string> | undefined;
+  known: Set<string> | null | undefined;
+  // The kind of every ref in `known`, so a ref that resolves can still be told apart from one that
+  // can SERVE the field. Absent (not merely empty) until the vault answers, exactly like `known`:
+  // an empty map would read as "no kind fits" and flag every credential on the page for one paint.
+  kinds: Map<string, string | null> | null | undefined;
+}
 
 // For one credentialed feature, decides which issue (if any) to raise:
 //   - not enabled → none;
@@ -277,13 +305,13 @@ type CredVerdict =
 function credIssue(
   enabled: boolean,
   ref: string,
-  pendingRefs: Set<string> | undefined,
-  knownRefs: Set<string> | null | undefined,
+  use: CredentialUse,
+  vault: VaultView,
 ): CredVerdict | null {
   if (!enabled) return null;
   if (!ref) return { kind: "missing" };
   const canonical = canonicalVaultRef(ref);
-  if (canonical !== null && pendingRefs?.has(canonical)) {
+  if (canonical !== null && vault.pending?.has(canonical)) {
     return {
       kind: "pending",
       vaultId: canonical.slice(VAULT_REF_PREFIX.length),
@@ -292,8 +320,20 @@ function credIssue(
   // A ref no id can be read out of is unresolvable on its own terms, but it is still only REPORTED
   // once the vault has answered: one panel that stays quiet until it knows is easier to trust than
   // one that is right about a rare case and wrong about every field for a paint.
-  if (knownRefs && (canonical === null || !knownRefs.has(canonical))) {
+  if (vault.known && (canonical === null || !vault.known.has(canonical))) {
     return { kind: "unresolved" };
+  }
+  // Present, filled, and the wrong TYPE for this field: a multi-field or managed-blob entry where a
+  // plain API key is read, or one the catalog says never leaves in a request. The write boundary
+  // refuses this pairing now (requireVaultRefFor), so what reaches here is what was already stored —
+  // an import, or a row that predates the rule. Reported last of the four because the other three
+  // are about the entry itself and this one is about the pairing; and only once the kinds have
+  // arrived, for the same reason `unresolved` waits on `known`. Issue #471.
+  if (canonical !== null && vault.kinds) {
+    const kind = vault.kinds.get(canonical);
+    if (kind !== undefined && !secretTypeFits(kind, use)) {
+      return { kind: "wrongKind" };
+    }
   }
   return null;
 }
@@ -360,14 +400,19 @@ function endpointVerdict(
 
 export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   const issues: ConfigIssue[] = [];
-  const pending = input.pendingRefs;
-  const known = input.knownRefs;
+  const vault: VaultView = {
+    pending: input.pendingRefs,
+    known: input.knownRefs,
+    kinds: input.refKinds,
+  };
   const push = (base: ConfigIssue, res: CredVerdict | null): void => {
     if (!res) return;
     if (res.kind === "pending") {
       issues.push({ ...base, pending: true, vaultId: res.vaultId });
     } else if (res.kind === "unresolved") {
       issues.push({ ...base, unresolved: true });
+    } else if (res.kind === "wrongKind") {
+      issues.push({ ...base, wrongKind: true });
     } else {
       issues.push(base);
     }
@@ -417,7 +462,7 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
     // replace an undialable string with a working host. The editor makes this concrete — it passes
     // `credentialBaseUrl ?? model.baseURL`, so while the vault is unread the typed `llama:8080` IS
     // what arrives here, and a verdict on it is a verdict on a value the runtime will not use.
-    const owed = known === null && Boolean(input.modelCredentialRef);
+    const owed = vault.known === null && Boolean(input.modelCredentialRef);
     if (endpoint !== null && !owed) {
       issues.push({
         ...modelTarget,
@@ -432,21 +477,21 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
         (input.modelProvider !== "openai-compatible" ||
           Boolean(input.modelCredentialRef)),
       input.modelCredentialRef,
-      pending,
-      known,
+      "apiKey",
+      vault,
     ),
   );
   push(
     { key: "stt", tab: "behavior", sectionId: "stt" },
-    credIssue(input.sttEnabled, input.sttCredentialRef, pending, known),
+    credIssue(input.sttEnabled, input.sttCredentialRef, "apiKey", vault),
   );
   push(
     { key: "tts", tab: "behavior", sectionId: "tts" },
     credIssue(
       input.ttsMode !== "never",
       input.ttsCredentialRef,
-      pending,
-      known,
+      "apiKey",
+      vault,
     ),
   );
   // The speech rewrite. Both ways it fails are SILENT at runtime (best-effort: the audio still goes
@@ -511,7 +556,7 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   // (`credentialBaseUrl ?? mc.baseURL`), so a credential still unread can replace an undialable
   // string with a working host. What settles it is having no credential to hear from, which is the
   // case in the reviewer's example — a keyless openai-compatible rewrite pointed at `llama:8080`.
-  const endpointsKnown = known !== null;
+  const endpointsKnown = vault.known !== null;
   const endpointStillOwed = endpointCouldStillArrive(
     endpointsKnown,
     {
@@ -538,8 +583,8 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
         normalizeResolution !== null &&
           Boolean(input.ttsNormalizeCredentialRef),
         input.ttsNormalizeCredentialRef ?? "",
-        pending,
-        known,
+        "apiKey",
+        vault,
       ),
     );
   }
@@ -612,8 +657,8 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
       credIssue(
         compactionResolution !== null && Boolean(compaction.credentialRef),
         compaction.credentialRef ?? "",
-        pending,
-        known,
+        "apiKey",
+        vault,
       ),
     );
   }
@@ -681,14 +726,14 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
       credIssue(
         fallbackResolution !== null && Boolean(fallback.credentialRef),
         fallback.credentialRef ?? "",
-        pending,
-        known,
+        "apiKey",
+        vault,
       ),
     );
   }
   push(
     { key: "vision", tab: "behavior", sectionId: "vision" },
-    credIssue(input.visionEnabled, input.visionCredentialRef, pending, known),
+    credIssue(input.visionEnabled, input.visionCredentialRef, "apiKey", vault),
   );
   // NOTE: gated on the ref being present, so "missing" can never fire for this feature: enabled
   // without a credential is a legitimate configuration here, unlike the blocks above.
@@ -698,8 +743,12 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
       Boolean(input.contactAuthEnabled) &&
         Boolean(input.contactAuthCredentialRef),
       input.contactAuthCredentialRef ?? "",
-      pending,
-      known,
+      // The one field here that is not an API key: the gate resolves it through
+      // `resolveInjectableCredentialEntry`, which hands back a fresh access token for the
+      // managed-OAuth kinds. A `google_oauth` entry is correct configuration here and a warning
+      // about it would be the panel contradicting a feature that works.
+      "injectable",
+      vault,
     ),
   );
   // The unlock flow and the handoff want opposite things from the same refusal. Forwarding the
@@ -750,8 +799,8 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
   const guardrailsCred = credIssue(
     Boolean(input.guardrailsEnabled),
     input.guardrailsCredentialRef ?? "",
-    pending,
-    known,
+    "apiKey",
+    vault,
   );
   push(
     { key: "guardrails", tab: "guardrails", sectionId: "gr-model" },
@@ -790,8 +839,8 @@ export function computeConfigIssues(input: ConfigHealthInput): ConfigIssue[] {
     const embedding = credIssue(
       true,
       input.embeddingCredentialRef ?? "",
-      pending,
-      known,
+      "apiKey",
+      vault,
     );
     if (embedding) {
       push({ key: "embedding" }, embedding);

--- a/src/modules/agents/credential-paths.ts
+++ b/src/modules/agents/credential-paths.ts
@@ -1,3 +1,4 @@
+import type { CredentialUse } from "@/modules/vault/secret-types";
 import type { BehaviorSettingsPatch } from "./behavior-settings";
 
 // Every field of the agent settings bag that holds a vault credential ref, with WHERE the editor shows
@@ -16,38 +17,66 @@ import type { BehaviorSettingsPatch } from "./behavior-settings";
 // own), and an import warning that deep-links to a section that does not exist dismisses itself
 // without showing the field it is about.
 export const SETTINGS_CREDENTIAL_PATHS = [
-  { path: ["stt", "credentialRef"], tab: "behavior", sectionId: "stt" },
+  {
+    path: ["stt", "credentialRef"],
+    tab: "behavior",
+    sectionId: "stt",
+    use: "apiKey",
+  },
+  // The one agent field that is not an API key. It goes through
+  // `resolveInjectableCredentialEntry`, which refreshes a managed-OAuth token and injects THAT, so
+  // a `google_oauth` entry here is correct configuration and refusing it would break the feature.
   {
     path: ["contactAuth", "credentialRef"],
     tab: "behavior",
     sectionId: "contactAuth",
+    use: "injectable",
   },
-  { path: ["tts", "credentialRef"], tab: "behavior", sectionId: "tts" },
+  {
+    path: ["tts", "credentialRef"],
+    tab: "behavior",
+    sectionId: "tts",
+    use: "apiKey",
+  },
   {
     path: ["tts", "normalizeCredentialRef"],
     tab: "behavior",
     sectionId: "tts",
+    use: "apiKey",
   },
-  { path: ["vision", "credentialRef"], tab: "behavior", sectionId: "vision" },
+  {
+    path: ["vision", "credentialRef"],
+    tab: "behavior",
+    sectionId: "vision",
+    use: "apiKey",
+  },
   {
     path: ["guardrails", "credentialRef"],
     tab: "guardrails",
     sectionId: "gr-model",
+    use: "apiKey",
   },
   {
     path: ["memory", "compaction", "credentialRef"],
     tab: "behavior",
     sectionId: "memory",
+    use: "apiKey",
   },
   {
     path: ["modelFallback", "credentialRef"],
     tab: "behavior",
     sectionId: "modelFallback",
+    use: "apiKey",
   },
 ] as const satisfies ReadonlyArray<{
   path: readonly [keyof BehaviorSettingsPatch, ...string[]];
   tab: "behavior" | "guardrails";
   sectionId: string;
+  // What the field DOES with the entry, and therefore which kinds can serve it (secretTypeFits).
+  // Required, so a credential field added to this list cannot be silently exempted from the check:
+  // seven of the eight read a plain API key and the eighth does not, which is exactly the split a
+  // derived rule would have got wrong.
+  use: CredentialUse;
 }>;
 
 // A PATH, not a (block, field) pair, because a block can hold its credential inside a sub-object:
@@ -122,6 +151,9 @@ export interface CredentialRefWrite {
   // bag it lives in: `modelConfig.credentialRef`, `settings.tts.normalizeCredentialRef`.
   path: string;
   ref: string;
+  // What this field reads the entry AS, carried alongside the ref so the write boundary can refuse a
+  // kind that cannot serve it without re-deriving the field's purpose from its path.
+  use: CredentialUse;
   // Writes the canonical spelling back where the ref was found. In place, for the same reason
   // clampOversizedTextInPlace is: the caller owns a freshly parsed payload whose bags hold keys this
   // module knows nothing about, and rebuilding them from the paths listed here would drop the rest.
@@ -154,12 +186,14 @@ export function collectCredentialRefWrites(
     holder: Record<string, unknown>,
     key: string,
     storedRef: unknown,
+    use: CredentialUse,
   ): void => {
     const ref = holder[key];
     if (typeof ref !== "string" || !ref || ref === storedRef) return;
     out.push({
       path,
       ref,
+      use,
       replace: (canonical) => {
         holder[key] = canonical;
       },
@@ -174,13 +208,15 @@ export function collectCredentialRefWrites(
       nextModel,
       "credentialRef",
       bagOf(stored.modelConfig)?.credentialRef,
+      // The agent's own model key, handed to the provider SDK by `createChatModel`.
+      "apiKey",
     );
   }
   const nextSettings =
     next.settings === undefined ? null : bagOf(next.settings);
   if (nextSettings) {
     const storedSettings = bagOf(stored.settings);
-    for (const { path } of SETTINGS_CREDENTIAL_PATHS) {
+    for (const { path, use } of SETTINGS_CREDENTIAL_PATHS) {
       const slot = credRefSlot(nextSettings, path);
       if (!slot) continue;
       const storedSlot = credRefSlot(storedSettings, path);
@@ -189,6 +225,7 @@ export function collectCredentialRefWrites(
         slot.holder,
         slot.key,
         storedSlot ? storedSlot.holder[storedSlot.key] : undefined,
+        use,
       );
     }
   }

--- a/src/modules/agents/service.ts
+++ b/src/modules/agents/service.ts
@@ -44,7 +44,7 @@ import {
   getToolpackToolNames,
   getToolpackToolViews,
 } from "@/modules/integrations/toolpacks";
-import { requireVaultRef } from "@/modules/vault/service";
+import { requireVaultRefFor } from "@/modules/vault/service";
 
 // Agent configuration CRUD — the config the whole system orbits (the same core the UI config
 // screen and the MCP `prompt_get/set` tools project over). All reads/writes are tenant-scoped;
@@ -580,13 +580,20 @@ function rawFullDetailUntil(settings: unknown): unknown {
 //
 // Canonical on the way in, not merely valid: requireVaultRef returns the one spelling every reader
 // agrees on, and it is written back where the ref was found.
+//
+// And USABLE on the way in, not merely present: `requireVaultRefFor` also asks whether an entry of
+// that kind can serve the field, which nothing did. Eight of these nine fields read a plain API key
+// and hand it to a provider SDK; a `google_oauth` entry holds `{ clientId, clientSecret }`, so it
+// resolved, stored, and reached `createChatModel` as an object typed `string` (#471).
 async function assertCredentialRefsResolve(
   db: ScopedDb,
   next: { modelConfig?: unknown; settings?: unknown },
   stored: { modelConfig?: unknown; settings?: unknown },
 ): Promise<void> {
   for (const write of collectCredentialRefWrites(next, stored)) {
-    write.replace(await requireVaultRef(db, write.ref, write.path));
+    write.replace(
+      await requireVaultRefFor(db, write.ref, write.path, write.use),
+    );
   }
 }
 

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -29,6 +29,7 @@ import { runScopedOn, type ScopedDb, type TenantContext } from "@/lib/tenancy";
 import { auditSafe } from "@/modules/agents/audit-projection";
 import {
   type CredentialFieldTab,
+  collectCredentialRefWrites,
   credRefSlot,
   remapCredRefAt,
   SETTINGS_CREDENTIAL_PATHS,
@@ -62,6 +63,7 @@ import {
 import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
 import { storableResponseTemplate } from "@/modules/tool-definitions/response-template";
 import { readHttpMethod } from "@/modules/tool-definitions/service";
+import { secretTypeFits } from "@/modules/vault/secret-types";
 import {
   createPendingVaultEntry,
   formatVaultRef,
@@ -69,6 +71,7 @@ import {
   readVaultRefId,
   resolveVaultRefByName,
   VAULT_REF_PREFIX,
+  vaultRefWhere,
 } from "@/modules/vault/service";
 import { generateRouteToken } from "@/modules/webhooks/inbound/route-token";
 import {
@@ -383,6 +386,22 @@ export function credentialFieldTargets(
     if (slot) add(slot.holder[slot.key], tab, sectionId);
   }
   return out;
+}
+
+// The editor location of a credential field named by its DOTTED PATH, which is how a refusal and an
+// import warning about a stored ref name it (`settings.tts.credentialRef`). The sibling above keys
+// the same map by credential NAME, which only works while the ref is still portable — after the
+// remap there are no names left, only `vault:<id>`.
+export function fieldTargetForPath(path: string): ImportWarningTarget {
+  if (path === "modelConfig.credentialRef") {
+    return { kind: "agentField", tab: "general", sectionId: "general-model" };
+  }
+  for (const { path: p, tab, sectionId } of SETTINGS_CREDENTIAL_PATHS) {
+    if (`settings.${p.join(".")}` === path) {
+      return { kind: "agentField", tab, sectionId };
+    }
+  }
+  return { kind: "vault" };
 }
 
 // Copies of modelConfig/settings with each credential ref passed through `map` (a null mapping
@@ -1058,6 +1077,40 @@ export async function importAgent(
         return refByName.get(ref) ?? null;
       },
     );
+
+    // Every credential the bags ended up wired to, judged against what the FIELD reads it as. Only
+    // reachable through an import: the direct write boundary refuses this pairing (requireVaultRefFor),
+    // and the ref that lands here can come from a payload authored anywhere — the export carries the
+    // kind, so a bundle can name a `google_oauth` entry on the model and the (name, kind) lookup above
+    // will happily match it.
+    //
+    // Warned rather than refused, and rather than unset. Refusing would reject a whole bundle over one
+    // field, which is the rule this file already rejects for over-cap prose; unsetting would erase the
+    // only record of which credential the author meant, and the entry EXISTS, unlike the
+    // `credentialNotFound` case that unsets. So the ref stays wired, the operator is told at import
+    // time, and config-health keeps saying it until they act. Issue #471.
+    const wiredKinds = new Map<string, string | null>();
+    for (const write of collectCredentialRefWrites(
+      { modelConfig, settings },
+      {},
+    )) {
+      let kind = wiredKinds.get(write.ref);
+      if (kind === undefined) {
+        const row = await db.vaultEntry.findFirst({
+          where: vaultRefWhere(write.ref),
+          select: { kind: true },
+        });
+        kind = row?.kind ?? null;
+        wiredKinds.set(write.ref, kind);
+      }
+      if (kind !== null && !secretTypeFits(kind, write.use)) {
+        warnings.push({
+          code: "credentialKindUnusable",
+          params: { field: write.path, kind },
+          target: fieldTargetForPath(write.path),
+        });
+      }
+    }
 
     // Operator prose over its cap is CLAMPED here, not refused. A direct write refuses (the person is
     // at the keyboard and can trim it), but a bundle authored somewhere else would be rejected whole

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -68,10 +68,11 @@ import {
   createPendingVaultEntry,
   formatVaultRef,
   isVaultIdRef,
+  readVaultRefFacts,
   readVaultRefId,
   resolveVaultRefByName,
   VAULT_REF_PREFIX,
-  vaultRefWhere,
+  type VaultEntryFacts,
 } from "@/modules/vault/service";
 import { generateRouteToken } from "@/modules/webhooks/inbound/route-token";
 import {
@@ -1089,24 +1090,25 @@ export async function importAgent(
     // only record of which credential the author meant, and the entry EXISTS, unlike the
     // `credentialNotFound` case that unsets. So the ref stays wired, the operator is told at import
     // time, and config-health keeps saying it until they act. Issue #471.
-    const wiredKinds = new Map<string, string | null>();
+    const wiredFacts = new Map<string, VaultEntryFacts | null>();
     for (const write of collectCredentialRefWrites(
       { modelConfig, settings },
       {},
     )) {
-      let kind = wiredKinds.get(write.ref);
-      if (kind === undefined) {
-        const row = await db.vaultEntry.findFirst({
-          where: vaultRefWhere(write.ref),
-          select: { kind: true },
-        });
-        kind = row?.kind ?? null;
-        wiredKinds.set(write.ref, kind);
+      let facts = wiredFacts.get(write.ref);
+      if (facts === undefined) {
+        facts = await readVaultRefFacts(db, write.ref);
+        wiredFacts.set(write.ref, facts);
       }
-      if (kind !== null && !secretTypeFits(kind, write.use)) {
+      // The same two questions the write boundary and config-health ask, from the same helper, so an
+      // import cannot admit a pairing a direct write refuses.
+      if (
+        facts !== null &&
+        (!secretTypeFits(facts.kind, write.use) || !facts.valueFitsKind)
+      ) {
         warnings.push({
           code: "credentialKindUnusable",
-          params: { field: write.path, kind },
+          params: { field: write.path, kind: facts.kind },
           target: fieldTargetForPath(write.path),
         });
       }

--- a/src/modules/agents/transfer.ts
+++ b/src/modules/agents/transfer.ts
@@ -63,7 +63,7 @@ import {
 import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
 import { storableResponseTemplate } from "@/modules/tool-definitions/response-template";
 import { readHttpMethod } from "@/modules/tool-definitions/service";
-import { secretTypeFits } from "@/modules/vault/secret-types";
+import { credentialServes } from "@/modules/vault/secret-types";
 import {
   createPendingVaultEntry,
   formatVaultRef,
@@ -1102,10 +1102,7 @@ export async function importAgent(
       }
       // The same two questions the write boundary and config-health ask, from the same helper, so an
       // import cannot admit a pairing a direct write refuses.
-      if (
-        facts !== null &&
-        (!secretTypeFits(facts.kind, write.use) || !facts.valueFitsKind)
-      ) {
+      if (facts !== null && !credentialServes(facts, write.use)) {
         warnings.push({
           code: "credentialKindUnusable",
           params: { field: write.path, kind: facts.kind },

--- a/src/modules/integrations/google-calendar.service.ts
+++ b/src/modules/integrations/google-calendar.service.ts
@@ -75,7 +75,7 @@ export async function listCredentialCalendars(
   const resolveEntry =
     deps.resolveEntry ??
     ((ref: string) =>
-      runScopedOn(base, ctx, (db) => tryResolveVaultEntry<unknown>(db, ref)));
+      runScopedOn(base, ctx, (db) => tryResolveVaultEntry(db, ref)));
   const entry = await resolveEntry(credentialRef);
   if (!entry)
     throw new NotFoundError(

--- a/src/modules/integrations/google-drive.service.ts
+++ b/src/modules/integrations/google-drive.service.ts
@@ -74,7 +74,7 @@ export async function listCredentialDriveFolders(
   const resolveEntry =
     deps.resolveEntry ??
     ((ref: string) =>
-      runScopedOn(base, ctx, (db) => tryResolveVaultEntry<unknown>(db, ref)));
+      runScopedOn(base, ctx, (db) => tryResolveVaultEntry(db, ref)));
   const entry = await resolveEntry(credentialRef);
   if (!entry)
     throw new NotFoundError(

--- a/src/modules/mcp-connections/service.ts
+++ b/src/modules/mcp-connections/service.ts
@@ -515,7 +515,7 @@ export async function discoverMcpTools(
       );
     }
     const entry = conn.credentialRef
-      ? await tryResolveVaultEntry<unknown>(db, conn.credentialRef)
+      ? await tryResolveVaultEntry(db, conn.credentialRef)
       : null;
     return {
       ...conn,

--- a/src/modules/models/service.ts
+++ b/src/modules/models/service.ts
@@ -4,7 +4,7 @@ import { MODEL_PROVIDERS } from "@/graph/model-config";
 import { AppError } from "@/lib/errors";
 import { assertSafeOutboundUrl as defaultAssertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
-import { tryResolveVaultEntry } from "@/modules/vault/service";
+import { tryResolveApiKeyEntry } from "@/modules/vault/service";
 import { readProviderJson } from "./provider-listing";
 
 // Non-chat model ids to filter out from OpenAI listings.
@@ -83,10 +83,12 @@ async function resolveApiKey(
   credentialRef: string,
 ): Promise<string | null> {
   const entry = await runScopedOn(base, ctx, (db) =>
-    tryResolveVaultEntry<unknown>(db, credentialRef),
+    tryResolveApiKeyEntry(db, credentialRef),
   );
-  if (!entry) return null;
-  return typeof entry.secret === "string" ? entry.secret : null;
+  // One null for three states, and that is right here: the picker's job is to list what it can, and
+  // an unusable credential produces the same empty list as a missing one. The `state` split exists
+  // for the runtime paths, where the operator needs the reason in a log line (issue #471).
+  return entry.state === "ok" ? entry.secret : null;
 }
 
 export type KeyResolver = (

--- a/src/modules/stt/service.ts
+++ b/src/modules/stt/service.ts
@@ -13,7 +13,7 @@ import {
   type FlowContext,
   withFlowStage,
 } from "@/modules/flowlog/service";
-import { tryResolveVaultEntry } from "@/modules/vault/service";
+import { tryResolveApiKeyEntry } from "@/modules/vault/service";
 import { getSttProvider } from "./providers";
 import { readSttConfig, type SttConfig } from "./settings";
 
@@ -113,9 +113,20 @@ export async function transcribeInboundAudio(
     return skip("no_credential");
   }
   const entry = await runScopedOn(base, sysCtx(params.tenantId), (db) =>
-    tryResolveVaultEntry<string>(db, cfg.credentialRef as string),
+    tryResolveApiKeyEntry(db, cfg.credentialRef as string),
   );
-  if (!entry) {
+  if (entry.state !== "ok") {
+    // Two reasons the credential cannot serve this, kept apart because the operator's move is not the
+    // same: gone or unfilled is a credential to re-pick, and the wrong KIND is one that belongs on
+    // another field (issue #471).
+    if (entry.state === "unusable") {
+      logger.warn(
+        "stt: credential %s is a %s credential, which cannot be used as an API key — skipping",
+        cfg.credentialRef,
+        entry.kind,
+      );
+      return skip("credential_unusable");
+    }
     logger.warn(
       "stt: credential %s not found in the vault — skipping",
       cfg.credentialRef,
@@ -266,9 +277,17 @@ export async function transcribePlaygroundAudio(
     );
   }
   const entry = await runScopedOn(base, params.ctx, (db) =>
-    tryResolveVaultEntry<string>(db, cfg.credentialRef as string),
+    tryResolveApiKeyEntry(db, cfg.credentialRef as string),
   );
-  if (!entry) {
+  if (entry.state !== "ok") {
+    if (entry.state === "unusable") {
+      throw new AppError(
+        `transcription credential is a "${entry.kind}" credential and cannot be used as an API key`,
+        400,
+        "errors.credentialKindUnusableAsKey",
+        { kind: entry.kind },
+      );
+    }
     throw new AppError(
       "transcription credential not found",
       400,

--- a/src/modules/tenant-settings/service.ts
+++ b/src/modules/tenant-settings/service.ts
@@ -282,7 +282,12 @@ export async function updateEmbeddingSettings(
     incoming == null
       ? incoming
       : await runScopedOn(base, ctx, (db) =>
-          requireVaultRefFor(db, incoming, "embedding.credentialRef", "apiKey"),
+          requireVaultRefFor(
+            db,
+            incoming,
+            "embedding.credentialRef",
+            "embeddingKey",
+          ),
         );
   return patchBlock(
     ctx,

--- a/src/modules/tenant-settings/service.ts
+++ b/src/modules/tenant-settings/service.ts
@@ -11,7 +11,11 @@ import {
   type SpendCeilingConfig,
   spendCeilingSettingsSchema,
 } from "@/modules/spend-ceiling/settings";
-import { requireVaultRef, vaultRefWhere } from "@/modules/vault/service";
+import {
+  requireVaultRef,
+  requireVaultRefFor,
+  vaultRefWhere,
+} from "@/modules/vault/service";
 
 // Per-tenant settings live in the Tenant.settings JSON column. RLS scopes the row to the active
 // tenant (the runtime role may read/update its own row), so the same reader works at runtime
@@ -268,12 +272,17 @@ export async function updateEmbeddingSettings(
   // stored it and indexing then failed with no credential the operator could see was wrong (#254).
   // The block holds one field, so naming it IS changing it — there is no unrelated save to protect
   // here, unlike the agent's bags.
+  //
+  // `…For` and not the plain ref check: this key is read as a plain string and POSTed to the
+  // embedding provider, and this module's own comment in rag/documents.ts already said the kind was
+  // never checked — an operator picking the Chatwoot credential here got every chunk of their
+  // knowledge base POSTed at the Chatwoot host. Issue #471.
   const incoming = patch.credentialRef;
   const credentialRef =
     incoming == null
       ? incoming
       : await runScopedOn(base, ctx, (db) =>
-          requireVaultRef(db, incoming, "embedding.credentialRef"),
+          requireVaultRefFor(db, incoming, "embedding.credentialRef", "apiKey"),
         );
   return patchBlock(
     ctx,

--- a/src/modules/tts/listing.ts
+++ b/src/modules/tts/listing.ts
@@ -4,7 +4,7 @@ import { AppError } from "@/lib/errors";
 import { assertSafeOutboundUrl as defaultAssertSafeOutboundUrl } from "@/lib/ssrf";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { readProviderJson } from "@/modules/models/provider-listing";
-import { tryResolveVaultEntry } from "@/modules/vault/service";
+import { tryResolveApiKeyEntry } from "@/modules/vault/service";
 import { TTS_PROVIDER_NAMES } from "./providers";
 
 // Lists the voices / models the editor's TTS combobox offers (item 10). OpenAI has no list endpoint
@@ -69,10 +69,12 @@ async function resolveApiKey(
   credentialRef: string,
 ): Promise<string | null> {
   const entry = await runScopedOn(base, ctx, (db) =>
-    tryResolveVaultEntry<unknown>(db, credentialRef),
+    tryResolveApiKeyEntry(db, credentialRef),
   );
-  if (!entry) return null;
-  return typeof entry.secret === "string" ? entry.secret : null;
+  // One null for three states, and that is right here: the picker's job is to list what it can, and
+  // an unusable credential produces the same empty list as a missing one. The `state` split exists
+  // for the runtime paths, where the operator needs the reason in a log line (issue #471).
+  return entry.state === "ok" ? entry.secret : null;
 }
 
 export type KeyResolver = (

--- a/src/modules/tts/service.ts
+++ b/src/modules/tts/service.ts
@@ -12,7 +12,7 @@ import {
   pickTtsFormat,
   type TtsResult,
 } from "@/modules/tts/providers";
-import { tryResolveVaultEntry } from "@/modules/vault/service";
+import { tryResolveApiKeyEntry } from "@/modules/vault/service";
 import { type TtsConfig, voiceSettingsOf } from "./settings";
 
 // Text-to-speech orchestration: normalize the reply for speech, synthesize via the configured
@@ -119,9 +119,19 @@ export async function synthesizeReply(
     return skip("no_credential");
   }
   const entry = await runScopedOn(base, sysCtx(params.tenantId), (db) =>
-    tryResolveVaultEntry<string>(db, cfg.credentialRef as string),
+    tryResolveApiKeyEntry(db, cfg.credentialRef as string),
   );
-  if (!entry) {
+  if (entry.state !== "ok") {
+    // Gone/unfilled and wrong-KIND are separate lines because the operator's move differs: re-pick or
+    // fill one, move the other to the field it belongs on (issue #471).
+    if (entry.state === "unusable") {
+      logger.warn(
+        "tts: credential %s is a %s credential, which cannot be used as an API key — skipping",
+        cfg.credentialRef,
+        entry.kind,
+      );
+      return skip("credential_unusable");
+    }
     logger.warn(
       "tts: credential %s not found in the vault — skipping",
       cfg.credentialRef,

--- a/src/modules/vault/injectable.ts
+++ b/src/modules/vault/injectable.ts
@@ -32,7 +32,7 @@ export async function resolveInjectableCredentialEntry(
   ref: string,
 ): Promise<InjectableCredential | null> {
   const entry = await runScopedOn(base, sysCtx(tenantId), (db) =>
-    tryResolveVaultEntry<unknown>(db, ref),
+    tryResolveVaultEntry(db, ref),
   );
   if (!entry) return null;
   if (entry.kind === "google_oauth" || entry.kind === "mcp_oauth") {

--- a/src/modules/vault/secret-types.ts
+++ b/src/modules/vault/secret-types.ts
@@ -310,11 +310,40 @@ export function secretTypeFits(
   return yieldsPlainString(type);
 }
 
+// Whether this use reads a PLAIN KEY out of the entry, as opposed to resolving it through the
+// injectable path. Two of the three do, and the difference matters twice: it is the kind rule below,
+// and it is which of the two refusal sentences the write boundary throws. Those two were derived
+// separately once — `use === "apiKey"` — and the day a third use appeared it silently told an
+// operator that their `google_oauth` embedding key "is never sent outbound", which is false about
+// that kind and about that field.
+export function readsPlainKey(use: CredentialUse): boolean {
+  return use !== "injectable";
+}
+
 // Whether a field of this use holds its credential's stored VALUE to the kind's declared shape, as
 // opposed to only holding its KIND to the field's needs. Exactly one use says no, and the comment on
 // `CredentialUse` says why.
 export function valueRuleApplies(use: CredentialUse): boolean {
   return use !== "embeddingKey";
+}
+
+// CAN THIS ENTRY SERVE THIS FIELD — the whole question, in one place, because it is the question the
+// write boundary, the import warning and config-health all ask and the defect this change exists to
+// fix was those three answering it differently. Three call sites spelling out `secretTypeFits(...) &&
+// (!valueRuleApplies(...) || ...)` is three chances to drift, and it drifted twice inside one review
+// round: config-health applied the value rule to a use that is exempt from it, and the import did the
+// same in a place no test could reach yet.
+//
+// `facts` is what the vault answers about one entry beyond its existence — read through
+// `readVaultRefFacts`, or off `listVaultInfos` for the console — never the secret itself.
+export function credentialServes(
+  facts: { kind: string | null; valueFitsKind: boolean },
+  use: CredentialUse,
+): boolean {
+  return (
+    secretTypeFits(facts.kind, use) &&
+    (!valueRuleApplies(use) || facts.valueFitsKind)
+  );
 }
 
 // Whether the stored VALUE is the shape its own KIND declares. The predicate above reads the catalog;

--- a/src/modules/vault/secret-types.ts
+++ b/src/modules/vault/secret-types.ts
@@ -260,6 +260,52 @@ export function isManagedOAuthKind(kind: string | null | undefined): boolean {
   return kind != null && MANAGED_OAUTH_KINDS.has(kind);
 }
 
+// What a field that names a credential DOES with it, and therefore what it needs the entry to be
+// able to give. The catalog knows the shapes; only the reading field knows which one it can use, and
+// until this existed nobody asked: every write boundary stopped at "does this ref resolve".
+//
+//   apiKey       The stored value IS the credential the request carries — an API key handed to a
+//                provider SDK (the agent's model and its four model overrides, STT, TTS, vision) or
+//                to a REST client. It needs the plain string itself.
+//   injectable   The value is resolved through `resolveInjectableCredentialEntry`, which hands back
+//                a FRESH access token for the managed-OAuth kinds and the stored string for the
+//                rest. It can therefore use a JSON blob it never sees (HTTP tools, MCP connections,
+//                the contact authorization gate).
+//
+// Both send the result to somebody else's endpoint, which is why `neverOutbound` fails for both:
+// mcp_env holds a perfectly good string that the stdio loader reads, and putting it in an API-key
+// field mails the operator's stdio token to a model vendor.
+export type CredentialUse = "apiKey" | "injectable";
+
+// Whether an entry of this KIND can supply what a field of this USE reads. The one question the
+// three surfaces ask — the write boundary refusing a pairing, config-health reporting a stored one,
+// the runtime declining to use it — so that they cannot answer it differently. Issue #471.
+//
+// A kind this build does not know (and a null kind, which is every entry created before the catalog)
+// is the legacy `generic` escape hatch: a plain string with no injection rule. Refusing those would
+// invalidate working installs over a catalog entry we removed.
+export function secretTypeFits(
+  kind: string | null | undefined,
+  use: CredentialUse,
+): boolean {
+  const type = getSecretType(kind);
+  if (!type) return true;
+  if (type.neverOutbound) return false;
+  if (use === "injectable") {
+    // Mirrors resolveInjectableCredentialEntry: managed OAuth resolves to a token, everything else
+    // has to already be the string.
+    return isManagedOAuthKind(type.id) || yieldsPlainString(type);
+  }
+  return yieldsPlainString(type);
+}
+
+// The two declarations that say the stored VALUE is not a string: a declared field list (the value
+// is a multi-field object) and a server-managed blob. Kept as one predicate so a third declaration
+// of the same idea has one place to be added.
+function yieldsPlainString(type: SecretType): boolean {
+  return !type.fields && !type.managedBlob;
+}
+
 export function getSecretTypeFields(
   id: string | null | undefined,
 ): { key: string; masked?: boolean }[] | null {

--- a/src/modules/vault/secret-types.ts
+++ b/src/modules/vault/secret-types.ts
@@ -271,11 +271,20 @@ export function isManagedOAuthKind(kind: string | null | undefined): boolean {
 //                a FRESH access token for the managed-OAuth kinds and the stored string for the
 //                rest. It can therefore use a JSON blob it never sees (HTTP tools, MCP connections,
 //                the contact authorization gate).
+//   embeddingKey The tenant's embedding key, and the one field whose reader takes a SECOND value
+//                form the catalog does not declare: `resolveEmbeddingStatus` accepts the plain
+//                string or `{ apiKey, baseURL }`, destructuring the object and using its `baseURL`
+//                as the last fallback. Same KIND rule as `apiKey` — a `google_oauth` or `mcp_env`
+//                entry is refused there exactly the same way — and exempt from the VALUE rule,
+//                because enforcing "a generic kind holds a string" would refuse a form that reader
+//                has always supported. The debt is the undeclared form, not this exemption:
+//                declaring it in the catalog is what would remove the third value, and that is a
+//                change to how embedding credentials are stored, not to this one.
 //
 // Both send the result to somebody else's endpoint, which is why `neverOutbound` fails for both:
 // mcp_env holds a perfectly good string that the stdio loader reads, and putting it in an API-key
 // field mails the operator's stdio token to a model vendor.
-export type CredentialUse = "apiKey" | "injectable";
+export type CredentialUse = "apiKey" | "injectable" | "embeddingKey";
 
 // Whether an entry of this KIND can supply what a field of this USE reads. The one question the
 // three surfaces ask — the write boundary refusing a pairing, config-health reporting a stored one,
@@ -296,7 +305,37 @@ export function secretTypeFits(
     // has to already be the string.
     return isManagedOAuthKind(type.id) || yieldsPlainString(type);
   }
+  // `apiKey` and `embeddingKey` are the same question about the KIND; they differ only in whether
+  // the stored VALUE is also held to it (see `valueRuleApplies`).
   return yieldsPlainString(type);
+}
+
+// Whether a field of this use holds its credential's stored VALUE to the kind's declared shape, as
+// opposed to only holding its KIND to the field's needs. Exactly one use says no, and the comment on
+// `CredentialUse` says why.
+export function valueRuleApplies(use: CredentialUse): boolean {
+  return use !== "embeddingKey";
+}
+
+// Whether the stored VALUE is the shape its own KIND declares. The predicate above reads the catalog;
+// this one reads what is actually in the row, and the two can disagree — an entry created before its
+// kind existed, or one written by a path that does not go through `validateVaultValue`.
+//
+// Deliberately asymmetric, and the asymmetry is the whole content. A string-valued kind is checked
+// strictly, because that is the case a reader breaks on. A multi-field or managed-blob kind is only
+// checked for being an object, NOT for its declared field list: the OAuth consent flows MERGE tokens
+// into `google_oauth` and `mcp_oauth` values outside `validateVaultValue` (the catalog says so at both
+// entries), so demanding exactly `{ clientId, clientSecret }` would report every CONNECTED Google
+// account as malformed.
+export function secretValueFitsKind(
+  kind: string | null | undefined,
+  value: unknown,
+): boolean {
+  const type = getSecretType(kind);
+  if (type && !yieldsPlainString(type)) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+  }
+  return typeof value === "string" && value.length > 0;
 }
 
 // The two declarations that say the stored VALUE is not a string: a declared field list (the value

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -12,15 +12,16 @@ import {
 } from "./secret-test";
 import {
   type CredentialUse,
+  credentialServes,
   getSecretTypeFields,
   isManagedOAuthKind,
   isSecretTypeId,
+  readsPlainKey,
   secretTypeFits,
   secretTypeIsManagedBlob,
   secretTypeNeedsParamName,
   secretTypeRequiresBaseUrl,
   secretValueFitsKind,
-  valueRuleApplies,
 } from "./secret-types";
 
 // Tenant-scoped secret vault. Secrets are encryptJson() base64 blobs in a String column
@@ -306,8 +307,13 @@ export async function tryResolveApiKeyEntry(
 ): Promise<ApiKeyResolution> {
   const entry = await tryResolveVaultEntry(db, ref);
   if (!entry) return { state: "unresolved" };
+  // The same two predicates the write boundary and config-health use, and `secretValueFitsKind`
+  // rather than a local `typeof`: the local one accepted an empty string, so an active legacy row
+  // holding `""` was refused on the way IN and handed to the provider as a blank key on the way OUT.
+  // The two readings of "unfit" have one source now, which is the only way they stay one answer.
   if (
     !secretTypeFits(entry.kind, "apiKey") ||
+    !secretValueFitsKind(entry.kind, entry.secret) ||
     typeof entry.secret !== "string"
   ) {
     return { state: "unusable", kind: entry.kind };
@@ -524,11 +530,19 @@ export async function requireVaultRefFor(
   // A PENDING entry is exempt from the value half and only from that half: it has no secret yet by
   // design (`credential_create` writes exactly that), and refusing it would break the reference-first
   // flow the write boundary admits deliberately. Its KIND is already knowable and is still checked.
+  // A PENDING entry has no value yet by design (`credential_create` writes exactly that), so it is
+  // reported as `valueFitsKind` and judged on its KIND alone — the one exemption, and only on the
+  // value half. Refusing it would break the reference-first flow the write boundary admits on purpose.
   if (
-    secretTypeFits(entry.kind, use) &&
-    (!valueRuleApplies(use) ||
-      entry.status === "pending" ||
-      vaultValueFits(entry.kind, entry.secret))
+    credentialServes(
+      {
+        kind: entry.kind,
+        valueFitsKind:
+          entry.status === "pending" ||
+          vaultValueFits(entry.kind, entry.secret),
+      },
+      use,
+    )
   ) {
     return canonical;
   }
@@ -537,7 +551,7 @@ export async function requireVaultRefFor(
   // computed in the argument position is invisible to it: it reported the outbound sentence as a key
   // nothing throws and the API-key one as thrown without its `{{kind}}`. Both readings were right
   // about the text and wrong about the code, which is the fence doing its job.
-  if (use === "apiKey") {
+  if (readsPlainKey(use)) {
     throw new AppError(
       `${field}: credential "${ref}" (kind "${entry.kind}") cannot serve a field that reads a plain API key`,
       400,

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -11,9 +11,11 @@ import {
   type SecretTestResult,
 } from "./secret-test";
 import {
+  type CredentialUse,
   getSecretTypeFields,
   isManagedOAuthKind,
   isSecretTypeId,
+  secretTypeFits,
   secretTypeIsManagedBlob,
   secretTypeNeedsParamName,
   secretTypeRequiresBaseUrl,
@@ -248,10 +250,17 @@ export async function resolveVaultEntry<T = unknown>(
   };
 }
 
-export async function tryResolveVaultEntry<T = unknown>(
+// The secret comes back as `unknown` and the generic parameter is gone ON PURPOSE. It used to
+// default to `unknown` and be spelled `<string>` at ten call sites, where it was not a check but an
+// assertion: `decryptJson<T>` casts, so a `google_oauth` entry's `{ clientId, clientSecret }` was
+// typed `string` all the way into `createChatModel` (issue #471). Callers that need a string now say
+// so through `tryResolveApiKeyEntry`, or narrow it themselves; the six that already narrowed keep
+// compiling unchanged, and the ten that did not could not be missed, because the compiler is what
+// found them.
+export async function tryResolveVaultEntry(
   db: ScopedDb,
   ref: string,
-): Promise<ResolvedVaultEntry<T> | null> {
+): Promise<ResolvedVaultEntry | null> {
   const entry = await db.vaultEntry.findFirst({
     where: vaultRefWhere(ref),
     select: {
@@ -265,12 +274,43 @@ export async function tryResolveVaultEntry<T = unknown>(
   });
   if (!entry || entry.status === "pending") return null;
   return {
-    secret: decryptJson<T>(entry.secret),
+    secret: decryptJson(entry.secret),
     kind: entry.kind,
     baseUrl: entry.baseUrl,
     paramName: entry.paramName,
     name: entry.name,
   };
+}
+
+// The same resolution for a field that reads a PLAIN API KEY and hands it to somebody else's SDK —
+// the agent's model and its four model overrides, STT, TTS and vision. Three outcomes rather than
+// two, because the operator's move differs and the log line that names it is the only trace any of
+// these leave: a ref that no longer resolves is a credential to re-pick or fill, and one that
+// resolves to the wrong KIND is a credential that belongs on another field.
+//
+// The shape check is belt AND braces on the kind check, and neither is redundant. The kind is the
+// catalog's declaration; the value is what is actually stored, and the two can disagree — a legacy
+// entry created before the kind existed, or a managed blob whose connect flow never ran.
+export type ApiKeyResolution =
+  | { state: "ok"; secret: string; baseUrl: string | null }
+  // Deleted, never resolvable, or referenced with its secret not filled in yet.
+  | { state: "unresolved" }
+  // Present and filled, and this is not a credential this field can use.
+  | { state: "unusable"; kind: string };
+
+export async function tryResolveApiKeyEntry(
+  db: ScopedDb,
+  ref: string,
+): Promise<ApiKeyResolution> {
+  const entry = await tryResolveVaultEntry(db, ref);
+  if (!entry) return { state: "unresolved" };
+  if (
+    !secretTypeFits(entry.kind, "apiKey") ||
+    typeof entry.secret !== "string"
+  ) {
+    return { state: "unusable", kind: entry.kind };
+  }
+  return { state: "ok", secret: entry.secret, baseUrl: entry.baseUrl };
 }
 
 // The MCP surface speaks vault entry NAMES (agent-friendly: the operator tells the agent a name);
@@ -384,6 +424,61 @@ export async function requireVaultRef(
     );
   }
   return formatVaultRef(entry.id);
+}
+
+// `requireVaultRef` plus the question it never asked: can an entry of THIS KIND supply what the
+// field reads? The two are separate functions rather than one parameter because the ref rule reaches
+// thirteen call sites and this one does not: four of them (langfuse, the two integration credentials,
+// and the webhook/alert signing secrets) answer a THIRD question — a fixed kind, or a string consumed
+// locally and never sent anywhere — and folding those into the two-value `CredentialUse` would have
+// meant inventing a use for each just to satisfy a required parameter. What this covers is the fields
+// whose use is already declared: the agent's nine (SETTINGS_CREDENTIAL_PATHS + modelConfig) and the
+// tenant's embedding key. Issue #471.
+//
+// The field is in the English sentence as well as in `AppError.field`, which is a duplication the
+// other vault refusals do not carry. MCP hands `message` to the caller verbatim on a surface with no
+// structured error channel, and `agent_settings_set` patches several credentialled blocks in one
+// call: without the path, "credential vault:32 cannot serve this field" names no field to fix.
+//
+// Refused rather than reported, and that is the split `credential-paths.ts` already documents: the
+// operator is at the keyboard and the reference is the thing they just picked. What is ALREADY stored
+// is left alone and reported by config-health, so one unusable pairing cannot freeze every other
+// edit of the agent that holds it.
+export async function requireVaultRefFor(
+  db: ScopedDb,
+  ref: string,
+  field: string,
+  use: CredentialUse,
+): Promise<string> {
+  const canonical = await requireVaultRef(db, ref, field);
+  const entry = await db.vaultEntry.findFirst({
+    where: vaultRefWhere(canonical),
+    select: { kind: true },
+  });
+  // Gone between the two reads: `requireVaultRef` has already answered for existence, and inventing
+  // a second refusal here would report a race as a shape problem.
+  if (!entry || secretTypeFits(entry.kind, use)) return canonical;
+  // Two spellings of one refusal, written out rather than ternaried into one `new AppError`. The
+  // error-catalog fence reads the key and its interpolation values out of the SOURCE, and a key
+  // computed in the argument position is invisible to it: it reported the outbound sentence as a key
+  // nothing throws and the API-key one as thrown without its `{{kind}}`. Both readings were right
+  // about the text and wrong about the code, which is the fence doing its job.
+  if (use === "apiKey") {
+    throw new AppError(
+      `${field}: credential "${ref}" (kind "${entry.kind}") cannot serve a field that reads a plain API key`,
+      400,
+      "errors.credentialKindUnusableAsKey",
+      { kind: entry.kind },
+      field,
+    );
+  }
+  throw new AppError(
+    `${field}: credential "${ref}" (kind "${entry.kind}") is never sent outbound and cannot authenticate a request`,
+    400,
+    "errors.credentialKindUnusableOutbound",
+    { kind: entry.kind },
+    field,
+  );
 }
 
 export async function vaultNameByRef(

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -19,6 +19,8 @@ import {
   secretTypeIsManagedBlob,
   secretTypeNeedsParamName,
   secretTypeRequiresBaseUrl,
+  secretValueFitsKind,
+  valueRuleApplies,
 } from "./secret-types";
 
 // Tenant-scoped secret vault. Secrets are encryptJson() base64 blobs in a String column
@@ -444,6 +446,62 @@ export async function requireVaultRef(
 // operator is at the keyboard and the reference is the thing they just picked. What is ALREADY stored
 // is left alone and reported by config-health, so one unusable pairing cannot freeze every other
 // edit of the agent that holds it.
+// Decrypts a stored blob far enough to answer "is this the shape its kind declares?", and never
+// further: the value is judged and dropped, never returned or logged.
+//
+// THREE answers, not two, and the third is the one that matters. A blob that cannot be decrypted at
+// all — a rotated `ENCRYPTION_KEY`, a truncated row — is not a malformed value, it is a value nobody
+// can read, and collapsing it into "unfit" would make a key rotation refuse every agent write in the
+// workspace while blaming the credential's TYPE for it. That is a real problem with a different
+// cause, a different fix and no verdict here today; this change is about shape, and inventing an
+// answer for it would be inventing a diagnosis. So `unreadable` never refuses and never warns, and
+// the runtime keeps failing on it exactly as it did before.
+type ValueVerdict = "fits" | "unfit" | "unreadable";
+
+function vaultValueVerdict(
+  kind: string | null,
+  encrypted: string,
+): ValueVerdict {
+  let value: unknown;
+  try {
+    value = decryptJson(encrypted);
+  } catch {
+    return "unreadable";
+  }
+  return secretValueFitsKind(kind, value) ? "fits" : "unfit";
+}
+
+// The permissive projection every caller here wants: only a value that was READ and judged wrong
+// counts against the credential.
+function vaultValueFits(kind: string | null, encrypted: string): boolean {
+  return vaultValueVerdict(kind, encrypted) !== "unfit";
+}
+
+// What the vault says about one ref beyond its existence, for the two callers that judge a PAIRING
+// without being the write boundary: the import warning and (through listVaultInfos) config-health.
+// One function so the three surfaces cannot end up asking different halves of the same question,
+// which is the defect this whole change is about. Null when the ref names no row in this tenant.
+export interface VaultEntryFacts {
+  kind: string;
+  valueFitsKind: boolean;
+}
+
+export async function readVaultRefFacts(
+  db: ScopedDb,
+  ref: string,
+): Promise<VaultEntryFacts | null> {
+  const row = await db.vaultEntry.findFirst({
+    where: vaultRefWhere(ref),
+    select: { kind: true, status: true, secret: true },
+  });
+  if (!row) return null;
+  return {
+    kind: row.kind,
+    valueFitsKind:
+      row.status === "pending" || vaultValueFits(row.kind, row.secret),
+  };
+}
+
 export async function requireVaultRefFor(
   db: ScopedDb,
   ref: string,
@@ -453,11 +511,27 @@ export async function requireVaultRefFor(
   const canonical = await requireVaultRef(db, ref, field);
   const entry = await db.vaultEntry.findFirst({
     where: vaultRefWhere(canonical),
-    select: { kind: true },
+    select: { kind: true, status: true, secret: true },
   });
   // Gone between the two reads: `requireVaultRef` has already answered for existence, and inventing
   // a second refusal here would report a race as a shape problem.
-  if (!entry || secretTypeFits(entry.kind, use)) return canonical;
+  if (!entry) return canonical;
+  // TWO questions, because the runtime asks two and a boundary that asks fewer accepts a
+  // configuration the turn then refuses — with config-health calling it healthy in between, which is
+  // the exact asymmetry this change exists to remove. The kind is the catalog's declaration; the
+  // value is what is in the row, and `validateVaultValue` is not the only way one gets written.
+  //
+  // A PENDING entry is exempt from the value half and only from that half: it has no secret yet by
+  // design (`credential_create` writes exactly that), and refusing it would break the reference-first
+  // flow the write boundary admits deliberately. Its KIND is already knowable and is still checked.
+  if (
+    secretTypeFits(entry.kind, use) &&
+    (!valueRuleApplies(use) ||
+      entry.status === "pending" ||
+      vaultValueFits(entry.kind, entry.secret))
+  ) {
+    return canonical;
+  }
   // Two spellings of one refusal, written out rather than ternaried into one `new AppError`. The
   // error-catalog fence reads the key and its interpolation values out of the SOURCE, and a key
   // computed in the argument position is invisible to it: it reported the outbound sentence as a key
@@ -666,6 +740,11 @@ export interface VaultEntryInfo {
   paramName: string | null;
   // "active" = a real secret is stored; "pending" = only the reference exists (not filled yet).
   status: string;
+  // Whether the stored value is the shape this kind declares. A VERDICT, never the value: it is
+  // computed server-side and crosses the wire as a boolean, so the console can judge a pairing the
+  // way the runtime does without the secret ever leaving the process. Always true for a `pending`
+  // entry, which has no value yet and is reported through `status` instead.
+  valueFitsKind: boolean;
 }
 
 export async function listVaultInfos(db: ScopedDb): Promise<VaultEntryInfo[]> {
@@ -677,6 +756,7 @@ export async function listVaultInfos(db: ScopedDb): Promise<VaultEntryInfo[]> {
       baseUrl: true,
       paramName: true,
       status: true,
+      secret: true,
     },
     orderBy: { name: "asc" },
   });
@@ -687,6 +767,7 @@ export async function listVaultInfos(db: ScopedDb): Promise<VaultEntryInfo[]> {
     baseUrl: r.baseUrl,
     paramName: r.paramName,
     status: r.status,
+    valueFitsKind: r.status === "pending" || vaultValueFits(r.kind, r.secret),
   }));
 }
 

--- a/src/modules/vision/service.ts
+++ b/src/modules/vision/service.ts
@@ -17,7 +17,7 @@ import {
   assertPlaygroundSpendCeiling,
   spendCeilingVerdict,
 } from "@/modules/spend-ceiling/service";
-import { tryResolveVaultEntry } from "@/modules/vault/service";
+import { tryResolveApiKeyEntry } from "@/modules/vault/service";
 import { visionAcceptsDocuments } from "./document-support";
 import {
   getVisionProvider,
@@ -238,9 +238,19 @@ export async function extractInboundFile(
     return skip("no_credential");
   }
   const entry = await runScopedOn(base, sysCtx(params.tenantId), (db) =>
-    tryResolveVaultEntry<string>(db, cfg.credentialRef as string),
+    tryResolveApiKeyEntry(db, cfg.credentialRef as string),
   );
-  if (!entry) {
+  if (entry.state !== "ok") {
+    // Gone/unfilled and wrong-KIND are separate lines because the operator's move differs: re-pick or
+    // fill one, move the other to the field it belongs on (issue #471).
+    if (entry.state === "unusable") {
+      logger.warn(
+        "vision: credential %s is a %s credential, which cannot be used as an API key — skipping",
+        cfg.credentialRef,
+        entry.kind,
+      );
+      return skip("credential_unusable");
+    }
     logger.warn(
       "vision: credential %s not found in the vault — skipping",
       cfg.credentialRef,
@@ -479,9 +489,17 @@ export async function extractPlaygroundFile(
     );
   }
   const entry = await runScopedOn(base, params.ctx, (db) =>
-    tryResolveVaultEntry<string>(db, cfg.credentialRef as string),
+    tryResolveApiKeyEntry(db, cfg.credentialRef as string),
   );
-  if (!entry) {
+  if (entry.state !== "ok") {
+    if (entry.state === "unusable") {
+      throw new AppError(
+        `vision credential is a "${entry.kind}" credential and cannot be used as an API key`,
+        400,
+        "errors.credentialKindUnusableAsKey",
+        { kind: entry.kind },
+      );
+    }
     throw new AppError(
       "vision credential not found",
       400,

--- a/tests/modules/credential-reader-fence.test.ts
+++ b/tests/modules/credential-reader-fence.test.ts
@@ -32,15 +32,27 @@ const ALLOWED: Record<string, string> = {
   "src/modules/integrations/google-calendar.service.ts":
     "asks for one specific kind (google_oauth) by name and refuses everything else",
   "src/modules/integrations/google-drive.service.ts": "same as google-calendar",
-  "src/modules/tenant-settings/service.ts":
-    "reads the entry to assert a fixed kind (langfuse) at the write boundary; no secret is used",
 };
+
+// Comments are not usage, and a fence that counts them lies in the direction that matters: it lets a
+// file stay on the list for a MENTION and then covers a real raw read added there later. Measured on
+// the first version of this file — `tenant-settings/service.ts` was listed and exempted while its
+// only occurrence was a note about which resolver it does not use.
+//
+// Line and block comments are stripped, string literals are not: a file that names the resolver
+// inside a string is doing something worth listing.
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
 
 async function rawReaders(root: string): Promise<string[]> {
   const out: string[] = [];
   for await (const rel of new Glob("**/*.{ts,tsx}").scan(root)) {
     const path = `${root}/${rel}`;
-    if ((await Bun.file(path).text()).includes(RAW_READER)) out.push(path);
+    const code = stripComments(await Bun.file(path).text());
+    if (code.includes(RAW_READER)) out.push(path);
   }
   return out.sort();
 }
@@ -71,6 +83,24 @@ describe("who may read a vault secret without asking what it is for", () => {
     }
   });
 
+  // The other direction, and the one the first version of this fence got wrong: a file whose only
+  // occurrence is a comment must NOT read as a reader, or an exemption granted for a mention keeps
+  // standing over the real read somebody adds under it later.
+  test("a file that only mentions the resolver in a comment is not a reader", async () => {
+    const path = `src/modules/vault/__fence_mention_${process.pid}.ts`;
+    await Bun.write(
+      path,
+      `// a note about ${RAW_READER} and why this file does not use it\n` +
+        `/* ${RAW_READER} again, in a block */\n` +
+        `export const y = 1;\n`,
+    );
+    try {
+      expect(await rawReaders("src")).not.toContain(path);
+    } finally {
+      await Bun.file(path).delete();
+    }
+  });
+
   // The other half of the rule, and the reason the list above is not just "these files are old": the
   // modules that DO send a secret outbound resolve it through the use-aware entry point.
   test("the API-key readers go through the use-aware resolver", async () => {
@@ -83,7 +113,10 @@ describe("who may read a vault secret without asking what it is for", () => {
       "src/modules/vision/service.ts",
     ];
     for (const path of expected) {
-      expect(await Bun.file(path).text()).toContain("tryResolveApiKeyEntry");
+      // Stripped for the same reason as above: a comment naming the resolver is not a call to it.
+      expect(stripComments(await Bun.file(path).text())).toContain(
+        "tryResolveApiKeyEntry",
+      );
     }
   });
 });

--- a/tests/modules/credential-reader-fence.test.ts
+++ b/tests/modules/credential-reader-fence.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { Glob } from "bun";
+
+// Who is allowed to read a vault secret RAW, and who has to go through a resolver that answers for
+// the pairing. Issue #471.
+//
+// `tryResolveVaultEntry` hands back `secret: unknown` plus the entry's `kind`, and answering "can
+// this serve my field?" from those two is the caller's job. Eight call sites got that wrong the same
+// way (they wrote `<string>` and used it), so the compiler now refuses the assertion — but a caller
+// can still narrow with a bare `typeof x === "string"`, which passes `mcp_env`: a real string the
+// catalog says must never leave this process. That is the hole a type cannot close, and this is the
+// fence over it.
+//
+// The rule: a module that sends a secret to somebody else's endpoint resolves it through
+// `tryResolveApiKeyEntry` (a plain key) or `resolveInjectableCredential*` (a key or a refreshed OAuth
+// token). Everything else is listed here with the reason it reads the entry directly.
+
+const RAW_READER = "tryResolveVaultEntry";
+
+// path → why this module reads the entry directly instead of through a use-aware resolver.
+const ALLOWED: Record<string, string> = {
+  "src/modules/vault/service.ts":
+    "defines both resolvers; the use-aware one is built on the raw one",
+  "src/modules/vault/injectable.ts":
+    "IS the use-aware resolver for the injectable case: refreshes managed-OAuth tokens, refuses a non-string otherwise",
+  "src/graph/observability.ts":
+    "langfuse is a declared key PAIR, not a string: it parses the object with langfuseKeysSchema and the value never leaves as a credential header",
+  "src/graph/tools/assemble.ts":
+    "MCP tool assembly: reads kind + paramName as well, and the token for a managed-OAuth kind is refreshed later, outside the tx",
+  "src/modules/mcp-connections/service.ts":
+    "same as assemble.ts, for the Discover path",
+  "src/modules/integrations/google-calendar.service.ts":
+    "asks for one specific kind (google_oauth) by name and refuses everything else",
+  "src/modules/integrations/google-drive.service.ts": "same as google-calendar",
+  "src/modules/tenant-settings/service.ts":
+    "reads the entry to assert a fixed kind (langfuse) at the write boundary; no secret is used",
+};
+
+async function rawReaders(root: string): Promise<string[]> {
+  const out: string[] = [];
+  for await (const rel of new Glob("**/*.{ts,tsx}").scan(root)) {
+    const path = `${root}/${rel}`;
+    if ((await Bun.file(path).text()).includes(RAW_READER)) out.push(path);
+  }
+  return out.sort();
+}
+
+describe("who may read a vault secret without asking what it is for", () => {
+  test("every raw reader is listed, and every listing is a raw reader", async () => {
+    const found = await rawReaders("src");
+    // Both directions: an unlisted reader is the defect, and a listing with no reader left is a stale
+    // exemption that would silently adopt the next module to take that path.
+    expect(new Set(found)).toEqual(new Set(Object.keys(ALLOWED)));
+  });
+
+  // The fence is only worth its line count if it fails on the thing it describes. The defect is a
+  // module outside the list reading the raw resolver, so the control is exactly that, in a file the
+  // scan actually walks.
+  test("it catches a reader that is not listed", async () => {
+    const path = `src/modules/vault/__fence_probe_${process.pid}.ts`;
+    await Bun.write(
+      path,
+      `import { ${RAW_READER} } from "./service";\nexport const x = ${RAW_READER};\n`,
+    );
+    try {
+      const found = await rawReaders("src");
+      expect(found).toContain(path);
+      expect(new Set(found)).not.toEqual(new Set(Object.keys(ALLOWED)));
+    } finally {
+      await Bun.file(path).delete();
+    }
+  });
+
+  // The other half of the rule, and the reason the list above is not just "these files are old": the
+  // modules that DO send a secret outbound resolve it through the use-aware entry point.
+  test("the API-key readers go through the use-aware resolver", async () => {
+    const expected = [
+      "src/graph/prepare.ts",
+      "src/modules/models/service.ts",
+      "src/modules/stt/service.ts",
+      "src/modules/tts/listing.ts",
+      "src/modules/tts/service.ts",
+      "src/modules/vision/service.ts",
+    ];
+    for (const path of expected) {
+      expect(await Bun.file(path).text()).toContain("tryResolveApiKeyEntry");
+    }
+  });
+});

--- a/tests/modules/credential-shape.test.ts
+++ b/tests/modules/credential-shape.test.ts
@@ -370,6 +370,11 @@ describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
       updateEmbeddingSettings(ctx(), { credentialRef: malformedRef }, appDb),
     );
     expect(envelope).toBeNull();
+
+    // ...and the refusal it DOES make has to name the right problem. `google_oauth` travels outbound
+    // perfectly well as a refreshed token; what it cannot do is be the plain key embedding reads, so
+    // the sentence is the API-key one and not "this type is never sent to another service".
+    expect(bad?.message).toContain("reads a plain API key");
   });
 
   // An import is the one way a bad pairing can still be CREATED, because the payload is authored
@@ -457,9 +462,87 @@ describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
       });
     });
 
+    // The write boundary calls an active row holding `""` unfit, so a runtime that only asked
+    // `typeof === "string"` would refuse it on the way IN and hand it to the provider as a blank key
+    // on the way OUT. Both readings come from `secretValueFitsKind` now.
+    test("an active row holding an empty string is unusable, not ok", async () => {
+      const blank = formatVaultRef(
+        String(
+          (
+            await suDb.vaultEntry.create({
+              data: {
+                tenantId,
+                name: "blank-secret",
+                kind: "openai",
+                secret: encryptJson(""),
+              },
+              select: { id: true },
+            })
+          ).id,
+        ),
+      );
+      expect(await resolve(blank)).toEqual({
+        state: "unusable",
+        kind: "openai",
+      });
+    });
+
     test("a ref the vault does not hold is unresolved", async () => {
       expect(await resolve("vault:99999999")).toEqual({ state: "unresolved" });
     });
+  });
+
+  // The exemption reaching the panel, which is where getting it wrong costs the most: a `wrongKind`
+  // on the embedding would replace the knowledge-indexing issue the operator actually has to act on.
+  test("config-health does not flag the embedding envelope the write accepts", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        modelConfig: {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          credentialRef: keyRef,
+        },
+      },
+    });
+    // The `embedding` issue only exists when a knowledge base is waiting to be indexed, so without
+    // one this asserts `undefined` on a row that was never computed — a test that would pass with
+    // the exemption removed. The base is what makes the assertion mean anything.
+    const kb = await suDb.knowledgeBase.create({
+      data: { tenantId, name: "Catálogo" },
+      select: { id: true },
+    });
+    await suDb.knowledgeDocument.create({
+      data: {
+        tenantId,
+        knowledgeBaseId: kb.id,
+        title: "tabela.pdf",
+        sourceType: "import",
+        content: "x",
+        status: "UNINDEXED",
+      },
+    });
+    await suDb.agentToolSelection.create({
+      data: {
+        tenantId,
+        agentId,
+        source: "RAG",
+        knowledgeBaseIds: [kb.id],
+        enabledTools: [],
+      },
+    });
+    await updateEmbeddingSettings(
+      ctx(),
+      { credentialRef: malformedRef },
+      appDb,
+    );
+    const h = await readAgentConfigHealth(ctx(), agentId, { base: appDb });
+    // Positive control: the reading DID reach this block, so the negative below is about the
+    // exemption and not about a check that never ran.
+    expect(h.issues.some((i) => i.key === "knowledge")).toBe(true);
+    expect(
+      h.issues.find((i) => i.key === "embedding")?.wrongKind,
+    ).toBeUndefined();
   });
 
   test("config-health reports a stored MALFORMED value the same way", async () => {

--- a/tests/modules/credential-shape.test.ts
+++ b/tests/modules/credential-shape.test.ts
@@ -60,6 +60,7 @@ let oauthRef = "";
 let blobRef = "";
 let envRef = "";
 let keyRef = "";
+let malformedRef = "";
 
 const ctx = (): TenantContext => ({
   tenantId,
@@ -137,6 +138,10 @@ describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
       paramName: "API_TOKEN",
     });
     keyRef = await mk("model-key", "openai", "sk-live");
+    // A kind that DECLARES a plain string, holding something else. `validateVaultValue` refuses this
+    // shape today, so it can only exist from before the kind did — or from a path that does not go
+    // through it. The catalog cannot see it: only the value can.
+    malformedRef = await mk("legacy-shaped", "generic", { apiKey: "sk-x" });
     agentId = (
       await suDb.agent.create({
         data: {
@@ -201,6 +206,64 @@ describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
       );
       expect(r?.status).toBe(400);
       expect(r?.field).toBe("settings.tts.credentialRef");
+    });
+
+    // The finding that made this section grow: the boundary asked the KIND and the runtime asked the
+    // kind AND the value, so there was a configuration the write accepted, config-health called
+    // healthy, and the turn then dropped. Three surfaces, one question.
+    test("a kind that should hold a string, holding something else, is refused", async () => {
+      const r = await refused(() =>
+        updateAgent(
+          ctx(),
+          agentId,
+          {
+            modelConfig: {
+              provider: "openai",
+              model: "gpt-4o-mini",
+              credentialRef: malformedRef,
+            },
+          },
+          appDb,
+        ),
+      );
+      expect(r?.status).toBe(400);
+      expect(r?.field).toBe("modelConfig.credentialRef");
+    });
+
+    // The one exemption on the VALUE half, and only that half: a reference-only entry has no secret
+    // yet by design, and refusing it would break the flow `credential_create` exists for.
+    test("a pending entry is still accepted", async () => {
+      const pending = formatVaultRef(
+        String(
+          (
+            await suDb.vaultEntry.create({
+              data: {
+                tenantId,
+                name: "not-filled-yet",
+                kind: "openai",
+                secret: encryptJson({}),
+                status: "pending",
+              },
+              select: { id: true },
+            })
+          ).id,
+        ),
+      );
+      const r = await refused(() =>
+        updateAgent(
+          ctx(),
+          agentId,
+          {
+            modelConfig: {
+              provider: "openai",
+              model: "gpt-4o-mini",
+              credentialRef: pending,
+            },
+          },
+          appDb,
+        ),
+      );
+      expect(r).toBeNull();
     });
 
     test("a usable kind still passes", async () => {
@@ -298,6 +361,15 @@ describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
       updateEmbeddingSettings(ctx(), { credentialRef: keyRef }, appDb),
     );
     expect(good).toBeNull();
+
+    // ...and the one place the VALUE rule does NOT apply. `resolveEmbeddingStatus` reads
+    // `{ apiKey, baseURL }` as well as a plain string, a second form the catalog does not declare,
+    // so holding this field's value to its kind would refuse a shape that reader has always taken.
+    // The KIND rule still applies to it, which is what the first half of this test proves.
+    const envelope = await refused(() =>
+      updateEmbeddingSettings(ctx(), { credentialRef: malformedRef }, appDb),
+    );
+    expect(envelope).toBeNull();
   });
 
   // An import is the one way a bad pairing can still be CREATED, because the payload is authored
@@ -379,22 +451,7 @@ describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
     // row is not one. Reachable for an entry written before its kind existed, or by any path that
     // stores a value the kind does not describe.
     test("a kind that should hold a string, holding something else, is unusable", async () => {
-      const odd = formatVaultRef(
-        String(
-          (
-            await suDb.vaultEntry.create({
-              data: {
-                tenantId,
-                name: "legacy-shaped",
-                kind: "generic",
-                secret: encryptJson({ apiKey: "sk-x" }),
-              },
-              select: { id: true },
-            })
-          ).id,
-        ),
-      );
-      expect(await resolve(odd)).toEqual({
+      expect(await resolve(malformedRef)).toEqual({
         state: "unusable",
         kind: "generic",
       });
@@ -403,6 +460,22 @@ describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
     test("a ref the vault does not hold is unresolved", async () => {
       expect(await resolve("vault:99999999")).toEqual({ state: "unresolved" });
     });
+  });
+
+  test("config-health reports a stored MALFORMED value the same way", async () => {
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        modelConfig: {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          credentialRef: malformedRef,
+        },
+      },
+    });
+    const h = await readAgentConfigHealth(ctx(), agentId, { base: appDb });
+    expect(h.healthy).toBe(false);
+    expect(h.issues.find((i) => i.key === "model")?.wrongKind).toBe(true);
   });
 
   test("config-health reports a STORED one instead of calling the agent healthy", async () => {

--- a/tests/modules/credential-shape.test.ts
+++ b/tests/modules/credential-shape.test.ts
@@ -1,0 +1,432 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { formatVaultRef } from "@/client/lib/credentialRef";
+import { AppError } from "@/lib/errors";
+import type { TenantContext } from "@/lib/tenancy";
+import { runScopedOn } from "@/lib/tenancy";
+import { readAgentConfigHealth } from "@/modules/agents/config-health-read";
+import { updateAgent } from "@/modules/agents/service";
+import {
+  AGENT_EXPORT_KIND,
+  AGENT_EXPORT_VERSION,
+  importAgent,
+} from "@/modules/agents/transfer";
+import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
+import { agentUpdate } from "@/modules/mcp/write-agents";
+import { updateEmbeddingSettings } from "@/modules/tenant-settings/service";
+import { tryResolveApiKeyEntry } from "@/modules/vault/service";
+
+// A credential reference names an entry that EXISTS; nothing asked whether that entry can produce
+// what the field reading it needs. Issue #471.
+//
+// The two shapes a vault entry can hold are declared in the catalog and neither is a string: a kind
+// with `fields` (google_oauth, langfuse) holds a multi-field object, and one with `managedBlob`
+// (mcp_oauth) holds a server-managed JSON blob. A third kind of mismatch is not about shape at all:
+// `neverOutbound` entries (mcp_env, langfuse) hold a perfectly good string that the catalog says
+// must never travel in an outbound request, and an API-key field sends exactly that.
+//
+// Measured on the base before this change: the REST write returned 200, the MCP write echoed the
+// diff, `readAgentConfigHealth` answered `healthy: true` with zero issues, and `loadAgentConfig`
+// handed `{ clientId, clientSecret }` down as `cfg.apiKey`, typed `string`.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const suDb = su as PrismaClient;
+const appDb = app as PrismaClient;
+
+let tenantId = 0n;
+let agentId = 0n;
+let oauthRef = "";
+let blobRef = "";
+let envRef = "";
+let keyRef = "";
+
+const ctx = (): TenantContext => ({
+  tenantId,
+  userId: null,
+  role: "TENANT_ADMIN",
+});
+const principal = (): VerifiedToken => ({
+  userId: 1n,
+  tenantId,
+  role: "TENANT_ADMIN",
+  scopes: ["mcp:read", "mcp:write"],
+  clientId: "c",
+  jti: "j",
+});
+
+async function refused(
+  fn: () => Promise<unknown>,
+): Promise<{ status: number; field?: string; message: string } | null> {
+  try {
+    await fn();
+    return null;
+  } catch (e) {
+    if (e instanceof AppError) {
+      return { status: e.statusCode, field: e.field, message: e.message };
+    }
+    throw e;
+  }
+}
+
+describe.skipIf(!dbUp)("a credential whose kind cannot serve the field", () => {
+  beforeAll(async () => {
+    tenantId = (
+      await suDb.tenant.create({
+        data: { name: "CS", slug: `cs-${process.pid}` },
+      })
+    ).id;
+    const mk = async (
+      name: string,
+      kind: string,
+      secret: unknown,
+      extra = {},
+    ) =>
+      formatVaultRef(
+        String(
+          (
+            await suDb.vaultEntry.create({
+              data: {
+                tenantId,
+                name,
+                kind,
+                secret: encryptJson(secret),
+                ...extra,
+              },
+              select: { id: true },
+            })
+          ).id,
+        ),
+      );
+    // Multi-field: the operator supplies the OAuth app pair and the consent flow merges tokens in.
+    oauthRef = await mk("google-conn", "google_oauth", {
+      clientId: "abc.apps.googleusercontent.com",
+      clientSecret: "GOCSPX-zzz",
+    });
+    // Server-managed blob, created empty by the connect flow.
+    blobRef = await mk(
+      "mcp-conn",
+      "mcp_oauth",
+      {},
+      {
+        baseUrl: "https://mcp.example.com",
+      },
+    );
+    // A plain string the catalog says must NEVER leave in an HTTP request: the stdio loader reads it.
+    envRef = await mk("stdio-token", "mcp_env", "tok-abc", {
+      paramName: "API_TOKEN",
+    });
+    keyRef = await mk("model-key", "openai", "sk-live");
+    agentId = (
+      await suDb.agent.create({
+        data: {
+          tenantId,
+          name: "Probe",
+          systemPrompt: "x",
+          modelConfig: {
+            provider: "openai",
+            model: "gpt-4o-mini",
+            credentialRef: keyRef,
+          },
+          settings: { stt: { enabled: false } },
+        },
+        select: { id: true },
+      })
+    ).id;
+  });
+
+  afterAll(async () => {
+    await suDb.agent.deleteMany({ where: { tenantId } });
+    await suDb.vaultEntry.deleteMany({ where: { tenantId } });
+    await suDb.tenant.delete({ where: { id: tenantId } });
+    await su?.$disconnect();
+    await app?.$disconnect();
+  });
+
+  describe("the REST/console write refuses it, naming the field", () => {
+    for (const [label, ref] of [
+      ["a multi-field kind", () => oauthRef],
+      ["a managed-blob kind", () => blobRef],
+      ["a never-outbound kind", () => envRef],
+    ] as [string, () => string][]) {
+      test(`model credential: ${label}`, async () => {
+        const r = await refused(() =>
+          updateAgent(
+            ctx(),
+            agentId,
+            {
+              modelConfig: {
+                provider: "openai",
+                model: "gpt-4o-mini",
+                credentialRef: ref(),
+              },
+            },
+            appDb,
+          ),
+        );
+        expect(r).not.toBeNull();
+        expect(r?.status).toBe(400);
+        expect(r?.field).toBe("modelConfig.credentialRef");
+      });
+    }
+
+    test("a settings credential is named by its dotted path", async () => {
+      const r = await refused(() =>
+        updateAgent(
+          ctx(),
+          agentId,
+          { settings: { tts: { enabled: true, credentialRef: oauthRef } } },
+          appDb,
+        ),
+      );
+      expect(r?.status).toBe(400);
+      expect(r?.field).toBe("settings.tts.credentialRef");
+    });
+
+    test("a usable kind still passes", async () => {
+      const r = await refused(() =>
+        updateAgent(
+          ctx(),
+          agentId,
+          {
+            modelConfig: {
+              provider: "openai",
+              model: "gpt-4o-mini",
+              credentialRef: keyRef,
+            },
+          },
+          appDb,
+        ),
+      );
+      expect(r).toBeNull();
+    });
+
+    // contactAuth is the one agent field that does NOT read a plain string: it goes through
+    // resolveInjectableCredentialEntry, which refreshes a managed-OAuth token and injects THAT. A
+    // rule that refused every non-string kind everywhere would break the feature it protects.
+    test("contact authorization accepts a managed-OAuth kind", async () => {
+      const r = await refused(() =>
+        updateAgent(
+          ctx(),
+          agentId,
+          {
+            settings: {
+              contactAuth: {
+                enabled: true,
+                credentialRef: oauthRef,
+                url: "https://x.example",
+              },
+            },
+          },
+          appDb,
+        ),
+      );
+      expect(r).toBeNull();
+    });
+
+    // ...and still refuses the one thing it cannot send: a secret the catalog marks never-outbound.
+    test("contact authorization refuses a never-outbound kind", async () => {
+      const r = await refused(() =>
+        updateAgent(
+          ctx(),
+          agentId,
+          {
+            settings: {
+              contactAuth: {
+                enabled: true,
+                credentialRef: envRef,
+                url: "https://x.example",
+              },
+            },
+          },
+          appDb,
+        ),
+      );
+      expect(r?.status).toBe(400);
+      expect(r?.field).toBe("settings.contactAuth.credentialRef");
+    });
+  });
+
+  test("the MCP write refuses it too, through the same boundary", async () => {
+    const r = await agentUpdate(
+      principal(),
+      {
+        agent_id: String(agentId),
+        model_config: {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          credentialRef: oauthRef,
+        },
+        dry_run: false,
+      } as never,
+      { base: appDb },
+    );
+    expect(r.ok).toBe(false);
+    expect(JSON.stringify(r)).toContain("modelConfig.credentialRef");
+  });
+
+  // The tenant's embedding key is the one credential outside the agent that this covers, and the
+  // reason is written down in rag/documents.ts: without a kind test, an operator who picks the
+  // Chatwoot credential here gets every chunk of their knowledge base POSTed at the Chatwoot host.
+  test("the tenant's embedding credential is held to the same rule", async () => {
+    const bad = await refused(() =>
+      updateEmbeddingSettings(ctx(), { credentialRef: oauthRef }, appDb),
+    );
+    expect(bad?.status).toBe(400);
+    expect(bad?.field).toBe("embedding.credentialRef");
+    const good = await refused(() =>
+      updateEmbeddingSettings(ctx(), { credentialRef: keyRef }, appDb),
+    );
+    expect(good).toBeNull();
+  });
+
+  // An import is the one way a bad pairing can still be CREATED, because the payload is authored
+  // elsewhere and the (name, kind) lookup will happily match a google_oauth entry on the model. It is
+  // warned rather than refused (a whole bundle must not fail over one field) and the ref stays wired,
+  // so the operator can see which credential the author meant.
+  test("an import warns instead of refusing, and leaves the ref wired", async () => {
+    const result = await importAgent(
+      ctx(),
+      {
+        kind: AGENT_EXPORT_KIND,
+        version: AGENT_EXPORT_VERSION,
+        agent: {
+          name: `Imported ${process.pid}`,
+          systemPrompt: "x",
+          transferWithSummary: false,
+          modelConfig: {
+            provider: "openai",
+            model: "gpt-4o-mini",
+            credentialRef: "google-conn",
+          },
+          settings: {},
+          businessHours: null,
+          followUpHours: null,
+          tools: [],
+          credentials: [{ name: "google-conn", kind: "google_oauth" }],
+        },
+      },
+      appDb,
+    );
+    const warn = result.warnings.find(
+      (w) => w.code === "credentialKindUnusable",
+    );
+    expect(warn).toBeDefined();
+    expect(warn?.params?.field).toBe("modelConfig.credentialRef");
+    expect(warn?.params?.kind).toBe("google_oauth");
+    // Wired, not unset: the entry exists, unlike the `credentialNotFound` case that drops the ref.
+    const row = await suDb.agent.findFirst({
+      where: { tenantId, name: `Imported ${process.pid}` },
+      select: { modelConfig: true },
+    });
+    expect(
+      (row?.modelConfig as { credentialRef?: string } | null)?.credentialRef,
+    ).toBe(oauthRef);
+  });
+
+  // The resolver every API-key field now goes through, and both halves of its check. They look
+  // redundant and are not: the KIND is what the catalog declares, the VALUE is what is actually
+  // stored, and each catches a case the other lets through.
+  describe("the runtime resolver", () => {
+    const resolve = (ref: string) =>
+      runScopedOn(appDb, ctx(), (db) => tryResolveApiKeyEntry(db, ref));
+
+    test("a usable kind with a string secret resolves", async () => {
+      expect(await resolve(keyRef)).toEqual({
+        state: "ok",
+        secret: "sk-live",
+        baseUrl: null,
+      });
+    });
+
+    test("a multi-field kind is unusable, not merely unresolved", async () => {
+      expect(await resolve(oauthRef)).toEqual({
+        state: "unusable",
+        kind: "google_oauth",
+      });
+    });
+
+    // The case only the KIND check catches: `mcp_env` holds a perfectly good string, so a bare
+    // `typeof x === "string"` would hand the operator's stdio token to a model vendor.
+    test("a never-outbound kind is unusable even though it holds a string", async () => {
+      expect(await resolve(envRef)).toEqual({
+        state: "unusable",
+        kind: "mcp_env",
+      });
+    });
+
+    // The case only the VALUE check catches: the catalog says `generic` is a plain string, and this
+    // row is not one. Reachable for an entry written before its kind existed, or by any path that
+    // stores a value the kind does not describe.
+    test("a kind that should hold a string, holding something else, is unusable", async () => {
+      const odd = formatVaultRef(
+        String(
+          (
+            await suDb.vaultEntry.create({
+              data: {
+                tenantId,
+                name: "legacy-shaped",
+                kind: "generic",
+                secret: encryptJson({ apiKey: "sk-x" }),
+              },
+              select: { id: true },
+            })
+          ).id,
+        ),
+      );
+      expect(await resolve(odd)).toEqual({
+        state: "unusable",
+        kind: "generic",
+      });
+    });
+
+    test("a ref the vault does not hold is unresolved", async () => {
+      expect(await resolve("vault:99999999")).toEqual({ state: "unresolved" });
+    });
+  });
+
+  test("config-health reports a STORED one instead of calling the agent healthy", async () => {
+    // Written past the boundary on purpose: this is the state a write can no longer create and an
+    // install can still be in (an import, or a row that predates the rule).
+    await suDb.agent.update({
+      where: { id: agentId },
+      data: {
+        modelConfig: {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          credentialRef: oauthRef,
+        },
+      },
+    });
+    const h = await readAgentConfigHealth(ctx(), agentId, { base: appDb });
+    expect(h.healthy).toBe(false);
+    const model = h.issues.find((i) => i.key === "model");
+    expect(model).toBeDefined();
+    expect(model?.wrongKind).toBe(true);
+    // Not the other two verdicts: the entry exists and its secret IS filled. The fix is a different
+    // credential, not filling this one in.
+    expect(model?.pending).toBeUndefined();
+    expect(model?.unresolved).toBeUndefined();
+    expect(h.counts.blocking).toBeGreaterThan(0);
+  });
+});

--- a/tests/modules/rag-ingest-block.test.ts
+++ b/tests/modules/rag-ingest-block.test.ts
@@ -192,7 +192,7 @@ describe.skipIf(!dbUp)(
           name: "embed-blank",
           kind: "generic",
           status: "active",
-          secret: encryptJson(""),
+          secret: encryptJson("sk-live"),
         },
       });
       await updateEmbeddingSettings(
@@ -200,6 +200,14 @@ describe.skipIf(!dbUp)(
         { credentialRef: `vault:${row.id}` },
         appDb,
       );
+      // Emptied AFTER it was wired, because that is the only way this state is reachable now: the
+      // write boundary refuses a ref whose value is not the shape its kind declares (issue #471), so
+      // a blank active secret can be arrived at but never chosen. What it does not change is what
+      // this test is about — the reader still has to tell `empty` from `pending` and from `gone`.
+      await suDb.vaultEntry.update({
+        where: { id: row.id },
+        data: { secret: encryptJson("") },
+      });
       expect((await readEmbeddingBlock(ctxOf(id), appDb))?.reason).toBe(
         "credential_empty",
       );

--- a/tests/modules/secret-type-fit.test.ts
+++ b/tests/modules/secret-type-fit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type CredentialUse,
+  SECRET_TYPES,
+  secretTypeFits,
+} from "@/modules/vault/secret-types";
+
+// The decision table for "can an entry of this KIND supply what a field of this USE reads?", which is
+// the one question the write boundary, config-health and the runtime all ask (issue #471). A pure
+// function with a table, rather than a rule re-derived at each of the three: the whole defect was
+// three surfaces answering it differently, and DB-backed tests prove the wiring, never the rule.
+//
+// Every catalog id appears below, enforced by the fence at the bottom, so adding a secret type fails
+// this file until somebody decides what it can serve.
+
+// [kind, apiKey?, injectable?]
+const TABLE: [string, boolean, boolean][] = [
+  // Plain-string kinds: the value IS the secret, and it is meant to travel.
+  ["generic", true, true],
+  ["bearer_token", true, true],
+  ["header", true, true],
+  ["basic_auth", true, true],
+  ["query", true, true],
+  ["openai", true, true],
+  ["anthropic", true, true],
+  ["gemini", true, true],
+  ["deepseek", true, true],
+  ["openrouter", true, true],
+  ["openai_compatible", true, true],
+  ["elevenlabs", true, true],
+  ["asaas", true, true],
+  ["chatwoot_api_token", true, true],
+  // Multi-field: the value is `{ clientId, clientSecret }` and the tokens the consent flow merges in.
+  // Injectable because `resolveInjectableCredentialEntry` refreshes an access token from it; never an
+  // API key, because the field would hand the OBJECT to a provider SDK.
+  ["google_oauth", false, true],
+  // Server-managed blob, same reasoning.
+  ["mcp_oauth", false, true],
+  // Multi-field AND never-outbound: observability reads the pair in-process.
+  ["langfuse", false, false],
+  // A plain string that must never leave: the stdio loader spawns the process with it. This is the
+  // one row where "holds a string" and "can serve an API-key field" come apart, and it is why the
+  // predicate asks the catalog instead of asking `typeof`.
+  ["mcp_env", false, false],
+];
+
+describe("secretTypeFits", () => {
+  for (const [kind, apiKey, injectable] of TABLE) {
+    test(`${kind}: apiKey=${apiKey} injectable=${injectable}`, () => {
+      expect(secretTypeFits(kind, "apiKey")).toBe(apiKey);
+      expect(secretTypeFits(kind, "injectable")).toBe(injectable);
+    });
+  }
+
+  // A kind this build does not know, and the null kind every entry created before the catalog has.
+  // Both are the legacy `generic` escape hatch: a plain string with no injection rule. Refusing them
+  // would invalidate working installs over a catalog entry we removed.
+  for (const use of ["apiKey", "injectable"] as CredentialUse[]) {
+    test(`an unknown or absent kind is permissive (${use})`, () => {
+      expect(secretTypeFits(null, use)).toBe(true);
+      expect(secretTypeFits(undefined, use)).toBe(true);
+      expect(secretTypeFits("", use)).toBe(true);
+      expect(secretTypeFits("a_type_this_build_removed", use)).toBe(true);
+    });
+  }
+
+  // The table is the catalog, not a sample of it: a new secret type has to be placed here before it
+  // can be wired anywhere, because a kind nobody judged defaults to "fits" via the unknown-kind rule
+  // above — which is right for a legacy entry and wrong for a type this build ships.
+  test("every catalog kind is in the table", () => {
+    expect(new Set(TABLE.map(([k]) => k))).toEqual(
+      new Set(SECRET_TYPES.map((s) => s.id)),
+    );
+  });
+});

--- a/tests/modules/secret-type-fit.test.ts
+++ b/tests/modules/secret-type-fit.test.ts
@@ -3,6 +3,8 @@ import {
   type CredentialUse,
   SECRET_TYPES,
   secretTypeFits,
+  secretValueFitsKind,
+  valueRuleApplies,
 } from "@/modules/vault/secret-types";
 
 // The decision table for "can an entry of this KIND supply what a field of this USE reads?", which is
@@ -49,13 +51,21 @@ describe("secretTypeFits", () => {
     test(`${kind}: apiKey=${apiKey} injectable=${injectable}`, () => {
       expect(secretTypeFits(kind, "apiKey")).toBe(apiKey);
       expect(secretTypeFits(kind, "injectable")).toBe(injectable);
+      // The embedding key differs from `apiKey` only on the VALUE rule, never on the kind, so it
+      // shares this column rather than getting one of its own — and this assertion is what keeps the
+      // two from drifting apart the day somebody special-cases one of them.
+      expect(secretTypeFits(kind, "embeddingKey")).toBe(apiKey);
     });
   }
 
   // A kind this build does not know, and the null kind every entry created before the catalog has.
   // Both are the legacy `generic` escape hatch: a plain string with no injection rule. Refusing them
   // would invalidate working installs over a catalog entry we removed.
-  for (const use of ["apiKey", "injectable"] as CredentialUse[]) {
+  for (const use of [
+    "apiKey",
+    "injectable",
+    "embeddingKey",
+  ] as CredentialUse[]) {
     test(`an unknown or absent kind is permissive (${use})`, () => {
       expect(secretTypeFits(null, use)).toBe(true);
       expect(secretTypeFits(undefined, use)).toBe(true);
@@ -72,4 +82,75 @@ describe("secretTypeFits", () => {
       new Set(SECRET_TYPES.map((s) => s.id)),
     );
   });
+});
+
+// The second half of the question, and the half only the ROW can answer. The catalog says what a kind
+// is supposed to hold; this says whether it does. Asymmetric on purpose, and the asymmetry is the
+// content: string-valued kinds are checked strictly because that is what a reader breaks on, while a
+// multi-field or blob kind is only checked for being an object — the OAuth consent flows merge tokens
+// into those values outside `validateVaultValue`, so demanding the declared field list would report
+// every CONNECTED Google account as malformed.
+describe("secretValueFitsKind", () => {
+  const CASES: [string, string | null, unknown, boolean][] = [
+    ["a plain key on a string kind", "openai", "sk-live", true],
+    ["an empty string on a string kind", "openai", "", false],
+    ["an object on a string kind", "generic", { apiKey: "sk-x" }, false],
+    ["an object on a null kind", null, { a: 1 }, false],
+    ["a string on a null kind", null, "sk-live", true],
+    [
+      "the declared pair on a fields kind",
+      "google_oauth",
+      { clientId: "a", clientSecret: "b" },
+      true,
+    ],
+    // The connected case: the consent flow has merged tokens in, so the object carries far more than
+    // the two declared fields. It is the NORMAL state of a working credential, not a malformed one.
+    [
+      "a connected OAuth blob, well past its declared fields",
+      "google_oauth",
+      {
+        clientId: "a",
+        clientSecret: "b",
+        accessToken: "t",
+        refreshToken: "r",
+        expiresAt: 1,
+        scopes: [],
+        email: "x@y",
+      },
+      true,
+    ],
+    [
+      "an empty managed blob, before the connect flow runs",
+      "mcp_oauth",
+      {},
+      true,
+    ],
+    ["a string on a fields kind", "langfuse", "sk-live", false],
+    ["an array on a blob kind", "mcp_oauth", ["a"], false],
+    ["null on a blob kind", "mcp_oauth", null, false],
+  ];
+  for (const [label, kind, value, fits] of CASES) {
+    test(`${label} -> ${fits}`, () => {
+      expect(secretValueFitsKind(kind, value)).toBe(fits);
+    });
+  }
+});
+
+// Which uses hold the stored VALUE to its kind, and the one that does not. Written as a table over
+// every use rather than as "not embeddingKey", so a fourth use has to be placed here before it can
+// silently inherit either answer.
+describe("valueRuleApplies", () => {
+  const USES: [CredentialUse, boolean][] = [
+    ["apiKey", true],
+    ["injectable", true],
+    // The exemption: `resolveEmbeddingStatus` accepts `{ apiKey, baseURL }` as well as the plain
+    // string, a second form the catalog does not declare. Holding the value to the kind here would
+    // refuse a shape that reader has always taken.
+    ["embeddingKey", false],
+  ];
+  for (const [use, applies] of USES) {
+    test(`${use} -> ${applies}`, () => {
+      expect(valueRuleApplies(use)).toBe(applies);
+    });
+  }
 });


### PR DESCRIPTION
## What was broken

A credential reference was validated for EXISTENCE and never for shape. Every field that reads a
plain API key — the agent's model, its four model overrides (guardrails, the speech rewrite, the
summariser, the fallback provider), STT, TTS, vision, and the tenant's embedding key — accepted a
`vault:<id>` pointing at any active entry, including one whose stored value is not a string.

Two kinds of entry are like that and the catalog already knew which: a kind with `fields` holds a
multi-field object (`google_oauth`, `langfuse`) and one with `managedBlob` holds a server-managed
JSON blob (`mcp_oauth`). A third mismatch is not about shape at all: `neverOutbound` kinds
(`mcp_env`, `langfuse`) hold a perfectly good string that the catalog says must never travel in an
outbound request, and an API-key field sends exactly that.

Measured on the base, with a `google_oauth` entry wired as the agent's model key:

| surface | answer on the base |
| --- | --- |
| REST/console write (`updateAgent`) | accepted, 200 |
| MCP write (`agent_update`) | accepted, echoed the diff |
| `readAgentConfigHealth` | `{"healthy":true,"counts":{"blocking":0,"degraded":0,"advisory":0},"issues":[]}` |
| `loadAgentConfig` | `cfg.apiKey = {"clientId":"…","clientSecret":"…"}`, typed `string` |

The runtime line explains the rest: `tryResolveVaultEntry<string>` is not a check. `decryptJson<T>`
casts, so ten call sites had written `<string>` and used the result, and the object travelled into
`createChatModel` wearing the type of a key.

## What the report got wrong

The issue is one we opened ourselves while reviewing #470, and three of its claims did not survive
being measured.

**"The object reaches the provider SDK as an API key."** Only on one of the six providers. Driven
through `createChatModel` with a captured `fetch`, five refuse in the constructor and NO request
leaves:

```
openai / openai-compatible / openrouter / anthropic / deepseek
    blob → THROW "Could not resolve authentication method…"   (nenhuma requisição saiu)
google
    blob → 400 from the vendor
           SAIU: generativelanguage.googleapis.com  x-goog-api-key="[object Object]"
```

The outbound half is one provider wide, and what leaves is the string `[object Object]`, not the
credential's contents. What is six providers wide is the silence: the turn dies with a vendor error
nobody asked for while the panel says the agent is healthy.

**"The tenant's embedding key."** Half true. The WRITE never checked the kind (fixed here), but the
runtime already did: `resolveEmbeddingStatus` destructures `{ apiKey }` off a non-string value and
reports `credential_empty`.

**"The reverse pairing is worth checking."** Already answered. `google-calendar.service.ts` and
`google-drive.service.ts` refuse anything but `kind === "google_oauth"`; `updateLangfuse` refuses
anything but `kind === "langfuse"` and `resolveLangfuseConfig` `safeParse`s the pair at read time;
the MCP paths narrow on `isManagedOAuthKind` plus `typeof secret === "string"`. Nothing was added
for those.

## The change

One question — **can this entry serve this field?** — in one function, `credentialServes(facts,
use)`, called by the write boundary, the import warning and config-health. It composes two
predicates over the catalog: whether the KIND can supply what the use reads, and whether the stored
VALUE is the shape that kind declares.

`use` is declared per field and required by the type:

- **`apiKey`** — the value IS the credential the request carries (the agent's nine fields bar one).
- **`injectable`** — resolved through `resolveInjectableCredentialEntry`, which hands back a fresh
  access token for the managed-OAuth kinds, so a `google_oauth` entry is correct configuration
  there. `contactAuth` is the one agent field that reads this way, which is exactly the split a rule
  derived from the field's path would have got wrong.
- **`embeddingKey`** — the tenant's embedding key, same KIND rule and exempt from the VALUE one,
  because `resolveEmbeddingStatus` accepts `{ apiKey, baseURL }` as well as a plain string. That
  second form is undeclared in the catalog and exercised by five existing tests; holding the value
  to its kind there would refuse a configuration that has always worked. The debt is the undeclared
  form, not the exemption.

Three surfaces then answer identically:

- **The write refuses.** `requireVaultRefFor` covers REST, the console and MCP in one place, plus
  the embedding key. Only refs a write INTRODUCES or CHANGES, which is the split
  `credential-paths.ts` already documents: what is already stored is reported, not refused, so one
  bad pairing cannot freeze every other edit of the agent holding it. A PENDING entry is exempt from
  the value half alone — it has no secret yet by design.
- **config-health reports.** A fourth verdict beside missing/pending/unresolved, with its own
  sentence per feature: the move is neither "fill it in" nor "it is gone".
- **The runtime declines, by construction.** The generic parameter of `tryResolveVaultEntry` is
  gone, `secret` is `unknown`, and the compiler is what found the ten sites that were asserting.
  They go through `tryResolveApiKeyEntry`, which judges the value with the same predicate the write
  does, so the two cannot disagree about what "unusable" means.

An undecryptable blob (a rotated `ENCRYPTION_KEY`, a truncated row) is a third answer and refuses
nothing. Collapsing it into "malformed" would make a key rotation reject every agent write in the
workspace while blaming the credential's type.

An import is the one path that can still create the pairing, so it warns and leaves the ref wired:
refusing would reject a bundle over one field, and unsetting would erase the only record of which
credential the author meant.

`listVaultInfos` computes the value verdict server-side and sends a boolean. Measured on the wire
with 50 entries: the fields are `baseUrl, id, kind, name, paramName, status, valueFitsKind`, and the
secret string appears nowhere in the payload. The added cost is the decrypt: 2.56 ms/call against
1.43 ms for the same SELECT without it, at 50 entries of ~190 chars.

## Review rounds

Three rounds, five findings, all confirmed. Round 2's three were one thing: the three-valued `use`
that round 1 introduced, applied to two of the three places that read it. No new mechanism entered —
the same one became correct, and the mutation battery is what said the copies had to go: deleting
the exemption in config-health killed two tests while deleting it in the import killed none, because
no agent field is `embeddingKey` yet. That copy was code nobody could exercise.

Round 2 also caught the original defect inverted: round 1 taught the write to refuse an active row
holding `""` and left the runtime accepting it. Measured on the base, that gap is real for three of
the four paths the finding named — the model's SDK refuses an empty key before any request leaves,
but the STT/TTS/vision providers build the header by hand:

```
openai      → api.openai.com     authorization="Bearer"     (a requisição SAI)
elevenlabs  → api.elevenlabs.io  xi-api-key=""              (a requisição SAI)
```

## Validation scope

**Proven by test** (`bun check` green: 8957 pass, 0 fail; CI green on all six checks):

- `tests/modules/secret-type-fit.test.ts` — the decision tables. All 18 catalog kinds × 3 uses, with
  a fence that fails when a kind is added without being placed; 11 rows over `secretValueFitsKind`,
  including the CONNECTED OAuth blob (seven keys past its two declared ones, and the normal state of
  a working credential — demanding the declared list would report every linked Google account as
  malformed); and a table over `valueRuleApplies` so a fourth use cannot silently inherit an answer.
- `tests/modules/credential-shape.test.ts` — DB-backed, 21 cases: the REST refusal per kind and per
  dotted path, the MCP refusal through the same boundary, `contactAuth` accepting managed OAuth and
  refusing never-outbound, the malformed value refused and the pending entry still accepted, the
  embedding key's kind rule enforced and its value rule exempt, the import warning with the ref left
  wired, both stored cases reported by config-health, and the runtime resolver's three states.
- `tests/modules/credential-reader-fence.test.ts` — who may read a secret raw, with the reason per
  module, both directions, and two controls: one plants an unlisted reader, the other plants a file
  whose only occurrence is a comment and requires it NOT to count.
- **Red first**: 7 of 9 failed on the base, with the two controls green from the start.
- **Mutation battery, 15 of 15 killed** across the three rounds. Two survivors in round 2 were the
  reason the rule became one function, and one of them was a test of mine passing for the wrong
  reason — it asserted `wrongKind === undefined` with no knowledge base pending, so the issue was
  never computed. It now seeds the base and asserts the `knowledge` issue appears first.

**Proven live**, the same script run on the base worktree and on this one, against the real vendors,
and re-run after the last round because the rounds changed the mechanism:

- Control: the workspace's real OpenAI key resolved and `api.openai.com` answered (`RESPONDEU "Ok."`).
- Defect: `generativelanguage.googleapis.com` returned `400` to a request that left with
  `x-goog-api-key: "[object Object]"`; the same blob on `openai` threw before any request left.
- Fix: against the same dev vault, `tryResolveApiKeyEntry` answers `state=unusable
  kind=google_oauth` for the OAuth entry, `state=ok` for the API key, and `state=unusable
  kind=openai` for an active row holding `""` — the arm the review rounds added. On the base the
  same script reports the resolver does not exist and the blob goes on to the provider.

**Not validated**: no browser pass over the editor panel — the fourth verdict's rendering is covered
by the shared message module and the locale catalogs, not by a rendered page. Three `requireVaultRef`
call sites outside this scope (the two integration credentials, the webhook and alert-channel signing
secrets) still check existence only; they answer a third question — a fixed kind, or a string
consumed in-process — that `CredentialUse` does not model, and inventing a use for each to satisfy a
required parameter would have been worse than saying so. An undecryptable blob still has no verdict
on any surface; that is the state this change deliberately declines to diagnose.

Fixes #471
