### PR TITLE
Measure a knowledge base's chunk overlap against the row it will produce

### DIFF
--- a/src/modules/mcp/write-knowledge.ts
+++ b/src/modules/mcp/write-knowledge.ts
@@ -3,6 +3,7 @@ import { AppError } from "@/lib/errors";
 import type { TenantContext } from "@/lib/tenancy";
 import { firstUnstorableField } from "@/lib/text";
 import {
+  assertChunkingUpdatable,
   createDocument,
   deleteDocument,
   type EmbeddingBlock,
@@ -159,14 +160,24 @@ export async function knowledgeUpdate(
     const beforeProj = {
       name: current.name,
       description: current.description,
+      chunkSize: current.chunkSize,
+      chunkOverlap: current.chunkOverlap,
     };
     if (args.dry_run !== false) {
+      // NOTE: ADVISORY, and deliberately so: the bound is a fact about the row, and this read is outside
+      // the transaction the apply validates in, so a concurrent update can move the pair between the
+      // two halves. What it buys is that the ordinary case — an operator sending one of the two
+      // numbers — gets the same answer here as it will get there, instead of an approved preview of
+      // a write that cannot happen (#490, #524).
+      assertChunkingUpdatable(current, patch);
       const previewAfter = {
         name: patch.name ?? current.name,
         description:
           patch.description === undefined
             ? current.description
             : patch.description,
+        chunkSize: patch.chunkSize ?? current.chunkSize,
+        chunkOverlap: patch.chunkOverlap ?? current.chunkOverlap,
       };
       return ok({
         dryRun: true,

--- a/src/modules/rag/documents.ts
+++ b/src/modules/rag/documents.ts
@@ -129,6 +129,32 @@ export async function resolveEmbeddingConfig(
   );
 }
 
+// The same rule asked of the ROW a patch will produce, rather than of the arguments it carries.
+//
+// A knowledge base holds both numbers, and `chunkOverlap <= floor(chunkSize/2)` relates them, so a
+// patch that names one of them is still a statement about the pair. `updateKnowledgeBase` used to
+// validate only when both arrived and, when one did, compared it against a constant — which meant
+// either single-field update landed a state the two-field update refuses by name, and the refusal it
+// did print named a bound it had not checked (issue #524).
+//
+// Merging here rather than at each caller is what keeps the rule single: the preview and the apply
+// both hand it the row they read, and neither restates the arithmetic.
+export function assertChunkingUpdatable(
+  stored: { chunkSize: number; chunkOverlap: number },
+  patch: { chunkSize?: number; chunkOverlap?: number },
+): void {
+  // NOTE: it answers a CHUNKING patch, and a patch naming neither number is not one. Without this
+  // line a row already holding an invalid pair — the state the old branch let through, and the only
+  // reason such rows exist — would refuse a rename, reporting a bound on a field the caller never
+  // sent. The invariant is enforced going forward; it is not retroactive repair, and blocking
+  // unrelated edits until someone fixes the chunking is not the same thing as fixing it.
+  if (patch.chunkSize === undefined && patch.chunkOverlap === undefined) return;
+  validateChunkParams(
+    patch.chunkSize ?? stored.chunkSize,
+    patch.chunkOverlap ?? stored.chunkOverlap,
+  );
+}
+
 // Validation: chunkSize 100–8000, chunkOverlap 0–floor(chunkSize/2)
 export function validateChunkParams(
   chunkSize: number,
@@ -138,8 +164,10 @@ export function validateChunkParams(
     throw new AppError("chunkSize must be between 100 and 8000", 400);
   }
   if (chunkOverlap < 0 || chunkOverlap > Math.floor(chunkSize / 2)) {
+    // NOTE: the ceiling is spelled out because a patch may not carry the chunk size it is measured
+    // against: an operator sending only `chunkOverlap` cannot otherwise tell which number lost.
     throw new AppError(
-      "chunkOverlap must be between 0 and floor(chunkSize/2)",
+      `chunkOverlap must be between 0 and ${Math.floor(chunkSize / 2)} (floor(chunkSize/2), for chunkSize ${chunkSize})`,
       400,
     );
   }

--- a/src/modules/rag/service.ts
+++ b/src/modules/rag/service.ts
@@ -6,11 +6,11 @@ import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { auditMutation, projectionMoved } from "@/modules/audit/service";
 import { readEmbeddingSettings } from "@/modules/tenant-settings/service";
 import {
+  assertChunkingUpdatable,
   cancelPendingJob,
   createDocument,
   refuseUnstorable,
   resolveEmbeddingConfig,
-  validateChunkParams,
 } from "./documents";
 import { embedQuery } from "./embeddings";
 import { type ChunkHit, searchChunks } from "./sql";
@@ -624,6 +624,8 @@ export async function getKnowledgeBase(params: {
   name: string;
   description: string | null;
   embeddingModel: string;
+  chunkSize: number;
+  chunkOverlap: number;
   chunkCount: number;
   createdAt: Date;
   updatedAt: Date;
@@ -637,6 +639,11 @@ export async function getKnowledgeBase(params: {
         name: true,
         description: true,
         embeddingModel: true,
+        // NOTE: the pair `listKnowledgeBases` has always returned. Reading one base was the only
+        // knowledge read that omitted it, which is why the MCP preview had nothing to measure a chunking patch
+        // against (#524).
+        chunkSize: true,
+        chunkOverlap: true,
         createdAt: true,
         updatedAt: true,
       },
@@ -669,21 +676,6 @@ export async function updateKnowledgeBase(params: {
     ["description", params.description],
   ]);
 
-  if (params.chunkSize !== undefined && params.chunkOverlap !== undefined) {
-    validateChunkParams(params.chunkSize, params.chunkOverlap);
-  } else if (params.chunkSize !== undefined) {
-    if (params.chunkSize < 100 || params.chunkSize > 8000) {
-      throw new AppError("chunkSize must be between 100 and 8000", 400);
-    }
-  } else if (params.chunkOverlap !== undefined) {
-    if (params.chunkOverlap < 0 || params.chunkOverlap > 4000) {
-      throw new AppError(
-        "chunkOverlap must be between 0 and floor(chunkSize/2)",
-        400,
-      );
-    }
-  }
-
   await runScopedOn(base, params.ctx, async (db) => {
     // NOTE: LOCKED and read before the write, because this snapshot is the row's `before`. Two
     // overlapping saves would otherwise both read the same base and the second would report a
@@ -699,6 +691,9 @@ export async function updateKnowledgeBase(params: {
         "errors.knowledgeBaseNotFound",
       );
     }
+    // NOTE: inside the transaction, and after the row is locked, because the bound is a fact about
+    // the row: a patch naming one of the two numbers is measured against the other as it will stand.
+    assertChunkingUpdatable(before, params);
     const res = await db.knowledgeBase.updateMany({
       where: { id: params.id },
       data: {

--- a/tests/modules/rag-chunking-bounds.test.ts
+++ b/tests/modules/rag-chunking-bounds.test.ts
@@ -1,0 +1,255 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
+import {
+  knowledgeCreate,
+  knowledgeUpdate,
+} from "@/modules/mcp/write-knowledge";
+
+// `chunkOverlap` is bounded by `floor(chunkSize/2)`, and a knowledge base carries BOTH values, so
+// the question is about the row rather than about the arguments. `updateKnowledgeBase` asked it of
+// the arguments: it validated the pair when both arrived and, when only one did, fell through to a
+// branch that compared against a constant. Either single-field update therefore landed a state the
+// two-field update refuses by name. Issue #524.
+//
+// The same gap left the MCP preview unable to ask at all: `getKnowledgeBase` is the only knowledge
+// read that does NOT carry the chunking pair (`listKnowledgeBases` has carried it all along, and
+// `knowledge_list` advertises it), so the preview had nothing to compare against and approved what
+// the apply refused -- the #490 divergence, on a tool whose fence row only ever proved ownership.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const suDb = su as PrismaClient;
+const appDb = app as PrismaClient;
+
+describe.skipIf(!dbUp)(
+  "a knowledge base's chunking bound is asked of the row",
+  () => {
+    let tenantId = 0n;
+    const principal = (): VerifiedToken => ({
+      userId: 1n,
+      tenantId,
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:read", "mcp:write"],
+      clientId: "c",
+      jti: "j",
+    });
+
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "Chunking", slug: `chunking-${process.pid}` },
+      });
+      tenantId = t.id;
+    });
+
+    afterAll(async () => {
+      const bases = await suDb.knowledgeBase.findMany({
+        where: { tenantId },
+        select: { id: true },
+      });
+      await suDb.knowledgeChunk.deleteMany({
+        where: { knowledgeBaseId: { in: bases.map((b) => b.id) } },
+      });
+      await suDb.knowledgeBase.deleteMany({ where: { tenantId } });
+      await suDb.tenant.delete({ where: { id: tenantId } });
+    });
+
+    // A fresh base, at whatever the schema defaults to (1000/200 today). Each test gets its own so a
+    // refusal in one cannot be read off a row another test moved.
+    async function freshBase(): Promise<string> {
+      const r = await knowledgeCreate(
+        principal(),
+        { name: `kb-${crypto.randomUUID().slice(0, 8)}`, dry_run: false },
+        { base: appDb },
+      );
+      if (!r.ok) throw new Error(`could not seed: ${r.error}`);
+      const data = r.data as Record<string, unknown>;
+      return String((data.result as { id?: unknown })?.id ?? data.id);
+    }
+
+    const apply = (id: string, args: Record<string, unknown>) =>
+      knowledgeUpdate(
+        principal(),
+        { knowledge_base_id: id, ...args, dry_run: false } as never,
+        { base: appDb },
+      );
+    const stored = (id: string) =>
+      suDb.knowledgeBase.findUniqueOrThrow({
+        where: { id: BigInt(id) },
+        select: { chunkSize: true, chunkOverlap: true },
+      });
+
+    test("an overlap alone is measured against the STORED chunk size", async () => {
+      const id = await freshBase();
+      // NOTE: the row is 1000/200, so the ceiling is 500. The old branch compared against a constant
+      // 4000.
+      const r = await apply(id, { chunk_overlap: 4000 });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("chunkOverlap");
+      expect(await stored(id)).toEqual({ chunkSize: 1000, chunkOverlap: 200 });
+    });
+
+    test("a chunk size alone is measured against the STORED overlap", async () => {
+      const id = await freshBase();
+      const wide = await apply(id, { chunk_size: 8000, chunk_overlap: 4000 });
+      expect(wide.ok).toBe(true);
+      // NOTE: shrinking the chunk alone would now leave overlap 4000 against a ceiling of 100.
+      const r = await apply(id, { chunk_size: 200 });
+      expect(r.ok).toBe(false);
+      expect(await stored(id)).toEqual({ chunkSize: 8000, chunkOverlap: 4000 });
+    });
+
+    // NOTE: the control that makes the two above mean something. The SAME end state, asked for in one
+    // call, was already refused before this change; without it they would pass on a tool that simply
+    // refuses every chunking update.
+    test("the pair that is legal together is still accepted", async () => {
+      const id = await freshBase();
+      const r = await apply(id, { chunk_size: 400, chunk_overlap: 200 });
+      expect(r.ok).toBe(true);
+      expect(await stored(id)).toEqual({ chunkSize: 400, chunkOverlap: 200 });
+    });
+
+    test("the pair that is illegal together is refused, as it always was", async () => {
+      const id = await freshBase();
+      const r = await apply(id, { chunk_size: 200, chunk_overlap: 4000 });
+      expect(r.ok).toBe(false);
+    });
+
+    // NOTE: rows already holding an invalid pair exist precisely because the old branch let them
+    // through, so the guard has to reach them without holding their metadata hostage. Enforcing an
+    // invariant going forward is not the same as refusing every unrelated edit until someone
+    // repairs the row, and the refusal it produced named a bound on a field the caller never sent.
+    // Review found this; the row here is written straight through Prisma because the fixed code can
+    // no longer produce it.
+    test("a row left invalid by the old behaviour can still be renamed", async () => {
+      const legacy = await suDb.knowledgeBase.create({
+        data: { tenantId, name: "legacy", chunkSize: 200, chunkOverlap: 4000 },
+        select: { id: true },
+      });
+      const id = String(legacy.id);
+      const previewed = await knowledgeUpdate(
+        principal(),
+        { knowledge_base_id: id, name: "renamed", dry_run: true },
+        { base: appDb },
+      );
+      expect(previewed.ok).toBe(true);
+      const applied = await apply(id, { name: "renamed" });
+      expect(applied.ok).toBe(true);
+      expect(await stored(id)).toEqual({ chunkSize: 200, chunkOverlap: 4000 });
+
+      // NOTE: the other half of the same sentence. Touching either number on that row IS a chunking
+      // patch, so it is judged, and the pair it would leave is still illegal.
+      const half = await apply(id, { chunk_overlap: 300 });
+      expect(half.ok).toBe(false);
+      const whole = await apply(id, { chunk_size: 800, chunk_overlap: 300 });
+      expect(whole.ok).toBe(true);
+    });
+  },
+);
+
+describe.skipIf(!dbUp)(
+  "knowledge_update's preview answers what its apply answers",
+  () => {
+    let tenantId = 0n;
+    const principal = (): VerifiedToken => ({
+      userId: 1n,
+      tenantId,
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:read", "mcp:write"],
+      clientId: "c",
+      jti: "j",
+    });
+
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "ChunkPrev", slug: `chunkprev-${process.pid}` },
+      });
+      tenantId = t.id;
+    });
+    afterAll(async () => {
+      await suDb.knowledgeBase.deleteMany({ where: { tenantId } });
+      await suDb.tenant.delete({ where: { id: tenantId } });
+      await su?.$disconnect();
+      await app?.$disconnect();
+    });
+
+    async function freshBase(): Promise<string> {
+      const r = await knowledgeCreate(
+        principal(),
+        { name: `kb-${crypto.randomUUID().slice(0, 8)}`, dry_run: false },
+        { base: appDb },
+      );
+      if (!r.ok) throw new Error(`could not seed: ${r.error}`);
+      const data = r.data as Record<string, unknown>;
+      return String((data.result as { id?: unknown })?.id ?? data.id);
+    }
+
+    const both = async (id: string, args: Record<string, unknown>) => ({
+      previewed: await knowledgeUpdate(
+        principal(),
+        { knowledge_base_id: id, ...args, dry_run: true } as never,
+        { base: appDb },
+      ),
+      applied: await knowledgeUpdate(
+        principal(),
+        { knowledge_base_id: id, ...args, dry_run: false } as never,
+        { base: appDb },
+      ),
+    });
+
+    test("a chunk size past the ceiling is refused by both halves", async () => {
+      const { previewed, applied } = await both(await freshBase(), {
+        chunk_size: 99999999,
+      });
+      expect(applied.ok).toBe(false);
+      expect(previewed.ok).toBe(false);
+    });
+
+    test("an overlap past the row's ceiling is refused by both halves", async () => {
+      const { previewed, applied } = await both(await freshBase(), {
+        chunk_overlap: 4000,
+      });
+      expect(applied.ok).toBe(false);
+      expect(previewed.ok).toBe(false);
+    });
+
+    // NOTE: a preview whose diff omits the fields it is about tells the operator nothing changes, and
+    // then the apply changes them. The tool accepts these two, so the preview names them.
+    test("the preview's diff names the chunking fields it will write", async () => {
+      const id = await freshBase();
+      const r = await knowledgeUpdate(
+        principal(),
+        {
+          knowledge_base_id: id,
+          chunk_size: 400,
+          chunk_overlap: 100,
+          dry_run: true,
+        },
+        { base: appDb },
+      );
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      const diff = (r.data as { diff: Record<string, unknown> }).diff;
+      expect(Object.keys(diff).sort()).toEqual(["chunkOverlap", "chunkSize"]);
+    });
+  },
+);


### PR DESCRIPTION
`chunkOverlap <= floor(chunkSize/2)` relates the two numbers a knowledge base holds, so a patch naming one of them is still a statement about the pair. `updateKnowledgeBase` asked it of the **arguments**:

```ts
if (params.chunkSize !== undefined && params.chunkOverlap !== undefined) {
  validateChunkParams(params.chunkSize, params.chunkOverlap);
} else if (params.chunkSize !== undefined) {
  if (params.chunkSize < 100 || params.chunkSize > 8000) { … }   // the STORED overlap is never re-checked
} else if (params.chunkOverlap !== undefined) {
  if (params.chunkOverlap < 0 || params.chunkOverlap > 4000) {   // a constant, not the row
    throw new AppError("chunkOverlap must be between 0 and floor(chunkSize/2)", 400);
```

The rule was written three times: once as `validateChunkParams`, twice inlined beside it. The third copy's `4000` is `floor(8000/2)` — half of the largest chunk size the repo allows — applied to every row whatever that row holds, and its message named `floor(chunkSize/2)`, which is not what it checked.

## Measured

On a fresh base, which the schema defaults to `1000/200`, through `knowledge_update` with `dry_run: false`:

```
chunk_size 200 + chunk_overlap 50      -> applied
chunk_overlap 4000 alone               -> applied
final row: { chunkSize: 200, chunkOverlap: 4000 }

chunk_size 8000 + chunk_overlap 4000   -> applied
chunk_size 200 alone                   -> applied
final row: { chunkSize: 200, chunkOverlap: 4000 }

control -- the same end state asked for in ONE call:
chunk_size 200 + chunk_overlap 4000    -> refused: "chunkOverlap must be between 0 and floor(chunkSize/2)"
```

An overlap twenty times the chunk: refused when asked for directly, stored when asked for in two steps. Reachable from both transports inside their published schemas — REST `PATCH /v1/knowledge/bases/:id` declares `chunkOverlap` as `minimum: 0, maximum: 4000`, and MCP `knowledge_update` publishes `chunk_overlap: z.number().int().optional()` with no bounds at all, so the core's constant was the only thing answering.

### Two more the same gap produced, found while measuring

```
chunk_size 99999999      previewed=ok  applied=refused   <- the #490 divergence
chunk_overlap 4000       previewed=ok  applied=ok
diff of both previews: {}
```

The preview approved what the apply refused, and announced an **empty diff** for an update that changes the row. Both have one mechanical cause: `getKnowledgeBase` was the only knowledge read that did not carry the chunking pair. `listKnowledgeBases` has always returned it and `knowledge_list` advertises it in its own description, so the single-item read was the outlier — and with nothing to compare against, the preview could neither ask the question nor name the fields it was about to write.

This is also a concrete instance of #510: `knowledge_update`'s row in the dry-run fence passes a nonexistent id, so it proved the ownership check and stopped there, and the divergence sat behind it.

## The fix

The rule exists once now, and is asked of the row:

```ts
export function assertChunkingUpdatable(
  stored: { chunkSize: number; chunkOverlap: number },
  patch: { chunkSize?: number; chunkOverlap?: number },
): void {
  validateChunkParams(
    patch.chunkSize ?? stored.chunkSize,
    patch.chunkOverlap ?? stored.chunkOverlap,
  );
}
```

- **The apply** calls it inside the transaction, immediately after `before` is read under `FOR UPDATE` — the row is locked, so the pair it validates is the pair the write produces. The three-way branch is gone.
- **The preview** calls it with the row it already fetched. That read is **advisory** and says so in the comment: it is outside the apply's transaction, so a concurrent update can move the pair between the halves. What it buys is that the ordinary case answers the same in both places instead of approving a write that cannot happen.
- **`getKnowledgeBase`** gained `chunkSize`/`chunkOverlap`, matching `listKnowledgeBases`.
- **The refusal names the ceiling it checked** and the chunk size that produced it. A caller sending only `chunk_overlap` could not otherwise tell which number it lost to, since that number was not in the request.

The preview's diff projecting the two fields rides along rather than arriving as its own change: the merged pair the validation needs is the same value the diff needs, so computing it twice to keep the diffs separate would be the worse outcome.

## Validation scope

**Proved by test.** `tests/modules/rag-chunking-bounds.test.ts`, DB-backed, seven tests in two blocks: the overlap-alone and chunk-size-alone directions each refuse and leave the row untouched; both halves of `knowledge_update` refuse an out-of-range chunk size and an out-of-range overlap; and the preview's diff names exactly `chunkSize` and `chunkOverlap`.

Two of the seven are **controls**, and they passed before this change as well as after: the pair that is legal together is still accepted, and the pair that is illegal together is still refused. Without them the five red ones would also pass against a tool that simply refused every chunking update.

**Mutation battery** (control first, 0 fail):

| mutation | fails |
| --- | --- |
| the apply's `assertChunkingUpdatable` deleted | **5** |
| the preview's `assertChunkingUpdatable` deleted | **2** |
| the merge stops reading the row (back to arguments only) | **3** |
| the preview stops projecting the chunking fields | **1** |

Full suite: 9718 pass, 4 skip, 0 fail. `tsc` clean, `i18n:extract` reports no change, and the four touched files pass biome on their own.

**Not validated live, and it does not apply.** No external system is on this path: the read and the write are both Prisma, and the live system here is the real Postgres the DB-backed tests run against.

**Not covered.** What an overlap larger than its chunk actually does at ingestion. The defect reported is that the row could hold such a pair at all, and it no longer can; the splitter's behaviour under one is a separate question, and `src/modules/rag/chunk.ts` defaulting `chunkOverlap` to 150 where the column defaults to 200 is another loose thread found nearby and deliberately left alone.

No row was added to `tests/modules/mcp/dry-run-coherence.test.ts`: `knowledge_update` already has one, so the registry sweep is satisfied, and the two halves are asserted directly in the new file instead. Making that fence's 33 not-found rows prove more than ownership is #510.

Fixes #524
