### PR TITLE
Read the branding a tool is about to replace from the client it was handed

### DIFF
--- a/src/modules/mcp/write.ts
+++ b/src/modules/mcp/write.ts
@@ -974,7 +974,7 @@ export async function brandingAssetSet(
 
   const target = `branding:asset:${kind}:${variant}`;
   try {
-    const before = await getGlobalBranding();
+    const before = await getGlobalBranding(base);
     const replacingExisting = before[kind][variant];
 
     // dry-run is the default: a binary has no field-level diff, so preview the metadata that WOULD

--- a/tests/modules/mcp-write.test.ts
+++ b/tests/modules/mcp-write.test.ts
@@ -1039,3 +1039,75 @@ describe.skipIf(!dbUp)("MCP write tools (DB)", () => {
     expect(entries).toHaveLength(1);
   });
 });
+
+// `brandingAssetSet` takes a Prisma client precisely so the caller decides which database the tool
+// answers from, and then read the CURRENT branding off the module-level client instead. The row it
+// reported as "already there" came from a different database than the one it was about to write.
+// Issue #502.
+//
+// Nothing reached it before: every other branding_asset_set test in this file refuses ahead of the
+// read (wrong scope, wrong kind, wrong mime, bad base64), and the dry-run fence's row for this tool
+// refuses on `content_base64` for the same reason. `brandingSet` had the identical defect and #490
+// fixed it because that tool had to be measurable; this is the sibling that was left behind.
+//
+// `app_branding` is a fleet singleton (id 1, no tenant column, outside RLS), so seeding it is a
+// global mutation rather than a per-tenant one. The block restores whatever it found.
+describe.skipIf(!dbUp)(
+  "branding_asset_set reads through the client it was handed",
+  () => {
+    const BRANDING_ID = 1;
+    const superAdmin = () =>
+      principal({ scopes: ["mcp:admin"], role: "SUPER_ADMIN", tenantId: null });
+    let saved: string | null = null;
+    let hadRow = false;
+
+    async function setLogoDark(key: string | null) {
+      await suDb.appBranding.upsert({
+        where: { id: BRANDING_ID },
+        create: { id: BRANDING_ID, logoDarkKey: key },
+        update: { logoDarkKey: key },
+      });
+    }
+
+    // The preview it returns, for a logo/dark upload that passes every cheap check.
+    async function previewLogoDark() {
+      const r = await brandingAssetSet(
+        superAdmin(),
+        {
+          kind: "logo",
+          variant: "dark",
+          content_base64: "AAAA",
+          mime: "image/png",
+        },
+        { base: appDb },
+      );
+      if (!r.ok) throw new Error(`expected a preview, got: ${r.error}`);
+      const preview = r.data.preview as Record<string, unknown>;
+      return preview;
+    }
+
+    beforeAll(async () => {
+      const row = await suDb.appBranding.findUnique({
+        where: { id: BRANDING_ID },
+      });
+      hadRow = row !== null;
+      saved = row?.logoDarkKey ?? null;
+    });
+
+    afterAll(async () => {
+      if (hadRow) await setLogoDark(saved);
+      else await suDb.appBranding.deleteMany({ where: { id: BRANDING_ID } });
+    });
+
+    // BOTH directions, on the same injected client. One of them alone is satisfied by a constant:
+    // asserting only `true` passes for a tool that always claims a replacement, and only `false`
+    // passes for one that never looks. The pair is what says the answer TRACKS the row.
+    test("replacingExisting follows the row written through that client", async () => {
+      await setLogoDark("seeded/logo-dark.png");
+      expect((await previewLogoDark()).replacingExisting).toBe(true);
+
+      await setLogoDark(null);
+      expect((await previewLogoDark()).replacingExisting).toBe(false);
+    });
+  },
+);

--- a/tests/modules/mcp/write-passes-its-client.test.ts
+++ b/tests/modules/mcp/write-passes-its-client.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { codeOnly } from "@/tests/utils/source-text";
+
+// Every MCP write tool opens with `const base = deps.base ?? basePrisma`, and the client it settles
+// on is the caller's answer to "which database is this write about". A tool that then calls a helper
+// WITHOUT passing it does not fail: the helper falls back to its own module-level client, and the
+// tool reads one database while writing another.
+//
+// The fallback is a default parameter (`base: PrismaClient = prisma`), which is the repo's
+// convention and is not the defect — 411 functions carry it, and the reason it exists is that most
+// callers have no client to offer. What it costs is a silent miss: dropping the argument is spelled
+// exactly like not having one.
+//
+// It has now happened twice in the same file. #490 fixed `brandingSet`, which was unmeasurable until
+// `getGlobalBranding` took the caller's client; #502 is `brandingAssetSet`, the sibling left behind,
+// where the preview reported a replacement that lived in a different database. Two sites, one
+// invariant, and nothing obliging the third — so the invariant is cobrado here instead of per tool.
+//
+// WHAT THIS DOES NOT COVER, measured rather than assumed. The same shape is possible anywhere in
+// `src/`, not only in these nine files. A tree-wide version of this sweep was written and thrown
+// away: it reported eleven sites, ten of them false — a Chatwoot client's `client.listInboxes()`
+// matched the module function `listInboxes` by bare name, a local closure shadowed an exported name,
+// and one "argument list" was the prose of a comment. The transports are where the invariant is
+// load-bearing (they are handed a client on purpose, by a caller that means it) and where the sweep
+// is exact, so that is what it claims.
+
+// Everything the sweep decides, over source text it is handed, so the fixture cases below drive the
+// same code the tree does. Returns one entry per call that reaches a client-taking function without
+// naming a client.
+function bareCalls(
+  code: string,
+  accepts: ReadonlySet<string>,
+): { name: string; line: number; args: string }[] {
+  const found: { name: string; line: number; args: string }[] = [];
+  // `[^\w.$]` in front is what keeps `client.listInboxes()` from matching the module-level
+  // `listInboxes`: a method call is a different function that happens to share a name.
+  for (const m of code.matchAll(/(^|[^\w.$])(\w+)\s*\(/g)) {
+    const name = m[2] as string;
+    if (!accepts.has(name)) continue;
+    const args = argsAt(code, m.index + (m[0] as string).length);
+    // The names a Prisma client goes by in these files. All three of `base`, `(base|db|tx)` and
+    // `(base|db|tx|suDb|client)` returned the same single offender when this was written, so the
+    // middle one is not buying an exemption for anything that exists — it is here because a helper
+    // called inside a `$transaction` receives `tx`, and `client` is left OUT because a Chatwoot
+    // client is called that.
+    if (/\b(base|db|tx)\b/.test(args)) continue;
+    found.push({
+      name,
+      line: code.slice(0, m.index).split("\n").length,
+      args: args.trim(),
+    });
+  }
+  return found;
+}
+
+// The parenthesised run starting just past an open paren, depth-aware so a nested call or object
+// literal does not end it early. Comments and string bodies are already blanked by `codeOnly`, which
+// is why a bare scan for the closing paren is enough here.
+//
+// MEASURED, so the next reader does not have to: `codeOnly` changes no number in this tree today.
+// Dropping it leaves the sweep at 174 calls reached and 0 offenders, identical. It is here so the
+// fence's answer does not depend on what the transports say ABOUT these calls in prose, which is the
+// failure `tests/utils/source-text.ts` was written for after a sweep read a comment as a use. The
+// fixture below is the proof that the predicate needs it; the tree is simply not exercising it yet.
+function argsAt(code: string, openEnd: number): string {
+  let depth = 1;
+  let i = openEnd;
+  for (; i < code.length && depth > 0; i++) {
+    const c = code[i];
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") depth--;
+  }
+  return code.slice(openEnd, i - 1);
+}
+
+// A function "takes a client" when a `PrismaClient` appears anywhere in its parameter list, whether
+// the parameter is required, optional, or defaulted. The defaulted ones are the whole point.
+async function clientTakingFunctions(): Promise<Set<string>> {
+  const names = new Set<string>();
+  for await (const rel of new Bun.Glob("**/*.ts").scan("src")) {
+    const code = codeOnly(await Bun.file(`src/${rel}`).text());
+    for (const m of code.matchAll(/\bfunction\s+(\w+)\s*\(/g)) {
+      const params = argsAt(code, m.index + (m[0] as string).length);
+      if (params.includes("PrismaClient")) names.add(m[1] as string);
+    }
+  }
+  return names;
+}
+
+describe("the sweep itself", () => {
+  // Every case is a spelling this sweep got wrong at some point, or would have. Without these the
+  // tree assertion below is a green that proves nothing: after #502 there is no offender left in
+  // `src/`, so a sweep that had stopped matching anything would look exactly the same.
+  const accepts = new Set(["getGlobalBranding", "listInboxes"]);
+
+  test("it flags a call that drops the client", () => {
+    const hits = bareCalls(
+      codeOnly("const before = await getGlobalBranding();"),
+      accepts,
+    );
+    expect(hits.map((h) => h.name)).toEqual(["getGlobalBranding"]);
+  });
+
+  test("it passes a call that hands the client on", () => {
+    expect(
+      bareCalls(codeOnly("await getGlobalBranding(base);"), accepts),
+    ).toEqual([]);
+    expect(
+      bareCalls(codeOnly("await getGlobalBranding(tx);"), accepts),
+    ).toEqual([]);
+  });
+
+  test("a method that shares the name is a different function", () => {
+    expect(
+      bareCalls(
+        codeOnly("const remote = await client.listInboxes();"),
+        accepts,
+      ),
+    ).toEqual([]);
+  });
+
+  test("prose naming the call is not the call", () => {
+    const code = codeOnly(`
+      // Do not call getGlobalBranding() here without a client.
+      const label = "getGlobalBranding()";
+      await getGlobalBranding(base);
+    `);
+    expect(bareCalls(code, accepts)).toEqual([]);
+  });
+
+  test("a nested argument does not end the argument list early", () => {
+    const code = codeOnly("await getGlobalBranding(pick({ a: f(1) }, base));");
+    expect(bareCalls(code, accepts)).toEqual([]);
+  });
+
+  test("it reports the line the call is on", () => {
+    const code = codeOnly(
+      "const a = 1;\nconst b = 2;\nawait getGlobalBranding();",
+    );
+    expect(bareCalls(code, accepts)[0]?.line).toBe(3);
+  });
+});
+
+describe("every MCP write transport hands its client on", () => {
+  test("no tool reaches a client-taking helper without naming a client", async () => {
+    const accepts = await clientTakingFunctions();
+    // Worthless if it matched nothing. A rename of `PrismaClient`, or a glob that stops finding the
+    // transports, would empty both numbers and leave the assertion below trivially true.
+    //
+    // The floors are far below what any edition reports, because this file runs in all three trees
+    // and a sweep with an edition-sensitive count is how a test passes on master and fails in Free
+    // (#516, days before this one). Measured on the derived trees: master and Pro 411 client-taking
+    // functions, Free 410 — the Pro-only admin service that is swapped for a stub — with 9 transport
+    // files, 174 calls reached and 0 offenders in all three, identically.
+    expect(accepts.size).toBeGreaterThan(200);
+
+    const offenders: string[] = [];
+    let reached = 0;
+    let files = 0;
+    for await (const rel of new Bun.Glob("write*.ts").scan("src/modules/mcp")) {
+      const path = `src/modules/mcp/${rel}`;
+      files++;
+      const code = codeOnly(await Bun.file(path).text());
+      for (const m of code.matchAll(/(^|[^\w.$])(\w+)\s*\(/g)) {
+        if (accepts.has(m[2] as string)) reached++;
+      }
+      for (const hit of bareCalls(code, accepts)) {
+        offenders.push(`${path}:${hit.line} ${hit.name}(${hit.args})`);
+      }
+    }
+    expect(files).toBeGreaterThan(5);
+    expect(reached).toBeGreaterThan(100);
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
`brandingAssetSet` takes a Prisma client so the caller decides which database the write is about,
and then asked a different one what was already there.

```ts
const base = deps.base ?? basePrisma;      // the caller's answer
...
const before = await getGlobalBranding();  // the module-level client, always
const replacingExisting = before[kind][variant];
```

`replacingExisting` is what the preview reports and, on apply, what comes back as `replacedExisting`.
Both were read from `@/api/lib/prisma`, built at import time off `DATABASE_URL` — so a caller that
injected a client got an answer about a database it had not named, and the read the write is based on
and the write itself could disagree.

Under `tests/setup.ts` that module client points at a database that deliberately does not exist, so
the read did not merely answer wrong, it threw `DatabaseDoesNotExist (P1003)` past the tool's
`catch` (a Prisma error is neither `AppError` nor `ZodError`, so it is rethrown). That is why nothing
covered this: the six existing `branding_asset_set` tests all refuse ahead of the read (wrong scope,
non-SUPER_ADMIN, bad kind, bad variant, bad mime, bad base64), and the dry-run fence's row for the
tool refuses on `content_base64` for the same reason.

## The fix, and why it comes with a fence

The fix is one line: `getGlobalBranding(base)`.

The fence is because this is the **second** occurrence of the same shape in the same file. #490 fixed
`brandingSet` — reading through the module client is exactly what made that tool unmeasurable, and
the divergence there survived a review comment that stated it as a feature until `getGlobalBranding`
took the caller's client. `brandingAssetSet` reads the same way and was left alone, correctly, because
fixing it was not needed to close #490.

Two sites, one invariant, nothing obliging the third. So `tests/modules/mcp/write-passes-its-client.test.ts`
sweeps the nine `src/modules/mcp/write*.ts` transports and fails while any call reaches a
client-taking function without naming a client.

The fallback that makes the miss silent is a default parameter (`base: PrismaClient = prisma`). That
is the repo's convention and is not the defect — 411 functions carry it, and most callers genuinely
have no client to offer. What it costs is that dropping the argument is spelled exactly like not
having one.

## Measured

**The family, before writing anything.** Sweeping `src/**/*.ts` for functions that accept a
`PrismaClient` and then scanning the transports for calls that drop it:

| tree | client-taking functions | transport files | calls reached | offenders |
| --- | --- | --- | --- | --- |
| master | 411 | 9 | 174 | 1 |
| derived Free | 410 | 9 | 174 | 1 |
| derived Pro | 411 | 9 | 174 | 1 |

The single offender is `src/modules/mcp/write.ts:977`. Free is one function short because the
Pro-only admin service is swapped for a stub; every other number is identical, which is what makes
the fence's floors safe to run in all three trees. That check exists because a test with an
edition-sensitive count is how a suite passes on master and fails in Free — measured on #516 days
before this one, on a sweep whose exact-equality assertion held only where the Pro services are real.

**A tree-wide version of the sweep was written and thrown away.** It reported eleven sites, ten of
them false: a Chatwoot client's `client.listInboxes()` matched the module-level `listInboxes` by bare
name, a local closure shadowed an exported one, and one "argument list" was the prose of a comment.
The transports are where the invariant is load-bearing and where the sweep is exact, so that is what
the fence claims; the same shape elsewhere in `src/` is not covered, and this paragraph is the record
of why.

**Mutation battery** (control first: 85 pass / 0 fail, both files):

| mutation | fails |
| --- | --- |
| restore the defect (`getGlobalBranding(base)` → `getGlobalBranding()`, this site only) | **2** |
| fence loses its method-call guard (`[^\w.$]` → `[^\w]`) | **1** |
| fence's `accepts` glob matches nothing (floor check) | **1** |
| fence reads raw text instead of `codeOnly` | 0 — survived |

The survivor is recorded in the file rather than papered over: stripping comments changes no number
in this tree today (174 reached, 0 offenders either way). It stays because the fence's answer should
not depend on what a transport says *about* these calls in prose, which is the failure
`tests/utils/source-text.ts` was written for, and the fixture case is what proves the predicate needs
it. The tree is simply not exercising it yet.

## Validation scope

**Proved by test.** `tests/modules/mcp-write.test.ts` gains a DB-backed block that seeds
`app_branding.logo_dark_key` through the injected client and asserts the preview's `replacingExisting`
follows it in **both** directions — a set row reads `true`, a cleared row reads `false`. One direction
alone is satisfied by a constant. Against the unfixed tool the block does not fail an expectation, it
throws `DatabaseDoesNotExist (P1003)`, which is the defect itself.

The fence carries six fixture cases for its own predicate: a bare call is flagged; a call passing
`base` or `tx` is not; a method call sharing the name is not; a mention in a comment or a string is
not; a nested argument does not end the argument list early; and the reported line number is right.
Those are not decoration — after this fix `src/` has no offender left, so a sweep that had silently
stopped matching anything would look identical to a clean tree.

Run in the **derived Free tree**, with its own migrated test database: 84 pass, 0 fail (one below
master's 85, the `@full-only` block the derivation drops).

`bun check` on master: green.

**Not validated live, and it does not apply.** This path talks to no external system — the read and
the write are both Prisma, and the "live" system here is the real Postgres the DB-backed test runs
against. No Chatwoot, model provider, or storage is involved.

**Not covered.** The apply half is not exercised end to end: it shares the single `before` read with
the preview, so the same line fixes both, but `setBrandingAsset` writes to disk and the block stops
at the preview. And `app_branding` is a fleet singleton (id 1, outside RLS), so the block mutates
global state; it snapshots and restores what it found, which is correct for a serial file and is
worth knowing if this suite is ever parallelised.

Fixes #502
