### PR TITLE
Ask the core before the preview promises, on all seventeen tools that were promising past it

### DIFF
--- a/src/api/features/branding/branding.service.ts
+++ b/src/api/features/branding/branding.service.ts
@@ -1,6 +1,8 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
 import prisma from "@/api/lib/prisma";
 import config from "@/config";
-import { sanitizeBranding } from "@/lib/branding";
+import { isValidColorToken, sanitizeBranding } from "@/lib/branding";
+import { AppError } from "@/lib/errors";
 import { clipText } from "@/lib/text";
 
 // Global app identity/branding (a single row, id = 1). GLOBAL state — NOT tenant-scoped — so this
@@ -171,11 +173,94 @@ export function toDto(row: BrandingRow): GlobalBrandingDto {
   };
 }
 
-export async function getGlobalBranding(): Promise<GlobalBrandingDto> {
-  const row = await prisma.appBranding.findUnique({
+export async function getGlobalBranding(
+  base: PrismaClient = prisma,
+): Promise<GlobalBrandingDto> {
+  const row = await base.appBranding.findUnique({
     where: { id: SINGLETON_ID },
   });
   return row ? toDto(row) : DEFAULT_DTO;
+}
+
+// Everything `updateBrandingColors` decides about its INPUT — the color mode, the brand color, the
+// two token maps, the footer links, and "did you name anything at all" — before any database is
+// involved. It lives HERE rather than beside the mutation because the Free derivation swaps
+// branding.admin.service for a stub, and the MCP preview has to ask the same question the apply
+// asks in both editions (#490). Returns the sanitized columns the caller goes on to write.
+export function assertBrandingColorsUpdatable(
+  input: ColorUpdate,
+): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  if (input.brandName !== undefined) {
+    // Empty/whitespace clears back to the default; otherwise sanitize (bounded, single-line).
+    data.brandName = sanitizeBrandName(input.brandName);
+  }
+  if (input.colorMode !== undefined) {
+    if (input.colorMode !== "SIMPLE" && input.colorMode !== "ADVANCED") {
+      throw new AppError("invalid color mode", 400, "errors.invalidColorMode");
+    }
+    data.colorMode = input.colorMode;
+  }
+  if (input.brandColor !== undefined) {
+    if (input.brandColor === null || input.brandColor === "") {
+      data.brandColor = null;
+    } else if (isValidColorToken(input.brandColor)) {
+      data.brandColor = input.brandColor.trim();
+    } else {
+      throw new AppError(
+        "invalid brand color",
+        400,
+        "errors.invalidColorToken",
+      );
+    }
+  }
+  // Both token maps are sanitized to the allowlist + valid color tokens (unknown keys dropped).
+  if (input.tokensLight !== undefined) {
+    data.tokensLight = sanitizeBranding(input.tokensLight);
+  }
+  if (input.tokensDark !== undefined) {
+    data.tokensDark = sanitizeBranding(input.tokensDark);
+  }
+  // Footer links: empty/null clears back to the default; a non-empty value must survive its
+  // sanitizer — silently dropping a typo'd URL/e-mail would read as "saved" while reverting the
+  // footer to the default, so invalid input fails loudly instead (same contract as brandColor).
+  if (input.siteUrl !== undefined) {
+    if (input.siteUrl === null || input.siteUrl.trim() === "") {
+      data.siteUrl = null;
+    } else {
+      const cleaned = sanitizeSiteUrl(input.siteUrl);
+      if (!cleaned) {
+        throw new AppError("invalid site url", 400, "errors.invalidSiteUrl");
+      }
+      data.siteUrl = cleaned;
+    }
+  }
+  if (input.supportEmail !== undefined) {
+    if (input.supportEmail === null || input.supportEmail.trim() === "") {
+      data.supportEmail = null;
+    } else {
+      const cleaned = sanitizeSupportEmail(input.supportEmail);
+      if (!cleaned) {
+        throw new AppError(
+          "invalid support email",
+          400,
+          "errors.invalidSupportEmail",
+        );
+      }
+      data.supportEmail = cleaned;
+    }
+  }
+  if (input.hideGithubLink !== undefined) {
+    data.hideGithubLink = input.hideGithubLink === true;
+  }
+  if (Object.keys(data).length === 0) {
+    throw new AppError(
+      "no updatable fields provided",
+      400,
+      "errors.noUpdatableFields",
+    );
+  }
+  return data;
 }
 
 export interface ColorUpdate {

--- a/src/api/v1/tenants.service.ts
+++ b/src/api/v1/tenants.service.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { parseDbId } from "@/lib/db-id";
-import { NotFoundError } from "@/lib/errors";
+import { AppError, ConflictError, NotFoundError } from "@/lib/errors";
+import { parseInput } from "@/lib/parse-input";
 import { asSuperAdminOn, runScopedOn, type TenantContext } from "@/lib/tenancy";
 
 // Read-side tenant service + the mutation type surface. BigInt ids are stringified (JSON-safe). A
@@ -142,3 +143,52 @@ export const tenantCreateSchema = z
   .strict();
 
 export type TenantCreate = z.infer<typeof tenantCreateSchema>;
+
+// What `createTenant`/`updateTenant` decide about their INPUT, before any database is involved.
+// They live HERE rather than beside the mutations because the Free derivation swaps
+// tenants.admin.service for a stub, and the MCP preview has to ask the same question the apply asks
+// in both editions (#490).
+export function assertTenantCreatable(input: TenantCreate): TenantCreate {
+  return parseInput(tenantCreateSchema, input);
+}
+
+// The other half of what `createTenant` refuses, and it is a DIFFERENT KIND of answer. The one
+// above judges the input, so its verdict cannot change between preview and apply. This one reads
+// the fleet, from outside the write's transaction: it is ADVISORY. Someone can take the slug in
+// the gap, and then the preview said "will create" and the apply answers 409 — which is the exact
+// divergence #490 is about, one race narrower.
+//
+// It is still worth asking, because the case that actually happens is a slug the operator already
+// used, not a slug someone takes in the millisecond after the preview. What keeps the GUARANTEE is
+// the unique index the create runs into; this only moves the common refusal to where the operator
+// asked for it. Nothing below may be read as "the slug is reserved".
+//
+// asSuperAdminOn for the same reason `resolveTenantSelector` uses it: slugs are unique fleet-wide,
+// and a scoped read would hide the very row that will cause the 409.
+export async function assertTenantSlugAvailable(
+  slug: string,
+  base: PrismaClient = basePrisma,
+): Promise<void> {
+  const taken = await asSuperAdminOn(base, (db) =>
+    db.tenant.findUnique({ where: { slug }, select: { id: true } }),
+  );
+  if (taken) {
+    throw new ConflictError(
+      "tenant slug already in use",
+      "errors.tenantSlugInUse",
+      "slug",
+    );
+  }
+}
+
+export function assertTenantUpdatable(patch: TenantUpdate): TenantUpdate {
+  const parsed = parseInput(tenantUpdateSchema, patch);
+  if (parsed.name === undefined) {
+    throw new AppError(
+      "no updatable fields provided",
+      400,
+      "errors.noUpdatableFields",
+    );
+  }
+  return parsed;
+}

--- a/src/lib/ssrf.ts
+++ b/src/lib/ssrf.ts
@@ -162,6 +162,35 @@ export function isBlockedIp(ip: string): boolean {
   return true; // not an IP literal → fail-closed
 }
 
+// The resolver codes that mean "this name does not exist", as opposed to "ask again later".
+//
+// Under the runtime this app actually runs on, the answer is: there is no such distinction to make.
+// Measured under Bun — a nonexistent name, a name with no A record, and a 300-character label all
+// arrive as `code: "ENOTFOUND", errno: 4`, and `errno` is that constant for every one of them. So
+// the error carries nothing to classify on, and this predicate is always true there.
+//
+// Node collapses less: reading its `DNSException`, exactly two libuv errnos are renamed
+// (`if (code === UV_EAI_NODATA || code === UV_EAI_NONAME) code = 'ENOTFOUND'`), everything else
+// keeps its own name, and `EAI_SYSTEM` becomes the underlying errno — descriptor exhaustion is
+// `EMFILE`. But the app does not run on Node, so that is a property of the fallback, not of
+// production.
+//
+// The predicate stays a GATE rather than being collapsed into "any failure refuses", and it is not
+// dead code: the resolver is injectable, and a runtime that does distinguish gets round 2's
+// behaviour immediately — a transient failure propagating instead of telling the caller its URL is
+// wrong. On Bun it is simply always true, and the refusal below is what a fail-closed SSRF guard
+// owes anyway: a lookup we could not complete is a destination we could not verify.
+//
+// A 400 rather than a 500 for that, deliberately, and it is the coherence argument this whole PR is
+// about: the empty-result branch two lines down already answers 400 for the same fact. Answering it
+// 400 through one branch and 500 through the other, for the same URL, is the split being closed.
+const PERMANENT_DNS_FAILURES = new Set(["ENOTFOUND"]);
+
+export function isNameNotFound(e: unknown): boolean {
+  const code = (e as { code?: unknown } | null)?.code;
+  return typeof code === "string" && PERMANENT_DNS_FAILURES.has(code);
+}
+
 export interface SafeUrlOptions {
   // NOTE: default https-only. Dev/self-hosted integrations may opt into http.
   allowHttp?: boolean;
@@ -171,6 +200,10 @@ export interface SafeUrlOptions {
   // SSRF_ALLOW_PRIVATE_TARGETS=true is set explicitly). Protocol and URL-parseability checks
   // always run regardless — file:, ftp:, etc. are never allowed.
   allowPrivate?: boolean;
+  // NOTE: the resolver, injectable. Same seam as `deps.assertSafe` elsewhere in the tree, and it
+  // exists for one thing the real resolver cannot be made to do on demand: fail TRANSIENTLY. Which
+  // failures become a 400 and which propagate is a decision with no other way to exercise it.
+  lookup?: typeof lookup;
 }
 
 export async function assertSafeOutboundUrl(
@@ -201,7 +234,28 @@ export async function assertSafeOutboundUrl(
     return url;
   }
 
-  const addresses = await lookup(host, { all: true });
+  // NOTE: a lookup that comes back with a PERMANENT not-found is the same answer as an empty
+  // result — the host does not exist — and has to leave here as the same 400, or the caller gets a
+  // 500 for a URL the operator simply typed wrong. Surfaced when the MCP previews started asking
+  // this ahead of the write (#490); the apply had the hole already, it was just harder to reach.
+  //
+  // Everything else propagates untouched, and the difference is not cosmetic: `EAI_AGAIN` and a
+  // timeout mean the RESOLVER failed, not that the name is bad, and answering 400 there tells the
+  // caller its input is wrong and not to retry — for a hostname that may be perfectly valid.
+  let addresses: { address: string }[];
+  try {
+    addresses = await (opts.lookup ?? lookup)(host, { all: true });
+  } catch (e) {
+    // NOTE: the code goes in the sentence. Under Bun it is `ENOTFOUND` for everything, so the
+    // message is the only place an operator debugging a resolver outage can see that the lookup
+    // threw rather than came back empty.
+    if (isNameNotFound(e)) {
+      throw new SsrfError(
+        `${host} did not resolve (${(e as { code?: string }).code})`,
+      );
+    }
+    throw e;
+  }
   if (addresses.length === 0) throw new SsrfError(`${host} did not resolve`);
   for (const { address } of addresses) {
     if (isBlockedIp(address)) {

--- a/src/modules/agents/service.ts
+++ b/src/modules/agents/service.ts
@@ -598,6 +598,27 @@ async function assertCredentialRefsResolve(
   }
 }
 
+// The credential half of `createAgent`'s verdict, on its own scoped read. ADVISORY: the entry it
+// finds can be deleted or re-kinded before the apply lands, and the copy inside the write's
+// transaction stays the authority.
+//
+// NOTE: it REWRITES the refs it was handed, because `assertCredentialRefsResolve` does — canonical
+// on the way in is the point of that function. The preview echoes the payload it validated, so what
+// the operator reads back is the spelling the apply would store, not the one they typed.
+export async function assertCredentialRefsUsable(
+  ctx: TenantContext,
+  next: { modelConfig?: unknown; settings?: unknown },
+  base: PrismaClient = basePrisma,
+  // The bag this write REPLACES. `{}` on create, where nothing is stored yet and every ref the
+  // payload carries is one this write introduces; the stored row on update, because "did this write
+  // change the ref" can only be asked of the value being replaced.
+  stored: { modelConfig?: unknown; settings?: unknown } = {},
+): Promise<void> {
+  await runScopedOn(base, ctx, (db) =>
+    assertCredentialRefsResolve(db, next, stored),
+  );
+}
+
 // Allowlist of editable fields. tenantId/id are never touched; modelConfig/settings must be
 // objects (the runtime's own parser validates their inner shape at load time).
 // NOTE: The EFFECTIVE follow-up state: an ENABLED agent with followUp.enabled, in ANY mode — the
@@ -632,16 +653,22 @@ export const agentUpdateSchema = z
 
 export type AgentUpdate = z.infer<typeof agentUpdateSchema>;
 
-export async function updateAgent(
-  ctx: TenantContext,
-  id: bigint,
-  patch: AgentUpdate,
-  base: PrismaClient = basePrisma,
-  // Optimistic concurrency (editor): when set, the update only applies if the row's updatedAt still
-  // matches; a mismatch yields 409 (errors.agentModifiedElsewhere) instead of silently overwriting a
-  // change made elsewhere (another tab, the REST API, or the MCP server). Omitted ⇒ last-write-wins.
-  opts: { expectedUpdatedAt?: Date } = {},
-): Promise<AgentDto> {
+// Everything `updateAgent` decides about its PATCH before any database is involved: the prompt
+// size, the schema, the model config, the "nothing to update" refusal, and the two schedule ids.
+// Split out so the MCP preview can ask the same question the apply asks (#490) — that preview had
+// no preflight at all, and its fence row passed an agent id that does not exist, so it proved the
+// not-found path and nothing else.
+//
+// The two ids come back parsed, for the same reason `assertAgentCreatable` hands them back: a
+// second `requireDbId` in the caller could disagree with this one about which row was asked for.
+export function assertAgentUpdatable(patch: AgentUpdate): {
+  data: AgentUpdate;
+  rest: Omit<AgentUpdate, "businessHoursId" | "followUpHoursId">;
+  hasBh: boolean;
+  hasFuh: boolean;
+  businessHoursId: bigint | null;
+  followUpHoursId: bigint | null;
+} {
   assertPromptSize(patch.systemPrompt);
   const data = parseInput(agentUpdateSchema, patch);
   validateModelConfigForWrite(data.modelConfig);
@@ -655,43 +682,45 @@ export async function updateAgent(
       "errors.noUpdatableFields",
     );
   }
-  // NOTE: refused, not collapsed into the NotFound the ownership check below raises. This used
-  // to answer 404 for a non-numeric id, which tells a caller who mistyped that the row is gone —
-  // and the same file already answered 400 for a malformed tool-grant id (`bigOrThrow`), so one
-  // mistake got two answers depending on which field carried it. Issue #407.
-  const bhId =
-    hasBh && businessHoursId !== null
-      ? requireDbId(businessHoursId, "businessHoursId")
-      : null;
-  const fuhId =
-    hasFuh && followUpHoursId !== null
-      ? requireDbId(followUpHoursId, "followUpHoursId")
-      : null;
+  // NOTE: refused, not collapsed into the NotFound the ownership check raises. This used to answer
+  // 404 for a non-numeric id, which tells a caller who mistyped that the row is gone — and the same
+  // file already answered 400 for a malformed tool-grant id (`bigOrThrow`), so one mistake got two
+  // answers depending on which field carried it. Issue #407.
+  return {
+    data,
+    rest,
+    hasBh,
+    hasFuh,
+    businessHoursId:
+      hasBh && businessHoursId !== null
+        ? requireDbId(businessHoursId, "businessHoursId")
+        : null,
+    followUpHoursId:
+      hasFuh && followUpHoursId !== null
+        ? requireDbId(followUpHoursId, "followUpHoursId")
+        : null,
+  };
+}
+
+export async function updateAgent(
+  ctx: TenantContext,
+  id: bigint,
+  patch: AgentUpdate,
+  base: PrismaClient = basePrisma,
+  // Optimistic concurrency (editor): when set, the update only applies if the row's updatedAt still
+  // matches; a mismatch yields 409 (errors.agentModifiedElsewhere) instead of silently overwriting a
+  // change made elsewhere (another tab, the REST API, or the MCP server). Omitted ⇒ last-write-wins.
+  opts: { expectedUpdatedAt?: Date } = {},
+): Promise<AgentDto> {
+  const {
+    rest,
+    hasBh,
+    hasFuh,
+    businessHoursId: bhId,
+    followUpHoursId: fuhId,
+  } = assertAgentUpdatable(patch);
   const dto = await runScopedOn(base, ctx, async (db) => {
-    if (bhId !== null) {
-      const bh = await db.businessHours.findUnique({
-        where: { id: bhId },
-        select: { id: true },
-      });
-      if (!bh) {
-        throw new NotFoundError(
-          "business hours not found",
-          "errors.businessHoursNotFound",
-        );
-      }
-    }
-    if (fuhId !== null) {
-      const fuh = await db.businessHours.findUnique({
-        where: { id: fuhId },
-        select: { id: true },
-      });
-      if (!fuh) {
-        throw new NotFoundError(
-          "business hours not found",
-          "errors.businessHoursNotFound",
-        );
-      }
-    }
+    await assertSchedulesExistOn(db, bhId, fuhId);
     const updateData: Record<string, unknown> = { ...rest };
     if (hasBh) updateData.businessHoursId = bhId;
     if (hasFuh) updateData.followUpHoursId = fuhId;
@@ -883,12 +912,54 @@ export const agentCreateSchema = z
   .strict();
 export type AgentCreate = z.infer<typeof agentCreateSchema>;
 
-export async function createAgent(
+// Everything `createAgent` can refuse about an input WITHOUT reading the database, as one call. It
+// exists so the MCP dry run can answer with the same verdict the apply will: the preview returns
+// before the core is ever reached, so a rule that lives only inside `createAgent` is a rule the
+// preview promises away (issue #490). Returns the parsed row so the caller does not parse twice.
+// The two schedule ids EXIST, asked on whatever scoped handle the caller already has. It reads,
+// so it lives here rather than in `assertAgentCreatable`, which is pure.
+async function assertSchedulesExistOn(
+  db: ScopedDb,
+  businessHoursId: bigint | null,
+  followUpHoursId: bigint | null,
+): Promise<void> {
+  for (const id of [businessHoursId, followUpHoursId]) {
+    if (id === null) continue;
+    const row = await db.businessHours.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!row) {
+      throw new NotFoundError(
+        "business hours not found",
+        "errors.businessHoursNotFound",
+      );
+    }
+  }
+}
+
+// The half of `createAgent`'s verdict that has to read. ADVISORY, like the uniqueness checks: the
+// schedule it finds can be deleted before the apply arrives, and the scoped read inside the write
+// stays the authority. `assertAgentCreatable` already parses both ids and hands them back, so the
+// preview passes those rather than parsing a second time — a caller that re-parsed could disagree
+// with the write about which row it even asked for.
+export async function assertSchedulesExist(
   ctx: TenantContext,
-  input: AgentCreate,
+  businessHoursId: bigint | null,
+  followUpHoursId: bigint | null,
   base: PrismaClient = basePrisma,
-): Promise<AgentDto> {
-  const tenantId = requireTenant(ctx);
+): Promise<void> {
+  if (businessHoursId === null && followUpHoursId === null) return;
+  await runScopedOn(base, ctx, (db) =>
+    assertSchedulesExistOn(db, businessHoursId, followUpHoursId),
+  );
+}
+
+export function assertAgentCreatable(input: AgentCreate): {
+  data: AgentCreate;
+  businessHoursId: bigint | null;
+  followUpHoursId: bigint | null;
+} {
   assertPromptSize(input.systemPrompt);
   assertSettingsTextSizes(input.settings, undefined);
   assertSettingsDebugWindow(input.settings, undefined);
@@ -896,14 +967,34 @@ export async function createAgent(
   assertSettingsToolPreconditions(input.settings, undefined);
   const data = parseInput(agentCreateSchema, input);
   validateModelConfigForWrite(data.modelConfig);
-  const bhId =
-    data.businessHoursId != null
-      ? requireDbId(data.businessHoursId, "businessHoursId")
-      : null;
-  const fuhId =
-    data.followUpHoursId != null
-      ? requireDbId(data.followUpHoursId, "followUpHoursId")
-      : null;
+  // NOTE: the two schedule ids are parsed HERE and handed back, not left to the caller. They are a
+  // pure judgement about the input — a malformed id, or one past the column's range — and leaving
+  // them out let the preview approve an `agent_create` the apply then 400s on. The ids come back
+  // rather than being parsed twice, so the two readings cannot disagree.
+  return {
+    data,
+    businessHoursId:
+      data.businessHoursId != null
+        ? requireDbId(data.businessHoursId, "businessHoursId")
+        : null,
+    followUpHoursId:
+      data.followUpHoursId != null
+        ? requireDbId(data.followUpHoursId, "followUpHoursId")
+        : null,
+  };
+}
+
+export async function createAgent(
+  ctx: TenantContext,
+  input: AgentCreate,
+  base: PrismaClient = basePrisma,
+): Promise<AgentDto> {
+  const tenantId = requireTenant(ctx);
+  const {
+    data,
+    businessHoursId: bhId,
+    followUpHoursId: fuhId,
+  } = assertAgentCreatable(input);
   const dto = await runScopedOn(base, ctx, async (db) => {
     if (bhId !== null) {
       const bh = await db.businessHours.findUnique({

--- a/src/modules/api-keys/service.ts
+++ b/src/modules/api-keys/service.ts
@@ -132,6 +132,24 @@ export async function createApiKey(
   return { apiKey: toDto(row), token: gen.token };
 }
 
+// The half of `revokeApiKey` that decides whether there is anything to revoke: a key this tenant
+// can see, not already revoked. Same rule as the `updateMany` below, asked ahead of the write so
+// the MCP preview refuses exactly where the apply refuses (#490).
+export async function assertApiKeyRevocable(
+  ctx: TenantContext,
+  id: bigint,
+  base: PrismaClient = basePrisma,
+): Promise<void> {
+  const found = await runScopedOn(base, ctx, (db) =>
+    db.apiKey.findFirst({
+      where: { id, revokedAt: null },
+      select: { id: true },
+    }),
+  );
+  if (!found)
+    throw new NotFoundError("api key not found", "errors.apiKeyNotFound");
+}
+
 // Soft-revoke (sets revokedAt). updateMany → count 0 for a foreign/missing id under RLS → NotFound
 // (never a cross-tenant write). Re-revoking an already-revoked key is a no-op NotFound.
 export async function revokeApiKey(

--- a/src/modules/business-hours/service.ts
+++ b/src/modules/business-hours/service.ts
@@ -210,6 +210,17 @@ export async function readSchedule(
   return row ? parseSchedule(row) : null;
 }
 
+// Everything `createBusinessHours` decides about its INPUT — the schema, the timezone, the windows
+// and the exceptions — before any database is involved. Split out so the MCP preview can ask the
+// same question the apply asks (#490).
+export function assertBusinessHoursCreatable(input: BusinessHoursCreate) {
+  const data = parseInput(businessHoursCreateSchema, input);
+  if (data.timezone) assertValidTimezone(data.timezone);
+  if (data.windows) assertValidWindows(data.windows);
+  if (data.exceptions) assertValidExceptions(data.exceptions);
+  return data;
+}
+
 export async function createBusinessHours(
   ctx: TenantContext,
   input: BusinessHoursCreate,
@@ -217,10 +228,7 @@ export async function createBusinessHours(
 ): Promise<BusinessHoursDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const data = parseInput(businessHoursCreateSchema, input);
-  if (data.timezone) assertValidTimezone(data.timezone);
-  if (data.windows) assertValidWindows(data.windows);
-  if (data.exceptions) assertValidExceptions(data.exceptions);
+  const data = assertBusinessHoursCreatable(input);
   return runScopedOn(base, ctx, async (db) => {
     const row = await db.businessHours.create({
       data: {

--- a/src/modules/chatwoot/management.ts
+++ b/src/modules/chatwoot/management.ts
@@ -251,6 +251,57 @@ export type ChatwootDeploymentConnectInput = z.infer<
   typeof chatwootDeploymentConnectSchema
 >;
 
+// What `connectChatwootDeployment` decides about its INPUT, before any database: the schema, the
+// normalized base URL it would store, and whether that URL may be reached at all. Split out so the
+// MCP preview can ask the same question the apply asks (#490).
+//
+// NOTE: the SSRF verdict is IN here, DNS included, and the writer below no longer repeats it. It is
+// a verdict about the argument — `http://127.0.0.1:9/` fails on the protocol, `https://localhost` on
+// where the name points — and leaving either half out let the preview approve a URL the apply then
+// answered "Blocked outbound URL" for. It costs nothing on an apply, because the preview branch is
+// the only caller that reaches this ahead of the write. The credential probe stays below: that one
+// is a call, and it is why a preview cannot promise the connection will succeed.
+// One tenant, one Chatwoot server: a connect that names a DIFFERENT base URL than the one already
+// stored is refused, and disconnecting is the only way to switch. Both the write and the preview
+// compare through here, so the two cannot end up disagreeing about what counts as "different" —
+// the comparison is against the NORMALIZED input, which is also what gets stored.
+function assertNotADifferentDeployment(
+  existing: { baseUrl: string } | null,
+  wantedBaseUrl: string,
+): void {
+  if (existing && existing.baseUrl !== wantedBaseUrl) {
+    throw new ConflictError(
+      "this tenant is already connected to a different Chatwoot deployment; disconnect it first to switch servers",
+      "errors.chatwootDifferentDeployment",
+    );
+  }
+}
+
+// The database half of `connectChatwootDeployment`'s verdict. ADVISORY, like the uniqueness checks:
+// it reads outside the write's transaction, so a tenant with nothing connected here can have a
+// deployment by the time the apply lands. What it buys is the refusal that actually happens — an
+// operator pointing at a second server — arriving before the preview promises a connection, and
+// before the apply spends a round trip validating credentials against a server it will not accept.
+export async function assertDeploymentNotSwitching(
+  ctx: TenantContext,
+  baseUrl: string,
+  base: PrismaClient = basePrisma,
+): Promise<void> {
+  const existing = await runScopedOn(base, ctx, (db) =>
+    db.chatwootDeployment.findFirst({ select: { baseUrl: true } }),
+  );
+  assertNotADifferentDeployment(existing, baseUrl);
+}
+
+export async function assertDeploymentConnectable(
+  input: ChatwootDeploymentConnectInput,
+) {
+  const data = parseInput(chatwootDeploymentConnectSchema, input);
+  data.baseUrl = normalizeChatwootBaseUrl(data.baseUrl);
+  await assertSafeOutboundUrl(data.baseUrl); // DNS lookup OUTSIDE the tx
+  return data;
+}
+
 // Connect (or re-point the token of) the tenant's Chatwoot deployment from a base URL + admin token,
 // entered ONCE. Validates the pair by probing /profile (which also yields the reachable accounts) so a
 // bad URL/token never persists. If a deployment already exists: same baseUrl ⇒ rotate the token
@@ -268,9 +319,14 @@ export async function connectChatwootDeployment(
 }> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const data = parseInput(chatwootDeploymentConnectSchema, input);
-  data.baseUrl = normalizeChatwootBaseUrl(data.baseUrl);
-  await assertSafeOutboundUrl(data.baseUrl); // DNS lookup OUTSIDE the tx
+  const data = await assertDeploymentConnectable(input);
+  // NOTE: BEFORE the credential round trip, not after. The transaction below asks this again and
+  // remains the authority; this early copy exists because the answer is already knowable from our
+  // own database, and reaching the network first means sending the operator's admin token to a
+  // server we are about to reject anyway. It also keeps the two halves agreeing on WHICH refusal
+  // the caller gets: the preview answers "different deployment" with no network at all, and an
+  // apply that validated credentials first would answer "bad credentials" for the same call (#490).
+  await assertDeploymentNotSwitching(ctx, data.baseUrl, base);
   // Validate the credentials (and discover accounts) before persisting anything.
   const accounts = await listChatwootAccounts(
     { baseUrl: data.baseUrl, token: data.adminToken },
@@ -282,12 +338,7 @@ export async function connectChatwootDeployment(
     const existing = await db.chatwootDeployment.findFirst({
       select: { id: true, baseUrl: true },
     });
-    if (existing && existing.baseUrl !== data.baseUrl) {
-      throw new ConflictError(
-        "this tenant is already connected to a different Chatwoot deployment; disconnect it first to switch servers",
-        "errors.chatwootDifferentDeployment",
-      );
-    }
+    assertNotADifferentDeployment(existing, data.baseUrl);
     if (existing) {
       await db.$queryRaw`SELECT id FROM chatwoot_deployments WHERE id = ${existing.id} FOR NO KEY UPDATE`;
     }
@@ -510,12 +561,9 @@ async function connectAccount(
   // A Chatwoot account belongs to ONE tenant fleet-wide. RLS hides another tenant's claim from the
   // scoped tx below, so pre-check cross-tenant (superuser read) for a friendly error; the unique
   // index on (serverKey, accountId) is the hard race-safe backstop on create.
-  await assertAccountNotTakenByAnotherTenant(
-    base,
-    tenantId,
-    serverKey,
+  await assertAccountsNotTakenByAnotherTenant(base, tenantId, serverKey, [
     accountId,
-  );
+  ]);
   const result = await runScopedOn(base, ctx, async (db) => {
     // NOTE: The DEPLOYMENT row first, outermost of the three (deployment, then account, then its
     // inboxes) so the whole module takes them in one order. It is also what makes the disconnect's
@@ -622,19 +670,86 @@ function accountTakenError(): ConflictError {
 // Cross-tenant guard (superuser read bypasses RLS): rejects claiming a (serverKey, accountId) that a
 // DIFFERENT tenant already owns. The same tenant reconnecting its own account is excluded by the
 // tenantId filter, so reactivation of a soft-disconnected own-account is unaffected.
-async function assertAccountNotTakenByAnotherTenant(
+//
+// It takes the WHOLE set rather than asking once per account: one `asSuperAdminOn` per element
+// would be a privileged transaction per element, over an array the published
+// `deployment_set_accounts` schema does not cap, and the preview would pay it before the apply paid
+// it again.
+//
+// It also does not put the whole set in ONE `IN`, for the same reason read the other way. Each id is
+// a bind parameter and Postgres takes at most 32767 of them, so a single query is fine until it is
+// not: measured, 32760 ids answer in 56ms and 32770 raise "The query parameter limit supported by
+// your database is exceeded" — a CRASH, not a refusal, for input the published schema accepts, on
+// the preview as much as on the apply. Chunking makes the query count grow with the input instead
+// of the query WIDTH, which is the axis with a hard ceiling. A realistic call is one chunk.
+const CLAIM_CHECK_CHUNK = 1000;
+
+async function assertAccountsNotTakenByAnotherTenant(
   base: PrismaClient,
   tenantId: bigint,
   serverKey: string,
-  accountId: number,
+  accountIds: number[],
 ): Promise<void> {
-  const taken = await asSuperAdminOn(base, (db) =>
-    db.chatwootInstance.findFirst({
-      where: { serverKey, accountId, tenantId: { not: tenantId } },
-      select: { id: true },
-    }),
-  );
+  if (accountIds.length === 0) return;
+  // NOTE: the chunks share ONE transaction. Chunking to dodge the parameter ceiling would otherwise
+  // hand back the per-element privileged transaction this function was written to remove, just
+  // divided by a thousand.
+  const taken = await asSuperAdminOn(base, async (db) => {
+    for (let i = 0; i < accountIds.length; i += CLAIM_CHECK_CHUNK) {
+      const hit = await db.chatwootInstance.findFirst({
+        where: {
+          serverKey,
+          accountId: { in: accountIds.slice(i, i + CLAIM_CHECK_CHUNK) },
+          tenantId: { not: tenantId },
+        },
+        select: { id: true },
+      });
+      if (hit) return hit;
+    }
+    return null;
+  });
   if (taken) throw accountTakenError();
+}
+
+// What `setConnectedAccounts` decides before it writes or calls anything: the tenant HAS a
+// deployment, and every account it was handed is claimable — not already owned by another tenant,
+// fleet-wide. Split out so the MCP preview can ask the same question the apply asks (#490).
+//
+// NOTE: both halves are here on purpose. An earlier version answered only the first, and the fence
+// stayed green because its row for this tool passes no deployment at all — while a preview handed
+// an account another tenant owns still said "will connect" and the apply answered "already
+// connected to another tenant". A preflight that covers part of its core's judgement reads exactly
+// like one that covers all of it.
+export async function assertAccountsClaimable(
+  ctx: TenantContext,
+  accountIds: number[],
+  base: PrismaClient = basePrisma,
+): Promise<{ id: bigint; baseUrl: string }> {
+  const dep = await assertDeploymentConnected(ctx, base);
+  const tenantId = ctx.tenantId;
+  if (tenantId === null) throw new AppError("tenant required", 400);
+  const serverKey = normalizeChatwootBaseUrl(dep.baseUrl);
+  await assertAccountsNotTakenByAnotherTenant(base, tenantId, serverKey, [
+    ...new Set(accountIds),
+  ]);
+  return dep;
+}
+
+// The tenant's connected deployment, or the refusal every account operation owes its caller.
+export async function assertDeploymentConnected(
+  ctx: TenantContext,
+  base: PrismaClient = basePrisma,
+): Promise<{ id: bigint; baseUrl: string }> {
+  const dep = await runScopedOn(base, ctx, (db) =>
+    db.chatwootDeployment.findFirst({ select: { id: true, baseUrl: true } }),
+  );
+  if (!dep) {
+    throw new NotFoundError(
+      "no chatwoot deployment connected",
+      "errors.chatwootDeploymentNotFound",
+    );
+  }
+  return dep;
 }
 
 // Apply the operator's account selection as a diff against the currently-connected accounts:
@@ -650,15 +765,7 @@ export async function setConnectedAccounts(
 ): Promise<ChatwootInstanceDto[]> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const wanted = [...new Set(accountIds)];
-  const dep = await runScopedOn(base, ctx, (db) =>
-    db.chatwootDeployment.findFirst({ select: { id: true, baseUrl: true } }),
-  );
-  if (!dep) {
-    throw new NotFoundError(
-      "no chatwoot deployment connected",
-      "errors.chatwootDeploymentNotFound",
-    );
-  }
+  const dep = await assertAccountsClaimable(ctx, wanted, base);
   const serverKey = normalizeChatwootBaseUrl(dep.baseUrl);
   // Names for the wanted accounts (best-effort; falls back to null → the #id badge still identifies).
   let nameById = new Map<number, string>();
@@ -1265,6 +1372,45 @@ export async function reconcileInboxBots(
   return result;
 }
 
+// Everything `reconnectInbox` decides before it calls Chatwoot: the inbox exists, it is bound, and
+// the agent it names is still there. Split out so the MCP preview can ask the same question the
+// apply asks (#490) without performing the reconnection.
+export async function assertInboxReconnectable(
+  ctx: TenantContext,
+  inboxId: bigint,
+  base: PrismaClient = basePrisma,
+) {
+  return runScopedOn(base, ctx, async (db) => {
+    const row = await db.inbox.findUnique({
+      where: { id: inboxId },
+      select: {
+        id: true,
+        chatwootInstanceId: true,
+        chatwootInboxId: true,
+        agentId: true,
+      },
+    });
+    if (!row) {
+      throw new NotFoundError("inbox not found", "errors.inboxNotFound");
+    }
+    if (row.agentId === null) {
+      throw new AppError(
+        "inbox has no agent to reconnect",
+        409,
+        "errors.inboxNotBound",
+      );
+    }
+    const agent = await db.agent.findUnique({
+      where: { id: row.agentId },
+      select: { name: true },
+    });
+    if (!agent) {
+      throw new NotFoundError("agent not found", "errors.agentNotFound");
+    }
+    return { inbox: row, agentId: row.agentId, agentName: agent.name };
+  });
+}
+
 // Re-provision + reconnect the persona bot for an inbox — the "Reconnect" action when the bot was
 // deleted out-of-band on Chatwoot. Bypasses bindInbox's same-agent no-op; ensureAgentBot self-heals
 // (detects the missing bot and re-provisions). Network failure → uniform 502.
@@ -1276,38 +1422,10 @@ export async function reconnectInbox(
 ): Promise<InboxDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const { inbox, agentId, agentName } = await runScopedOn(
-    base,
+  const { inbox, agentId, agentName } = await assertInboxReconnectable(
     ctx,
-    async (db) => {
-      const row = await db.inbox.findUnique({
-        where: { id: inboxId },
-        select: {
-          id: true,
-          chatwootInstanceId: true,
-          chatwootInboxId: true,
-          agentId: true,
-        },
-      });
-      if (!row) {
-        throw new NotFoundError("inbox not found", "errors.inboxNotFound");
-      }
-      if (row.agentId === null) {
-        throw new AppError(
-          "inbox has no agent to reconnect",
-          409,
-          "errors.inboxNotBound",
-        );
-      }
-      const agent = await db.agent.findUnique({
-        where: { id: row.agentId },
-        select: { name: true },
-      });
-      if (!agent) {
-        throw new NotFoundError("agent not found", "errors.agentNotFound");
-      }
-      return { inbox: row, agentId: row.agentId, agentName: agent.name };
-    },
+    inboxId,
+    base,
   );
   try {
     const client = await loadChatwootClient(

--- a/src/modules/mcp-connections/service.ts
+++ b/src/modules/mcp-connections/service.ts
@@ -251,6 +251,31 @@ async function assertNameFree(
   }
 }
 
+// Everything `createMcpConnection` refuses about an input WITHOUT reading the database, as one
+// call, so the MCP dry run can answer with the verdict the apply will (issue #490). See the note on
+// `assertAgentCreatable`. Async only because `assertTransportValid` is; it makes no query.
+export async function assertMcpConnectionCreatable(input: McpConnectionCreate) {
+  const data = parseInput(mcpConnectionCreateSchema, input);
+  await assertTransportValid(data);
+  return data;
+}
+
+// Same split, same caveat as `assertToolNameAvailable`: ADVISORY. It reads outside the write's
+// transaction, so a name free here can be taken before the apply arrives; `assertNameFree` inside
+// the tx stays the authority. It exists so the preview refuses the reuse the operator actually
+// makes, instead of promising a connection the apply will not create (#490).
+// `exceptId` for the update path: a connection keeping its own name is not a collision, and
+// omitting it would make every rename-to-itself preview refuse a write that succeeds — the inverse
+// divergence, which is just as wrong.
+export async function assertMcpConnectionNameAvailable(
+  ctx: TenantContext,
+  name: string,
+  base: PrismaClient = basePrisma,
+  exceptId?: bigint,
+): Promise<void> {
+  await runScopedOn(base, ctx, (db) => assertNameFree(db, name, exceptId));
+}
+
 export async function createMcpConnection(
   ctx: TenantContext,
   input: McpConnectionCreate,
@@ -258,8 +283,7 @@ export async function createMcpConnection(
 ): Promise<McpConnectionDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const data = parseInput(mcpConnectionCreateSchema, input);
-  await assertTransportValid(data);
+  const data = await assertMcpConnectionCreatable(input);
   return runScopedOn(base, ctx, async (db) => {
     await assertNameFree(db, data.name);
     const credentialRef = data.credentialRef
@@ -286,13 +310,34 @@ export async function createMcpConnection(
   });
 }
 
+// Everything `updateMcpConnection` decides before it writes: the schema, that the row exists, and
+// that the MERGED transport/url/command is coherent and reachable. Split out so the MCP preview can
+// ask the same question the apply asks (#490) — the merge is the point, since a patch that only
+// moves the url is judged against the transport already stored.
+// The judgement `updateMcpConnection` makes about a patch, against a snapshot the CALLER supplies.
+// The snapshot is a parameter rather than a read of its own so the MCP preview can validate and
+// render from the same row: reading it twice means a concurrent write can land between the two, and
+// the preview then describes a diff against one state while having approved another (#490).
+export async function assertMcpConnectionUpdatable(
+  patch: McpConnectionUpdate,
+  current: { transport: string; url: string | null; command: string | null },
+): Promise<McpConnectionUpdate> {
+  const data = parseInput(mcpConnectionUpdateSchema, patch);
+  // Re-validate the merged result (SSRF/DNS outside the tx).
+  await assertTransportValid({
+    transport: data.transport ?? current.transport,
+    url: data.url !== undefined ? data.url : current.url,
+    command: data.command !== undefined ? data.command : current.command,
+  });
+  return data;
+}
+
 export async function updateMcpConnection(
   ctx: TenantContext,
   id: bigint,
   patch: McpConnectionUpdate,
   base: PrismaClient = basePrisma,
 ): Promise<McpConnectionDto> {
-  const data = parseInput(mcpConnectionUpdateSchema, patch);
   const current = await runScopedOn(base, ctx, (db) =>
     db.mcpServerConnection.findUnique({
       where: { id },
@@ -305,12 +350,7 @@ export async function updateMcpConnection(
       "errors.mcpConnectionNotFound",
     );
   }
-  // Re-validate the merged result (SSRF/DNS outside the tx).
-  await assertTransportValid({
-    transport: data.transport ?? current.transport,
-    url: data.url !== undefined ? data.url : current.url,
-    command: data.command !== undefined ? data.command : current.command,
-  });
+  const data = await assertMcpConnectionUpdatable(patch, current);
   return runScopedOn(base, ctx, async (db) => {
     // LOCKED before the snapshot the trail compares against. The `current` read above is outside
     // this transaction on purpose — it feeds the SSRF check, which does DNS — so it is not the

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -7,6 +7,10 @@ import type { AgentMode } from "@/modules/agents/mode";
 import {
   type AgentCreate,
   type AgentUpdate,
+  assertAgentCreatable,
+  assertAgentUpdatable,
+  assertCredentialRefsUsable,
+  assertSchedulesExist,
   cloneAgent,
   createAgent,
   deleteAgent,
@@ -18,6 +22,9 @@ import {
 } from "@/modules/agents/service";
 import { agentExportSchema, importAgent } from "@/modules/agents/transfer";
 import {
+  assertMcpConnectionCreatable,
+  assertMcpConnectionNameAvailable,
+  assertMcpConnectionUpdatable,
   createMcpConnection,
   deleteMcpConnection,
   discoverMcpTools,
@@ -33,6 +40,8 @@ import {
   storableResponseTemplate,
 } from "@/modules/tool-definitions/response-template";
 import {
+  assertToolDefinitionCreatable,
+  assertToolNameAvailable,
   createToolDefinition,
   deleteToolDefinition,
   getToolDefinition,
@@ -122,6 +131,20 @@ export async function agentCreate(
 
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      const { businessHoursId, followUpHoursId } = assertAgentCreatable(input);
+      // ADVISORY, unlike the line above it: this one READS. It passes the ids that line already
+      // PARSED rather than re-reading `input`, so the preview and the write cannot end up asking
+      // about different rows (#490).
+      await assertSchedulesExist(ctx, businessHoursId, followUpHoursId, base);
+      // ADVISORY too, and it asks the OTHER thing `createAgent` reads for: that every credential
+      // ref in the payload resolves AND that an entry of that kind can serve the field. A
+      // `google_oauth` entry holds an object where eight of these nine fields hand a plain string
+      // to a provider SDK, so "it exists" is not the question (#471, #490).
+      await assertCredentialRefsUsable(ctx, input, base);
       return ok({
         dryRun: true,
         action: "create",
@@ -197,6 +220,18 @@ export async function agentUpdate(
     }
     const target = `agent:${id}`;
     if (args.dry_run !== false) {
+      // NOTE: this preview had NO preflight, and its fence row hid that — the row passes an agent
+      // id that does not exist, so it proved the not-found path and every rule `updateAgent`
+      // applies after it went unasked. Measured: an empty name, a schedule id naming no row, and a
+      // credentialRef whose kind cannot serve the field all previewed ok and applied refused (#490).
+      const { rest, businessHoursId, followUpHoursId } =
+        assertAgentUpdatable(patch);
+      await assertSchedulesExist(ctx, businessHoursId, followUpHoursId, base);
+      // Against the STORED bag, not `{}`: on an update the question is whether this write CHANGES
+      // a ref, and `current` is the same row the diff above was rendered from.
+      await assertCredentialRefsUsable(ctx, rest, base, {
+        modelConfig: current.modelConfig,
+      });
       return ok({
         dryRun: true,
         target,
@@ -520,6 +555,16 @@ export async function toolCreate(
   const warnings = norm.warnings.length > 0 ? { warnings: norm.warnings } : {};
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      const parsed = assertToolDefinitionCreatable(input);
+      // ADVISORY, unlike the line above it: this one READS, outside the transaction the apply
+      // will write in, so a free name here can be taken before the apply arrives. It answers the
+      // collision that actually happens (a name the operator already used), and the unique index
+      // inside the write remains what guarantees one name to one row (#490).
+      await assertToolNameAvailable(ctx, parsed.name, base);
       return ok({
         dryRun: true,
         action: "create",
@@ -697,6 +742,16 @@ export async function mcpConnectionCreate(
   } as McpConnectionCreate;
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      const parsed = await assertMcpConnectionCreatable(input);
+      // ADVISORY, unlike the line above it: this one READS, outside the transaction the apply
+      // will write in, so a free name here can be taken before the apply arrives. It answers the
+      // collision that actually happens (a name the operator already used), and the unique index
+      // inside the write remains what guarantees one name to one row (#490).
+      await assertMcpConnectionNameAvailable(ctx, parsed.name, base);
       return ok({
         dryRun: true,
         action: "create",
@@ -738,6 +793,19 @@ export async function mcpConnectionUpdate(
     }
     const target = `mcp_connection:${id}`;
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      // NOTE: judged against `current` — the SAME row the diff above was rendered from. Reading it
+      // again here would let a concurrent write land between the two, and the preview would then
+      // approve one state while describing a diff against another.
+      await assertMcpConnectionUpdatable(built.patch, current);
+      // ADVISORY, and only when the patch actually renames. `exceptId` is what keeps a connection
+      // keeping its own name from being read as a collision (#490).
+      if (built.patch.name !== undefined) {
+        await assertMcpConnectionNameAvailable(ctx, built.patch.name, base, id);
+      }
       return ok({
         dryRun: true,
         target,

--- a/src/modules/mcp/write-channels.ts
+++ b/src/modules/mcp/write-channels.ts
@@ -1,6 +1,10 @@
 import basePrisma from "@/api/lib/prisma";
 import { AppError } from "@/lib/errors";
 import {
+  assertAccountsClaimable,
+  assertDeploymentConnectable,
+  assertDeploymentNotSwitching,
+  assertInboxReconnectable,
   bindInbox,
   connectChatwootDeployment,
   getChatwootInstance,
@@ -61,16 +65,28 @@ export async function deploymentConnect(
   const ctx = adminGate(principal);
   if ("ok" in ctx) return ctx;
   if (!args.admin_token) return err("admin_token is required");
-  if (args.dry_run !== false) {
-    return ok({
-      dryRun: true,
-      action: "connect",
-      resource: "chatwoot_deployment",
-      // The raw token is never echoed back, not even in the preview.
-      preview: { baseUrl: args.base_url, adminToken: "(redacted)" },
-    });
-  }
   try {
+    if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      const data = await assertDeploymentConnectable({
+        baseUrl: args.base_url,
+        adminToken: args.admin_token,
+      });
+      // ADVISORY, unlike the line above it: this one READS. It passes the base URL that line
+      // NORMALIZED, because that is what the write compares against and what it stores — asking
+      // with the raw string would call a connect to the same server a switch (#490).
+      await assertDeploymentNotSwitching(ctx, data.baseUrl, base);
+      return ok({
+        dryRun: true,
+        action: "connect",
+        resource: "chatwoot_deployment",
+        // The raw token is never echoed back, not even in the preview.
+        preview: { baseUrl: args.base_url, adminToken: "(redacted)" },
+      });
+    }
     const result = await connectChatwootDeployment(
       ctx,
       { baseUrl: args.base_url, adminToken: args.admin_token },
@@ -144,16 +160,21 @@ export async function deploymentSetAccounts(
   const ctx = adminGate(principal);
   if ("ok" in ctx) return ctx;
   const target = "chatwoot_deployment:accounts";
-  if (args.dry_run !== false) {
-    return ok({
-      dryRun: true,
-      action: "set_accounts",
-      target,
-      accountIds: args.account_ids,
-      note: "Connects newly-selected accounts (syncs their inboxes) and soft-disconnects de-selected ones (history kept). Calls Chatwoot.",
-    });
-  }
   try {
+    if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      await assertAccountsClaimable(ctx, args.account_ids, base);
+      return ok({
+        dryRun: true,
+        action: "set_accounts",
+        target,
+        accountIds: args.account_ids,
+        note: "Connects newly-selected accounts (syncs their inboxes) and soft-disconnects de-selected ones (history kept). Calls Chatwoot.",
+      });
+    }
     const accounts = await setConnectedAccounts(
       ctx,
       args.account_ids,
@@ -340,15 +361,20 @@ export async function inboxReconnect(
   const inboxId = parseMcpId(args.inbox_id, "inbox_id");
   if (typeof inboxId !== "bigint") return inboxId;
   const target = `inbox:${inboxId}`;
-  if (args.dry_run !== false) {
-    return ok({
-      dryRun: true,
-      action: "reconnect",
-      target,
-      note: "Re-provisions the inbox's bot on Chatwoot (calls Chatwoot).",
-    });
-  }
   try {
+    if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      await assertInboxReconnectable(ctx, inboxId, base);
+      return ok({
+        dryRun: true,
+        action: "reconnect",
+        target,
+        note: "Re-provisions the inbox's bot on Chatwoot (calls Chatwoot).",
+      });
+    }
     const updated = await reconnectInbox(ctx, inboxId, {}, base);
     return ok({ dryRun: false, applied: true, target, inbox: updated });
   } catch (e) {

--- a/src/modules/mcp/write-fleet.ts
+++ b/src/modules/mcp/write-fleet.ts
@@ -1,6 +1,11 @@
 import basePrisma from "@/api/lib/prisma";
 import { createTenant } from "@/api/v1/tenants.admin.service";
-import { getTenant, listTenants } from "@/api/v1/tenants.service";
+import {
+  assertTenantCreatable,
+  assertTenantSlugAvailable,
+  getTenant,
+  listTenants,
+} from "@/api/v1/tenants.service";
 import { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
 import { parseMcpId } from "@/modules/mcp/write";
@@ -70,6 +75,19 @@ export async function tenantCreate(
   if ("ok" in ctx) return ctx;
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      const parsed = assertTenantCreatable({
+        name: args.name,
+        slug: args.slug,
+      });
+      // ADVISORY, unlike the line above it: this one READS, outside the transaction the apply
+      // will write in, so a free name here can be taken before the apply arrives. It answers the
+      // collision that actually happens (a name the operator already used), and the unique index
+      // inside the write remains what guarantees one name to one row (#490).
+      await assertTenantSlugAvailable(parsed.slug, base);
       return ok({
         dryRun: true,
         action: "create",

--- a/src/modules/mcp/write-knowledge.ts
+++ b/src/modules/mcp/write-knowledge.ts
@@ -234,6 +234,11 @@ export async function knowledgeDocumentCreate(
   if (bad) return bad;
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      await getKnowledgeBase({ ctx, id: kbId, base });
       return ok({
         dryRun: true,
         action: "create",

--- a/src/modules/mcp/write-settings.ts
+++ b/src/modules/mcp/write-settings.ts
@@ -2,9 +2,13 @@ import { z } from "zod";
 import basePrisma from "@/api/lib/prisma";
 import { AppError } from "@/lib/errors";
 import { parseInput } from "@/lib/parse-input";
-import { revokeApiKey } from "@/modules/api-keys/service";
+import {
+  assertApiKeyRevocable,
+  revokeApiKey,
+} from "@/modules/api-keys/service";
 import { truncForAudit } from "@/modules/audit/projection";
 import {
+  assertBusinessHoursCreatable,
   createBusinessHours,
   deleteBusinessHours,
   getBusinessHours,
@@ -23,6 +27,7 @@ import {
   updateLangfuse,
 } from "@/modules/tenant-settings/service";
 import {
+  assertVaultEntryCreatable,
   createVaultEntry,
   resolveVaultRefByName,
   updateVaultEntry,
@@ -255,6 +260,16 @@ export async function businessHoursCreate(
   if ("ok" in ctx) return ctx;
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      assertBusinessHoursCreatable({
+        name: args.name,
+        timezone: args.timezone,
+        windows: args.windows,
+        exceptions: args.exceptions,
+      });
       return ok({
         dryRun: true,
         action: "create",
@@ -532,22 +547,36 @@ export async function langfuseConnect(
   if (!args.base_url) return err("base_url is required");
   const name = args.name?.trim() || "langfuse";
   const enabled = args.enabled ?? true;
-  if (args.dry_run !== false) {
-    return ok({
-      dryRun: true,
-      action: "connect",
-      resource: "langfuse",
-      // The keys are never echoed back, not even in the preview.
-      preview: {
-        name,
-        baseUrl: args.base_url,
-        enabled,
-        publicKey: "(redacted)",
-        secretKey: "(redacted)",
-      },
-    });
-  }
   try {
+    if (args.dry_run !== false) {
+      // NOTE: the vault's own rule, asked before the preview answers, on the ENTRY THE APPLY WOULD
+      // BUILD rather than on one field of it. An earlier version checked `base_url` alone, and the
+      // apply also judges the vault name and both key values through `createVaultEntry` — a key
+      // with surrounding whitespace previewed clean and then refused, which is the same shape as
+      // the divergence this whole change is about, one level in (#490).
+      //
+      // `langfuse` is a kind that REQUIRES a base URL, so "   " — which normalizes to the empty
+      // string without raising — is refused in here rather than by a separate check out here.
+      assertVaultEntryCreatable({
+        name,
+        value: { publicKey: args.public_key, secretKey: args.secret_key },
+        kind: "langfuse",
+        baseUrl: args.base_url,
+      });
+      return ok({
+        dryRun: true,
+        action: "connect",
+        resource: "langfuse",
+        // The keys are never echoed back, not even in the preview.
+        preview: {
+          name,
+          baseUrl: args.base_url,
+          enabled,
+          publicKey: "(redacted)",
+          secretKey: "(redacted)",
+        },
+      });
+    }
     // Upsert the filled vault entry so a re-connect (e.g. rotated keys) is idempotent.
     const existing = await resolveVaultRefByName(ctx, name, "langfuse", base);
     let ref: string;
@@ -620,6 +649,11 @@ export async function apiKeyRevoke(
   const target = `api_key:${id}`;
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      await assertApiKeyRevocable(ctx, id, base);
       return ok({
         dryRun: true,
         action: "revoke",

--- a/src/modules/mcp/write-webhooks.ts
+++ b/src/modules/mcp/write-webhooks.ts
@@ -21,6 +21,8 @@ import {
 } from "@/modules/webhooks/outbound/deliveries";
 import { isOutboundEvent } from "@/modules/webhooks/outbound/events";
 import {
+  assertWebhookSubscriptionCreatable,
+  assertWebhookSubscriptionUpdatable,
   createWebhookSubscription,
   deleteWebhookSubscription,
   listWebhookSubscriptions,
@@ -80,6 +82,16 @@ export async function webhookCreate(
   }
   try {
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      await assertWebhookSubscriptionCreatable({
+        url: args.url,
+        events: args.events,
+        secretRef,
+        enabled: args.enabled,
+      });
       return ok({
         dryRun: true,
         action: "create",
@@ -166,6 +178,11 @@ export async function webhookUpdate(
       afterProj[k] = patch[k];
     }
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      await assertWebhookSubscriptionUpdatable(patch);
       return ok({
         dryRun: true,
         target,

--- a/src/modules/mcp/write.ts
+++ b/src/modules/mcp/write.ts
@@ -7,12 +7,13 @@ import {
 import {
   ALLOWED_ASSET_TYPES,
   ASSET_MAX_BYTES,
+  assertBrandingColorsUpdatable,
   type ColorUpdate,
   getGlobalBranding,
 } from "@/api/features/branding/branding.service";
 import basePrisma from "@/api/lib/prisma";
 import { updateTenant } from "@/api/v1/tenants.admin.service";
-import { getTenant } from "@/api/v1/tenants.service";
+import { assertTenantUpdatable, getTenant } from "@/api/v1/tenants.service";
 import { parseDbId } from "@/lib/db-id";
 import { AppError } from "@/lib/errors";
 import {
@@ -47,10 +48,8 @@ import type { LoadChatwootClientDeps } from "@/modules/chatwoot/instance";
 import { readDebugModes } from "@/modules/flowlog/debug-mode";
 import { getTenantSettings } from "@/modules/tenant-settings/service";
 import {
-  PARAM_NAME_KIND_IDS,
-  secretTypeRefusesParamName,
-} from "@/modules/vault/secret-types";
-import {
+  assertPendingVaultEntryCreatable,
+  assertVaultNameAvailable,
   createPendingVaultEntry,
   isVaultIdRef,
   resolveVaultRefByName,
@@ -308,26 +307,31 @@ export async function credentialCreate(
     paramName: args.param_name ?? null,
   };
 
-  // NOTE: BEFORE the dry-run branch, because the preview returns without touching the core and a
-  // rule the core learns after that shortcut is a rule the preview promises away. `param_name` is
-  // read only for the kinds that declare `needsParamName`, so on any other kind it is a field the
-  // runtime discards, and `createPendingVaultEntry` now refuses it (issue #488) — previewing it
-  // clean would promise a write that apply rejects. Same question in two shapes: the transport
-  // answers with a `WriteResult`, the core with an `AppError`, and the catalog predicate in the
-  // middle is what keeps them from drifting.
-  //
-  // NOTE: this covers THIS rule only. The preview still returns ok for five other inputs the apply
-  // refuses (a kind the catalog does not know, a managed-blob kind, a missing required base URL, a
-  // missing required param name, and a name the write rejects) — measured, all six diverging, and
-  // filed separately rather than widened into here.
-  if (args.param_name?.trim() && secretTypeRefusesParamName(kind)) {
-    return err(
-      `the "${kind}" credential type does not use a param name. The types that do are: ${PARAM_NAME_KIND_IDS.join(", ")}.`,
-    );
-  }
-
   // dry-run is the default: create ONLY when dry_run is explicitly false.
   if (args.dry_run !== false) {
+    // NOTE: everything `createPendingVaultEntry` decides about its input — the name, the kind
+    // against the catalog, the connect-flow kinds that cannot be created pending, a required base
+    // URL, and the param name the kind has no use for (#488) — asked here before the preview
+    // answers. The apply below reaches the core, which asks it again; the pure function in the
+    // middle is what keeps the transport's `WriteResult` and the domain's `AppError` from drifting
+    // into two different verdicts (#490).
+    try {
+      const { name, kind } = assertPendingVaultEntryCreatable({
+        name: args.name,
+        kind: args.kind ?? null,
+        baseUrl: args.base_url ?? null,
+        paramName: args.param_name ?? null,
+      });
+      // ADVISORY, and the only preflight here that is. See `assertVaultNameAvailable`: it reads
+      // outside the write's transaction, so it answers the collision the operator already made,
+      // not a reservation. It takes the pair the line above NORMALIZED, since that is what the
+      // uniqueness is on.
+      await assertVaultNameAvailable(ctx, name, kind, base);
+    } catch (e) {
+      if (e instanceof AppError) return err(e.message);
+      if (e instanceof ZodError) return err(zodIssuesMessage(e));
+      throw e;
+    }
     return ok({ dryRun: true, target: "vault:new", preview });
   }
 
@@ -742,6 +746,11 @@ export async function tenantUpdate(
     const target = `tenant:${tenantId}`;
 
     if (args.dry_run !== false) {
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      assertTenantUpdatable(patch);
       const previewAfter = {
         name: patch.name ?? current.name,
       };
@@ -815,7 +824,7 @@ export async function brandingSet(
   }
 
   try {
-    const before = await getGlobalBranding();
+    const before = await getGlobalBranding(base);
     const beforeProj = {
       brandName: before.brandName,
       colorMode: before.colorMode,
@@ -830,7 +839,11 @@ export async function brandingSet(
 
     // dry-run is the default: apply ONLY when dry_run is explicitly false.
     if (args.dry_run !== false) {
-      // Preview reflects the requested patch (sanitization is applied on apply).
+      // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
+      // branch rather than above it because the apply reaches the core, which asks it again —
+      // and several of these read a row or resolve DNS, so above the branch is a second lookup
+      // that can even disagree with the first (#490).
+      assertBrandingColorsUpdatable(update);
       const previewAfter = {
         brandName:
           update.brandName === undefined

--- a/src/modules/tool-definitions/service.ts
+++ b/src/modules/tool-definitions/service.ts
@@ -371,6 +371,29 @@ function assertSupportedBody(body: unknown): void {
   if (reason) throw new AppError(reason, 400);
 }
 
+// Everything `createToolDefinition` decides about its INPUT — the schema (the name pattern, the
+// URL template, the declared response template) and the body shape — before any database is
+// involved. Split out so the MCP preview can ask the same question the apply asks (#490).
+export function assertToolDefinitionCreatable(input: ToolDefinitionCreate) {
+  const data = parseInput(toolDefinitionCreateSchema, input);
+  assertSupportedBody(data.body);
+  return data;
+}
+
+// The half of `createToolDefinition`'s verdict that has to READ, so the preview can give it too.
+// It is ADVISORY, and that word is load-bearing: `assertToolDefinitionCreatable` above judges the
+// input and cannot change its mind, while this runs its own scoped read outside the write's
+// transaction and can be overtaken. `assertNameFree` INSIDE the tx, and the unique index under it,
+// are what actually keep one name to one tool. This only moves the refusal an operator will hit
+// almost every time — a name they already used — to where they asked the question (#490).
+export async function assertToolNameAvailable(
+  ctx: TenantContext,
+  name: string,
+  base: PrismaClient = basePrisma,
+): Promise<void> {
+  await runScopedOn(base, ctx, (db) => assertNameFree(db, name));
+}
+
 export async function createToolDefinition(
   ctx: TenantContext,
   input: ToolDefinitionCreate,
@@ -380,8 +403,7 @@ export async function createToolDefinition(
     throw new AppError("tenant required", 400);
   }
   const tenantId = ctx.tenantId;
-  const data = parseInput(toolDefinitionCreateSchema, input);
-  assertSupportedBody(data.body);
+  const data = assertToolDefinitionCreatable(input);
   // NOTE: canonicalize programmatic authoring shapes (JSON-Schema inputSchema, single-brace
   // {var}) so storage always holds what the runtime executes.
   const { shapes } = normalizeToolShapes({

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -596,7 +596,7 @@ export async function vaultNameByRef(
 const HTTPS_RE = /^https?:\/\//i;
 const PARAM_NAME_RE = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 
-function validateBaseUrl(raw: string): string {
+export function validateBaseUrl(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return "";
   if (!HTTPS_RE.test(trimmed)) {
@@ -854,6 +854,70 @@ export interface CreateVaultEntryInput {
   paramName?: string | null;
 }
 
+// Everything `createVaultEntry` decides about its input, before any database is involved: the name,
+// the kind against the catalog, the VALUE against that kind's declared fields (non-empty, no
+// surrounding whitespace, no unexpected key), the base URL, and the param name. Split out so a
+// caller that will eventually reach this write can ask the same question first (#490).
+//
+// Its RETURN is part of the verdict, not a convenience: `kind` defaults to "generic" and `baseUrl`
+// normalizes, and a caller that re-derives either from the raw input will disagree with what gets
+// stored.
+// The base URL a write would STORE, refusing when the kind requires one and this is not it.
+//
+// It exists because the check has to sit after the normalization, and `updateVaultEntry` had it
+// before: it asked `secretTypeRequiresBaseUrl` only on the `null`/`""` branch, while the other
+// branch ran `validateBaseUrl`, which turns "   " into the empty string WITHOUT raising, and stored
+// the `null` that branch had just refused. So a langfuse entry that already existed could be
+// updated to `baseUrl: null` — a state its own create path rejects. Found by the MCP preview
+// answering the question the apply did not (#490), and it is the inverse of every other divergence
+// in that issue: the preview refused and the apply succeeded, leaving invalid configuration behind.
+function normalizeRequiredBaseUrl(
+  raw: string | null | undefined,
+  kind: string,
+): string | null {
+  const normalized =
+    raw == null || raw === "" ? null : validateBaseUrl(raw) || null;
+  if (normalized === null && secretTypeRequiresBaseUrl(kind)) {
+    throw new AppError(
+      "baseUrl is required for this credential type",
+      400,
+      "errors.vaultBaseUrlRequired",
+    );
+  }
+  return normalized;
+}
+
+export function assertVaultEntryCreatable(input: CreateVaultEntryInput): {
+  name: string;
+  kind: string;
+  baseUrl: string | null;
+  paramName: string | null;
+} {
+  const name = validateVaultName(input.name);
+  if (input.kind != null && !isSecretTypeId(input.kind)) {
+    throw new AppError("invalid secret type", 400, "errors.invalidSecretType");
+  }
+  const kind = input.kind ?? "generic";
+  validateVaultValue(kind, input.value);
+
+  const baseUrl = normalizeRequiredBaseUrl(input.baseUrl, kind);
+
+  const paramName =
+    input.paramName != null
+      ? validateParamName(input.paramName, kind)
+      : secretTypeNeedsParamName(kind)
+        ? (() => {
+            throw new AppError(
+              "paramName is required for this credential type",
+              400,
+              "errors.vaultParamNameRequired",
+            );
+          })()
+        : null;
+
+  return { name, kind, baseUrl, paramName };
+}
+
 // INSERT-only create: 409 if both name and kind already exist in the tenant.
 // What a credential's audit row carries, and what it only compares.
 //
@@ -970,44 +1034,18 @@ export async function createVaultEntry(
     rawParamName = undefined;
   }
 
-  const validName = validateVaultName(rawName);
-  if (rawKind != null && !isSecretTypeId(rawKind)) {
-    throw new AppError("invalid secret type", 400, "errors.invalidSecretType");
-  }
-
-  const normalizedKind = rawKind ?? "generic";
-
-  // Validate value shape for the kind.
-  validateVaultValue(normalizedKind, rawValue);
-
-  // Validate and normalize baseUrl.
-  let normalizedBaseUrl: string | null = null;
-  if (rawBaseUrl != null && rawBaseUrl !== "") {
-    const validated = validateBaseUrl(rawBaseUrl);
-    normalizedBaseUrl = validated || null;
-  }
-
-  if (secretTypeRequiresBaseUrl(normalizedKind) && !normalizedBaseUrl) {
-    throw new AppError(
-      "baseUrl is required for this credential type",
-      400,
-      "errors.vaultBaseUrlRequired",
-    );
-  }
-
-  // Validate paramName.
-  const normalizedParamName =
-    rawParamName != null
-      ? validateParamName(rawParamName, normalizedKind)
-      : secretTypeNeedsParamName(normalizedKind)
-        ? (() => {
-            throw new AppError(
-              "paramName is required for this credential type",
-              400,
-              "errors.vaultParamNameRequired",
-            );
-          })()
-        : null;
+  const {
+    name: validName,
+    kind: normalizedKind,
+    baseUrl: normalizedBaseUrl,
+    paramName: normalizedParamName,
+  } = assertVaultEntryCreatable({
+    name: rawName,
+    value: rawValue,
+    kind: rawKind,
+    baseUrl: rawBaseUrl,
+    paramName: rawParamName,
+  });
 
   return runScopedOn(base, ctx, async (db) => {
     const existing = await db.vaultEntry.findFirst({
@@ -1060,20 +1098,46 @@ export interface CreatePendingVaultEntryInput {
   paramName?: string | null;
 }
 
-// Creates a reference-only ("pending") vault entry: NO secret is supplied. Stores encryptJson({}) as
-// a placeholder with status="pending"; resolution treats it as missing (resolve* throw
-// errors.credentialPending, try* return null) until the operator fills it in the UI — updateVaultEntry
-// with a real value promotes it to "active". Used by the MCP `credential_create` tool, which by design
-// never receives a secret. INSERT-only: 409 if (name, kind) already exists in the tenant. baseUrl /
-// paramName are not secrets, so they are validated/required up front to keep the entry coherent.
-export async function createPendingVaultEntry(
+// Everything `createPendingVaultEntry` decides about its INPUT, before any database is involved: the
+// name, the kind against the catalog, the two kinds that can only come from a connect flow, the base
+// URL, and the param name. Split out so the MCP preview can ask the same question the apply asks
+// (#490) — the preview answers without reaching the core, so a rule that lives only inside it is a
+// rule the preview promises away. Returns the normalized fields the caller goes on to store.
+// The database half of `createPendingVaultEntry`'s verdict, ADVISORY like the others: it reads
+// outside the write's transaction, so the `(name, kind)` pair it finds free can be taken before the
+// apply gets there. The pre-read inside the write, and the unique index behind it, stay the
+// authority — this only lets the preview refuse the collision the operator actually causes, which
+// is reusing a name they already used (#490).
+//
+// It takes the NORMALIZED pair, not the raw input, because `kind` defaults to "generic" and the
+// uniqueness is on the stored value: asking with the raw `kind: null` would look up a row that
+// cannot exist and answer "free" for a name that is not.
+export async function assertVaultNameAvailable(
   ctx: TenantContext,
-  input: CreatePendingVaultEntryInput,
+  name: string,
+  kind: string,
   base: PrismaClient = basePrisma,
-): Promise<{ id: bigint; ref: string }> {
-  if (ctx.tenantId === null) throw new AppError("tenant required", 400);
-  const tenantId = ctx.tenantId;
+): Promise<void> {
+  const taken = await runScopedOn(base, ctx, (db) =>
+    db.vaultEntry.findFirst({ where: { name, kind }, select: { id: true } }),
+  );
+  if (taken) {
+    throw new ConflictError(
+      "vault entry name and type already in use",
+      "errors.vaultNameInUse",
+      "name",
+    );
+  }
+}
 
+export function assertPendingVaultEntryCreatable(
+  input: CreatePendingVaultEntryInput,
+): {
+  name: string;
+  kind: string;
+  baseUrl: string | null;
+  paramName: string | null;
+} {
   const validName = validateVaultName(input.name);
   if (input.kind != null && !isSecretTypeId(input.kind)) {
     throw new AppError("invalid secret type", 400, "errors.invalidSecretType");
@@ -1117,6 +1181,34 @@ export async function createPendingVaultEntry(
             );
           })()
         : null;
+
+  return {
+    name: validName,
+    kind: normalizedKind,
+    baseUrl: normalizedBaseUrl,
+    paramName: normalizedParamName || null,
+  };
+}
+
+// Creates a reference-only ("pending") vault entry: NO secret is supplied. Stores encryptJson({}) as
+// a placeholder with status="pending"; resolution treats it as missing (resolve* throw
+// errors.credentialPending, try* return null) until the operator fills it in the UI — updateVaultEntry
+// with a real value promotes it to "active". Used by the MCP `credential_create` tool, which by design
+// never receives a secret. INSERT-only: 409 if (name, kind) already exists in the tenant. baseUrl /
+// paramName are not secrets, so they are validated/required up front to keep the entry coherent.
+export async function createPendingVaultEntry(
+  ctx: TenantContext,
+  input: CreatePendingVaultEntryInput,
+  base: PrismaClient = basePrisma,
+): Promise<{ id: bigint; ref: string }> {
+  if (ctx.tenantId === null) throw new AppError("tenant required", 400);
+  const tenantId = ctx.tenantId;
+  const {
+    name: validName,
+    kind: normalizedKind,
+    baseUrl: normalizedBaseUrl,
+    paramName: normalizedParamName,
+  } = assertPendingVaultEntryCreatable(input);
 
   return runScopedOn(base, ctx, async (db) => {
     const existing = await db.vaultEntry.findFirst({
@@ -1237,19 +1329,7 @@ export async function updateVaultEntry(
     }
 
     if (patch.baseUrl !== undefined) {
-      if (patch.baseUrl === null || patch.baseUrl === "") {
-        if (secretTypeRequiresBaseUrl(entry.kind)) {
-          throw new AppError(
-            "baseUrl is required for this credential type",
-            400,
-            "errors.vaultBaseUrlRequired",
-          );
-        }
-        data.baseUrl = null;
-      } else {
-        const validated = validateBaseUrl(patch.baseUrl);
-        data.baseUrl = validated || null;
-      }
+      data.baseUrl = normalizeRequiredBaseUrl(patch.baseUrl, entry.kind);
     }
 
     if (patch.paramName !== undefined) {

--- a/src/modules/webhooks/outbound/subscriptions.ts
+++ b/src/modules/webhooks/outbound/subscriptions.ts
@@ -119,7 +119,10 @@ function assertKnownEvents(events: string[]): OutboundEvent[] {
 }
 
 // allowHttp follows the SSRF guard default (https-only). A blocked URL surfaces as a 400 SsrfError.
-async function assertUrlSafe(url: string): Promise<void> {
+// Exported because the MCP preview has to reach the same verdict the write does: it answers without
+// calling either writer below, so a URL only vetted in here is a URL the preview promises away
+// (#490).
+export async function assertUrlSafe(url: string): Promise<void> {
   await assertSafeOutboundUrl(url);
 }
 
@@ -146,6 +149,22 @@ export type WebhookSubscriptionCreate = z.infer<
   typeof webhookSubscriptionCreateSchema
 >;
 
+// EVERYTHING `createWebhookSubscription` decides about its input: the schema (a url at most 2048
+// characters, at least one event), the events against the catalog, and where the url points. Split
+// out so the MCP preview can ask the same question the apply asks (#490).
+//
+// It replaces a preview that asked only `assertUrlSafe`, which is the failure mode this whole PR
+// is about one level down: a preflight that covers part of its core's judgement reads exactly like
+// one that covers all of it. `events: []` with a safe url previewed ok and applied refused.
+export async function assertWebhookSubscriptionCreatable(
+  input: WebhookSubscriptionCreate,
+): Promise<{ parsed: WebhookSubscriptionCreate; events: string[] }> {
+  const parsed = parseInput(webhookSubscriptionCreateSchema, input);
+  const events = assertKnownEvents(parsed.events);
+  await assertUrlSafe(parsed.url);
+  return { parsed, events };
+}
+
 export async function createWebhookSubscription(
   ctx: TenantContext,
   input: WebhookSubscriptionCreate,
@@ -153,9 +172,7 @@ export async function createWebhookSubscription(
 ): Promise<WebhookSubscriptionDto> {
   if (ctx.tenantId === null) throw new AppError("tenant required", 400);
   const tenantId = ctx.tenantId;
-  const parsed = parseInput(webhookSubscriptionCreateSchema, input);
-  const events = assertKnownEvents(parsed.events);
-  await assertUrlSafe(parsed.url);
+  const { parsed, events } = await assertWebhookSubscriptionCreatable(input);
   const row = await runScopedOn(base, ctx, async (db) => {
     const secretRef = parsed.secretRef
       ? await requireVaultRef(db, parsed.secretRef, "secretRef")
@@ -195,20 +212,32 @@ export type WebhookSubscriptionUpdate = z.infer<
   typeof webhookSubscriptionUpdateSchema
 >;
 
+// The update's half of the same split. `events` is optional here but still `.min(1)` when present,
+// so an explicit empty array is a refusal the preview owed its caller.
+export async function assertWebhookSubscriptionUpdatable(
+  patch: WebhookSubscriptionUpdate,
+): Promise<{ parsed: WebhookSubscriptionUpdate; events?: string[] }> {
+  const parsed = parseInput(webhookSubscriptionUpdateSchema, patch);
+  if (parsed.url !== undefined) await assertUrlSafe(parsed.url);
+  return {
+    parsed,
+    events:
+      parsed.events !== undefined
+        ? assertKnownEvents(parsed.events)
+        : undefined,
+  };
+}
+
 export async function updateWebhookSubscription(
   ctx: TenantContext,
   id: bigint,
   patch: WebhookSubscriptionUpdate,
   base: PrismaClient = basePrisma,
 ): Promise<WebhookSubscriptionDto> {
-  const parsed = parseInput(webhookSubscriptionUpdateSchema, patch);
+  const { parsed, events } = await assertWebhookSubscriptionUpdatable(patch);
   const data: Record<string, unknown> = {};
-  if (parsed.url !== undefined) {
-    await assertUrlSafe(parsed.url);
-    data.url = parsed.url;
-  }
-  if (parsed.events !== undefined)
-    data.events = assertKnownEvents(parsed.events);
+  if (parsed.url !== undefined) data.url = parsed.url;
+  if (events !== undefined) data.events = events;
   // secretRef: undefined = leave; null = clear; string = set.
   if (parsed.secretRef !== undefined) data.secretRef = parsed.secretRef;
   if (parsed.enabled !== undefined) data.enabled = parsed.enabled;

--- a/tests/lib/ssrf.test.ts
+++ b/tests/lib/ssrf.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { assertSafeOutboundUrl, isBlockedIp, isBlockedIpv6 } from "@/lib/ssrf";
+import { AppError } from "@/lib/errors";
+import {
+  assertSafeOutboundUrl,
+  isBlockedIp,
+  isBlockedIpv6,
+  isNameNotFound,
+} from "@/lib/ssrf";
 
 describe("isBlockedIp", () => {
   test("blocks private / loopback / link-local / CGNAT / metadata IPv4", () => {
@@ -123,5 +129,81 @@ describe("assertSafeOutboundUrl — allowPrivate escape", () => {
     await expect(
       assertSafeOutboundUrl("file:///etc/passwd", { allowPrivate: true }),
     ).rejects.toThrow(/protocol/);
+  });
+});
+
+describe("isNameNotFound", () => {
+  // A permanent not-found is a statement about the INPUT and becomes a 400; a resolver that failed
+  // is a statement about the infrastructure and has to stay a 500, or the caller is told its
+  // perfectly valid hostname is wrong and not to retry.
+  test("only permanent resolver codes count", () => {
+    expect(
+      isNameNotFound(Object.assign(new Error("x"), { code: "ENOTFOUND" })),
+    ).toBe(true);
+    // `EMFILE` and `ENOMEM` are the ones worth naming: getaddrinfo can fail for a purely LOCAL
+    // reason (descriptor exhaustion), and the question is whether that failure gets reported as
+    // "your hostname does not exist". It cannot — libuv translates `EAI_SYSTEM` to the underlying
+    // errno, so the code that arrives is `EMFILE`, and only a real not-found is `ENOTFOUND`.
+    for (const code of [
+      "EAI_AGAIN",
+      "ETIMEDOUT",
+      "ENOMEM",
+      "EMFILE",
+      "ECONNREFUSED",
+      // The getaddrinfo spellings `dns.lookup` never emits: it renames both to `ENOTFOUND`.
+      // Listing them as not-found would be dead code claiming a platform difference that the
+      // runtime's own `DNSException` rules out.
+      "EAI_NONAME",
+      "EAI_NODATA",
+    ]) {
+      expect(isNameNotFound(Object.assign(new Error("x"), { code }))).toBe(
+        false,
+      );
+    }
+  });
+
+  test("a value with no code is not a not-found", () => {
+    expect(isNameNotFound(new Error("boom"))).toBe(false);
+    expect(isNameNotFound(null)).toBe(false);
+    expect(isNameNotFound(undefined)).toBe(false);
+    expect(isNameNotFound({ code: 404 })).toBe(false);
+  });
+});
+
+describe("assertSafeOutboundUrl — how a resolver failure is classified", () => {
+  const failing = (code: string) => () =>
+    Promise.reject(Object.assign(new Error(`getaddrinfo ${code}`), { code }));
+
+  test("a permanent not-found is the caller's 400", async () => {
+    const err = await assertSafeOutboundUrl("https://whatever.example/x", {
+      lookup: failing("ENOTFOUND") as never,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AppError);
+    expect((err as AppError).statusCode).toBe(400);
+  });
+
+  test("a transient failure is NOT the caller's fault and propagates", async () => {
+    // The distinction the 400 would erase: `EAI_AGAIN` means the resolver failed, not that the
+    // hostname is bad, and a 400 tells the caller its input is wrong and not to retry.
+    //
+    // It exercises the SEAM, not production. Measured under Bun, every lookup failure arrives as
+    // `code: "ENOTFOUND", errno: 4` — a nonexistent name, a name with no A record and a
+    // 300-character label are indistinguishable — so no real resolver reaches this branch today.
+    // What it pins is that the gate is a gate: a runtime that does distinguish gets this behaviour
+    // without another change here, and a future edit that collapses the classification into "any
+    // failure is a 400" turns this red.
+    const err = await assertSafeOutboundUrl("https://whatever.example/x", {
+      lookup: failing("EAI_AGAIN") as never,
+    }).catch((e: unknown) => e);
+    expect(err).not.toBeInstanceOf(AppError);
+    expect((err as { code?: string }).code).toBe("EAI_AGAIN");
+  });
+
+  test("an empty result is still a 400", async () => {
+    const err = await assertSafeOutboundUrl("https://whatever.example/x", {
+      lookup: (() => Promise.resolve([])) as never,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(AppError);
+    expect((err as AppError).message).toContain("did not resolve");
   });
 });

--- a/tests/modules/audit-channel-family.test.ts
+++ b/tests/modules/audit-channel-family.test.ts
@@ -252,7 +252,7 @@ function afterAccountLookup(
               const res = await (
                 inner as (a: unknown) => Promise<unknown>
               ).call(d, args);
-              // Only the lookup that DECIDES the connect. `assertAccountNotTakenByAnotherTenant`
+              // Only the lookup that DECIDES the connect. `assertAccountsNotTakenByAnotherTenant`
               // runs first and also asks by `accountId`, from OUTSIDE the transaction: firing there
               // deletes the row before the decision is even reached, the create path runs on its
               // own, and the test passes with the fix removed. The two are told apart by the

--- a/tests/modules/mcp-write-channels.test.ts
+++ b/tests/modules/mcp-write-channels.test.ts
@@ -7,6 +7,7 @@ import {
   type ChatwootClient,
 } from "@/modules/chatwoot/client";
 import {
+  connectChatwootDeployment,
   disconnectChatwootDeployment,
   reconnectChatwootInstance,
   softDisconnectChatwootInstance,
@@ -80,17 +81,17 @@ describe("MCP channels gate (no DB)", () => {
     if (!r.ok) expect(r.error).toContain("admin_token is required");
   });
 
-  test("deployment_connect dry-run previews without echoing the token", async () => {
+  test("deployment_connect dry-run refuses a malformed base_url", async () => {
+    // NOTE: what is still answerable with NO database. The preview used to approve every base URL
+    // and this block previewed a successful connect; it now reads the tenant's current deployment
+    // to refuse a server switch (#490), so a successful preview belongs in the DB block below.
+    // What survives here is the pure half: a base URL that is not a URL needs nothing to refuse.
     const r = await deploymentConnect(principal({}), {
-      base_url: "https://chat.example.com",
+      base_url: "not-a-url",
       admin_token: "raw-secret-xyz",
     });
-    expect(r.ok).toBe(true);
-    if (r.ok) {
-      expect(r.data.dryRun).toBe(true);
-      // The raw token is never echoed back, not even in the preview.
-      expect(JSON.stringify(r.data)).not.toContain("raw-secret-xyz");
-    }
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).not.toContain("raw-secret-xyz");
   });
 
   test("deployment_set_accounts without mcp:admin → insufficient_scope", async () => {
@@ -199,11 +200,117 @@ describe.skipIf(!dbUp)("MCP channel tools (DB)", () => {
     await appDb.$disconnect();
   });
 
-  test("deployment_connect dry-run with a raw token previews, creates nothing", async () => {
+  // The APPLY's own refusal, which had no test at all until a mutation deleting it from
+  // `connectChatwootDeployment` survived the whole suite. Writing it is also what showed that the
+  // apply reached the network FIRST and refused the switch afterwards — so this test hung for 30s
+  // against a server that is not there, and the operator's admin token had already been sent to a
+  // deployment we were always going to reject. The check now runs before that round trip.
+  test("deployment_connect refuses a second, different Chatwoot server", async () => {
     const r = await deploymentConnect(
       principal({ tenantId: tenantA }),
       {
-        base_url: "https://new.example.com",
+        base_url: "https://93.184.216.34",
+        admin_token: "cw-token",
+        dry_run: false,
+      },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain("different Chatwoot deployment");
+  });
+
+  // The refusal above is asked TWICE on purpose, and this is the second one. The early copy runs
+  // outside any transaction so it can save the credential round trip; a deployment created in the
+  // window between it and the write would slip past it, and only the copy inside the transaction
+  // still answers. Deleting that copy passes every other test in this file, which is why the race
+  // is driven here rather than assumed: the hook inserts the competing deployment after the early
+  // read has already come back empty.
+  test("a deployment created after the early check is still refused", async () => {
+    let reads = 0;
+    // NOTE: `$transaction` has to be wrapped, not just the delegate. Both reads go through
+    // `runScopedOn`, so they are issued on the TRANSACTION handle and a proxy on the client's own
+    // `chatwootDeployment` never sees either of them — it counts zero and the test passes for the
+    // wrong reason.
+    const wrap = (c: object): object =>
+      new Proxy(c, {
+        get(t, prop, recv) {
+          const inner = Reflect.get(t, prop, recv);
+          // `runScopedOn` calls `base.$extends(...)` FIRST and issues everything on the client
+          // that comes back, so a proxy that only wraps `$transaction` is bypassed entirely and
+          // silently — the counter stays at zero and the test passes for the wrong reason.
+          if (prop === "$extends") {
+            return (...a: unknown[]) =>
+              wrap(
+                (inner as (...x: unknown[]) => object).apply(t, a) as object,
+              );
+          }
+          if (prop === "$transaction") {
+            return (fn: (tx: unknown) => unknown, ...rest: unknown[]) =>
+              (inner as (...a: unknown[]) => unknown).call(
+                t,
+                (tx: unknown) => fn(wrap(tx as object)),
+                ...rest,
+              );
+          }
+          if (prop !== "chatwootDeployment") return inner;
+          return new Proxy(inner as object, {
+            get(d, k, r) {
+              const fn = Reflect.get(d, k, r);
+              if (k !== "findFirst") return fn;
+              return async (a: unknown) => {
+                const res = await (fn as (x: unknown) => Promise<unknown>).call(
+                  d,
+                  a,
+                );
+                // Only after the FIRST read — the one outside the transaction — and only once.
+                if (++reads === 1) {
+                  await suDb.chatwootDeployment.create({
+                    data: {
+                      tenantId: tenantB,
+                      baseUrl: "https://cw-raced.example.com",
+                      adminToken: encryptJson("tok"),
+                    },
+                  });
+                }
+                return res;
+              };
+            },
+          });
+        },
+      });
+    const racing = wrap(appDb as object) as typeof appDb;
+
+    // The CORE, not the tool: the race lives past the credential probe, and only the core takes a
+    // seam for it. Driving the tool would send this at a server that is not there and measure a
+    // 30-second timeout instead of the refusal.
+    const err = await connectChatwootDeployment(
+      { userId: 1n, tenantId: tenantB, role: "TENANT_ADMIN" },
+      { baseUrl: "https://93.184.216.34", adminToken: "cw-token" },
+      { fetchProfile: async () => ({ id: 1, accounts: [] }) },
+      racing,
+    ).catch((e: unknown) => e);
+    // BEFORE the assertions, not after. The row the hook inserted is this test's, not the
+    // fixture's, and leaving it makes tenantB look connected to every test that runs after — so a
+    // failure here would take an unrelated test down with it and hide which one actually broke.
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM chatwoot_deployments WHERE tenant_id = ${tenantB}`,
+    );
+    expect(reads).toBeGreaterThan(1);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("different Chatwoot deployment");
+  });
+
+  test("deployment_connect dry-run with a raw token previews, creates nothing", async () => {
+    // NOTE: tenantB, not tenantA. `tenantA` is seeded with a deployment at chat.example.com, so
+    // previewing a connect to a DIFFERENT server is a switch — which the preview now refuses the
+    // way the apply always did (#490). This test is about the token and the absent row, so it
+    // needs the tenant that has nothing connected.
+    const r = await deploymentConnect(
+      principal({ tenantId: tenantB }),
+      {
+        // NOTE: a public IP literal for the same reason as the gate test above — the preview
+        // resolves a hostname now, and this test is about the token and the absent row (#490).
+        base_url: "https://93.184.216.34",
         admin_token: "cw-token",
       },
       { base: appDb },
@@ -216,7 +323,7 @@ describe.skipIf(!dbUp)("MCP channel tools (DB)", () => {
     }
     // No deployment is created for the previewed base URL (the dry-run touches no DB).
     const count = await suDb.chatwootDeployment.count({
-      where: { tenantId: tenantA, baseUrl: "https://new.example.com" },
+      where: { tenantId: tenantB, baseUrl: "https://93.184.216.34" },
     });
     expect(count).toBe(0);
   });

--- a/tests/modules/mcp/dry-run-coherence.test.ts
+++ b/tests/modules/mcp/dry-run-coherence.test.ts
@@ -1,0 +1,1391 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import { AppError } from "@/lib/errors";
+import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
+import { buildMcpServer } from "@/modules/mcp/server";
+import * as writeRoot from "@/modules/mcp/write";
+import * as writeAgents from "@/modules/mcp/write-agents";
+import * as writeChannels from "@/modules/mcp/write-channels";
+import * as writeConversations from "@/modules/mcp/write-conversations";
+import * as writeDocuments from "@/modules/mcp/write-documents";
+import * as writeFleet from "@/modules/mcp/write-fleet";
+import * as writeKnowledge from "@/modules/mcp/write-knowledge";
+import * as writeSettings from "@/modules/mcp/write-settings";
+import * as writeWebhooks from "@/modules/mcp/write-webhooks";
+import { seedChatwootInstance, withRunNamespace } from "../../utils/chatwoot";
+
+// A write tool with `dry_run` answers its preview WITHOUT touching the core, and that shortcut is
+// what makes the preview cheap. It is also what makes every rule the core learns start out
+// unmirrored: the preview keeps answering `ok`, nobody notices, and the operator (or the model
+// driving MCP) reads a confident description of a write that cannot happen. Issue #490.
+//
+// Two things this harness learned the hard way, both worth keeping written down. It does NOT drive
+// the tools through the MCP client, tempting as that is: the server's handlers use `basePrisma`,
+// built at import time off `DATABASE_URL`, which `tests/setup.ts` deliberately points at a dead
+// database — so every apply "refused" with `Database 'test' does not exist` and eleven tools looked
+// broken that were not. And a refusal is not any failure: a thrown Prisma error is a CRASH, and
+// counting it as a refusal is what made that contamination invisible. `verdict` below separates the
+// three outcomes and the rows fail loudly on the third.
+//
+// The fence has two halves and needs both. The TABLE below gives every dry-run tool one input the
+// APPLY refuses; the first test derives the tool list from the live registry and fails when a tool
+// has no row, so a tool added later cannot join silently. The second drives both halves of each row
+// and requires them to agree — and requires the apply to have actually refused, because a row whose
+// apply succeeds proves nothing and would quietly become decoration.
+
+const NOPE = "999999999";
+
+// `skip` states, in writing, why a tool has no refusable input reachable from its arguments alone.
+// It is not an escape hatch for a row that is merely awkward: the reason has to be a property of the
+// tool, and the fence prints it.
+type Case = { args: Record<string, unknown>; why: string };
+// `also` carries the inputs a one-row-per-tool table cannot: a tool agrees on the row's input and
+// still diverges on another, and each of these was a real second divergence found after the row for
+// that tool was already green.
+type Row = (Case & { also?: Case[] }) | { skip: string };
+
+const TABLE: Record<string, Row> = {
+  agent_clone: {
+    args: { agent_id: NOPE, name: "x" },
+    why: "agent does not exist",
+  },
+  agent_create: {
+    args: { name: "" },
+    why: "empty name",
+    also: [
+      {
+        args: { name: "a", business_hours_id: "not-an-id" },
+        why: "business_hours_id is not a db id",
+      },
+    ],
+  },
+  agent_delete: { args: { agent_id: NOPE }, why: "agent does not exist" },
+  agent_import: { args: { export: {} }, why: "export bundle has no agent" },
+  agent_settings_set: {
+    args: { agent_id: NOPE, debounce: {} },
+    why: "agent does not exist",
+  },
+  agent_tools_set: {
+    args: { agent_id: NOPE, grants: [] },
+    why: "agent does not exist",
+  },
+  agent_update: {
+    args: { agent_id: NOPE, name: "x" },
+    why: "agent does not exist",
+  },
+  alert_channel_create: {
+    args: { name: "n", type: "webhook", url_ref: `vault:${NOPE}` },
+    why: "url_ref names no credential",
+  },
+  alert_channel_delete: {
+    args: { channel_id: NOPE },
+    why: "channel does not exist",
+  },
+  alert_channel_update: {
+    args: { channel_id: NOPE, name: "x" },
+    why: "channel does not exist",
+  },
+  api_key_revoke: { args: { api_key_id: NOPE }, why: "key does not exist" },
+  branding_asset_set: {
+    args: {
+      kind: "logo",
+      variant: "light",
+      content_base64: "!!not base64!!",
+      mime: "image/png",
+    },
+    why: "content is not base64",
+  },
+  branding_set: {
+    args: { brand_color: "not-a-hex" },
+    why: "brand_color is not #rrggbb",
+  },
+  business_hours_create: { args: { name: "" }, why: "empty name" },
+  business_hours_delete: {
+    args: { business_hours_id: NOPE },
+    why: "schedule does not exist",
+  },
+  business_hours_update: {
+    args: { business_hours_id: NOPE, name: "x" },
+    why: "schedule does not exist",
+  },
+  conversation_handoff: {
+    args: { conversation_id: NOPE },
+    why: "conversation does not exist",
+  },
+  conversation_reengage: {
+    args: { conversation_id: NOPE },
+    why: "conversation does not exist",
+  },
+  conversation_reply: {
+    args: { conversation_id: NOPE, content: "x" },
+    why: "conversation does not exist",
+  },
+  conversation_return: {
+    args: { conversation_id: NOPE },
+    why: "conversation does not exist",
+  },
+  conversation_status: {
+    args: { conversation_id: NOPE, status: "open" },
+    why: "conversation does not exist",
+  },
+  credential_create: {
+    args: { name: "c", kind: "not_a_kind" },
+    why: "kind is not in the catalog",
+  },
+  deployment_connect: {
+    args: { base_url: "not-a-url", admin_token: "t" },
+    why: "base_url is not a URL",
+  },
+  deployment_list_accounts: {
+    skip: "takes no arguments: every refusal it has is a property of the deployment, not of an input",
+  },
+  deployment_rotate_token: { args: { admin_token: "" }, why: "empty token" },
+  deployment_set_accounts: {
+    args: { account_ids: [999999999] },
+    why: "no Chatwoot deployment is connected",
+  },
+  document_template_create: { args: { name: "" }, why: "empty name" },
+  document_template_delete: {
+    args: { document_template_id: NOPE },
+    why: "template does not exist",
+  },
+  document_template_update: {
+    args: { document_template_id: NOPE, name: "x" },
+    why: "template does not exist",
+  },
+  experiment_create: {
+    args: { name: "e", agent_id: "abc", variants: [] },
+    why: "agent_id is not a number",
+  },
+  experiment_delete: {
+    args: { experiment_id: NOPE },
+    why: "experiment does not exist",
+  },
+  experiment_update: {
+    args: { experiment_id: NOPE, name: "x" },
+    why: "experiment does not exist",
+  },
+  inbox_bind: { args: { inbox_id: NOPE }, why: "inbox does not exist" },
+  inbox_reconcile: {
+    skip: "takes no arguments: every refusal it has is a property of the deployment, not of an input",
+  },
+  inbox_reconnect: { args: { inbox_id: NOPE }, why: "inbox does not exist" },
+  inbox_remove: { args: { inbox_id: NOPE }, why: "inbox does not exist" },
+  instance_disconnect: {
+    args: { instance_id: NOPE },
+    why: "instance does not exist",
+  },
+  instance_sync_inboxes: {
+    args: { instance_id: NOPE },
+    why: "instance does not exist",
+  },
+  integration_create: {
+    args: { catalog_type: "not_a_provider", name: "n" },
+    why: "provider is not in the catalog",
+  },
+  integration_delete: {
+    args: { integration_id: NOPE },
+    why: "instance does not exist",
+  },
+  integration_update: {
+    args: { integration_id: NOPE, name: "x" },
+    why: "instance does not exist",
+  },
+  knowledge_approve: {
+    args: { approval_id: "abc" },
+    why: "approval_id is not a number",
+  },
+  knowledge_create: {
+    // NOTE: a NUL, because this core refuses almost nothing else about a create — an empty name, a
+    // 5000-character name and a chunk_size of 99999999 all APPLY. That leniency is its own issue.
+    args: { name: "a\u0000b" },
+    why: "the column cannot store a NUL",
+  },
+  knowledge_delete: {
+    args: { knowledge_base_id: NOPE },
+    why: "base does not exist",
+  },
+  knowledge_document_create: {
+    args: { knowledge_base_id: NOPE, title: "t", text: "x" },
+    why: "base does not exist",
+  },
+  knowledge_document_delete: {
+    args: { document_id: NOPE },
+    why: "document does not exist",
+  },
+  knowledge_document_retry: {
+    args: { document_id: NOPE },
+    why: "document does not exist",
+  },
+  knowledge_edit: {
+    args: { approval_id: "abc", title: "t" },
+    why: "approval_id is not a number",
+  },
+  knowledge_reindex: {
+    args: { knowledge_base_id: NOPE },
+    why: "base does not exist",
+  },
+  knowledge_reject: {
+    args: { approval_id: "abc" },
+    why: "approval_id is not a number",
+  },
+  knowledge_update: {
+    args: { knowledge_base_id: NOPE, name: "x" },
+    why: "base does not exist",
+  },
+  langfuse_connect: {
+    args: { public_key: "pk", secret_key: "sk", base_url: "not-a-url" },
+    why: "base_url is not a URL",
+    also: [
+      {
+        // NOTE: whitespace normalizes to the empty string WITHOUT raising, and `langfuse` is a kind
+        // that requires a base URL — so the verdict is the validator's return, not its throwing.
+        args: { public_key: "pk", secret_key: "sk", base_url: "   " },
+        why: "base_url normalizes to empty, and langfuse requires one",
+      },
+    ],
+  },
+  mcp_connection_create: {
+    args: { name: "n", transport: "streamableHttp" },
+    why: "a network transport with no url",
+  },
+  mcp_connection_delete: {
+    args: { connection_id: NOPE },
+    why: "connection does not exist",
+  },
+  mcp_connection_update: {
+    args: { connection_id: NOPE, name: "x" },
+    why: "connection does not exist",
+  },
+  prompt_set: {
+    args: { agent_id: NOPE, system_prompt: "x" },
+    why: "agent does not exist",
+  },
+  tenant_create: { args: { name: "n", slug: "" }, why: "empty slug" },
+  tenant_settings_update: {
+    args: { embedding: { credential_ref: `vault:${NOPE}` } },
+    why: "credential_ref names no credential",
+  },
+  tenant_update: { args: { name: "" }, why: "empty name" },
+  tool_create: {
+    // NOTE: the NAME, not the URL and not the method. `createToolDefinition` never validates
+    // `url_template`, so "not-a-url" is stored and both halves say ok; and the method IS an enum on
+    // the published schema, so "PURGE" is a row the transport could never deliver. Measured.
+    args: {
+      name: "not a valid name!",
+      url_template: "https://example.com/x",
+      allowed_hosts: ["example.com"],
+    },
+    why: "name is not [A-Za-z0-9_-]{1,64}",
+  },
+  tool_delete: { args: { tool_id: NOPE }, why: "tool does not exist" },
+  tool_update: {
+    args: { tool_id: NOPE, name: "x" },
+    why: "tool does not exist",
+  },
+  webhook_create: {
+    args: { url: "not-a-url", events: ["message.created"] },
+    why: "url is not a URL",
+  },
+  webhook_delete: {
+    args: { webhook_id: NOPE },
+    why: "subscription does not exist",
+  },
+  webhook_delivery_requeue: {
+    args: { delivery_id: NOPE },
+    why: "delivery does not exist",
+  },
+  webhook_update: {
+    // NOTE: a literal IP, not a hostname. The preview now vets this URL the way the write does, and
+    // for a hostname that means a DNS lookup — which would make this row measure the resolver.
+    args: { webhook_id: NOPE, url: "https://93.184.216.34/hook" },
+    why: "subscription does not exist",
+  },
+};
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+afterAll(async () => {
+  await su?.$disconnect();
+  await app?.$disconnect();
+});
+
+const suDb = su as PrismaClient;
+const appDb = app as PrismaClient;
+
+// The dispatch, DERIVED rather than authored: every tool name is its function name in snake case,
+// with no exceptions across all 66 — so the lookup is the mapping, and a tool whose function this
+// cannot resolve fails the coverage test below instead of silently going unexercised.
+type WriteFn = (
+  principal: VerifiedToken,
+  args: Record<string, unknown>,
+  deps: { base: PrismaClient },
+) => Promise<{ ok: boolean }>;
+
+const FNS = {
+  ...writeAgents,
+  ...writeChannels,
+  ...writeConversations,
+  ...writeDocuments,
+  ...writeFleet,
+  ...writeKnowledge,
+  ...writeSettings,
+  ...writeWebhooks,
+  ...writeRoot,
+} as unknown as Record<string, WriteFn | undefined>;
+
+const camel = (snake: string): string =>
+  snake.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+
+const fnFor = (tool: string): WriteFn | undefined => {
+  const f = FNS[camel(tool)];
+  return typeof f === "function" ? f : undefined;
+};
+
+// The three outcomes, kept apart. `refused` is the tool saying no on purpose — a falsy `ok` on the
+// WriteResult, or a 4xx `AppError`. Anything else thrown is a CRASH: the tool did not answer, and a
+// row that reads a crash as a refusal measures the harness instead of the tool.
+type Verdict = "ok" | "refused" | "crash";
+
+async function verdict(run: () => Promise<{ ok: boolean }>): Promise<Verdict> {
+  try {
+    return (await run()).ok ? "ok" : "refused";
+  } catch (e) {
+    if (e instanceof AppError && e.statusCode >= 400 && e.statusCode < 500) {
+      return "refused";
+    }
+    return "crash";
+  }
+}
+
+// The registry is the source: a tool that publishes `dry_run` is a tool this fence covers, whether
+// or not anyone remembered to add a row. Read under BOTH principals, because the fleet tier
+// (`mcp:admin`) registers eight the tenant tier never sees.
+const TENANT_SCOPES = ["mcp:read", "mcp:write"];
+const FLEET_SCOPES = ["mcp:read", "mcp:write", "mcp:admin"];
+
+// The published schema of one tool, as much of JSON Schema as the registry actually emits.
+interface JsonSchema {
+  type?: string;
+  enum?: unknown[];
+  anyOf?: JsonSchema[];
+  items?: JsonSchema;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+}
+
+async function publishedDryRunTools(): Promise<{
+  all: string[];
+  fleetOnly: Set<string>;
+  schemas: Map<string, JsonSchema>;
+}> {
+  const seen = new Map<string, Set<string>>();
+  // Tenant tier first, then fleet, and the FIRST wins: a tenant-scoped tool published to both tiers
+  // is exercised by the fence under the tenant principal, and only that tier's schema describes the
+  // arguments it will get (the fleet one carries the wrapper's extra `tenant`).
+  const schemas = new Map<string, JsonSchema>();
+  for (const [tier, over] of [
+    ["tenant", { role: "TENANT_ADMIN", scopes: TENANT_SCOPES }],
+    ["fleet", { role: "SUPER_ADMIN", scopes: FLEET_SCOPES }],
+  ] as const) {
+    const server = buildMcpServer({
+      userId: 1n,
+      tenantId: 1n,
+      clientId: "c",
+      jti: "j",
+      ...over,
+    } as VerifiedToken);
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    const client = new Client({ name: "fence", version: "0" });
+    await client.connect(ct);
+    const published = (await client.listTools()).tools.filter((t) => {
+      const props = (t.inputSchema as JsonSchema).properties;
+      return !!props && "dry_run" in props;
+    });
+    for (const t of published) {
+      if (!schemas.has(t.name))
+        schemas.set(t.name, t.inputSchema as JsonSchema);
+    }
+    seen.set(tier, new Set(published.map((t) => t.name)));
+    await client.close();
+  }
+  const tenant = seen.get("tenant") ?? new Set<string>();
+  const fleet = seen.get("fleet") ?? new Set<string>();
+  const all = [...new Set([...tenant, ...fleet])].sort();
+  return {
+    all,
+    fleetOnly: new Set(all.filter((t) => !tenant.has(t))),
+    schemas,
+  };
+}
+
+// Does this value fit what the registry says the argument is? Enough of JSON Schema to judge the
+// shapes the registry emits (type, enum, anyOf, array items), and no more.
+function fits(value: unknown, schema: JsonSchema): boolean {
+  if (schema.anyOf) return schema.anyOf.some((s) => fits(value, s));
+  if (schema.enum && !schema.enum.includes(value)) return false;
+  switch (schema.type) {
+    case undefined:
+      return true;
+    case "null":
+      return value === null;
+    case "string":
+      return typeof value === "string";
+    case "boolean":
+      return typeof value === "boolean";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "array":
+      return (
+        Array.isArray(value) &&
+        (!schema.items ||
+          value.every((v) => fits(v, schema.items as JsonSchema)))
+      );
+    case "object": {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return false;
+      }
+      // A nested block with DECLARED properties is judged like the top level: an undeclared key
+      // there is the same artifact, one level down, and that is exactly where the first one hid
+      // (`embedding: { credentialRef }` against a block publishing `credential_ref`). A block with
+      // no `properties` is free-form by design (tool headers, a body) and passes.
+      const nested = schema.properties;
+      if (!nested) return true;
+      return Object.entries(value as Record<string, unknown>).every(
+        ([k, v]) => !!nested[k] && fits(v, nested[k] as JsonSchema),
+      );
+    }
+    default:
+      return true;
+  }
+}
+
+// Why a row's arguments could never reach the tool it claims to measure. The fence dispatches
+// DIRECTLY, past the registry's own input schema, which buys it a live database and costs it this:
+// an argument the schema would have rejected exercises a path the transport has no way to produce,
+// and the row reads as a divergence that no client can hit. Three of the first thirteen failures
+// were exactly that — `account_ids: ["not-a-number"]` against `z.array(z.number().int())`, a
+// `method` outside its enum, and `credentialRef` where the tool publishes `credential_ref`.
+function schemaComplaints(
+  args: Record<string, unknown>,
+  schema: JsonSchema,
+): string[] {
+  const props = schema.properties ?? {};
+  const out: string[] = [];
+  for (const [key, value] of Object.entries(args)) {
+    const prop = props[key];
+    if (!prop) {
+      out.push(`${key}: not a published argument`);
+      continue;
+    }
+    if (!fits(value, prop)) {
+      out.push(`${key}: ${JSON.stringify(value)} does not fit the schema`);
+    }
+  }
+  for (const key of schema.required ?? []) {
+    // `tenant` is the wrapper's, resolved into the principal before the handler runs, so a direct
+    // dispatch supplies it by choosing the principal rather than by naming it.
+    if (key === "tenant" || key in args) continue;
+    out.push(`${key}: required and missing`);
+  }
+  return out;
+}
+
+describe.skipIf(!dbUp)(
+  "every dry-run tool previews what it would apply",
+  () => {
+    let tenantId = 0n;
+    let fleetOnly = new Set<string>();
+
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "DryRunFence", slug: `dryfence-${process.pid}` },
+      });
+      tenantId = t.id;
+      fleetOnly = (await publishedDryRunTools()).fleetOnly;
+    });
+
+    afterAll(async () => {
+      if (su && tenantId) {
+        await su.$executeRawUnsafe(
+          `DELETE FROM vault_entries WHERE tenant_id = ${tenantId}`,
+        );
+        await su.$executeRawUnsafe(
+          `DELETE FROM tenants WHERE id = ${tenantId}`,
+        );
+      }
+    });
+
+    const principalFor = (tool: string): VerifiedToken =>
+      ({
+        userId: 1n,
+        tenantId,
+        clientId: "c",
+        jti: "j",
+        ...(fleetOnly.has(tool)
+          ? { role: "SUPER_ADMIN", scopes: FLEET_SCOPES }
+          : { role: "TENANT_ADMIN", scopes: TENANT_SCOPES }),
+      }) as VerifiedToken;
+
+    test("the table and the dispatch cover exactly what the registry publishes", async () => {
+      const { all } = await publishedDryRunTools();
+      expect(all.filter((t) => !TABLE[t])).toEqual([]);
+      expect(Object.keys(TABLE).filter((t) => !all.includes(t))).toEqual([]);
+      expect(all.filter((t) => !fnFor(t))).toEqual([]);
+    });
+
+    test("every row's arguments are ones the registry would actually deliver", async () => {
+      const { schemas } = await publishedDryRunTools();
+      const bad: Record<string, string[]> = {};
+      for (const [name, row] of Object.entries(TABLE)) {
+        if ("skip" in row) continue;
+        const schema = schemas.get(name);
+        if (!schema) continue;
+        const complaints = [row, ...(row.also ?? [])].flatMap((c) =>
+          schemaComplaints(c.args, schema),
+        );
+        if (complaints.length > 0) bad[name] = complaints;
+      }
+      expect(bad).toEqual({});
+    });
+
+    for (const [name, row] of Object.entries(TABLE)) {
+      if ("skip" in row) {
+        test.skip(`${name} — ${row.skip}`, () => {});
+        continue;
+      }
+      test(`${name}: preview and apply agree (${row.why})`, async () => {
+        const fn = fnFor(name) as WriteFn;
+        const p = principalFor(name);
+        for (const extra of row.also ?? []) {
+          const label = `${name} (${extra.why})`;
+          expect({
+            row: label,
+            applied: await verdict(() =>
+              fn(p, { ...extra.args, dry_run: false }, { base: appDb }),
+            ),
+          }).toEqual({ row: label, applied: "refused" });
+          expect({
+            row: label,
+            previewed: await verdict(() =>
+              fn(p, { ...extra.args }, { base: appDb }),
+            ),
+          }).toEqual({ row: label, previewed: "refused" });
+        }
+        // NOTE: the control, and it runs first on purpose. A row whose apply SUCCEEDS has nothing to
+        // disagree about — the comparison below would pass forever measuring nothing, and the row
+        // would have created a real record getting there. A row that CRASHES is worse: it is the
+        // harness failing, dressed as the tool refusing.
+        const applied = await verdict(() =>
+          fn(p, { ...row.args, dry_run: false }, { base: appDb }),
+        );
+        expect({ row: name, applied }).toEqual({
+          row: name,
+          applied: "refused",
+        });
+        const previewed = await verdict(() =>
+          fn(p, { ...row.args }, { base: appDb }),
+        );
+        expect({ row: name, previewed }).toEqual({
+          row: name,
+          previewed: "refused",
+        });
+      });
+    }
+  },
+);
+
+// ── The same rule, asked of one input the row-per-tool table above cannot reach ──────────────────
+//
+// The fence gives every tool ONE refusable input, which is a floor and not a proof: a tool can agree
+// on that input and still diverge on another. This is the second one worth naming, because it is a
+// CLASS rather than a tool — a caller-supplied outbound URL, vetted by the core through
+// `assertSafeOutboundUrl` after the preview has already approved it.
+//
+// It was found by measuring a sentence in the PR body that had no number behind it ("the SSRF check
+// stays on the apply — it is a call, not a judgement about the arguments"). It is both: with the
+// guard armed, `http://127.0.0.1:9/` is refused on the PROTOCOL, before any lookup, and the preview
+// was approving exactly that. Four tools reach the check; `mcp_connection_create` was the only one
+// already covered, by the assert extracted for its own row.
+// Two of them, and the pair is the point. The first fails on the PROTOCOL, with no lookup involved;
+// the second fails on where the NAME points, which no amount of reading the string can tell you.
+// Skipping the resolution — which is what an earlier round of this PR did, to avoid a doubled lookup
+// on the apply — closes the first gap and leaves the second wide open, and `https://localhost` is a
+// URL an operator types by accident constantly. The doubled lookup was the wrong thing to fix: the
+// preflight lives inside the preview branch, so an apply never reaches it at all.
+const BLOCKED_URLS = {
+  protocol: "http://127.0.0.1:9/hook",
+  resolution: "https://localhost/hook",
+} as const;
+
+describe.skipIf(!dbUp)("a preview vets the outbound URL its apply vets", () => {
+  let tenantId = 0n;
+  let webhookId = "";
+  let connectionId = "";
+
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "SsrfFence", slug: `ssrffence-${process.pid}` },
+    });
+    tenantId = t.id;
+    // Seeded through Prisma rather than through the create tools: the row only has to EXIST, and
+    // going through the tools would make this fence depend on their apply paths working.
+    const hook = await suDb.webhookSubscription.create({
+      data: {
+        tenantId,
+        url: "https://example.com/hook",
+        events: ["heartbeat"],
+      },
+    });
+    webhookId = String(hook.id);
+    const conn = await suDb.mcpServerConnection.create({
+      data: {
+        tenantId,
+        name: "ssrf-fence",
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+      },
+    });
+    connectionId = String(conn.id);
+  });
+
+  afterAll(async () => {
+    if (su && tenantId) {
+      await su.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+    }
+  });
+
+  const principal = (admin: boolean): VerifiedToken =>
+    ({
+      userId: 1n,
+      tenantId,
+      clientId: "c",
+      jti: "j",
+      ...(admin
+        ? { role: "SUPER_ADMIN", scopes: FLEET_SCOPES }
+        : { role: "TENANT_ADMIN", scopes: TENANT_SCOPES }),
+    }) as VerifiedToken;
+
+  const ROWS: {
+    tool: string;
+    admin: boolean;
+    args: (url: string) => Record<string, unknown>;
+  }[] = [
+    {
+      tool: "deployment_connect",
+      admin: true,
+      args: (url) => ({ base_url: url, admin_token: "t" }),
+    },
+    {
+      tool: "webhook_create",
+      admin: false,
+      args: (url) => ({ url, events: ["heartbeat"] }),
+    },
+    {
+      tool: "webhook_update",
+      admin: false,
+      args: (url) => ({ webhook_id: webhookId, url }),
+    },
+    {
+      tool: "mcp_connection_create",
+      admin: false,
+      args: (url) => ({ name: "x", transport: "streamableHttp", url }),
+    },
+    {
+      tool: "mcp_connection_update",
+      admin: false,
+      args: (url) => ({ connection_id: connectionId, url }),
+    },
+  ];
+
+  for (const row of ROWS) {
+    for (const [why, url] of Object.entries(BLOCKED_URLS)) {
+      test(`${row.tool}: a URL blocked by ${why} is refused by both halves`, async () => {
+        const fn = fnFor(row.tool) as WriteFn;
+        const p = principal(row.admin);
+        const label = `${row.tool}/${why}`;
+        const applied = await verdict(() =>
+          fn(p, { ...row.args(url), dry_run: false }, { base: appDb }),
+        );
+        expect({ row: label, applied }).toEqual({
+          row: label,
+          applied: "refused",
+        });
+        const previewed = await verdict(() =>
+          fn(p, { ...row.args(url) }, { base: appDb }),
+        );
+        expect({ row: label, previewed }).toEqual({
+          row: label,
+          previewed: "refused",
+        });
+      });
+    }
+  }
+});
+
+// ── The other way a row can be green while the tool diverges ─────────────────────────────────────
+//
+// A row gives its tool ONE refusable input, so it certifies the preflight exists — not that the
+// preflight covers everything its core decides. `deployment_set_accounts` is the measured case: its
+// row passes no deployment at all, and stayed green while a preview handed an account ANOTHER tenant
+// owns answered "will connect" and the apply answered "already connected to another tenant". The
+// preflight had half of `setConnectedAccounts`'s judgement, and half reads exactly like all of it.
+describe.skipIf(!dbUp)("a preflight covers its core's whole judgement", () => {
+  let mine = 0n;
+  let theirs = 0n;
+  const TAKEN_ACCOUNT = 4242;
+  const SERVER = "https://cw.claimfence.local";
+
+  beforeAll(async () => {
+    const a = await suDb.tenant.create({
+      data: { name: "ClaimA", slug: `claim-a-${process.pid}` },
+    });
+    mine = a.id;
+    const b = await suDb.tenant.create({
+      data: { name: "ClaimB", slug: `claim-b-${process.pid}` },
+    });
+    theirs = b.id;
+    // The other tenant already owns the account, on the same Chatwoot server.
+    await seedChatwootInstance(suDb, {
+      tenantId: theirs,
+      baseUrl: SERVER,
+      accountId: TAKEN_ACCOUNT,
+      adminToken: encryptJson("tok"),
+    });
+    await suDb.chatwootDeployment.create({
+      data: {
+        tenantId: mine,
+        baseUrl: withRunNamespace(SERVER),
+        adminToken: encryptJson("tok"),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    for (const id of [mine, theirs]) {
+      if (!su || !id) continue;
+      await su.$executeRawUnsafe(
+        `DELETE FROM chatwoot_instances WHERE tenant_id = ${id}`,
+      );
+      await su.$executeRawUnsafe(
+        `DELETE FROM chatwoot_deployments WHERE tenant_id = ${id}`,
+      );
+      await su.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${id}`);
+    }
+  });
+
+  test("deployment_set_accounts: an account another tenant owns", async () => {
+    const p = {
+      userId: 1n,
+      tenantId: mine,
+      clientId: "c",
+      jti: "j",
+      role: "SUPER_ADMIN",
+      scopes: FLEET_SCOPES,
+    } as VerifiedToken;
+    // The taken account is NOT first. A batched claim check that only ever looks at the head of the
+    // array answers "will connect" here, and the one-query rewrite is exactly the kind of change
+    // that can introduce that without any single-account test noticing.
+    const args = { account_ids: [9001, TAKEN_ACCOUNT] };
+    const applied = await verdict(() =>
+      writeChannels.deploymentSetAccounts(
+        p,
+        { ...args, dry_run: false },
+        { base: appDb },
+      ),
+    );
+    expect(applied).toBe("refused");
+    const previewed = await verdict(() =>
+      writeChannels.deploymentSetAccounts(p, { ...args }, { base: appDb }),
+    );
+    expect(previewed).toBe("refused");
+  });
+
+  // The cost of the answer, not just the answer. `account_ids` is an uncapped array on the
+  // published schema, so a claim check that asks per account opens one privileged transaction per
+  // element — and the PREVIEW pays it, before the apply pays it again. The assertion is a shape,
+  // not a magic number: whatever the preview spends on one account, it spends on twenty-five.
+  test("deployment_set_accounts: the claim check does not scale with the array", async () => {
+    const p = {
+      userId: 1n,
+      tenantId: mine,
+      clientId: "c",
+      jti: "j",
+      role: "SUPER_ADMIN",
+      scopes: FLEET_SCOPES,
+    } as VerifiedToken;
+
+    let transactions = 0;
+    let claimQueries = 0;
+    // `$extends` too: `runScopedOn` calls it and issues everything on the client that comes back,
+    // so a proxy that only wraps `$transaction` counts the outer call and none of the queries.
+    const wrap = (c: object): object =>
+      new Proxy(c, {
+        get(t, prop, recv) {
+          const inner = Reflect.get(t, prop, recv);
+          if (prop === "$extends") {
+            return (...a: unknown[]) =>
+              wrap((inner as (...x: unknown[]) => object).apply(t, a));
+          }
+          if (prop === "$transaction") {
+            return (fn: (tx: unknown) => unknown, ...rest: unknown[]) => {
+              transactions += 1;
+              return (inner as (...a: unknown[]) => unknown).call(
+                t,
+                (tx: unknown) => fn(wrap(tx as object)),
+                ...rest,
+              );
+            };
+          }
+          if (prop !== "chatwootInstance") return inner;
+          return new Proxy(inner as object, {
+            get(d, k, r) {
+              const fn = Reflect.get(d, k, r);
+              if (k !== "findFirst") return fn;
+              return (...a: unknown[]) => {
+                claimQueries += 1;
+                return (fn as (...x: unknown[]) => unknown).apply(d, a);
+              };
+            },
+          });
+        },
+      });
+    const counting = wrap(appDb as object) as typeof appDb;
+
+    // Both axes come back, because they fail differently and one hides the other: a query too WIDE
+    // does not spend an extra transaction, it raises — and a count-only assertion reads that as
+    // success.
+    const spend = async (accountIds: number[]) => {
+      transactions = 0;
+      claimQueries = 0;
+      const outcome = await verdict(() =>
+        writeChannels.deploymentSetAccounts(
+          p,
+          { account_ids: accountIds },
+          { base: counting },
+        ),
+      );
+      return { transactions, claimQueries, outcome };
+    };
+
+    // Free account ids, so neither run is short-circuited by the cross-tenant refusal above.
+    const one = await spend([9001]);
+    const many = await spend(Array.from({ length: 25 }, (_, i) => 9100 + i));
+    expect(one.transactions).toBeGreaterThan(0);
+    expect(many.transactions).toBe(one.transactions);
+
+    // And the other axis, which the assertion above cannot see: each id is a BIND PARAMETER, and
+    // Postgres takes at most 32767. Measured before the chunking, 32760 ids answered in 56ms and
+    // 32770 raised "The query parameter limit supported by your database is exceeded" — a CRASH,
+    // not a refusal, on input the published schema accepts, and on the preview as much as on the
+    // apply. Still one privileged transaction: the chunks share it.
+    const huge = await spend(
+      Array.from({ length: 40_000 }, (_, i) => 20_000 + i),
+    );
+    expect(huge.outcome).not.toBe("crash");
+    expect(huge.transactions).toBe(one.transactions);
+    // And the chunk cannot be shrunk to dodge the ceiling one id at a time: that is the per-element
+    // query this function was written to remove, divided by nothing. 40k ids at 1000 per chunk is
+    // 40 queries; the bound is generous so it pins the SHAPE, not the constant.
+    expect(huge.claimQueries).toBeLessThan(100);
+  });
+});
+
+// The class the TABLE structurally cannot reach: a divergence that depends on what is ALREADY IN
+// THE DATABASE. Every row above passes an input bad on its face, so it needs no fixture; a name
+// already taken is bad only relative to a row that exists, and the row has to be created first.
+// Measured before it was fixed: all four previewed `ok` while their applies refused.
+//
+// These four preflights are ADVISORY and the distinction is the point. The rest of this fence
+// covers questions whose answer cannot change between preview and apply, so a preview that agrees
+// agrees forever. Uniqueness is not one of those: someone can take the name in the gap, and then
+// the preview was right when it spoke and wrong when the apply ran. That residue is deliberate and
+// is not what these tests pin — they pin the case that actually happens, an operator reusing a name
+// they already used, which before this went out as "will create".
+describe.skipIf(!dbUp)("a preview asks the questions that need a row", () => {
+  let tenantId = 0n;
+  const TAKEN = `dupfence-${process.pid}`;
+
+  const principal = () =>
+    ({
+      userId: 1n,
+      tenantId,
+      clientId: "c",
+      jti: "j",
+      role: "SUPER_ADMIN",
+      scopes: FLEET_SCOPES,
+    }) as VerifiedToken;
+
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "DupFence", slug: TAKEN },
+    });
+    tenantId = t.id;
+    await suDb.toolDefinition.create({
+      data: {
+        tenantId,
+        name: TAKEN,
+        label: "taken",
+        urlTemplate: "https://example.com/x",
+        allowedHosts: ["example.com"],
+      },
+    });
+    await suDb.mcpServerConnection.create({
+      data: {
+        tenantId,
+        name: TAKEN,
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+      },
+    });
+    await suDb.vaultEntry.create({
+      data: {
+        tenantId,
+        name: TAKEN,
+        kind: "generic",
+        secret: encryptJson("s"),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    if (!su || !tenantId) return;
+    for (const table of [
+      "tool_definitions",
+      "mcp_server_connections",
+      "vault_entries",
+    ]) {
+      await su.$executeRawUnsafe(
+        `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+      );
+    }
+    await su.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+  });
+
+  const both = async (
+    run: (args: Record<string, unknown>) => Promise<{ ok: boolean }>,
+    args: Record<string, unknown>,
+  ) => ({
+    applied: await verdict(() => run({ ...args, dry_run: false })),
+    previewed: await verdict(() => run({ ...args })),
+  });
+
+  test("tenant_create: a slug another tenant already has", async () => {
+    const r = await both(
+      (a) => writeFleet.tenantCreate(principal(), a as never, { base: appDb }),
+      { name: "dup", slug: TAKEN },
+    );
+    expect(r.applied).toBe("refused");
+    expect(r.previewed).toBe("refused");
+  });
+
+  test("tool_create: a name this tenant already used", async () => {
+    const r = await both(
+      (a) => writeAgents.toolCreate(principal(), a as never, { base: appDb }),
+      {
+        name: TAKEN,
+        label: "dup",
+        url_template: "https://example.com/x",
+        allowed_hosts: ["example.com"],
+      },
+    );
+    expect(r.applied).toBe("refused");
+    expect(r.previewed).toBe("refused");
+  });
+
+  test("mcp_connection_create: a name this tenant already used", async () => {
+    const r = await both(
+      (a) =>
+        writeAgents.mcpConnectionCreate(principal(), a as never, {
+          base: appDb,
+        }),
+      {
+        name: TAKEN,
+        transport: "streamableHttp",
+        url: "https://example.com/mcp",
+      },
+    );
+    expect(r.applied).toBe("refused");
+    expect(r.previewed).toBe("refused");
+  });
+
+  test("credential_create: a (name, kind) pair this tenant already used", async () => {
+    const r = await both(
+      (a) =>
+        writeRoot.credentialCreate(principal(), a as never, { base: appDb }),
+      { name: TAKEN },
+    );
+    expect(r.applied).toBe("refused");
+    expect(r.previewed).toBe("refused");
+  });
+
+  // The normalization the advisory check depends on, and the reason it takes the NORMALIZED pair.
+  // `kind` defaults to "generic" on the way in, and the uniqueness is on what gets STORED — so a
+  // preview that looked the pair up with the raw `kind: null` would find nothing and answer "will
+  // create" for the exact name it just refused above.
+  test("credential_create: the default kind is the one the lookup uses", async () => {
+    const r = await both(
+      (a) =>
+        writeRoot.credentialCreate(principal(), a as never, { base: appDb }),
+      { name: TAKEN, kind: "generic" },
+    );
+    expect(r.applied).toBe("refused");
+    expect(r.previewed).toBe("refused");
+  });
+});
+
+// Round 6 of review, four findings, all four measured and all four real — and all four the SAME
+// shape as `deployment_set_accounts` above: a preflight that answered part of what its core decides.
+// The class is worth a block of its own because it does not announce itself: a tool with a
+// preflight looks covered, and the fence's row for it stays green as long as the row happens to
+// trip the part that IS covered.
+describe.skipIf(!dbUp)(
+  "a preflight answers all of its core, not the easy half",
+  () => {
+    let tenantId = 0n;
+    let otherConnId = 0n;
+    const TAKEN = `r6-${process.pid}`;
+
+    const principal = () =>
+      ({
+        userId: 1n,
+        tenantId,
+        clientId: "c",
+        jti: "j",
+        role: "SUPER_ADMIN",
+        scopes: FLEET_SCOPES,
+      }) as VerifiedToken;
+
+    const both = async (
+      run: (args: Record<string, unknown>) => Promise<{ ok: boolean }>,
+      args: Record<string, unknown>,
+    ) => ({
+      applied: await verdict(() => run({ ...args, dry_run: false })),
+      previewed: await verdict(() => run({ ...args })),
+    });
+
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "R6", slug: `r6-fence-${process.pid}` },
+      });
+      tenantId = t.id;
+      await suDb.mcpServerConnection.create({
+        data: {
+          tenantId,
+          name: TAKEN,
+          transport: "streamableHttp",
+          url: "https://example.com/a",
+        },
+      });
+      const other = await suDb.mcpServerConnection.create({
+        data: {
+          tenantId,
+          name: `${TAKEN}-other`,
+          transport: "streamableHttp",
+          url: "https://example.com/b",
+        },
+      });
+      otherConnId = other.id;
+      await suDb.chatwootDeployment.create({
+        data: {
+          tenantId,
+          baseUrl: withRunNamespace("https://cw-one.example.com"),
+          adminToken: encryptJson("tok"),
+        },
+      });
+    });
+
+    afterAll(async () => {
+      if (!su || !tenantId) return;
+      for (const table of [
+        "mcp_server_connections",
+        "chatwoot_deployments",
+        "agents",
+        "webhook_subscriptions",
+      ]) {
+        await su.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await su.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+    });
+
+    // ADVISORY. `assertAgentCreatable` already PARSES both schedule ids and hands them back; what it
+    // cannot say is whether the row exists, which is a read.
+    test("agent_create: a well-formed business_hours_id naming no row", async () => {
+      const r = await both(
+        (a) =>
+          writeAgents.agentCreate(principal(), a as never, { base: appDb }),
+        { name: "a", business_hours_id: NOPE },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    test("agent_create: the same hole on follow_up_hours_id", async () => {
+      const r = await both(
+        (a) =>
+          writeAgents.agentCreate(principal(), a as never, { base: appDb }),
+        { name: "a", follow_up_hours_id: NOPE },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    // The UPDATE side of the uniqueness class. It needs `exceptId`, and the test below it is what
+    // keeps that from being answered by refusing every rename.
+    test("mcp_connection_update: renaming onto a name already used", async () => {
+      const r = await both(
+        (a) =>
+          writeAgents.mcpConnectionUpdate(principal(), a as never, {
+            base: appDb,
+          }),
+        { connection_id: String(otherConnId), name: TAKEN },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    // The inverse divergence, which is just as wrong and is what `exceptId` exists for: a connection
+    // keeping its own name is not a collision. Without this, "refuse every rename" passes the test
+    // above and breaks every real rename.
+    test("mcp_connection_update: a connection keeping its own name is not a collision", async () => {
+      const previewed = await verdict(() =>
+        writeAgents.mcpConnectionUpdate(
+          principal(),
+          {
+            connection_id: String(otherConnId),
+            name: `${TAKEN}-other`,
+            url: "https://example.com/b2",
+          } as never,
+          { base: appDb },
+        ),
+      );
+      expect(previewed).toBe("ok");
+    });
+
+    // The preflight here asked only whether the URL was safe, and the schema asks two more things.
+    test("webhook_create: an empty events array with a safe url", async () => {
+      const r = await both(
+        (a) =>
+          writeWebhooks.webhookCreate(principal(), a as never, { base: appDb }),
+        { url: "https://example.com/hook", events: [] },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    test("webhook_update: the same hole on the patch", async () => {
+      const hook = await suDb.webhookSubscription.create({
+        data: {
+          tenantId,
+          url: "https://example.com/hook",
+          events: ["conversation.created"],
+        },
+      });
+      const r = await both(
+        (a) =>
+          writeWebhooks.webhookUpdate(principal(), a as never, { base: appDb }),
+        { webhook_id: String(hook.id), events: [] },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    // Round 7, same class again — and the reason this block keeps growing is that "the tool has a
+    // preflight" is not the property that matters. `agent_create` had TWO by this point and still
+    // approved a credential the apply refuses.
+    test("agent_create: a credentialRef whose KIND cannot serve the field", async () => {
+      const oauth = await suDb.vaultEntry.create({
+        data: {
+          tenantId,
+          name: `oauth-${process.pid}`,
+          kind: "google_oauth",
+          secret: encryptJson({ clientId: "a", clientSecret: "b" }),
+        },
+      });
+      // NOTE: a COMPLETE model config. The first cut passed `{ credentialRef }` alone, which the
+      // schema refuses on its own shape — so both halves said no and the row measured nothing, the
+      // same artifact the schema-conformance guard catches for table rows.
+      const r = await both(
+        (a) =>
+          writeAgents.agentCreate(principal(), a as never, { base: appDb }),
+        {
+          name: "a",
+          model_config: {
+            provider: "openai",
+            model: "gpt-4o-mini",
+            credentialRef: `vault:${oauth.id}`,
+          },
+        },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    // NOT from a review round: found by asking what `agent_update`'s row actually proves. It passes an
+    // agent id that does not exist, so it proved the not-found path and stopped there — while the
+    // tool's preview had no preflight at all and `updateAgent` applies half a dozen rules after the
+    // ownership check. Thirty-three of the fifty-five rows in the table above are shaped like that;
+    // the class is filed as its own issue, and this is the one that was measured.
+    test("agent_update: three rules the row's not-found could never reach", async () => {
+      const ag = await suDb.agent.create({
+        data: {
+          tenantId,
+          name: "A",
+          systemPrompt: "p",
+          modelConfig: {},
+          settings: {},
+        },
+      });
+      const oauth = await suDb.vaultEntry.create({
+        data: {
+          tenantId,
+          name: `oauth-upd-${process.pid}`,
+          kind: "google_oauth",
+          secret: encryptJson({ clientId: "a", clientSecret: "b" }),
+        },
+      });
+      const cases: Record<string, unknown>[] = [
+        { name: "" },
+        { business_hours_id: NOPE },
+        {
+          model_config: {
+            provider: "openai",
+            model: "gpt-4o-mini",
+            credentialRef: `vault:${oauth.id}`,
+          },
+        },
+      ];
+      for (const c of cases) {
+        const r = await both(
+          (a) =>
+            writeAgents.agentUpdate(principal(), a as never, { base: appDb }),
+          { agent_id: String(ag.id), ...c },
+        );
+        expect([JSON.stringify(c), r.applied]).toEqual([
+          JSON.stringify(c),
+          "refused",
+        ]);
+        expect([JSON.stringify(c), r.previewed]).toEqual([
+          JSON.stringify(c),
+          "refused",
+        ]);
+      }
+    });
+
+    test("langfuse_connect: a key with surrounding whitespace", async () => {
+      const r = await both(
+        (a) =>
+          writeSettings.langfuseConnect(principal(), a as never, {
+            base: appDb,
+          }),
+        {
+          public_key: "  pk  ",
+          secret_key: "sk",
+          base_url: "https://cloud.langfuse.com",
+        },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    // The INVERSE divergence, and the only one in this PR. Everywhere else the preview approved a
+    // write the apply refuses; here the preview refused and the apply SUCCEEDED — storing
+    // `baseUrl: null` on a kind whose own create path rejects exactly that. `updateVaultEntry` asked
+    // "does this kind require a base URL" only on the null/empty branch, while the other branch
+    // normalized "   " to empty without raising and stored the null it had just refused.
+    //
+    // It needs the entry to ALREADY EXIST, because that is the branch `langfuse_connect` takes then
+    // — which is why the create-side case above stayed green while this was broken.
+    test("langfuse_connect: a whitespace base_url on an entry that already exists", async () => {
+      await suDb.vaultEntry.create({
+        data: {
+          tenantId,
+          name: "langfuse",
+          kind: "langfuse",
+          secret: encryptJson({ publicKey: "pk", secretKey: "sk" }),
+          baseUrl: "https://cloud.langfuse.com",
+        },
+      });
+      const args = { public_key: "pk2", secret_key: "sk2", base_url: "   " };
+      const r = await both(
+        (a) =>
+          writeSettings.langfuseConnect(principal(), a as never, {
+            base: appDb,
+          }),
+        args,
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+      // And the row is intact. A refusal that still cleared the column would satisfy the two lines
+      // above and leave the configuration this test exists to protect.
+      const after = await suDb.vaultEntry.findFirst({
+        where: { tenantId, kind: "langfuse" },
+        select: { baseUrl: true },
+      });
+      expect(after?.baseUrl).toBe("https://cloud.langfuse.com");
+    });
+
+    test("langfuse_connect: a key that is only whitespace", async () => {
+      const r = await both(
+        (a) =>
+          writeSettings.langfuseConnect(principal(), a as never, {
+            base: appDb,
+          }),
+        {
+          public_key: "pk",
+          secret_key: "   ",
+          base_url: "https://cloud.langfuse.com",
+        },
+      );
+      expect(r.applied).toBe("refused");
+      expect(r.previewed).toBe("refused");
+    });
+
+    // ADVISORY, and the only one of the four whose apply spends a NETWORK round trip before it
+    // refuses — which is why the preview answering it matters beyond coherence. Only the preview is
+    // driven: the apply's refusal is reached after `listChatwootAccounts` calls a server that is not
+    // there, so exercising it would measure a timeout. The core's own refusal is proven by the
+    // mutation that deletes it, not by a row here.
+    test("deployment_connect: a second, different Chatwoot server", async () => {
+      const previewed = await verdict(() =>
+        writeChannels.deploymentConnect(
+          principal(),
+          {
+            base_url: "https://93.184.216.34",
+            admin_token: "tok",
+          } as never,
+          { base: appDb },
+        ),
+      );
+      expect(previewed).toBe("refused");
+    });
+  },
+);


### PR DESCRIPTION
Fixes #490

## The defect

A write tool with `dry_run` answers its preview **without touching the core**, and that shortcut is what makes the preview cheap. It is also what makes every rule the core learns start out unmirrored: the preview keeps answering `ok`, nobody notices, and the operator (or the model driving MCP) reads a confident description of a write that cannot happen.

**Eighteen** of the sixty-six tools that publish `dry_run` did that. Fourteen were found by the fence below, which gives every tool one refusable input; the rest by sweeping the classes that the fourteenth turned up, and by asking what the fence's own rows actually prove.

| tool | input the apply refuses, the preview approved |
| --- | --- |
| `agent_create` | empty name · a malformed `business_hours_id` · a well-formed one naming no row · a `credentialRef` whose kind cannot serve the field |
| `agent_update` | empty name · a `business_hours_id` naming no row · a `credentialRef` whose kind cannot serve the field |
| `api_key_revoke` | key does not exist |
| `branding_set` | `brand_color` is not a color token |
| `business_hours_create` | empty name |
| `credential_create` | kind is not in the catalog · a `(name, kind)` pair already used |
| `deployment_connect` | `base_url` is not a URL · a blocked outbound URL · a second, different server |
| `deployment_set_accounts` | no Chatwoot deployment is connected · an account another tenant owns |
| `inbox_reconnect` | inbox does not exist |
| `knowledge_document_create` | knowledge base does not exist |
| `langfuse_connect` | `base_url` is not a URL · `base_url` normalizes to empty · a key with surrounding whitespace |
| `mcp_connection_create` | a network transport with no url · a name already used |
| `mcp_connection_update` | a blocked outbound URL · renaming onto a name already used |
| `tenant_create` | empty slug · a slug another tenant has |
| `tenant_update` | empty name |
| `tool_create` | name is not `[A-Za-z0-9_-]{1,64}` · a name already used |
| `webhook_create` | a blocked outbound URL · an empty `events` array |
| `webhook_update` | a blocked outbound URL · an empty `events` array |

## The fix

The shape the repo prescribes: the pure validation split out of the core, called by both halves — the transport wrapping it into a `WriteResult`, the core into an `AppError` — never the rule written twice. Twenty-two new `assert*` functions, each carrying exactly the judgement its core already made.

Three placement decisions, each of which was wrong first:

- **Inside the preview branch, not above it.** Above it, an apply pays the preflight and then reaches the core, which asks the same question again. Free for a `parseInput`; a doubled DNS lookup for an SSRF check, with a second answer that can disagree with the first.
- **The tenant and branding asserts live in `tenants.service.ts` / `branding.service.ts`**, not beside the mutations they came from. The Free derivation swaps `*.admin.service.ts` for a stub, and the preview has to ask the same question in both editions.
- **The preview resolves the hostname, and an earlier version of this PR had it skip that.** Round 1 asked for the doubled DNS lookup to go away, and round 3 found what the obvious reading of that had cost: a preview that stops before resolution approves `https://localhost`, and the apply refuses it. The doubling was already gone from moving the preflight inside the branch — the second half of the fix was undoing the first half of the answer.

`credential_create` also loses the guard #489 added: `assertPendingVaultEntryCreatable` subsumes it, with the same sentence, and the two can no longer drift.

### The one that runs the other way

Every divergence above is a preview approving a write the apply refuses. Review found one that runs
backwards, and it is the only defect in this PR that sits in the **core** rather than in a transport.

`langfuse_connect` on an entry that already exists, with `base_url: "   "`: the preview refused, the
apply **succeeded**, and the row came back `{ baseUrl: null, kind: "langfuse" }` — a state the
credential's own create path rejects, reported to the caller as success. `updateVaultEntry` asked
`secretTypeRequiresBaseUrl` on the `null`/`""` branch only, while the other branch ran
`validateBaseUrl`, which turns `"   "` into the empty string without raising, and stored the `null`
the first branch had just refused. The check was on the wrong side of the normalization.

Both paths now go through one `normalizeRequiredBaseUrl`, where the check runs after the
normalization and there is no branch for it to be on the wrong side of. The fence case seeds the row
(`langfuse_connect` takes the update branch only then, which is why the create-side case stayed
green) and asserts the stored column is untouched as well as the verdict.

### Some of these answers are not like the others

Nine of the preflights are **advisory**, and the PR is explicit about it because the difference is not cosmetic.

The rest judge the **input**. Their verdict cannot change between preview and apply, so a preview that agrees agrees forever. The advisory ones — the five uniqueness checks (`tenant_create`'s slug, `tool_create`'s, `mcp_connection_create`'s and `mcp_connection_update`'s name, `credential_create`'s `(name, kind)`), the schedule and credential lookups on `agent_create` and `agent_update`, and `deployment_connect`'s server check — read the database from *outside* the write's transaction. Someone can take the name in the gap, and then the preview was right when it spoke and wrong when the apply ran.

That residue is deliberate, and none of the nine may be read as reserving anything. What guarantees one name to one row is still the unique index the write runs into. What these buy is the refusal an operator hits almost every time — reusing a name they already used — arriving where they asked the question instead of after they committed to the apply. Each of the nine says exactly this at its definition.

The vault one takes the **normalized** `(name, kind)` pair, not the raw input: `kind` defaults to `"generic"` and the uniqueness is on what gets stored, so looking the pair up with the raw `kind: null` would find nothing and answer "will create" for the exact name it just refused. There is a test for that alone.

## The fence

`tests/modules/mcp/dry-run-coherence.test.ts` — 66 rows, one per published tool, plus two written `skip`s, plus three blocks for the classes a one-row table cannot reach.

- The tool list comes from the **live registry** under both principals, so a tool with no row **fails**: one added later cannot join silently.
- The dispatch is **derived** (snake→camel, 66/66, no exceptions), and a tool whose function it cannot resolve fails rather than going unexercised.
- Each row drives both halves and requires them to agree.

Three properties earn their keep, and each came from a way of measuring nothing that looked exactly like a finding:

- A row whose apply **succeeds** fails: it has nothing to disagree about, and it would create a real record getting there.
- A row that **crashes** fails. The first harness drove the tools through the MCP client, whose handlers use `basePrisma` — built at import time off a `DATABASE_URL` that `tests/setup.ts` deliberately points at a database that does not exist. Counting any thrown error as a refusal made eleven tools look broken that were not.
- A row's arguments must satisfy the tool's **published input schema**, nested keys included. Dispatching directly buys a live database and costs this: an argument the schema would have rejected exercises a path no client can produce. Three of the first thirteen failures were exactly that — `account_ids: ["not-a-number"]` against `z.array(z.number().int())`, a `method` outside its enum, and `credentialRef` where the tool publishes `credential_ref`.

That last one **retracted three findings**: `experiment_create`, `knowledge_create` and `tenant_settings_update` are not divergent, and `tool_create` diverges on the name and not on `url_template` (which the core never validates). The issue body carries the correction.

One row per tool is a floor, not a proof — a tool can agree on that input and diverge on another. Four mechanisms cover what it cannot reach:

- an `also` list per row, for a second input to the same tool;
- **the outbound-URL block**, because a blocked URL is a property of *five* tools rather than of one;
- **the whole-judgement block**, from `deployment_set_accounts`: its preflight had the deployment lookup and not the cross-tenant account check, and half a preflight reads exactly like a whole one. The row for that tool stayed green throughout, because it passes no deployment at all;
- **the already-in-the-database block**, for the four create-side uniqueness checks. The table structurally cannot reach these: every row in it passes an input bad on its face, and a name already taken is bad only relative to a row that exists;
- **the whole-judgement block again**, for four more found in round 6 of review and two more in round 7. That class is worth its own block precisely because it does not announce itself: a tool *with* a preflight looks covered, and its row stays green as long as that row happens to trip the part that is covered. `agent_create` had **two** preflights by round 7 and still approved a credential the apply refuses.

And one thing the fence does **not** cover, found by asking what its own rows prove rather than whether they pass. `agent_update`'s row passes an agent id that does not exist, so it proved the ownership check and stopped — while the tool's preview had no preflight at all and `updateAgent` applies half a dozen rules after that check. Three of them diverged. **33 of the 55 rows are shaped that way**, and that is a property of the fence rather than of these eighteen tools, so it is filed as #510 rather than expanded here; the one that was measured is fixed.

## Also here

- `getGlobalBranding` now takes the Prisma client its caller is using. `brandingSet` read the current branding off the module-level client while ignoring the one it was handed, so no injected database could reach it — the tool was unmeasurable, which is how its divergence survived a preview comment that stated it as a feature ("sanitization is applied on apply"). `brandingAssetSet` still does this; noted in the issue.
- `assertSafeOutboundUrl` was letting a **rejected** DNS lookup escape raw, so an unresolvable host answered 500 two lines above the branch that answers 400 for an empty result. The apply had that hole already; asking the question earlier is what surfaced it.

  Which failures become that 400 took three rounds to get right, and the last one is worth reading. Round 2 asked for transient failures to propagate rather than telling a caller its URL is wrong; round 5 said `ENOTFOUND` is not reliably permanent and was answered by reading **Node's** `DNSException`; round 8 said it again and named the thing that makes it right — **Bun**, which is what this app runs on. Measured there, a nonexistent name, a name with no A record and a 300-character label all arrive as `code: "ENOTFOUND", errno: 4`. The error carries nothing to classify on.

  The gate stays anyway, and not out of stubbornness. The remedy on offer is `dns.resolve*` (c-ares), which does **not** consult /etc/hosts or the OS resolver — for an SSRF guard that is a hole, since a hostname mapped locally to `127.0.0.1` resolves for the request that goes out and answers NOTFOUND to the check. So the predicate is documented as what it is: always true on Bun, a real gate on a runtime that distinguishes, and a fail-closed refusal either way. It answers **400** rather than 500 because the empty-result branch two lines down already answers 400 for the same fact, and that split is the one this PR exists to close.
- `assertSafeOutboundUrl` takes an **injectable resolver**, the same seam as `deps.assertSafe` elsewhere. It exists for the one thing the real resolver cannot be asked to do on demand: fail *transiently*. A mutation restoring the blanket DNS catch survived until it existed.
- The cross-tenant account check asks **once** for the whole set rather than opening one privileged transaction per account, over an array the published schema does not cap. That took two rounds to get right in both directions: collapsing the transactions put every id in a single `IN`, and each id is a bind parameter, of which Postgres takes 32767. Measured, 32760 ids answer in 56ms and 32770 raise "The query parameter limit supported by your database is exceeded" — a **crash**, not a refusal, on input the schema accepts. It is chunked now, with all the chunks inside one transaction, because chunking across transactions hands back the per-element privileged transaction the change removed, divided by a thousand.
- `connectChatwootDeployment` refuses a **server switch before the credential round trip**, not after. It was validating the operator's admin token against the new deployment and only then reading the current one — so the token went to a server we were always going to reject, for an answer already sitting in our own database. This also makes the two halves agree on *which* refusal the caller gets, not just on whether there is one.
- The two webhook cores now go through `assertWebhookSubscriptionCreatable`/`Updatable` rather than inlining the parse, the event-catalog check and the URL check, so the preview cannot be handed a subset of them.

## Measured against the running system

The before/after, driven through the tools themselves against a live Postgres — the same probe run
in a worktree at `origin/main` and in this branch. Every one of these is an input the apply refuses.

| input | preview on `main` | preview here |
| --- | --- | --- |
| `tool_create` · name already used | **approved** | refused |
| `mcp_connection_create` · name already used | **approved** | refused |
| `mcp_connection_update` · renamed onto a taken name | **approved** | refused |
| `tenant_create` · slug already used | **approved** | refused |
| `credential_create` · `(name, kind)` already used | **approved** | refused |
| `agent_create` · credentialRef of a kind that cannot serve the field | **approved** | refused |
| `agent_update` · empty name | **approved** | refused |
| `agent_update` · `business_hours_id` naming no row | **approved** | refused |
| `webhook_create` · `events: []` | **approved** | refused |
| `deployment_connect` · a second, different server | **approved** | refused |
| `deployment_set_accounts` · an account another tenant owns | **approved** | refused |
| `langfuse_connect` · a key with surrounding whitespace | **approved** | refused |

Twelve of twelve approved before, twelve of twelve refuse now.

## Proof

- **Fence:** 95 pass, 2 skip, 0 fail.
- **Mutation battery, 46 killed.** Each preflight was deleted from its transport in turn — the apply still refuses, the preview stops — and the fence's own row for that tool failed, every time. Tree verified restored bit-for-bit after each pass.
- **Five mutations survived across the whole PR, and each one bought a test.** A blanket DNS catch (nothing tested that `assertSafeOutboundUrl` *used* `isNameNotFound`, only that the predicate was right); a batched account check reading only `accountIds[0]` (the taken-account case was passing a single-element array); the `mcp_connection_create` duplicate-name case, whose first cut passed `transport: "http"` — not a value the schema accepts — so the preview refused on the transport and the test passed with the guard deleted; and the two halves of the `deployment_connect` switch refusal, which had **no test at all** before this and now has one for each, the second driven as an actual race.
- **The fence's own guards, mutated:** a row typed against the schema (`account_ids: ["nope"]`) and a row with a wrong nested key (`credentialRef`) each turn it red.
- **A test that measured the wrong axis, caught by its own battery.** The cost assertion for `deployment_set_accounts` counted transactions, and a query that is too WIDE does not spend an extra transaction — it raises, which a count-only assertion reads as success. Both mutations survived it. It now returns the outcome and the chunk-query count as well, and is red for an un-chunked `IN`, a chunk above the ceiling, a chunk of 1, and a transaction per chunk.
- `bun check` green: 9329 pass, 2 skip, 0 fail.
- Both derived trees compile (`build:free`, `build:pro`), and the fence passes in the Free tree, which is what the second placement decision above claims.

## Not in scope

Four things this measured and did not fix. None is a preview/apply divergence — the two halves agree on all of them — and each now has an issue rather than a line in a PR body nobody will read again.

- **#501** — the core applies several inputs it arguably should refuse (`knowledge_create` with an empty name or `chunk_size: 99999999`, `experiment_create` with an unknown `agent_id`, `tool_create` with a `url_template` that is not a URL, which `createToolDefinition` never validates at all).
- **#502** — `brandingAssetSet` still reads branding off the module-level Prisma client. `brandingSet` had the same defect and is fixed here, because that tool had to be measurable for this PR to prove anything about it.
- **#503** — `account_ids` is uncapped on the published `deployment_set_accounts` schema. That is the apply's own property and predates this work: it iterates the array doing a network probe per account, far more than the one `IN` clause the preview now costs. Capping a published tool schema is a public contract change.
- **#504** — `base_url` is honoured for credential kinds the console hides it for, and nothing warns about an HTTP tool referencing a `generic` credential no template interpolates.
- **#510** — 33 of the fence's 55 rows pass a nonexistent id, so they prove the ownership check and nothing after it. Found here, and one of the 33 (`agent_update`) is fixed here; the sweep of the rest is its own work.
