### PR TITLE
Refuse a param name on a credential kind that has no use for one

### DIFF
--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -195,6 +195,7 @@
     "vaultFieldUnknown": "This credential type has no field called \"{{field}}\"",
     "vaultFieldWhitespace": "The \"{{field}}\" field must not begin or end with a space or line break. Remove it and save again.",
     "vaultNameInUse": "A secret with this name and type already exists",
+    "vaultParamNameNotApplicable": "The \"{{kind}}\" credential type does not use a param name. The types that do are: {{kinds}}.",
     "vaultParamNameRequired": "Param name is required for this credential type",
     "vaultRefNotFound": "That vault reference does not point to any credential: {{ref}}",
     "vaultSecretWhitespace": "A vault secret must not begin or end with a space or line break. Remove it and save again.",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -195,6 +195,7 @@
     "vaultFieldUnknown": "Este tipo de credencial não tem um campo chamado \"{{field}}\"",
     "vaultFieldWhitespace": "O campo \"{{field}}\" não pode começar nem terminar com espaço ou quebra de linha. Remova e salve de novo.",
     "vaultNameInUse": "Já existe um segredo com esse nome e tipo",
+    "vaultParamNameNotApplicable": "O tipo de credencial \"{{kind}}\" não usa nome de parâmetro. Os tipos que usam são: {{kinds}}.",
     "vaultParamNameRequired": "O nome do parâmetro é obrigatório para este tipo de credencial",
     "vaultRefNotFound": "Essa referência do cofre não aponta para nenhuma credencial: {{ref}}",
     "vaultSecretWhitespace": "Um segredo do cofre não pode começar nem terminar com espaço ou quebra de linha. Remova e salve de novo.",

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -40,6 +40,7 @@ import {
 // translate('errors.vaultBaseUrlRequired', 'This credential type requires a base URL.')
 // translate('errors.vaultNameInUse', 'A secret with this name and type already exists')
 // translate('errors.vaultParamNameRequired', 'Param name is required for this credential type')
+// translate('errors.vaultParamNameNotApplicable', 'The "{{kind}}" credential type does not use a param name. The types that do are: {{kinds}}.')
 // translate('errors.vaultRefNotFound', 'That vault reference does not point to any credential: {{ref}}')
 // translate('errors.vaultFieldWhitespace', 'The "{{field}}" field must not begin or end with a space or line break. Remove it and save again.')
 // translate('errors.vaultSecretWhitespace', 'A vault secret must not begin or end with a space or line break. Remove it and save again.')

--- a/src/modules/mcp/write.ts
+++ b/src/modules/mcp/write.ts
@@ -47,6 +47,10 @@ import type { LoadChatwootClientDeps } from "@/modules/chatwoot/instance";
 import { readDebugModes } from "@/modules/flowlog/debug-mode";
 import { getTenantSettings } from "@/modules/tenant-settings/service";
 import {
+  PARAM_NAME_KIND_IDS,
+  secretTypeRefusesParamName,
+} from "@/modules/vault/secret-types";
+import {
   createPendingVaultEntry,
   isVaultIdRef,
   resolveVaultRefByName,
@@ -303,6 +307,24 @@ export async function credentialCreate(
     baseUrl: args.base_url ?? null,
     paramName: args.param_name ?? null,
   };
+
+  // NOTE: BEFORE the dry-run branch, because the preview returns without touching the core and a
+  // rule the core learns after that shortcut is a rule the preview promises away. `param_name` is
+  // read only for the kinds that declare `needsParamName`, so on any other kind it is a field the
+  // runtime discards, and `createPendingVaultEntry` now refuses it (issue #488) — previewing it
+  // clean would promise a write that apply rejects. Same question in two shapes: the transport
+  // answers with a `WriteResult`, the core with an `AppError`, and the catalog predicate in the
+  // middle is what keeps them from drifting.
+  //
+  // NOTE: this covers THIS rule only. The preview still returns ok for five other inputs the apply
+  // refuses (a kind the catalog does not know, a managed-blob kind, a missing required base URL, a
+  // missing required param name, and a name the write rejects) — measured, all six diverging, and
+  // filed separately rather than widened into here.
+  if (args.param_name?.trim() && secretTypeRefusesParamName(kind)) {
+    return err(
+      `the "${kind}" credential type does not use a param name. The types that do are: ${PARAM_NAME_KIND_IDS.join(", ")}.`,
+    );
+  }
 
   // dry-run is the default: create ONLY when dry_run is explicitly false.
   if (args.dry_run !== false) {

--- a/src/modules/vault/secret-types.ts
+++ b/src/modules/vault/secret-types.ts
@@ -236,6 +236,30 @@ export function secretTypeNeedsParamName(
   return !!getSecretType(id)?.needsParamName;
 }
 
+// The kinds that read `paramName`, in catalog order. Both halves of the applicability rule are
+// derived from the same declaration, so a kind added to `SECRET_TYPES` lands on whichever side its
+// own entry puts it, and the refusal below can NAME the alternatives instead of only saying no.
+export const PARAM_NAME_KIND_IDS: string[] = SECRET_TYPES.filter(
+  (s) => s.needsParamName,
+).map((s) => s.id);
+
+// Whether a non-empty `paramName` on this kind must be REFUSED at the write boundary. Not the
+// negation of `secretTypeNeedsParamName`, and the difference is the whole reason this is a function:
+// that one answers false for a kind the catalog does not know, and refusing those would strand every
+// row an older build wrote with a kind this one has since dropped — the same carve-out
+// `secretTypeFits` makes, for the same reason.
+//
+// The field is only ever read through `resolveSecretInjection`, which takes the name from a
+// `needsParamName` entry and from nowhere else. Storing it on any other kind is storing something
+// the runtime discards: the write answered 200, the console read the name back, and the outbound
+// request carried no credential at all (issue #488).
+export function secretTypeRefusesParamName(
+  id: string | null | undefined,
+): boolean {
+  const type = getSecretType(id);
+  return type != null && !type.needsParamName;
+}
+
 export function secretTypeRequiresBaseUrl(
   id: string | null | undefined,
 ): boolean {

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -16,10 +16,12 @@ import {
   getSecretTypeFields,
   isManagedOAuthKind,
   isSecretTypeId,
+  PARAM_NAME_KIND_IDS,
   readsPlainKey,
   secretTypeFits,
   secretTypeIsManagedBlob,
   secretTypeNeedsParamName,
+  secretTypeRefusesParamName,
   secretTypeRequiresBaseUrl,
   secretValueFitsKind,
 } from "./secret-types";
@@ -619,6 +621,16 @@ function validateBaseUrl(raw: string): string {
   }
 }
 
+// The catalog declares WHICH kinds read a param name (`needsParamName`), and until issue #488 this
+// only enforced half of that: required where declared, and accepted-then-ignored everywhere else.
+// The field is read in exactly one place (`resolveSecretInjection`, off a `needsParamName` entry),
+// so a name stored on any other kind is a name nothing will ever send — the operator configures an
+// `Authorization` header, the write answers 200, the console reads it back, and the request goes
+// out with no credential on it. Refusing is the only half that reaches them: whoever gets this
+// picked the kind, and the fix is to pick one that injects (that is what the sentence names).
+//
+// Empty stays empty: "" has always meant "no param name", and refusing it would break a client that
+// sends the field unconditionally.
 function validateParamName(raw: string, kind: string): string {
   const trimmed = raw.trim();
   if (secretTypeNeedsParamName(kind) && !trimmed) {
@@ -626,6 +638,16 @@ function validateParamName(raw: string, kind: string): string {
       "paramName is required for this credential type",
       400,
       "errors.vaultParamNameRequired",
+    );
+  }
+  if (trimmed && secretTypeRefusesParamName(kind)) {
+    const kinds = PARAM_NAME_KIND_IDS.join(", ");
+    throw new AppError(
+      `the "${kind}" credential type does not use a param name. The types that do are: ${kinds}.`,
+      400,
+      "errors.vaultParamNameNotApplicable",
+      { kind, kinds },
+      "paramName",
     );
   }
   if (trimmed && !PARAM_NAME_RE.test(trimmed)) {

--- a/tests/client/components/CredentialFormParamName.test.tsx
+++ b/tests/client/components/CredentialFormParamName.test.tsx
@@ -1,0 +1,161 @@
+/// <reference lib="dom" />
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { CredentialForm } from "@/client/components/CredentialForm";
+import { ToastProvider } from "@/client/components/Toast";
+
+// The write refuses a param name on a kind that declares none (issue #488), and the argument for
+// that refusal being safe is that the CONSOLE can never send one: the input is drawn only under
+// `needsParamName`, and every payload gates on the same flag. That is a claim about REACHABILITY,
+// and reachability is measured, not read — so this drives the one path where the two can disagree.
+// A param name typed while the type was `header` survives in form state after the operator switches
+// the type to `generic`, and if the payload carried it, the save would come back 400 naming a field
+// the form no longer renders: a refusal with no door.
+
+describe("CredentialForm never sends a param name a kind cannot use", () => {
+  const realFetch = globalThis.fetch;
+  const calls: {
+    method: string;
+    url: string;
+    body: Record<string, unknown>;
+  }[] = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : String((input as Request).url ?? input);
+    const method = String(init?.method ?? "GET");
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+    calls.push({ method, url, body });
+    if (url.includes("/api/v1/vault/test")) {
+      return new Response(JSON.stringify({ testable: false }), {
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ id: "1", ref: "vault:1" }), {
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  beforeEach(() => {
+    calls.length = 0;
+  });
+  afterEach(cleanup);
+  afterAll(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const posts = () =>
+    calls.filter((c) => c.method === "POST" && !c.url.includes("/vault/test"));
+
+  // NOTE: the value input carries no placeholder on create (only on update, where blank keeps the
+  // stored secret), so it is addressed by its type.
+  const secretInput = (): HTMLElement => {
+    const el = document.querySelector('input[type="password"]');
+    if (!el) throw new Error("no secret input rendered");
+    return el as HTMLElement;
+  };
+
+  // NOTE: Radix opens on pointerdown with a real pointerType, not on click, and the FormField label
+  // carries the same accessible name as the trigger — so this asks for the BUTTON, and then reads
+  // the option INSIDE the menu (an open menu takes the rest of the form out of the a11y tree).
+  const pickType = async (label: string) => {
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Type" }), {
+      button: 0,
+      pointerType: "mouse",
+    });
+    await waitFor(() =>
+      expect(screen.queryAllByRole("menu", { hidden: true }).length).toBe(1),
+    );
+    const menu = screen.getByRole("menu", { hidden: true });
+    // NOTE: by ROLE, not by text: the type list renders the label more than once (the row and its
+    // hint), and a bare text query is ambiguous.
+    const item = within(menu)
+      .getAllByRole("menuitem", { hidden: true })
+      .find((el) => (el.textContent ?? "").trim().startsWith(label));
+    if (!item) throw new Error(`no menu item for ${label}`);
+    fireEvent.click(item);
+    await waitFor(() =>
+      expect(screen.queryAllByRole("menu", { hidden: true }).length).toBe(0),
+    );
+  };
+
+  test("a name typed under `header` does not travel after the type is switched to `generic`", async () => {
+    render(
+      <ToastProvider>
+        <CredentialForm
+          mode="create"
+          initialKind="header"
+          onSaved={() => {}}
+          onCancel={() => {}}
+        />
+      </ToastProvider>,
+    );
+
+    // NOTE: the input exists only because the type is `header` — that is the premise being tested.
+    const paramInput = screen.getByPlaceholderText("X-API-Key");
+    fireEvent.change(paramInput, { target: { value: "Authorization" } });
+
+    await pickType("Generic");
+    // NOTE: by LABEL, not by placeholder: the placeholder is derived from the kind ("X-API-Key" for
+    // header, "api_key" otherwise), so a form that kept drawing the field for `generic` would still
+    // satisfy a query for the header one. Measured — that mutation survived until this line asked
+    // by the name the field actually carries.
+    expect(screen.queryByText("Parameter name")).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText("my-api-key"), {
+      target: { value: "avec-jwt" },
+    });
+    fireEvent.change(secretInput(), {
+      target: { value: "eyJhbGciOiJIUzI1NiJ9.e30.sig" },
+    });
+
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(posts().length).toBe(1));
+
+    const sent = posts()[0]?.body ?? {};
+    expect(sent.kind ?? null).toBeNull();
+    expect("paramName" in sent && sent.paramName !== undefined).toBe(false);
+  });
+
+  test("and it DOES travel while the type still takes one — the control", async () => {
+    render(
+      <ToastProvider>
+        <CredentialForm
+          mode="create"
+          initialKind="header"
+          onSaved={() => {}}
+          onCancel={() => {}}
+        />
+      </ToastProvider>,
+    );
+    fireEvent.change(screen.getByPlaceholderText("X-API-Key"), {
+      target: { value: "Authorization" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("my-api-key"), {
+      target: { value: "avec-header" },
+    });
+    fireEvent.change(secretInput(), {
+      target: { value: "eyJhbGciOiJIUzI1NiJ9.e30.sig" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(posts().length).toBe(1));
+    expect(posts()[0]?.body.paramName).toBe("Authorization");
+  });
+});

--- a/tests/modules/secret-types-mirror.test.ts
+++ b/tests/modules/secret-types-mirror.test.ts
@@ -27,7 +27,7 @@ describe("secret-types client mirror", () => {
     }
   });
 
-  // `needsParamName` is the one meta field the two copies have to agree on for the SERVER's sake,
+  // NOTE: `needsParamName` is the one meta field the two copies have to agree on for the SERVER's sake,
   // and it became load-bearing with issue #488: the write now REFUSES a param name on a kind that
   // declares none, and the form is what keeps the console from ever sending one (it submits
   // `paramName: undefined` unless its own copy says the kind needs it). Drift in either direction

--- a/tests/modules/secret-types-mirror.test.ts
+++ b/tests/modules/secret-types-mirror.test.ts
@@ -26,4 +26,17 @@ describe("secret-types client mirror", () => {
       expect(!!meta?.testable).toBe(!!type.test);
     }
   });
+
+  // `needsParamName` is the one meta field the two copies have to agree on for the SERVER's sake,
+  // and it became load-bearing with issue #488: the write now REFUSES a param name on a kind that
+  // declares none, and the form is what keeps the console from ever sending one (it submits
+  // `paramName: undefined` unless its own copy says the kind needs it). Drift in either direction
+  // is a save the operator cannot fix — the form does not render the input for a kind it thinks
+  // takes no name, so the refusal would name a field with nowhere to go.
+  test("client needsParamName matches the server catalog for every type", () => {
+    for (const type of SECRET_TYPES) {
+      const meta = SECRET_TYPE_META[type.id as keyof typeof SECRET_TYPE_META];
+      expect(!!meta?.needsParamName).toBe(!!type.needsParamName);
+    }
+  });
 });

--- a/tests/modules/vault/param-name-applicability.test.ts
+++ b/tests/modules/vault/param-name-applicability.test.ts
@@ -1,0 +1,337 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { AppError } from "@/lib/errors";
+import type { TenantContext } from "@/lib/tenancy";
+import {
+  getSecretType,
+  getSecretTypeFields,
+  PARAM_NAME_KIND_IDS,
+  SECRET_TYPE_IDS,
+  secretTypeIsManagedBlob,
+  secretTypeNeedsParamName,
+  secretTypeRefusesParamName,
+  secretTypeRequiresBaseUrl,
+} from "@/modules/vault/secret-types";
+import {
+  createPendingVaultEntry,
+  createVaultEntry,
+  updateVaultEntry,
+} from "@/modules/vault/service";
+
+// A `paramName` is only ever read for the kinds whose catalog entry declares `needsParamName`
+// (`resolveSecretInjection` takes the name from there, and from nowhere else). Every other kind
+// used to STORE the field and then discard it: the write said 200, the console read the name back,
+// and the outbound request carried no credential at all. That is issue #488 — an operator wired a
+// `generic` credential with `paramName: Authorization`, expecting the bare JWT the API wanted, and
+// got a 401 with nothing anywhere saying the field was dead.
+//
+// The rule is the CATALOG, not a list written here: a kind that declares no use for the field
+// refuses it, and a kind this build does not know keeps passing (the same carve-out
+// `secretTypeFits` makes, so a row written by an older build stays editable).
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+
+// OUTSIDE the skipIf, for the same reason value-whitespace.test.ts keeps it there: a superuser probe
+// that connects while the app one does not leaves an open pool nothing else closes.
+afterAll(async () => {
+  await su?.$disconnect();
+  await app?.$disconnect();
+});
+
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+let tenantId = 0n;
+
+const refusal = async (run: () => Promise<unknown>): Promise<AppError> => {
+  try {
+    await run();
+  } catch (e) {
+    if (e instanceof AppError) return e;
+    throw e;
+  }
+  throw new Error("expected the write to be refused, and it was not");
+};
+
+// A value and a baseUrl this kind accepts, so the paramName decision is the ONLY thing under test.
+// `createVaultEntry` validates value, then baseUrl, then paramName: a kind whose value shape is
+// wrong never reaches the rule, and the test would pass on the wrong refusal.
+const validValue = (kind: string): string | Record<string, string> => {
+  if (secretTypeIsManagedBlob(kind)) return {};
+  const fields = getSecretTypeFields(kind);
+  if (fields) return Object.fromEntries(fields.map((f) => [f.key, "abc123"]));
+  return "abc123TOKEN";
+};
+const validBaseUrl = (kind: string): string | null =>
+  secretTypeRequiresBaseUrl(kind) ? "https://example.invalid" : null;
+
+describe("the catalog is the rule", () => {
+  test("exactly the kinds that declare needsParamName take one", () => {
+    const takes = SECRET_TYPE_IDS.filter(secretTypeNeedsParamName);
+    expect(takes).toEqual(["header", "query", "mcp_env"]);
+    expect(PARAM_NAME_KIND_IDS).toEqual(takes);
+    // The other side of the same count, spelled out so a kind added to the catalog without a
+    // decision about this field shows up here instead of silently joining the refusing majority.
+    expect(SECRET_TYPE_IDS.filter(secretTypeRefusesParamName).length).toBe(
+      SECRET_TYPE_IDS.length - takes.length,
+    );
+  });
+
+  test("every known kind either takes the field or refuses it, never neither nor both", () => {
+    for (const id of SECRET_TYPE_IDS) {
+      expect(secretTypeRefusesParamName(id)).toBe(
+        !secretTypeNeedsParamName(id),
+      );
+    }
+  });
+
+  test("a kind this build does not know refuses nothing", () => {
+    // The legacy escape hatch: an entry written by a build whose catalog had a kind this one
+    // dropped must stay editable, so the refusal is scoped to kinds the catalog KNOWS.
+    expect(getSecretType("kind_from_a_future_build")).toBeNull();
+    expect(secretTypeRefusesParamName("kind_from_a_future_build")).toBe(false);
+    expect(secretTypeRefusesParamName(null)).toBe(false);
+    expect(secretTypeRefusesParamName(undefined)).toBe(false);
+  });
+});
+
+describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
+  const ctx = (): TenantContext => ({
+    tenantId,
+    userId: null,
+    role: "TENANT_ADMIN",
+  });
+
+  beforeAll(async () => {
+    if (!su) return;
+    const t = await su.tenant.create({
+      data: { name: "VaultParamName", slug: `vaultpn-${process.pid}` },
+    });
+    tenantId = t.id;
+  });
+
+  afterAll(async () => {
+    if (su && tenantId) {
+      await su.$executeRawUnsafe(
+        `DELETE FROM vault_entries WHERE tenant_id = ${tenantId}`,
+      );
+      await su.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+    }
+  });
+
+  // The matrix: every kind in the catalog, against the same non-empty param name. Enumerating it
+  // instead of sampling is what makes the rule the catalog's — a kind added later is covered the
+  // day it is added, on whichever side its own entry puts it.
+  for (const kind of SECRET_TYPE_IDS) {
+    const takes = secretTypeNeedsParamName(kind);
+    test(`createVaultEntry ${takes ? "stores" : "refuses"} a param name on ${kind}`, async () => {
+      const input = {
+        name: `pn-create-${kind}`,
+        value: validValue(kind),
+        kind,
+        baseUrl: validBaseUrl(kind),
+        paramName: "Authorization",
+      };
+      if (!takes) {
+        const e = await refusal(() =>
+          createVaultEntry(ctx(), input, undefined, undefined, appDb),
+        );
+        expect(e.statusCode).toBe(400);
+        expect(e.translationKey).toBe("errors.vaultParamNameNotApplicable");
+        // The refusal is ABOUT the field, by the name the server uses for it, so the console and
+        // the MCP caller key on the same string.
+        expect(e.field).toBe("paramName");
+        // The door: the sentence has to say which kinds do take one, or the operator learns only
+        // that this one does not.
+        for (const id of PARAM_NAME_KIND_IDS) expect(e.message).toContain(id);
+        const rows = await suDb.vaultEntry.count({
+          where: { tenantId, name: input.name },
+        });
+        expect(rows).toBe(0);
+        return;
+      }
+      const { id } = await createVaultEntry(
+        ctx(),
+        input,
+        undefined,
+        undefined,
+        appDb,
+      );
+      const row = await suDb.vaultEntry.findUnique({
+        where: { id },
+        select: { paramName: true },
+      });
+      expect(row?.paramName).toBe("Authorization");
+    });
+  }
+
+  test("the reporter's config is refused, and the one that works is not", async () => {
+    // Issue #488 verbatim: a bare JWT that the API wants in `Authorization`, with no Bearer. The
+    // kind that does that is `header`; `generic` never injects anything.
+    const e = await refusal(() =>
+      createVaultEntry(
+        ctx(),
+        {
+          name: "pn-avec-generic",
+          value: "eyJhbGciOiJIUzI1NiJ9.e30.sig",
+          kind: "generic",
+          paramName: "Authorization",
+        },
+        undefined,
+        undefined,
+        appDb,
+      ),
+    );
+    expect(e.translationKey).toBe("errors.vaultParamNameNotApplicable");
+    expect(e.message).toContain("generic");
+
+    const { id } = await createVaultEntry(
+      ctx(),
+      {
+        name: "pn-avec-header",
+        value: "eyJhbGciOiJIUzI1NiJ9.e30.sig",
+        kind: "header",
+        paramName: "Authorization",
+      },
+      undefined,
+      undefined,
+      appDb,
+    );
+    const row = await suDb.vaultEntry.findUnique({
+      where: { id },
+      select: { kind: true, paramName: true },
+    });
+    expect(row).toEqual({ kind: "header", paramName: "Authorization" });
+  });
+
+  test("an empty param name still means none, on a kind that cannot use one", async () => {
+    // A client that always sends the field (the console sends `undefined`, an API caller may not)
+    // must not be refused for sending nothing in it: "" has always meant absent here.
+    for (const paramName of ["", "   "]) {
+      const { id } = await createVaultEntry(
+        ctx(),
+        {
+          name: `pn-empty-${paramName.length}`,
+          value: "abc123TOKEN",
+          kind: "generic",
+          paramName,
+        },
+        undefined,
+        undefined,
+        appDb,
+      );
+      const row = await suDb.vaultEntry.findUnique({
+        where: { id },
+        select: { paramName: true },
+      });
+      expect(row?.paramName).toBeNull();
+    }
+  });
+
+  test("createPendingVaultEntry refuses it too — the surface the MCP tool writes through", async () => {
+    // `credential_create` is reference-only and never carries a secret, so it is the one path where
+    // paramName is the only thing the operator supplies besides name and kind.
+    const e = await refusal(() =>
+      createPendingVaultEntry(
+        ctx(),
+        {
+          name: "pn-pending",
+          kind: "bearer_token",
+          paramName: "Authorization",
+        },
+        appDb,
+      ),
+    );
+    expect(e.statusCode).toBe(400);
+    expect(e.translationKey).toBe("errors.vaultParamNameNotApplicable");
+    expect(
+      await suDb.vaultEntry.count({ where: { tenantId, name: "pn-pending" } }),
+    ).toBe(0);
+  });
+
+  test("updateVaultEntry refuses it against the STORED kind, which is immutable", async () => {
+    const { id } = await createVaultEntry(
+      ctx(),
+      { name: "pn-update", value: "abc123TOKEN", kind: "generic" },
+      undefined,
+      undefined,
+      appDb,
+    );
+    const e = await refusal(() =>
+      updateVaultEntry(ctx(), id, { paramName: "Authorization" }, appDb),
+    );
+    expect(e.translationKey).toBe("errors.vaultParamNameNotApplicable");
+    const row = await suDb.vaultEntry.findUnique({
+      where: { id },
+      select: { paramName: true },
+    });
+    expect(row?.paramName).toBeNull();
+  });
+
+  test("a row that already carries a dead param name stays editable", async () => {
+    // The refusal covers what a write INTRODUCES. Rows written before it exists keep their stray
+    // value, and a save that does not touch the field must still go through, or the rule strands
+    // exactly the operators who hit the defect.
+    const { id } = await createVaultEntry(
+      ctx(),
+      { name: "pn-legacy", value: "abc123TOKEN", kind: "generic" },
+      undefined,
+      undefined,
+      appDb,
+    );
+    await suDb.$executeRawUnsafe(
+      `UPDATE vault_entries SET param_name = 'Authorization' WHERE id = ${id}`,
+    );
+    await updateVaultEntry(ctx(), id, { name: "pn-legacy-renamed" }, appDb);
+    const row = await suDb.vaultEntry.findUnique({
+      where: { id },
+      select: { name: true, paramName: true },
+    });
+    expect(row).toEqual({
+      name: "pn-legacy-renamed",
+      paramName: "Authorization",
+    });
+  });
+
+  test("a stored kind this build no longer knows keeps accepting one", async () => {
+    // `createVaultEntry` refuses an unknown kind up front, so this state is only reachable through
+    // a row an older build wrote. Patching it must not be refused by a catalog that has moved on.
+    const { id } = await createVaultEntry(
+      ctx(),
+      { name: "pn-unknown-kind", value: "abc123TOKEN", kind: "generic" },
+      undefined,
+      undefined,
+      appDb,
+    );
+    await suDb.$executeRawUnsafe(
+      `UPDATE vault_entries SET kind = 'kind_from_an_older_build' WHERE id = ${id}`,
+    );
+    await updateVaultEntry(ctx(), id, { paramName: "X-Legacy" }, appDb);
+    const row = await suDb.vaultEntry.findUnique({
+      where: { id },
+      select: { paramName: true },
+    });
+    expect(row?.paramName).toBe("X-Legacy");
+  });
+});

--- a/tests/modules/vault/param-name-applicability.test.ts
+++ b/tests/modules/vault/param-name-applicability.test.ts
@@ -3,6 +3,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
+import { credentialCreate } from "@/modules/mcp/write";
 import {
   getSecretType,
   getSecretTypeFields,
@@ -91,7 +92,7 @@ describe("the catalog is the rule", () => {
     const takes = SECRET_TYPE_IDS.filter(secretTypeNeedsParamName);
     expect(takes).toEqual(["header", "query", "mcp_env"]);
     expect(PARAM_NAME_KIND_IDS).toEqual(takes);
-    // The other side of the same count, spelled out so a kind added to the catalog without a
+    // NOTE: The other side of the same count, spelled out so a kind added to the catalog without a
     // decision about this field shows up here instead of silently joining the refusing majority.
     expect(SECRET_TYPE_IDS.filter(secretTypeRefusesParamName).length).toBe(
       SECRET_TYPE_IDS.length - takes.length,
@@ -107,7 +108,7 @@ describe("the catalog is the rule", () => {
   });
 
   test("a kind this build does not know refuses nothing", () => {
-    // The legacy escape hatch: an entry written by a build whose catalog had a kind this one
+    // NOTE: The legacy escape hatch: an entry written by a build whose catalog had a kind this one
     // dropped must stay editable, so the refusal is scoped to kinds the catalog KNOWS.
     expect(getSecretType("kind_from_a_future_build")).toBeNull();
     expect(secretTypeRefusesParamName("kind_from_a_future_build")).toBe(false);
@@ -140,7 +141,7 @@ describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
     }
   });
 
-  // The matrix: every kind in the catalog, against the same non-empty param name. Enumerating it
+  // NOTE: The matrix: every kind in the catalog, against the same non-empty param name. Enumerating it
   // instead of sampling is what makes the rule the catalog's — a kind added later is covered the
   // day it is added, on whichever side its own entry puts it.
   for (const kind of SECRET_TYPE_IDS) {
@@ -159,10 +160,10 @@ describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
         );
         expect(e.statusCode).toBe(400);
         expect(e.translationKey).toBe("errors.vaultParamNameNotApplicable");
-        // The refusal is ABOUT the field, by the name the server uses for it, so the console and
+        // NOTE: The refusal is ABOUT the field, by the name the server uses for it, so the console and
         // the MCP caller key on the same string.
         expect(e.field).toBe("paramName");
-        // The door: the sentence has to say which kinds do take one, or the operator learns only
+        // NOTE: The door: the sentence has to say which kinds do take one, or the operator learns only
         // that this one does not.
         for (const id of PARAM_NAME_KIND_IDS) expect(e.message).toContain(id);
         const rows = await suDb.vaultEntry.count({
@@ -187,7 +188,7 @@ describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
   }
 
   test("the reporter's config is refused, and the one that works is not", async () => {
-    // Issue #488 verbatim: a bare JWT that the API wants in `Authorization`, with no Bearer. The
+    // NOTE: Issue #488 verbatim: a bare JWT that the API wants in `Authorization`, with no Bearer. The
     // kind that does that is `header`; `generic` never injects anything.
     const e = await refusal(() =>
       createVaultEntry(
@@ -226,7 +227,7 @@ describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
   });
 
   test("an empty param name still means none, on a kind that cannot use one", async () => {
-    // A client that always sends the field (the console sends `undefined`, an API caller may not)
+    // NOTE: A client that always sends the field (the console sends `undefined`, an API caller may not)
     // must not be refused for sending nothing in it: "" has always meant absent here.
     for (const paramName of ["", "   "]) {
       const { id } = await createVaultEntry(
@@ -249,8 +250,58 @@ describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
     }
   });
 
+  test("the MCP dry run refuses it too, so the preview cannot promise what apply rejects", async () => {
+    // NOTE: `credential_create` defaults to dry_run and answers BEFORE reaching the core, so a rule
+    // the core learns later is a rule the preview promises away (padroes: "dry run tem que prever o
+    // apply"). Both halves have to refuse, and the apply half must not create a row.
+    const p = {
+      tenantId,
+      userId: null,
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:write"],
+    } as unknown as Parameters<typeof credentialCreate>[0];
+    for (const dry_run of [undefined, false]) {
+      const r = await credentialCreate(
+        p,
+        {
+          name: "pn-mcp",
+          kind: "generic",
+          param_name: "Authorization",
+          dry_run,
+        },
+        { base: appDb },
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error).toContain("does not use a param name");
+        for (const id of PARAM_NAME_KIND_IDS) expect(r.error).toContain(id);
+      }
+    }
+    expect(
+      await suDb.vaultEntry.count({ where: { tenantId, name: "pn-mcp" } }),
+    ).toBe(0);
+  });
+
+  test("the MCP dry run still previews the config that works", async () => {
+    // NOTE: the control for the case above — the guard has to refuse the dead field and nothing
+    // else, or it is the preview lying in the other direction.
+    const p = {
+      tenantId,
+      userId: null,
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:write"],
+    } as unknown as Parameters<typeof credentialCreate>[0];
+    const r = await credentialCreate(
+      p,
+      { name: "pn-mcp-ok", kind: "header", param_name: "Authorization" },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.dryRun).toBe(true);
+  });
+
   test("createPendingVaultEntry refuses it too — the surface the MCP tool writes through", async () => {
-    // `credential_create` is reference-only and never carries a secret, so it is the one path where
+    // NOTE: `credential_create` is reference-only and never carries a secret, so it is the one path where
     // paramName is the only thing the operator supplies besides name and kind.
     const e = await refusal(() =>
       createPendingVaultEntry(
@@ -290,7 +341,7 @@ describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
   });
 
   test("a row that already carries a dead param name stays editable", async () => {
-    // The refusal covers what a write INTRODUCES. Rows written before it exists keep their stray
+    // NOTE: The refusal covers what a write INTRODUCES. Rows written before it exists keep their stray
     // value, and a save that does not touch the field must still go through, or the rule strands
     // exactly the operators who hit the defect.
     const { id } = await createVaultEntry(
@@ -315,7 +366,7 @@ describe.skipIf(!dbUp)("vault: a param name the kind cannot use", () => {
   });
 
   test("a stored kind this build no longer knows keeps accepting one", async () => {
-    // `createVaultEntry` refuses an unknown kind up front, so this state is only reachable through
+    // NOTE: `createVaultEntry` refuses an unknown kind up front, so this state is only reachable through
     // a row an older build wrote. Patching it must not be refused by a catalog that has moved on.
     const { id } = await createVaultEntry(
       ctx(),


### PR DESCRIPTION
## What broke, and why

`paramName` is read in exactly one place: `resolveSecretInjection`, off a catalog entry that declares `needsParamName`. The write boundary only enforced the *required* half of that declaration — `validateParamName` refused an empty name where the kind needs one, checked the character set, and stored anything else. There was no *applicability* half, so a param name on any of the other 15 kinds was accepted, persisted, read back by the console, and then discarded at injection time.

Reported by a community member wiring an `External HTTP Tool` against an API that wants a bare JWT in `Authorization` (no `Bearer`, no `Basic`). They created the credential as `kind=generic, paramName=Authorization`, linked it to the tool, and got `401 - Não autenticado` — from a tool with no other parameters, while the same JWT by hand returned 200.

`generic` is the escape hatch (`injection: "none"`): it deliberately injects nothing, and the secret travels only where the operator writes `{{secret}}`. That part is correct and stays — it is what makes `generic` usable for a webhook secret and for a hand-written header. The defect is that nothing said so. The kind that does what they wanted is `header`, which sends the value literally, with no prefix.

## What changed

`validateParamName` now refuses a non-empty param name on a kind the catalog knows and that declares no use for one, and the sentence names the kinds that do take one (`header`, `query`, `mcp_env`), so it carries the fix and not just the no. Both halves of the rule read the same declaration, so a kind added to `SECRET_TYPES` lands on whichever side its own entry puts it.

Three deliberate limits:

- **Empty stays empty.** `""` has always meant "no param name"; refusing it would break a client that sends the field unconditionally.
- **A kind this build does not know keeps passing** — the same carve-out `secretTypeFits` already makes. Refusing those would strand rows written by a build whose catalog had a kind this one dropped.
- **Rows that already carry a dead param name are left alone.** The rule covers what a write introduces; a save that does not touch the field still goes through, which matters precisely for the operators who already hit this.

The client mirror gains `needsParamName`. That is what keeps the console from ever reaching the refusal — the form submits the field only for a kind its own copy says needs it — and nothing tested that the two copies agree. Drift there would name a field the form does not render, which is a refusal with no door.

The MCP `credential_create` guard runs **before** the dry-run branch. The preview returns without touching the core, so a rule the core learns after that shortcut is a rule the preview promises away: the same payload previewed as a coming `vault:new` entry and then 400'd on apply. Measured, the preview diverges from the apply on five more inputs that predate this change (a kind the catalog does not know, a managed-blob kind, a missing required base URL, a missing required param name, and a name the write rejects). Those are #490, not this — the fix there is one shared coherence check, not five more `if`s before the preview.

## Validation scope

**Proved by test** (`tests/modules/vault/param-name-applicability.test.ts`, 29 cases — 11 written out plus one per catalog kind — and 2 more in `tests/client/components/CredentialFormParamName.test.tsx`; red before the change: 18 failing, exactly the 15 kinds without `needsParamName` plus the three write boundaries):

- The catalog is the rule: exactly `header`, `query`, `mcp_env` take a param name; every known kind either takes it or refuses it, never neither nor both; an unknown kind and a null kind refuse nothing.
- A matrix over **all 18 kinds** through `createVaultEntry`, each with a value and base URL that kind accepts so the param-name decision is the only thing under test. The 15 refusing kinds get a 400, `errors.vaultParamNameNotApplicable`, `field: "paramName"`, a message naming all three alternatives, and **no row created**; the 3 accepting kinds store the name.
- The report verbatim: `generic` refused, `header` stored.
- `""` and `"   "` still store `null` on a refusing kind.
- `createPendingVaultEntry` (the MCP `credential_create` path) and `updateVaultEntry` (against the immutable stored kind) refuse too, leaving the row untouched.
- A row whose `param_name` was set before the rule stays renameable; a row whose stored kind this build no longer knows still accepts a patch.
- The mirror fence fails if the client and server copies of `needsParamName` drift.

**Mutation battery** — 11 mutations across three rounds, all killed, each against a control run printed first (`38 pass / 0 fail`, then `117 pass / 0 fail`, then `2 pass / 0 fail`):

| mutation | tests killed |
| --- | --- |
| `secretTypeRefusesParamName` drops the "catalog knows this kind" guard | 2 |
| the rule is inverted | 23 |
| `PARAM_NAME_KIND_IDS` filters the wrong way | 1 |
| the refusal loses its empty-string guard | 1 |
| the refusal loses `field: "paramName"` | 15 |
| the message stops naming the alternatives | 15 |
| the client mirror drops `needsParamName` on `mcp_env` | 1 |
| the MCP guard moves to AFTER the dry-run branch | 1 |
| the MCP guard loses its empty-string test | 3 |
| the create POST is ungated on the client | 1 |
| the param-name field is drawn for every kind | 1 |

**Proved live**, on the wire, both halves against a real HTTP server that answers 401 without the exact JWT in `Authorization`, driven through `runToolTest` with a real vault row in Postgres (the same surface the console's "test this tool" button uses, which reads the credential's kind and param name where the turn reads them):

- **Base code** (`main` at `3960e7d`), `kind=generic, paramName=Authorization`: the row stores `param_name=Authorization`, and the request arrives with `authorization: <ABSENT>` — headers seen were `accept, accept-encoding, connection, host, user-agent` — and the server answers `401 {"error":"Não autenticado"}`. That is the report, reproduced.
- **This branch**, same input: the write is refused, `400 errors.vaultParamNameNotApplicable field=paramName`, `the "generic" credential type does not use a param name. The types that do are: header, query, mcp_env.`
- **Both**, `kind=header, paramName=Authorization`: `authorization: eyJhbGciOiJIUzI1NiJ9…` arrives verbatim, with no `Bearer`, and the server answers 200. The correct config is unchanged by this PR.

The probe asserts `config.ssrf.allowPrivateTargets` is true before it runs, so a blocked loopback fails loudly instead of being read as a missing header.

**The console's reachability, driven rather than read.** The argument that this refusal is safe is that the console can never send a param name on a refusing kind. That was originally read off the five call sites in `CredentialForm.tsx`; the one path where form state and kind can disagree is real (a name typed while the type is `header` survives the switch to `generic`), so it is now exercised: the payload carries no param name after the switch, and a control proves it still carries one while the kind takes it. Two mutations prove the test — ungating the create POST kills it, and so does drawing the field for every kind. The second only started killing once the assertion stopped asking by placeholder: `X-API-Key` belongs to `header` and `generic` renders `api_key`, so a form that kept drawing the field satisfied the query.

**Not validated:** nothing was exercised against a real third-party API — the server on the other end of the live run is local, standing in for the reporter's vendor. What it proves is which bytes leave this side, which is the whole of the defect.

`bun check` green: 9157 pass, 0 fail across 573 files.

Fixes #488

