### PR TITLE
Position the shell's scroller, so an sr-only label stops stretching the document

### DIFF
--- a/src/client/components/Layout.tsx
+++ b/src/client/components/Layout.tsx
@@ -25,10 +25,24 @@ export function Layout({ children }: LayoutProps) {
       <AnnouncementBanner />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
+        {/* NOTE: `relative` is load-bearing, and it is about `sr-only` rather than about anything
+            this element positions. `sr-only` is `position: absolute`, so a screen-reader label
+            anywhere in the page tree resolves against the nearest POSITIONED ancestor — and with
+            this one static, that was the initial containing block, i.e. the document. A label far
+            down the scrolled content stream then landed at that document coordinate and stretched
+            `documentElement.scrollHeight` past the viewport, giving the page a SECOND scrollbar that
+            scrolled the whole shell (header and sidebar) out of view.
+
+            The scroller's own `overflow-y: auto` could not clip it either, by the same rule read
+            from the other side: a scroll container only clips absolutely positioned descendants
+            whose containing block is inside it. Measured on /audit with one row expanded, at
+            1280x720: `document.scrollHeight` 2529 with this static, 720 with it relative (issue
+            #511). Fixing the label instead would fix one instance of a class that ~20 files under
+            src/client can reach. */}
         <main
           id="main-content"
           tabIndex={-1}
-          className="flex-1 overflow-y-auto p-6 focus:outline-none"
+          className="relative flex-1 overflow-y-auto p-6 focus:outline-none"
         >
           {children}
         </main>

--- a/tests/client/shell-scroll-containment.test.ts
+++ b/tests/client/shell-scroll-containment.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+// The app shell scrolls in exactly ONE place, and the element that does it has to be POSITIONED.
+//
+// `sr-only` is `position: absolute`, so a screen-reader label anywhere under the shell resolves
+// against the nearest positioned ancestor. With the scroller static that ancestor was the initial
+// containing block — the document — and a label far down the scrolled content stream landed at that
+// document coordinate, stretching `documentElement.scrollHeight` past the viewport. The page then
+// had a SECOND scrollbar, the outer one, which scrolled the header and the sidebar out of view.
+// The scroller's own `overflow-y: auto` did not clip it either: a scroll container only clips
+// absolutely positioned descendants whose containing block is inside it.
+//
+// Measured on /audit with one row expanded, at 1280x720 (issue #511):
+//
+//   document.scrollHeight   2529   with `main` static
+//   document.scrollHeight    720   with `main` relative   (= the viewport)
+//
+// THIS FENCE READS THE SOURCE, AND THAT IS A COMPROMISE WORTH NAMING. The defect is a layout fact,
+// and the assertion that would catch it directly — `document.scrollHeight === innerHeight` with a
+// tall page mounted — cannot be written here: happy-dom computes no layout, `scrollHeight` is a
+// stub, and Tailwind's classes reach no stylesheet in this environment, so `getComputedStyle` would
+// answer `static` for every element regardless. There is no browser harness in this repo to put it
+// in. What this file can still do is refuse the EDIT that reintroduces the bug, and it follows the
+// scroller rather than the id or the class order: whichever element in the shell carries the
+// page-level scroll must carry a positioning class beside it.
+const source = await Bun.file(
+  new URL("../../src/client/components/Layout.tsx", import.meta.url),
+).text();
+
+const POSITIONED = /\b(relative|absolute|fixed|sticky)\b/;
+const PAGE_SCROLL = /\boverflow-(y-)?(auto|scroll)\b/;
+
+// Every `className="..."` literal in the file, JSX attribute or not.
+function classLists(src: string): string[] {
+  return [...src.matchAll(/className="([^"]*)"/g)].map((m) => m[1] ?? "");
+}
+
+describe("the app shell contains its own scrolling", () => {
+  test("the element that scrolls the page is positioned", () => {
+    const scrollers = classLists(source).filter((c) => PAGE_SCROLL.test(c));
+    // If this is 0 the shell stopped scrolling where this file thinks it does, and the fence is
+    // measuring nothing — which is the failure mode a green sweep hides.
+    expect(scrollers.length).toBeGreaterThan(0);
+    for (const cls of scrollers) {
+      expect(cls).toMatch(POSITIONED);
+    }
+  });
+
+  // The other half of the shape, and the reason the bug is invisible until something escapes: the
+  // shell is pinned to the viewport, so anything that outgrows it can only show up as a second
+  // scrollbar rather than as a longer page.
+  test("the shell is pinned to the viewport and hides its own overflow", () => {
+    // NOT `\bh-dvh\b`: a hyphen is a word boundary, so that pattern also matches `min-h-dvh` —
+    // which sets a FLOOR rather than a height and lets the shell grow past the viewport, the very
+    // thing this asserts it does not do. The mutation survived the first spelling of this line.
+    const shell = classLists(source).find((c) =>
+      /(?<![\w-])h-dvh(?![\w-])/.test(c),
+    );
+    expect(shell).toBeDefined();
+    expect(shell).toMatch(/\boverflow-hidden\b/);
+  });
+});


### PR DESCRIPTION
Fixes #511.

Expanding a row on `/audit` gave the page a **second** scrollbar — the outer one, on the document — and it scrolled the whole app shell, header and sidebar included, out of the viewport.

Measured in the browser at 1280×720, with the console's own layout:

| | `document.scrollHeight` | `main.scrollHeight` / `clientHeight` |
| --- | --- | --- |
| every row collapsed | **720** (= viewport, no document scroll) | 3430 / 656 |
| one row expanded | **2529** | 3204 / 656 |

## The accordion is not the cause

The two elements that stretched the document were the per-value labels inside the expanded diff:

```
SPAN .mb-0.5.block.text-text-muted.text-xs.sm:sr-only   position: absolute   top: 2528   height: 1   "Antes"
SPAN ... same ...                                        position: absolute   top: 2528   height: 1   "Depois"
```

`sr-only` is `position: absolute`. Absolute positioning resolves against the nearest **positioned** ancestor, and there was none: `main`, the shell and `body` were all static, so the containing block was the initial containing block — the document. The label's static position sits ~2528px down the scrolled content stream, so it landed at document y=2528 and `documentElement.scrollHeight` grew to match.

`main`'s `overflow-y: auto` could not clip it either, which is the same rule read from the other side: **a scroll container only clips absolutely positioned descendants whose containing block is inside it.** With `main` static, the span's containing block was an ancestor of the scroller.

## The fix is one class, and it is deliberately structural

`main` becomes `relative`. Verified live on the running console with the row still expanded:

```
document.scrollHeight   2529 -> 720     (= viewport; the outer scrollbar is gone)
main still scrolls:     true            (the inner one is untouched)
```

**Fixing the two spans would have been the wrong repair.** Twenty-odd files under `src/client` use `sr-only`, and any of them deep inside `main` without a positioned ancestor of its own carries this bug latent; the audit page is only where a label happened to land far enough down to be seen. A scroll container that is expected to contain its descendants should be positioned.

## Validation scope

**Proved by test** (`tests/client/shell-scroll-containment.test.ts`): whichever element in the shell carries the page-level scroll must also carry a positioning class, and the shell itself must be pinned to the viewport with its own overflow hidden.

**Proved by mutation** — 4 mutations, each applied and reverted:

| mutation | outcome |
| --- | --- |
| `relative` removed from the scroller | 1 fail |
| `relative` → `isolate` (a class that creates a stacking context but does not position) | 1 fail |
| `overflow-hidden` removed from the shell | 1 fail |
| `h-dvh` → `min-h-dvh` on the shell | **survived**, then 1 fail |

The fourth is worth naming. `\bh-dvh\b` also matches `min-h-dvh`, because a hyphen is a word boundary — and `min-h-dvh` sets a floor rather than a height, so the shell can grow past the viewport, which is exactly what that assertion claims it cannot do. The pattern is `(?<![\w-])h-dvh(?![\w-])` now.

**The fence reads the SOURCE, and that is a compromise the test names in its own comment.** The defect is a layout fact, and the assertion that would catch it directly — `document.scrollHeight === innerHeight` with a tall page mounted — cannot be written in this suite: happy-dom computes no layout, `scrollHeight` is a stub, and Tailwind's classes reach no stylesheet there, so `getComputedStyle` answers `static` for every element regardless. There is no browser harness in this repo to put it in. What the fence can still do is refuse the edit that reintroduces the bug, and it follows the scroller rather than the element's id or its class order.

**Not validated:** no automated check that the rendered page's `document.scrollHeight` stays at the viewport — that is the browser-level assertion above, and it was performed by hand rather than by CI.
