### PR TITLE
Acknowledge the contact's message on WhatsApp when a turn answers it

### DIFF
--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -600,6 +600,19 @@ type RunTurnBodyParams = RunLoadedTurnParams & {
   claimBeforeSend?: () => Promise<boolean>;
 };
 
+// Whether a read receipt on this channel can reach anything. Written as "not known to be something
+// else" rather than `=== "Channel::Whatsapp"`, because the question has THREE answers and the third
+// is the common one: `channelType` is mirrored from Chatwoot into the local Inbox row and stays null
+// until a sync populates it, so the strict form would silently drop the tick on a real WhatsApp
+// conversation whose mirror lags — the single outcome this feature exists to produce. The two
+// mistakes are not the same size. Treating unknown as WhatsApp costs one request that Chatwoot
+// answers 200 and its listener drops (`return unless channel.respond_to?(:read_messages)`), so
+// Api/Instagram/WebWidget never reach a provider; treating unknown as not-WhatsApp costs the
+// feature, without a log line to say so.
+function channelCanReadReceipt(channelType: string | null): boolean {
+  return channelType === null || channelType === "Channel::Whatsapp";
+}
+
 async function runTurnBody(
   params: RunTurnBodyParams,
 ): Promise<RunAgentTurnOutcome> {
@@ -650,7 +663,7 @@ async function runTurnBody(
   // `conversationId > 0` keeps the playground out: it runs turns against a dummy client and id 0.
   // Best-effort, because a Chatwoot older than the endpoint answers 401 (its bot allowlist predates
   // `read_receipt`) or 404 (no route), and no blue tick is worth failing a turn over.
-  if (params.conversationId > 0) {
+  if (params.conversationId > 0 && channelCanReadReceipt(loaded.channelType)) {
     // try/catch and NOT `.catch()`: the latter only covers a rejected promise, and the failure this
     // has to survive can happen while INVOKING — a client that predates the method (a test double,
     // an older build) throws TypeError synchronously and walks straight past a `.catch()`. Measured:

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -650,6 +650,16 @@ async function runTurnBody(
     botToken: loaded.agentBotToken ?? undefined,
   });
 
+  // The question, and it is asked AT each outward write rather than somewhere upstream of it. Four
+  // review rounds found the same defect in four different places, and every one of them was an ask
+  // that sat next to its effect when it was written and then had a round trip grow between the two:
+  // the output guardrail, the supersede re-fetch, the speech normalizer, the synthesis call.
+  // Adjacency is not something a call site can be trusted to keep — it has to be where the question
+  // is asked.
+  const writeCalledOff = async (): Promise<boolean> =>
+    params.stillWanted !== null &&
+    !(await params.stillWanted({ strict: false }));
+
   // Blue-ticks the contact's messages on WhatsApp. Here because this is the tail BOTH entry points
   // share, so the direct path and the debounce flush get it from one site instead of two that can
   // drift; and because a turn reaching this line has read the messages, which is exactly what the
@@ -663,7 +673,19 @@ async function runTurnBody(
   // `conversationId > 0` keeps the playground out: it runs turns against a dummy client and id 0.
   // Best-effort, because a Chatwoot older than the endpoint answers 401 (its bot allowlist predates
   // `read_receipt`) or 404 (no route), and no blue tick is worth failing a turn over.
-  if (params.conversationId > 0 && channelCanReadReceipt(loaded.channelType)) {
+  //
+  // Asked BEFORE the tick, because a blue tick is an outward write like any other and `docs/graph.md`
+  // requires every one of them to ask. This was the only write in this function that reached the wire
+  // ahead of the first ask: a `/reset` (or a retirement) landing between the debounce claim and this
+  // line left the contact looking at ticks from a turn that then returned "stale" and answered
+  // nothing. `strict: false` for the same reason every other write here uses it — an unreadable fence
+  // is not evidence that anybody withdrew the run. And nothing is lost by skipping: a job is retired
+  // because a NEWER burst took over, and that flush acknowledges a superset of these ids.
+  if (
+    params.conversationId > 0 &&
+    channelCanReadReceipt(loaded.channelType) &&
+    !(await writeCalledOff())
+  ) {
     // try/catch and NOT `.catch()`: the latter only covers a rejected promise, and the failure this
     // has to survive can happen while INVOKING — a client that predates the method (a test double,
     // an older build) throws TypeError synchronously and walks straight past a `.catch()`. Measured:
@@ -674,15 +696,6 @@ async function runTurnBody(
       // Swallowed on purpose: see above.
     }
   }
-  // The question, and it is asked AT each outward write rather than somewhere upstream of it. Four
-  // review rounds found the same defect in four different places, and every one of them was an ask
-  // that sat next to its effect when it was written and then had a round trip grow between the two:
-  // the output guardrail, the supersede re-fetch, the speech normalizer, the synthesis call.
-  // Adjacency is not something a call site can be trusted to keep — it has to be where the question
-  // is asked.
-  const writeCalledOff = async (): Promise<boolean> =>
-    params.stillWanted !== null &&
-    !(await params.stillWanted({ strict: false }));
 
   // The two gates that stand between this turn and a post, and neither is the fence — the fences are
   // the asks at the sends themselves. This is where a run that is already called off stops before

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -660,6 +660,42 @@ async function runTurnBody(
     params.stillWanted !== null &&
     !(await params.stillWanted({ strict: false }));
 
+  // WHO OWNS IT ACCORDING TO THE MIRROR, RIGHT NOW (issue #457, review round 7). The receiver's gate
+  // proved bot ownership before this turn was queued, and the note is written much later — after the
+  // toolset is built, after the ingestion drain, and after a claim that WAITS on an append's lease
+  // and on the row lock a /reset holds. A person taking the conversation over inside that window
+  // leaves the gate's answer saying the bot owns it, and the note would then state that a human
+  // attendance ended while the human is in it. The post-generation recheck suppresses the SEND and
+  // cannot unwrite a message. Same read that recheck makes, asked at the moment this writes; a read
+  // that fails leaves the note OWED, which costs nothing because nothing is consumed to write it.
+  const botOwnsItNow = async (): Promise<boolean> =>
+    await runScopedOn(base, sysCtx(tenantId), async (db) => {
+      const conv = await db.conversation.findUnique({
+        where: {
+          tenantId_chatwootInstanceId_chatwootConversationId: {
+            tenantId,
+            chatwootInstanceId: instanceId,
+            chatwootConversationId: conversationId,
+          },
+        },
+        select: { assigneeType: true, assigneeId: true, status: true },
+      });
+      return shouldBotHandle(
+        {
+          assigneeType: conv?.assigneeType ?? null,
+          assigneeId: conv?.assigneeId ?? null,
+          status: conv?.status ?? null,
+        },
+        { ourAgentBotId: loaded.agentBotId ?? agentBotId },
+      );
+    }).catch((err) => {
+      logger.warn(
+        { err, conv: conversationId },
+        "hand-back note: ownership read failed; leaving the note owed",
+      );
+      return false;
+    });
+
   // Blue-ticks the contact's messages on WhatsApp. Here because this is the tail BOTH entry points
   // share, so the direct path and the debounce flush get it from one site instead of two that can
   // drift; and because a turn reaching this line has read the messages, which is exactly what the
@@ -674,17 +710,35 @@ async function runTurnBody(
   // Best-effort, because a Chatwoot older than the endpoint answers 401 (its bot allowlist predates
   // `read_receipt`) or 404 (no route), and no blue tick is worth failing a turn over.
   //
-  // Asked BEFORE the tick, because a blue tick is an outward write like any other and `docs/graph.md`
-  // requires every one of them to ask. This was the only write in this function that reached the wire
-  // ahead of the first ask: a `/reset` (or a retirement) landing between the debounce claim and this
-  // line left the contact looking at ticks from a turn that then returned "stale" and answered
-  // nothing. `strict: false` for the same reason every other write here uses it — an unreadable fence
-  // is not evidence that anybody withdrew the run. And nothing is lost by skipping: a job is retired
-  // because a NEWER burst took over, and that flush acknowledges a superset of these ids.
+  // A blue tick is an outward write, so it asks what every other outward write in this function asks,
+  // AT the write. Two review rounds arrived here one question at a time; the set is enumerated from
+  // the decision rather than grepped from the code, and it is closed:
+  //
+  //   1. a real conversation      `conversationId > 0`   — the playground runs on a dummy client, id 0
+  //   2. a channel that can show it  `channelCanReadReceipt`
+  //   3. the caller still wants the turn  `writeCalledOff` — `/reset`, or a retired job
+  //   4. the bot still holds the conversation  `botOwnsItNow` — a human took it over mid-turn
+  //   5. something to acknowledge  — inside `markRead`, which does not call on an empty list
+  //
+  // And deliberately NOT `shouldPost`/`claimBeforeSend`, the sixth question the send path asks. That
+  // one CLAIMS the burst as its CAS, advancing the handled watermark; a tick that claimed would mark
+  // messages handled on the way to acknowledging them, which is the defect the watermark rule exists
+  // to prevent. A receipt observes, it does not consume.
+  //
+  // (3) and (4) both suppress the SEND further down and neither can unwrite a tick, which is the
+  // whole reason they are asked here instead. `strict: false` on the fence for the same reason every
+  // other write uses it: an unreadable fence is not evidence that anybody withdrew the run. (4) is
+  // fail-closed, inherited from the read's existing caller and left that way on purpose — "a human
+  // owns it" and "cannot tell" are the same answer to a customer-visible claim made by a bot that
+  // may already have stood down.
+  //
+  // Nothing is lost to (3): a job is retired because a NEWER burst took over, and that flush
+  // acknowledges a superset of these ids.
   if (
     params.conversationId > 0 &&
     channelCanReadReceipt(loaded.channelType) &&
-    !(await writeCalledOff())
+    !(await writeCalledOff()) &&
+    (await botOwnsItNow())
   ) {
     // try/catch and NOT `.catch()`: the latter only covers a rejected promise, and the failure this
     // has to survive can happen while INVOKING — a client that predates the method (a test double,
@@ -1128,41 +1182,6 @@ async function runTurnBody(
   // this turn reading a transfer with no ending — which is the silence this whole PR is about, on
   // the first turn after the return, for the customer who is waiting right now.
   let handbackDeferred = false;
-  // WHO OWNS IT ACCORDING TO THE MIRROR, RIGHT NOW (issue #457, review round 7). The receiver's gate
-  // proved bot ownership before this turn was queued, and the note is written much later — after the
-  // toolset is built, after the ingestion drain, and after a claim that WAITS on an append's lease
-  // and on the row lock a /reset holds. A person taking the conversation over inside that window
-  // leaves the gate's answer saying the bot owns it, and the note would then state that a human
-  // attendance ended while the human is in it. The post-generation recheck suppresses the SEND and
-  // cannot unwrite a message. Same read that recheck makes, asked at the moment this writes; a read
-  // that fails leaves the note OWED, which costs nothing because nothing is consumed to write it.
-  const botOwnsItNow = async (): Promise<boolean> =>
-    await runScopedOn(base, sysCtx(tenantId), async (db) => {
-      const conv = await db.conversation.findUnique({
-        where: {
-          tenantId_chatwootInstanceId_chatwootConversationId: {
-            tenantId,
-            chatwootInstanceId: instanceId,
-            chatwootConversationId: conversationId,
-          },
-        },
-        select: { assigneeType: true, assigneeId: true, status: true },
-      });
-      return shouldBotHandle(
-        {
-          assigneeType: conv?.assigneeType ?? null,
-          assigneeId: conv?.assigneeId ?? null,
-          status: conv?.status ?? null,
-        },
-        { ourAgentBotId: loaded.agentBotId ?? agentBotId },
-      );
-    }).catch((err) => {
-      logger.warn(
-        { err, conv: conversationId },
-        "hand-back note: ownership read failed; leaving the note owed",
-      );
-      return false;
-    });
   try {
     // ── Attendance boundary. A NEW conversation reusing this contact-inbox thread gets the
     //    "fresh attendance" divider, and the attendance it replaced becomes compactable.

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -222,6 +222,14 @@ export interface RunLoadedTurnParams {
   // Chatwoot id of the triggering message, surfaced to HTTP tools as {{message_id}}. Direct path: the
   // incoming message id; debounce flush: the burst watermark. Omitted ⇒ {{message_id}} stays unset.
   messageId?: number;
+  // Every inbound message this turn is answering, for the WhatsApp read receipt. A debounce flush
+  // passes the whole burst; the direct path passes its single message. Empty ⇒ no receipt is sent.
+  //
+  // MANDATORY, and that is the point. Optional, a third entry point that coalesces messages would
+  // compile while acknowledging only the newest of them, leaving every earlier message of the burst
+  // on grey ticks — a silent loss the type system is perfectly able to prevent. Required, `tsc`
+  // names the site.
+  readMessageIds: number[];
   // Whether the customer's turn included a voice note — drives the "mirror" TTS reply mode.
   userSentAudio?: boolean;
   base?: PrismaClient;
@@ -628,6 +636,31 @@ async function runTurnBody(
     makeClient: params.deps?.makeClient,
     botToken: loaded.agentBotToken ?? undefined,
   });
+
+  // Blue-ticks the contact's messages on WhatsApp. Here because this is the tail BOTH entry points
+  // share, so the direct path and the debounce flush get it from one site instead of two that can
+  // drift; and because a turn reaching this line has read the messages, which is exactly what the
+  // tick claims. It says nothing about a reply coming, so a turn that later defers, hands off or is
+  // silenced keeps it honest.
+  //
+  // Deliberately NOT driven by `lastHandledMessageId`. That watermark also advances for a burst the
+  // bot skipped on purpose (nothing renders to answerable text, a mid-turn takeover, a guardrail
+  // silence), and ticking those would tell the contact somebody read what nobody read.
+  //
+  // `conversationId > 0` keeps the playground out: it runs turns against a dummy client and id 0.
+  // Best-effort, because a Chatwoot older than the endpoint answers 401 (its bot allowlist predates
+  // `read_receipt`) or 404 (no route), and no blue tick is worth failing a turn over.
+  if (params.conversationId > 0) {
+    // try/catch and NOT `.catch()`: the latter only covers a rejected promise, and the failure this
+    // has to survive can happen while INVOKING — a client that predates the method (a test double,
+    // an older build) throws TypeError synchronously and walks straight past a `.catch()`. Measured:
+    // the first version of this line took 95 turn tests down with it.
+    try {
+      await client.markRead(params.conversationId, params.readMessageIds);
+    } catch {
+      // Swallowed on purpose: see above.
+    }
+  }
   // The question, and it is asked AT each outward write rather than somewhere upstream of it. Four
   // review rounds found the same defect in four different places, and every one of them was an ask
   // that sat next to its effect when it was written and then had a round trip grow between the two:
@@ -2156,6 +2189,8 @@ export async function runAgentTurn(
       : undefined;
 
   const outcome = await runLoadedTurn({
+    // The direct path answers exactly one message, so the receipt set is that message.
+    readMessageIds: typeof n.message?.id === "number" ? [n.message.id] : [],
     // Nothing QUEUED this turn — it is the delivery itself, arriving from the webhook — so there is
     // no job for /reset to retire. What names this run instead is the EPISODE, read off the message
     // it is answering, and ./reset-episode.ts carries the measurement: without it the operator's

--- a/src/modules/chatwoot/client.ts
+++ b/src/modules/chatwoot/client.ts
@@ -748,6 +748,30 @@ export class ChatwootClient {
     );
   }
 
+  // Tells WhatsApp the contact's messages were read, which is what turns the ticks blue on their
+  // phone. `read_receipt` IS in the fork's BOT_ACCESSIBLE_ENDPOINTS (same allowlist as
+  // `toggle_typing_status`), so the bot token carries it and the receipt is attributed to us.
+  //
+  // It writes NO read state inside Chatwoot: the conversation keeps its unread badge for the human
+  // agents, so a bot acknowledging a message it is about to answer does not hand a human a thread
+  // that already looks read. Naming the ids matters — omitting them makes the endpoint fall back to
+  // a window over the thread, and we always know exactly which messages this turn took.
+  //
+  // Best-effort at every call site, and the reason is version skew: an instance older than the
+  // endpoint answers 401 (its bot allowlist predates `read_receipt`) or 404 (no route), and a blue
+  // tick is never worth failing a turn over.
+  markRead(conversationId: number, messageIds: number[]): Promise<unknown> {
+    const ids = messageIds.filter((id) => Number.isInteger(id) && id > 0);
+    // An empty list means "I processed nothing", which acknowledges nothing. Not a call.
+    if (ids.length === 0) return Promise.resolve(undefined);
+    return this.request(
+      this.config.botToken,
+      "POST",
+      `/conversations/${conversationId}/read_receipt`,
+      { message_ids: ids },
+    );
+  }
+
   // ── admin-token (history, provisioning, anything outside the bot allowlist) ──
 
   getConversation(conversationId: number): Promise<unknown> {

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -310,6 +310,9 @@ export async function coalesceAndRunTurn(
     text,
     // The id of the burst's most recent message, exposed to tools as {{message_id}}.
     messageId: lastMessageId,
+    // The WHOLE burst for the read receipt, not just the id above: WhatsApp acknowledges the
+    // messages it is given, so passing only the newest leaves the ones before it on grey ticks.
+    readMessageIds: pending.map((m) => m.id),
     userSentAudio: pending.some((m) => m.attachmentTypes.includes("audio")),
     base,
     deps,

--- a/tests/graph/read-receipt-turn.test.ts
+++ b/tests/graph/read-receipt-turn.test.ts
@@ -55,6 +55,9 @@ const suDb = su as PrismaClient;
 let tenantId = 0n;
 let instanceId = 0n;
 let agentId = 0n;
+let whatsappInboxDbId = 0n;
+let apiInboxDbId = 0n;
+let unclassifiedInboxDbId = 0n;
 
 const REPLY = "Claro, já verifico.";
 
@@ -112,12 +115,13 @@ const incoming = (
   message: { id: messageId, content, messageType: "incoming", private: false },
 });
 
-async function seedConversation(convId: number) {
+async function seedConversation(convId: number, inboxDbId?: bigint) {
   await suDb.conversation.create({
     data: {
       tenantId,
       chatwootInstanceId: instanceId,
       chatwootConversationId: convId,
+      ...(inboxDbId === undefined ? {} : { inboxId: inboxDbId }),
       status: "pending",
       threadId: `${tenantId}:${instanceId}:${convId}`,
       lastEventAt: new Date(),
@@ -177,6 +181,31 @@ describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
         agentId: agent.id,
       },
     });
+    // Three mirror rows for the three answers `channelType` can give, because the gate has three
+    // branches and not two: WhatsApp, a channel that is known NOT to be WhatsApp, and a row the
+    // mirror has not classified. The conversation's own `inboxId` is what carries the answer into
+    // the turn (`loadAgentConfig` reads `conversation.inbox.channelType`); the event's `inboxId`
+    // resolves the AGENT, which is a different lookup and stays on inbox 7 throughout.
+    const mirrored = async (
+      chatwootInboxId: number,
+      channelType: string | null,
+    ) =>
+      (
+        await suDb.inbox.create({
+          data: {
+            tenantId,
+            chatwootInstanceId: instanceId,
+            chatwootInboxId,
+            name: `Mirror ${chatwootInboxId}`,
+            agentId: agent.id,
+            ...(channelType === null ? {} : { channelType }),
+          },
+          select: { id: true },
+        })
+      ).id;
+    whatsappInboxDbId = await mirrored(17, "Channel::Whatsapp");
+    apiInboxDbId = await mirrored(27, "Channel::Api");
+    unclassifiedInboxDbId = await mirrored(37, null);
   });
 
   afterAll(async () => {
@@ -248,6 +277,84 @@ describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
     });
 
     expect(receipts).toEqual([]);
+  });
+
+  // A read receipt is a WhatsApp gesture, and a turn on any other channel would spend a Chatwoot
+  // round trip on the hot path before every model invocation to achieve nothing: the endpoint
+  // answers 200 and its listener returns unless the channel responds to `read_messages`, so
+  // Api/Instagram/WebWidget never reach a provider. Asserting `sent` too, because "no receipt" is
+  // also what a turn that died on the gate would produce.
+  test("a channel that is not WhatsApp gets no receipt", async () => {
+    const convId = 8105;
+    await seedConversation(convId, apiInboxDbId);
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+
+    const outcome = await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: incoming(convId, 5901, "oi pelo app"),
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+    });
+
+    expect(receipts).toEqual([]);
+    expect(outcome).toBe("posted");
+    expect(sent).toEqual([convId]);
+  });
+
+  test("a WhatsApp inbox gets the receipt", async () => {
+    const convId = 8106;
+    await seedConversation(convId, whatsappInboxDbId);
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+
+    await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: incoming(convId, 5902, "oi pelo whats"),
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+    });
+
+    expect(receipts).toEqual([{ conversationId: convId, messageIds: [5902] }]);
+  });
+
+  // The third branch, and the reason the gate is written as "skip what is known not to be WhatsApp"
+  // instead of "send only to Channel::Whatsapp". `channelType` comes from the local inbox mirror,
+  // which lags Chatwoot and is null until a sync populates it, so the strict form would silently
+  // drop the tick on a real WhatsApp conversation — the exact outcome this feature exists to
+  // produce. Unknown costs a 200 that does nothing; unknown-treated-as-no costs the feature.
+  test("an inbox the mirror has not classified still gets the receipt", async () => {
+    const convId = 8107;
+    await seedConversation(convId, unclassifiedInboxDbId);
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+
+    await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: incoming(convId, 5903, "oi, e por aqui?"),
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+    });
+
+    expect(receipts).toEqual([{ conversationId: convId, messageIds: [5903] }]);
   });
 
   // A debounce flush hands the WHOLE burst, and that is not the same set as the triggering id:

--- a/tests/graph/read-receipt-turn.test.ts
+++ b/tests/graph/read-receipt-turn.test.ts
@@ -1,0 +1,332 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { loadAgentConfig } from "@/graph/prepare";
+import { runAgentTurn, runLoadedTurn } from "@/graph/runtime";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import {
+  ChatwootApiError,
+  type ChatwootClient,
+} from "@/modules/chatwoot/client";
+import type { NormalizedChatwootEvent } from "@/modules/chatwoot/types";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// The blue tick on the contact's phone, end to end. The client unit tests cover the request shape;
+// only a real turn shows the two things that matter here.
+//
+// First, that a turn actually acknowledges the message it is answering. The receipt lives in
+// `runTurnBody`, the tail BOTH entry points share, so proving it on the direct path proves it for
+// the debounce flush too — and the flush's own contribution (the WHOLE burst, not just the newest
+// id) is asserted separately below.
+//
+// Second, and this is the one that decides whether the feature is safe to ship: an instance whose
+// Chatwoot predates the `read_receipt` endpoint answers 401 (its bot allowlist has no such action)
+// or 404 (no route at all), and the turn must go through anyway. Every fazer.ai agents deployment
+// talks to a Chatwoot the operator upgrades on their own schedule, so this is the ordinary case for
+// a while, not an edge one.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+let instanceId = 0n;
+let agentId = 0n;
+
+const REPLY = "Claro, já verifico.";
+
+class StubModel {
+  async invoke(_messages: BaseMessage[]): Promise<AIMessage> {
+    return new AIMessage(REPLY);
+  }
+  bindTools(_tools: unknown) {
+    return { invoke: (m: BaseMessage[]) => this.invoke(m) };
+  }
+}
+
+interface Receipt {
+  conversationId: number;
+  messageIds: number[];
+}
+
+// Personifies the fork: `markRead` records what it was asked to acknowledge, and `failWith` makes it
+// answer like an instance that does not have the endpoint. A stub that merely returned undefined
+// would prove nothing about the failing case, which is the case this file exists for.
+function stubClient(
+  sent: number[],
+  receipts: Receipt[],
+  failWith?: number,
+): () => Promise<ChatwootClient> {
+  const client = {
+    sendMessage: async (conversationId: number) => {
+      sent.push(conversationId);
+      return {};
+    },
+    markRead: async (conversationId: number, messageIds: number[]) => {
+      receipts.push({ conversationId, messageIds });
+      if (failWith !== undefined) {
+        throw new ChatwootApiError(failWith, "read_receipt", "nope");
+      }
+      return {};
+    },
+  } as unknown as ChatwootClient;
+  return async () => client;
+}
+
+const incoming = (
+  conversationId: number,
+  messageId: number,
+  content: string,
+): NormalizedChatwootEvent => ({
+  event: "message_created",
+  conversationId,
+  inboxId: 7,
+  status: "pending",
+  assigneeType: null,
+  assigneeId: null,
+  assigneeName: null,
+  contactInboxId: null,
+  message: { id: messageId, content, messageType: "incoming", private: false },
+});
+
+async function seedConversation(convId: number) {
+  await suDb.conversation.create({
+    data: {
+      tenantId,
+      chatwootInstanceId: instanceId,
+      chatwootConversationId: convId,
+      status: "pending",
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      lastEventAt: new Date(),
+    },
+  });
+}
+
+describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "RR", slug: `rr-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 9,
+      baseUrl: "https://chat.example.com",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const llmKey = await suDb.vaultEntry.create({
+      data: { tenantId, name: "llm-key", secret: encryptJson("sk-test") },
+      select: { id: true },
+    });
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Atendente",
+        systemPrompt: "Você é uma secretária prestativa.",
+        modelConfig: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          credentialRef: `vault:${llmKey.id}`,
+        },
+        settings: { split: { enabled: false } },
+      },
+    });
+    agentId = agent.id;
+    await suDb.chatwootAgentBot.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        agentId: agent.id,
+        chatwootAgentBotId: 9,
+        accessToken: encryptJson("BOT"),
+        webhookSecret: encryptJson("S"),
+        webhookRouteTokenHash: `rr-route-${process.pid}`,
+        name: "Atendente",
+      },
+    });
+    await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: 7,
+        name: "Suporte",
+        agentId: agent.id,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const table of [
+        "execution_logs",
+        "llm_usage",
+        "agent_threads",
+        "conversations",
+        "contacts",
+        "inboxes",
+        "chatwoot_agent_bots",
+        "agents",
+        "vault_entries",
+        "chatwoot_instances",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  test("a turn acknowledges the message it is answering", async () => {
+    const convId = 8101;
+    await seedConversation(convId);
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+
+    const outcome = await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: incoming(convId, 5501, "oi, tudo bem?"),
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+    });
+
+    expect(outcome).toBe("posted");
+    expect(receipts).toEqual([{ conversationId: convId, messageIds: [5501] }]);
+  });
+
+  // The playground runs turns against a dummy client on conversation 0. A receipt there would be a
+  // request to `/conversations/0/read_receipt` on every operator test-drive.
+  test("the playground sends no receipt", async () => {
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+
+    await runAgentTurn({
+      tenantId,
+      instanceId,
+      agentBotId: 9,
+      event: incoming(0, 5701, "teste do playground"),
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+    });
+
+    expect(receipts).toEqual([]);
+  });
+
+  // A debounce flush hands the WHOLE burst, and that is not the same set as the triggering id:
+  // WhatsApp acknowledges the messages it is given, so passing only the newest leaves every earlier
+  // message of the burst on grey ticks forever. Driven through `runLoadedTurn` because that is the
+  // parameter the flush fills in.
+  test("a burst acknowledges every message in it, not just the newest", async () => {
+    const convId = 8104;
+    await seedConversation(convId);
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+    const loadedConfig = await runScopedOn(
+      appDb,
+      { tenantId, userId: null, role: "TENANT_ADMIN" } as TenantContext,
+      (db) =>
+        loadAgentConfig(db, {
+          tenantId,
+          instanceId,
+          conversationId: convId,
+          agentId,
+          threadId: `${tenantId}:${instanceId}:${convId}`,
+        }),
+    );
+    if (!loadedConfig) throw new Error("agent config did not load");
+
+    await runLoadedTurn({
+      stillWanted: null,
+      loaded: loadedConfig,
+      authContext: null,
+      tenantId,
+      instanceId,
+      conversationId: convId,
+      agentBotId: 9,
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      text: "oi\ntudo bem?\nvoce atende hoje?",
+      messageId: 5803,
+      readMessageIds: [5801, 5802, 5803],
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+      claimReply: null,
+    });
+
+    expect(receipts).toEqual([
+      { conversationId: convId, messageIds: [5801, 5802, 5803] },
+    ]);
+  });
+
+  // The whole point of the feature surviving a version-skewed fleet. Asserting only that no
+  // exception escaped would pass with the reply never sent, so the assertion is the REPLY.
+  test.each([401, 404])(
+    "a Chatwoot without the endpoint (%s) still gets its reply",
+    async (status) => {
+      const convId = 8102 + status;
+      await seedConversation(convId);
+      const sent: number[] = [];
+      const receipts: Receipt[] = [];
+
+      const outcome = await runAgentTurn({
+        tenantId,
+        instanceId,
+        agentBotId: 9,
+        event: incoming(convId, 5601, "consegue me ajudar?"),
+        base: appDb,
+        deps: {
+          makeModel: () => new StubModel() as unknown as BaseChatModel,
+          makeClient: stubClient(sent, receipts, status),
+          checkpointer: new MemorySaver(),
+        },
+      });
+
+      // The receipt was attempted and it failed, which is what makes the next two lines mean
+      // something: the turn went through DESPITE the failure, not because it never happened.
+      expect(receipts).toHaveLength(1);
+      expect(outcome).toBe("posted");
+      expect(sent).toEqual([convId]);
+    },
+  );
+});

--- a/tests/graph/read-receipt-turn.test.ts
+++ b/tests/graph/read-receipt-turn.test.ts
@@ -129,6 +129,25 @@ async function seedConversation(convId: number, inboxDbId?: bigint) {
   });
 }
 
+// `runLoadedTurn` is the parameter the debounce flush fills in, so the tests that drive the flush's
+// side of the contract go through it and need the config the caller would already hold.
+async function loadFor(convId: number) {
+  const loaded = await runScopedOn(
+    appDb,
+    { tenantId, userId: null, role: "TENANT_ADMIN" } as TenantContext,
+    (db) =>
+      loadAgentConfig(db, {
+        tenantId,
+        instanceId,
+        conversationId: convId,
+        agentId,
+        threadId: `${tenantId}:${instanceId}:${convId}`,
+      }),
+  );
+  if (!loaded) throw new Error("agent config did not load");
+  return loaded;
+}
+
 describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
   beforeAll(async () => {
     const t = await suDb.tenant.create({
@@ -366,19 +385,7 @@ describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
     await seedConversation(convId);
     const sent: number[] = [];
     const receipts: Receipt[] = [];
-    const loadedConfig = await runScopedOn(
-      appDb,
-      { tenantId, userId: null, role: "TENANT_ADMIN" } as TenantContext,
-      (db) =>
-        loadAgentConfig(db, {
-          tenantId,
-          instanceId,
-          conversationId: convId,
-          agentId,
-          threadId: `${tenantId}:${instanceId}:${convId}`,
-        }),
-    );
-    if (!loadedConfig) throw new Error("agent config did not load");
+    const loadedConfig = await loadFor(convId);
 
     await runLoadedTurn({
       stillWanted: null,
@@ -404,6 +411,78 @@ describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
     expect(receipts).toEqual([
       { conversationId: convId, messageIds: [5801, 5802, 5803] },
     ]);
+  });
+
+  // A blue tick is an outward write, and `docs/graph.md` requires every one of them to ask whether
+  // the caller still wants this turn — the receipt was the only write in `runTurnBody` reaching the
+  // wire before the first ask. The window is real on the debounce path: `/reset` (or a retirement)
+  // landing between the claim and this line left the contact looking at ticks from a turn that then
+  // returned "stale" and answered nothing. Nothing is lost by skipping: a retired job was retired
+  // because a NEWER burst took over, and that flush acknowledges a superset of these ids.
+  test("a turn the caller withdrew sends no receipt", async () => {
+    const convId = 8108;
+    await seedConversation(convId, whatsappInboxDbId);
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+    const loadedConfig = await loadFor(convId);
+
+    const outcome = await runLoadedTurn({
+      stillWanted: async () => false,
+      loaded: loadedConfig,
+      authContext: null,
+      tenantId,
+      instanceId,
+      conversationId: convId,
+      agentBotId: 9,
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      text: "oi, ainda precisa?",
+      messageId: 6001,
+      readMessageIds: [6001],
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+      claimReply: null,
+    });
+
+    expect(receipts).toEqual([]);
+    expect(sent).toEqual([]);
+    expect(outcome).toBe("stale");
+  });
+
+  // The control for the one above: the same call shape with a fence that says yes still ticks, so
+  // "no receipt" is the withdrawal talking and not the fence's mere presence.
+  test("a live fence does not block the receipt", async () => {
+    const convId = 8109;
+    await seedConversation(convId, whatsappInboxDbId);
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+    const loadedConfig = await loadFor(convId);
+
+    await runLoadedTurn({
+      stillWanted: async () => true,
+      loaded: loadedConfig,
+      authContext: null,
+      tenantId,
+      instanceId,
+      conversationId: convId,
+      agentBotId: 9,
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      text: "oi, ainda precisa?",
+      messageId: 6002,
+      readMessageIds: [6002],
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+      claimReply: null,
+    });
+
+    expect(receipts).toEqual([{ conversationId: convId, messageIds: [6002] }]);
   });
 
   // The whole point of the feature surviving a version-skewed fleet. Asserting only that no

--- a/tests/graph/read-receipt-turn.test.ts
+++ b/tests/graph/read-receipt-turn.test.ts
@@ -115,13 +115,18 @@ const incoming = (
   message: { id: messageId, content, messageType: "incoming", private: false },
 });
 
-async function seedConversation(convId: number, inboxDbId?: bigint) {
+async function seedConversation(
+  convId: number,
+  inboxDbId?: bigint,
+  assignee?: { assigneeType: string; assigneeId: number },
+) {
   await suDb.conversation.create({
     data: {
       tenantId,
       chatwootInstanceId: instanceId,
       chatwootConversationId: convId,
       ...(inboxDbId === undefined ? {} : { inboxId: inboxDbId }),
+      ...(assignee ?? {}),
       status: "pending",
       threadId: `${tenantId}:${instanceId}:${convId}`,
       lastEventAt: new Date(),
@@ -278,7 +283,14 @@ describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
 
   // The playground runs turns against a dummy client on conversation 0. A receipt there would be a
   // request to `/conversations/0/read_receipt` on every operator test-drive.
+  //
+  // The mirror row for id 0 is what makes this test about the playground guard and nothing else.
+  // Without it the ownership read finds no conversation, answers "not ours" and closes the gate for
+  // its own reasons — so the test passed either way and `conversationId > 0` was pinned by nobody.
+  // Measured: mutating it to `>= 0` left all 11 green. With an owned row seeded there, the guard is
+  // the only thing standing between the playground and a tick.
   test("the playground sends no receipt", async () => {
+    await seedConversation(0, whatsappInboxDbId);
     const sent: number[] = [];
     const receipts: Receipt[] = [];
 
@@ -483,6 +495,47 @@ describe.skipIf(!dbUp)("the WhatsApp read receipt of a turn", () => {
     });
 
     expect(receipts).toEqual([{ conversationId: convId, messageIds: [6002] }]);
+  });
+
+  // The third question the turn already asks before its other outward writes, and the receipt was
+  // not asking it either. The receiver's gate proved bot ownership before the turn was queued; a
+  // person taking the conversation over inside the window that follows leaves that answer stale, and
+  // the post-generation recheck suppresses the SEND without being able to unwrite a tick. Same
+  // window `botOwnsItNow` was added for in issue #457 (hand-back note, review round 7), so the
+  // receipt asks the same read at the moment it writes.
+  test("a conversation a human took over gets no receipt", async () => {
+    const convId = 8110;
+    await seedConversation(convId, whatsappInboxDbId, {
+      assigneeType: "User",
+      assigneeId: 42,
+    });
+    const sent: number[] = [];
+    const receipts: Receipt[] = [];
+
+    const outcome = await runLoadedTurn({
+      stillWanted: null,
+      loaded: await loadFor(convId),
+      authContext: null,
+      tenantId,
+      instanceId,
+      conversationId: convId,
+      agentBotId: 9,
+      threadId: `${tenantId}:${instanceId}:${convId}`,
+      text: "oi, tem alguem ai?",
+      messageId: 6101,
+      readMessageIds: [6101],
+      base: appDb,
+      deps: {
+        makeModel: () => new StubModel() as unknown as BaseChatModel,
+        makeClient: stubClient(sent, receipts),
+        checkpointer: new MemorySaver(),
+      },
+      claimReply: null,
+    });
+
+    expect(receipts).toEqual([]);
+    expect(sent).toEqual([]);
+    expect(outcome).toBe("taken-over");
   });
 
   // The whole point of the feature surviving a version-skewed fleet. Asserting only that no

--- a/tests/modules/chatwoot-client.test.ts
+++ b/tests/modules/chatwoot-client.test.ts
@@ -132,6 +132,46 @@ describe("ChatwootClient", () => {
     expect(calls[0]?.headers["api-access-token"]).toBe("BOT_TOK");
   });
 
+  test("markRead uses the bot token (read_receipt is bot-accessible)", async () => {
+    const { fetchImpl, calls } = stub();
+    const client = await createChatwootClient(baseConfig, {
+      fetchImpl,
+      assertSafe: passthroughSafe,
+    });
+    await client.markRead(42, [7, 9]);
+    expect(calls[0]?.url).toContain("/conversations/42/read_receipt");
+    expect(calls[0]?.body).toMatchObject({ message_ids: [7, 9] });
+    expect(calls[0]?.headers["api-access-token"]).toBe("BOT_TOK");
+  });
+
+  // An empty list is the endpoint's "I processed nothing", which acknowledges nothing. Sending it
+  // would be a wasted round trip on every turn that has no ids to name, so the call never happens.
+  test("markRead sends nothing when there are no message ids", async () => {
+    const { fetchImpl, calls } = stub();
+    const client = await createChatwootClient(baseConfig, {
+      fetchImpl,
+      assertSafe: passthroughSafe,
+    });
+    await client.markRead(42, []);
+    expect(calls.length).toBe(0);
+  });
+
+  // A Chatwoot older than the endpoint answers 401 (the bot allowlist has no `read_receipt`) or 404
+  // (no route at all). The client reports it like any other failure; swallowing it is the caller's
+  // job, and every call site does exactly that.
+  test("markRead surfaces the failure of a Chatwoot without the endpoint", async () => {
+    for (const status of [401, 404]) {
+      const { fetchImpl } = stub(status, { error: "nope" });
+      const client = await createChatwootClient(baseConfig, {
+        fetchImpl,
+        assertSafe: passthroughSafe,
+      });
+      await expect(client.markRead(42, [7])).rejects.toBeInstanceOf(
+        ChatwootApiError,
+      );
+    }
+  });
+
   test("read methods use the admin token", async () => {
     const { fetchImpl, calls } = stub(200, { id: 42 });
     const client = await createChatwootClient(baseConfig, {


### PR DESCRIPTION
## What this adds

An agent turn now tells WhatsApp that the contact's messages were read, so the ticks turn blue on
their phone while the agent works on the answer. Until now nothing here ever acknowledged an inbound
message: the contact saw two grey ticks even after the agent had read the message and replied to it.

The receipt is a Chatwoot endpoint the fork gained in fazer-ai/chatwoot#450,
`POST /api/v1/accounts/:id/conversations/:display_id/read_receipt`, which is in
`BOT_ACCESSIBLE_ENDPOINTS` alongside `toggle_typing_status`. It writes **no** read state inside
Chatwoot, so the conversation keeps its unread badge for the human agents: a bot acknowledging a
message does not hand a human a thread that already looks read.

## Where it fires, and why there

In `runTurnBody`, right after the Chatwoot client is built. That is the tail **both** entry points
share (the direct webhook path through `runAgentTurn`, and the debounce flush through
`runLoadedTurn`), so the two get the receipt from one site instead of two that can drift.

Two things it is deliberately **not**:

- **Not driven by `lastHandledMessageId`.** That watermark is the obvious candidate and it is the
  wrong one: it also advances for a burst the bot skipped on purpose — nothing rendered to
  answerable text, a mid-turn takeover, a guardrail silence (`src/modules/debounce/handler.ts`, five
  advance sites). Ticking those would tell the contact somebody read a message nobody read.
- **Not the triggering id alone.** WhatsApp acknowledges the messages it is given, so a debounce
  flush passes the WHOLE burst via `readMessageIds`; passing only the newest would leave every
  earlier message of the burst on grey ticks forever.

`readMessageIds` is **mandatory** on `RunLoadedTurnParams`. Optional, a third entry point that
coalesces messages would compile while acknowledging only the newest of them — a silent loss the
type system can prevent. Making it required immediately caught that `n.message?.id` can be `null`,
which the optional fallback had been swallowing.

## Version skew is the ordinary case, not an edge one

Every deployment talks to a Chatwoot the operator upgrades on their own schedule, so an instance
older than the endpoint answers **401** (its bot allowlist predates `read_receipt`) or **404** (no
route). The call is best-effort and the turn goes through regardless.

It is `try/catch` and **not** `.catch()`, which is where the first version of this was wrong:
`.catch()` covers a rejected promise but not a failure to *invoke*, and a client without the method
throws `TypeError` synchronously and walks straight past it. Measured: that first version took 95
`runAgentTurn` tests down with it.

## Validation scope

**Proven by test** (`bun check` green: 9037 pass, 0 fail):

- `tests/modules/chatwoot-client.test.ts` — bot token, request shape, no call for an empty id list,
  and `ChatwootApiError` surfaced for both 401 and 404.
- `tests/graph/read-receipt-turn.test.ts` (DB-backed) — a real turn acknowledges the message it
  answers; a Chatwoot answering 401/404 still gets its reply (asserting the REPLY, not merely that
  no exception escaped); a burst acknowledges every message in it; the playground (conversation 0)
  sends nothing.
- Mutation battery, six mutations with an unmutated control, all killed. Two survived the first pass
  — the playground guard and the burst list — and became the last two tests above.

**Proven live**, same script run from two worktrees against the same local Chatwoot (4.17.0,
account 1, inbox 138, a paired Baileys WhatsApp) and the same provider:

- *Without* the change: no `read-messages` request reaches the provider at all.
- *With* it: `POST http://localhost:3025/connections/+5511999990001/read-messages [200]` at
  19:23:55, carrying `msgId 3EB0E860E50A76C5B3560E` — the real WhatsApp id of the contact's message.
- The blue ticks themselves were confirmed on the contact's handset earlier the same day, driving
  the same Chatwoot endpoint directly.
- Both turns used a model that answers nothing, so the path was exercised without posting anything
  to the contact.

**Re-measured after the review rounds**, on the gated code, against the same local Chatwoot and the
same account/inbox/conversation. The earlier run above predates the three gates, and it also seeded a
conversation with no inbox link, so `channelType` came back null and the channel gate was exercised
on its *unknown* branch. This one seeds the real shape (`Channel::Whatsapp`, provider `baileys`):

- Bot owns the conversation: `POST /api/v1/accounts/1/conversations/20684/read_receipt` → **200 OK**,
  and `Whatsapp::SelfReadReceipts` holds a marker for `3EB078E05D8F792B76A79F` and for no other id.
  That marker is written inside `Channel::Whatsapp#read_messages`, immediately before the provider
  send, so it is evidence the whole chain ran and that it acknowledged exactly the id the turn read.
- Mirror says a human took over: outcome `taken-over`, **no request at all**, no marker. Gate (4)
  measured against the real endpoint rather than only against a seeded row.
- `agent_last_seen_at` and `assignee_last_seen_at` stayed `nil` throughout, which is the point of not
  writing Chatwoot read state.

**Not validated**: the receipt against a hosted Chatwoot older than the endpoint. The 401/404
behaviour is covered by the mockup, not by a real old instance.

**Not re-validated**: the blue ticks on the handset, for the gated code. The Baileys session for that
inbox is no longer paired (`provider_config` carries no `phone_number`), so the last leg had nothing
to deliver to. It was confirmed on a real phone earlier the same day on the pre-review commit, and
rounds 1-3 only decide whether the request is made at all — none of them touch the delivery leg.

## What the review rounds changed

Four rounds, three findings, all three about the same thing from different angles: a blue tick is an
outward write, and it was not asking what the turn's other outward writes ask. Round 3 stopped
answering them one at a time and enumerated the inputs to the decision instead. The set is written at
the call site and is closed:

| | question | asked by |
| --- | --- | --- |
| 1 | is there a real conversation | `conversationId > 0` (the playground runs on id 0) |
| 2 | can the channel show a tick | `channelCanReadReceipt` |
| 3 | does the caller still want this turn | `writeCalledOff` (`/reset`, retired job) |
| 4 | does the bot still hold the conversation | `botOwnsItNow` (a human took over mid-turn) |
| 5 | is there anything to acknowledge | `markRead`, which does not call on an empty list |

Deliberately **not** `shouldPost`/`claimBeforeSend`, the sixth question the send path asks: that one
claims the burst as its CAS and advances the handled watermark, so a tick that asked it would mark
messages handled on the way to acknowledging them. A receipt observes, it does not consume.

Three notes on how those were resolved, because in each case the fix is not the one the finding
proposed:

- **(2) is the negative test, not `=== "Channel::Whatsapp"`.** `channelType` is mirrored from
  Chatwoot into the local `Inbox` row and is null until a sync populates it, so the strict form drops
  the tick on a real WhatsApp conversation whose mirror lags. Measured: it takes 5 of the 11 tests
  down. Unknown costs one request Chatwoot answers 200 and drops; unknown-treated-as-no costs the
  feature, silently.
- **(3) also refuted half a premise.** The finding said non-WhatsApp channels incur a *failing*
  request and risk the client's 15s timeout. They do not: `read_receipt` answers 200 for any channel
  and `ChannelListener#messages_read` returns unless the channel responds to `read_messages`. The
  real cost is the wasted round trip, which is reason enough.
- **(4) reuses `botOwnsItNow` rather than adding a third copy of the read.** It already existed for
  this same window (issue #457, review round 7), a few hundred lines down; it is hoisted, not copied,
  and the 35 deletions in the diff are that move.

**A test that had been passing for the wrong reason.** Adding (4) made the playground test green
regardless of (1): with no mirror row at conversation 0, the ownership read closes the gate by
itself, and mutating `> 0` to `>= 0` left all 11 tests passing. The test now seeds an owned row
there, which puts the guard back under measurement.

Battery is nine mutations now, nine killed: four forms of the channel gate, the fence removed and
inverted, ownership removed and inverted, and the playground guard widened.

## No `Fixes #N`

There is no issue for this: the work came from the Chatwoot side, where the endpoint was built, and
the decision was to skip opening one. Flagging it because the process treats the `Fixes` pair as the
granularity test of both sides, and this PR has only one half of it.


