### PR TITLE
Refuse a base URL the credential's own type has no use for, and say when nothing sends the credential

### DIFF
--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -194,6 +194,7 @@
     "unsupportedFileType": "Unsupported file type: {{type}}",
     "unsupportedImageType": "Unsupported image type. Allowed: {{allowed}}",
     "userNotFound": "User not found",
+    "vaultBaseUrlNotApplicable": "The \"{{kind}}\" credential type does not use a base URL. The types that do are: {{kinds}}.",
     "vaultBaseUrlRequired": "This credential type requires a base URL.",
     "vaultFieldRequired": "The \"{{field}}\" field must not be empty",
     "vaultFieldUnknown": "This credential type has no field called \"{{field}}\"",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -194,6 +194,7 @@
     "unsupportedFileType": "Tipo de arquivo não suportado: {{type}}",
     "unsupportedImageType": "Tipo de imagem não suportado. Permitidos: {{allowed}}",
     "userNotFound": "Usuário não encontrado",
+    "vaultBaseUrlNotApplicable": "O tipo de credencial \"{{kind}}\" não usa URL base. Os tipos que usam são: {{kinds}}.",
     "vaultBaseUrlRequired": "Este tipo de credencial exige uma URL base.",
     "vaultFieldRequired": "O campo \"{{field}}\" não pode ficar vazio",
     "vaultFieldUnknown": "Este tipo de credencial não tem um campo chamado \"{{field}}\"",

--- a/src/api/v1/oauth-mcp.controller.ts
+++ b/src/api/v1/oauth-mcp.controller.ts
@@ -32,7 +32,11 @@ import {
   computeCodeChallenge,
   generateCodeVerifier,
 } from "@/modules/vault/oauth-core";
-import { replaceVaultSecret, vaultRefWhere } from "@/modules/vault/service";
+import {
+  dialableBaseUrl,
+  replaceVaultSecret,
+  vaultRefWhere,
+} from "@/modules/vault/service";
 
 // Generic MCP OAuth 2.1 *consumer* flow for the `mcp_oauth` vault kind (this app acting as an OAuth
 // client of an external MCP server — distinct from the PROVIDER-side mcpOAuthController under
@@ -110,7 +114,7 @@ async function loadMcpCredential(
     }
     return {
       cred: decryptJson<McpOAuthCredential>(entry.secret),
-      baseUrl: entry.baseUrl,
+      baseUrl: dialableBaseUrl(entry.kind, entry.baseUrl),
     };
   });
 }

--- a/src/api/v1/vault.controller.ts
+++ b/src/api/v1/vault.controller.ts
@@ -38,6 +38,7 @@ import {
 // translate('errors.vaultFieldRequired', 'The "{{field}}" field must not be empty')
 // translate('errors.vaultFieldUnknown', 'This credential type has no field called "{{field}}"')
 // translate('errors.vaultBaseUrlRequired', 'This credential type requires a base URL.')
+// translate('errors.vaultBaseUrlNotApplicable', 'The "{{kind}}" credential type does not use a base URL. The types that do are: {{kinds}}.')
 // translate('errors.vaultNameInUse', 'A secret with this name and type already exists')
 // translate('errors.vaultParamNameRequired', 'Param name is required for this credential type')
 // translate('errors.vaultParamNameNotApplicable', 'The "{{kind}}" credential type does not use a param name. The types that do are: {{kinds}}.')

--- a/src/client/lib/secretTypes.ts
+++ b/src/client/lib/secretTypes.ts
@@ -122,6 +122,31 @@ export function secretTypeSupportsBaseUrl(
   return !!(id && SECRET_TYPE_META[id as SecretTypeId]?.supportsBaseUrl);
 }
 
+// The client half of the server's gate (#504). A base URL stored on a kind that has no use for one is
+// no longer prepended to anything, so the console must not decide with it either: the tool editor
+// accepts a RELATIVE url_template only when a credential supplies a base, and reading the stray value
+// there would let an operator save a tool the runtime refuses to build.
+//
+// The carve-out is the server's, to the letter: a kind this build does not KNOW refuses nothing, so a
+// row written by a newer build keeps whatever it has. `Object.hasOwn` and not `in`, because `in`
+// walks the prototype and would call `toString` a known credential type.
+export function secretTypeRefusesBaseUrl(
+  id: string | null | undefined,
+): boolean {
+  return (
+    !!id &&
+    Object.hasOwn(SECRET_TYPE_META, id) &&
+    !SECRET_TYPE_META[id as SecretTypeId].supportsBaseUrl
+  );
+}
+
+export function dialableBaseUrl(
+  kind: string | null | undefined,
+  baseUrl: string | null | undefined,
+): string | null {
+  return secretTypeRefusesBaseUrl(kind) ? null : (baseUrl ?? null);
+}
+
 export function secretTypeRequiresBaseUrl(
   id: string | null | undefined,
 ): boolean {

--- a/src/client/lib/vaultCache.ts
+++ b/src/client/lib/vaultCache.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getActiveTenantId } from "@/client/lib/activeTenant";
 import { api } from "@/client/lib/api";
 import { canonicalVaultRef, formatVaultRef } from "@/client/lib/credentialRef";
+import { dialableBaseUrl } from "@/client/lib/secretTypes";
 import type { VaultRefFacts } from "@/modules/agents/config-health";
 
 // Derived from the treaty response, never hand-mirrored (see docs/eden-treaty.md).
@@ -139,11 +140,15 @@ export function useVaultBaseUrls(): (ref: string) => string | null {
     return () => window.removeEventListener(VAULT_CHANGED_EVENT, onChanged);
   }, [load]);
   return useCallback(
-    (ref: string) =>
-      (ref
-        ? entries.find((e) => formatVaultRef(e.id) === canonicalVaultRef(ref))
-            ?.baseUrl
-        : null) ?? null,
+    (ref: string) => {
+      if (!ref) return null;
+      // NOTE: the DIALABLE one. The listing reports the row as it is, so a stray base URL stays
+      // visible; what a page DECIDES with has to be what the runtime will use (#504).
+      const entry = entries.find(
+        (e) => formatVaultRef(e.id) === canonicalVaultRef(ref),
+      );
+      return entry ? dialableBaseUrl(entry.kind, entry.baseUrl) : null;
+    },
     [entries],
   );
 }

--- a/src/client/pages/resources/McpEditModal.tsx
+++ b/src/client/pages/resources/McpEditModal.tsx
@@ -18,6 +18,7 @@ import {
 import { useAuth } from "@/client/contexts/AuthContext";
 import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
+import { dialableBaseUrl } from "@/client/lib/secretTypes";
 import { isValidHttpUrl } from "@/client/lib/validation";
 import {
   composeStdioCommand,
@@ -414,7 +415,10 @@ export function McpEditModal({
               defaultCreateType={isStdio ? "mcp_env" : "mcp_oauth"}
               defaultCreateBaseUrl={mcpCredBaseUrl ?? form.url}
               onEntryChange={(entry: VaultEntry | null) => {
-                const credUrl = entry?.baseUrl ?? null;
+                // NOTE: the DIALABLE base (#504). This value LOCKS the connection URL field and
+                // fills it, so a stray base on a kind that carries none would show the operator an
+                // endpoint the runtime ignores — and let Save pass with `form.url` empty.
+                const credUrl = dialableBaseUrl(entry?.kind, entry?.baseUrl);
                 setMcpCredBaseUrl(credUrl);
                 if (credUrl) {
                   mcpUserUrlRef.current = form.url;

--- a/src/client/pages/resources/ToolEditModal.tsx
+++ b/src/client/pages/resources/ToolEditModal.tsx
@@ -23,6 +23,7 @@ import {
 import { Tooltip } from "@/client/components/Tooltip";
 import { useFieldRefusal } from "@/client/hooks/useFieldRefusal";
 import { api } from "@/client/lib/api";
+import { dialableBaseUrl } from "@/client/lib/secretTypes";
 import { cn } from "@/client/lib/utils";
 import { isValidUrlTemplate } from "@/client/lib/validation";
 import { normalizeToolName } from "@/graph/tools/toolName";
@@ -1345,7 +1346,13 @@ export function ToolEditModal({
     }
   }
 
-  const credBaseUrl = selectedCredential?.baseUrl ?? null;
+  // NOTE: the DIALABLE base, not the stored one (#504): a relative url_template is valid only when a
+  // credential supplies a base the runtime will actually prepend, and a stray value on a kind that
+  // takes none is no longer one.
+  const credBaseUrl = dialableBaseUrl(
+    selectedCredential?.kind,
+    selectedCredential?.baseUrl,
+  );
   // A relative path (starts with /) is valid only when a credential provides its base.
   const isRelativeTemplate =
     form.urlTemplate.trim().startsWith("/") &&

--- a/src/graph/tools/assemble.ts
+++ b/src/graph/tools/assemble.ts
@@ -6,6 +6,7 @@ import { parseTemplateContent } from "@/modules/documents/validate";
 import type { IntegrationSelection } from "@/modules/integrations/toolpacks";
 import { isManagedOAuthKind } from "@/modules/vault/secret-types";
 import {
+  dialableBaseUrl,
   formatVaultRef,
   readVaultRefId,
   tryResolveVaultEntry,
@@ -417,7 +418,9 @@ export async function loadToolSelections(
         : null;
       d.credentialKind = meta?.kind ?? null;
       d.credentialParamName = meta?.paramName ?? null;
-      d.credentialBaseUrl = meta?.baseUrl ?? null;
+      d.credentialBaseUrl = meta
+        ? dialableBaseUrl(meta.kind, meta.baseUrl)
+        : null;
     }
   }
   return result;

--- a/src/modules/agents/config-health-read.ts
+++ b/src/modules/agents/config-health-read.ts
@@ -34,7 +34,7 @@ import { readMemoryConfig } from "@/modules/memory/settings";
 import { readSttConfig } from "@/modules/stt/settings";
 import { getTenantSettings } from "@/modules/tenant-settings/service";
 import { readTtsConfig } from "@/modules/tts/settings";
-import { listVaultEntryInfos } from "@/modules/vault/service";
+import { dialableBaseUrl, listVaultEntryInfos } from "@/modules/vault/service";
 import { readVisionConfig } from "@/modules/vision/settings";
 
 // "Is this agent's configuration healthy?", answered for a caller that is not the browser.
@@ -149,8 +149,14 @@ export async function readAgentConfigHealth(
       { kind: e.kind, valueFitsKind: e.valueFitsKind },
     ]),
   );
+  // NOTE: the DIALABLE one, not the stored one. `listVaultInfos` reports the row as it is, so the
+  // console can show a base URL sitting on a kind whose form never rendered the field; what the
+  // runtime will actually use is the resolved value, and this block answers for the runtime.
   const baseUrlByRef = new Map(
-    vault.map((e) => [formatVaultRef(e.id), e.baseUrl]),
+    vault.map((e) => [
+      formatVaultRef(e.id),
+      dialableBaseUrl(e.kind, e.baseUrl),
+    ]),
   );
   const vaultBaseUrl = (ref: string | null | undefined): string | null => {
     const canonical = canonicalVaultRef(ref ?? "");

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -572,7 +572,11 @@ async function credentialWiringWarning(
     readVaultRefFacts(db, credentialRef),
   );
   const warning = unusedCredentialWarning(
-    { kind: facts?.kind ?? null, paramName: facts?.paramName ?? null },
+    {
+      kind: facts?.kind ?? null,
+      paramName: facts?.paramName ?? null,
+      baseUrl: facts?.baseUrl ?? null,
+    },
     method,
     shapes,
   );

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -766,8 +766,12 @@ export async function toolUpdate(
           : current.credentialRef,
         built.patch.method ?? current.method,
         { ...toolShapesOf(current), ...toolShapesOf(built.patch) },
+        // NOTE: `!== undefined` and not `??`: `ack_message: null` CLEARS the message, and reading a
+        // cleared field as "unchanged" restored the ack the applied row will not have.
         (built.patch.ackEnabled ?? current.ackEnabled)
-          ? (built.patch.ackMessage ?? current.ackMessage)
+          ? built.patch.ackMessage !== undefined
+            ? built.patch.ackMessage
+            : current.ackMessage
           : null,
       );
       const all = [...norm.warnings, ...wiring];

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -730,12 +730,26 @@ export async function toolUpdate(
     const appliedProj: Record<string, unknown> = {};
     for (const k of keys)
       appliedProj[k] = (updated as unknown as Record<string, unknown>)[k];
+    // NOTE: recomputed from the row the write RETURNED, like `appliedProj` beside it, rather than
+    // reused from the preview. The preview reads outside the write's transaction, so a second
+    // administrator can change the credential or a template in between — and the response would
+    // then report a diff of the row that was written next to a warning about the row that was read.
+    // No test distinguishes the two: the divergence needs a write landing inside that window, and
+    // the consistency with the line above is the argument.
+    const appliedWiring = await credentialWiringWarning(
+      ctx,
+      base,
+      updated.credentialRef,
+      updated.method,
+      toolShapesOf(updated),
+    );
+    const applied = [...norm.warnings, ...appliedWiring];
     return ok({
       dryRun: false,
       applied: true,
       target,
       diff: diffFields(beforeProj, appliedProj),
-      ...warnings,
+      ...(applied.length > 0 ? { warnings: applied } : {}),
     });
   } catch (e) {
     return failOf(e);

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -560,12 +560,42 @@ function toolShapesOf(src: {
 // normalization itself, because `buildHttpTool` runs it too and a legacy single-brace `{secret}`
 // sitting in a stored template is therefore sent. Normalizing only the patch, as the preview does
 // for its own purposes, would leave the stored half raw and report a working tool as unwired.
+// The same read AFTER the write has committed, and it can never take the write down with it. The
+// rule is docs/mcp.md's, for config-health: "the write had already committed, so a rejection is
+// reported rather than raised". A pool timeout on this advisory lookup would otherwise answer
+// `ok: false` for a tool that exists, and the caller's retry would meet a name conflict.
+//
+// Spelled out rather than forwarded with `...args`: the #502 fence reads these call sites for the
+// client they hand on, and a spread names none — it caught this one.
+async function appliedWiringWarning(
+  ctx: TenantContext,
+  base: PrismaClient,
+  credentialRef: string | null | undefined,
+  method: string | null | undefined,
+  shapes: ToolShapePatch,
+  ackMessage: string | null | undefined,
+): Promise<string[]> {
+  try {
+    return await credentialWiringWarning(
+      ctx,
+      base,
+      credentialRef,
+      method,
+      shapes,
+      ackMessage,
+    );
+  } catch {
+    return [];
+  }
+}
+
 async function credentialWiringWarning(
   ctx: TenantContext,
   base: PrismaClient,
   credentialRef: string | null | undefined,
   method: string | null | undefined,
   shapes: ToolShapePatch,
+  ackMessage: string | null | undefined,
 ): Promise<string[]> {
   if (!credentialRef) return [];
   const facts = await runScopedOn(base, ctx, (db) =>
@@ -580,6 +610,7 @@ async function credentialWiringWarning(
     { kind: facts.kind, paramName: facts.paramName, baseUrl: facts.baseUrl },
     method,
     shapes,
+    { ackMessage },
   );
   return warning ? [warning] : [];
 }
@@ -635,6 +666,7 @@ export async function toolCreate(
         input.credentialRef,
         input.method,
         toolShapesOf(input),
+        input.ackEnabled ? input.ackMessage : null,
       );
       const all = [...norm.warnings, ...wiring];
       return ok({
@@ -650,12 +682,13 @@ export async function toolCreate(
     // NOTE: recomputed from the row that was CREATED, for the reason the update path gives: the
     // preview's vault read happens before the write, and a credential's param name or base URL can
     // change in between — the response would then describe wiring that is already not the wiring.
-    const appliedWiring = await credentialWiringWarning(
+    const appliedWiring = await appliedWiringWarning(
       ctx,
       base,
       created.credentialRef,
       created.method,
       toolShapesOf(created),
+      created.ackEnabled ? created.ackMessage : null,
     );
     const applied = [...norm.warnings, ...appliedWiring];
     return ok({
@@ -733,6 +766,9 @@ export async function toolUpdate(
           : current.credentialRef,
         built.patch.method ?? current.method,
         { ...toolShapesOf(current), ...toolShapesOf(built.patch) },
+        (built.patch.ackEnabled ?? current.ackEnabled)
+          ? (built.patch.ackMessage ?? current.ackMessage)
+          : null,
       );
       const all = [...norm.warnings, ...wiring];
       return ok({
@@ -752,12 +788,13 @@ export async function toolUpdate(
     // then report a diff of the row that was written next to a warning about the row that was read.
     // No test distinguishes the two: the divergence needs a write landing inside that window, and
     // the consistency with the line above is the argument.
-    const appliedWiring = await credentialWiringWarning(
+    const appliedWiring = await appliedWiringWarning(
       ctx,
       base,
       updated.credentialRef,
       updated.method,
       toolShapesOf(updated),
+      updated.ackEnabled ? updated.ackMessage : null,
     );
     const applied = [...norm.warnings, ...appliedWiring];
     return ok({

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -574,6 +574,7 @@ async function appliedWiringWarning(
   method: string | null | undefined,
   shapes: ToolShapePatch,
   ackMessage: string | null | undefined,
+  allowedHosts: string[] | null | undefined,
 ): Promise<string[]> {
   try {
     return await credentialWiringWarning(
@@ -583,6 +584,7 @@ async function appliedWiringWarning(
       method,
       shapes,
       ackMessage,
+      allowedHosts,
     );
   } catch {
     return [];
@@ -596,6 +598,7 @@ async function credentialWiringWarning(
   method: string | null | undefined,
   shapes: ToolShapePatch,
   ackMessage: string | null | undefined,
+  allowedHosts: string[] | null | undefined,
 ): Promise<string[]> {
   if (!credentialRef) return [];
   const facts = await runScopedOn(base, ctx, (db) =>
@@ -610,7 +613,7 @@ async function credentialWiringWarning(
     { kind: facts.kind, paramName: facts.paramName, baseUrl: facts.baseUrl },
     method,
     shapes,
-    { ackMessage },
+    { ackMessage, allowedHosts },
   );
   return warning ? [warning] : [];
 }
@@ -667,6 +670,7 @@ export async function toolCreate(
         input.method,
         toolShapesOf(input),
         input.ackEnabled ? input.ackMessage : null,
+        input.allowedHosts,
       );
       const all = [...norm.warnings, ...wiring];
       return ok({
@@ -689,6 +693,7 @@ export async function toolCreate(
       created.method,
       toolShapesOf(created),
       created.ackEnabled ? created.ackMessage : null,
+      created.allowedHosts,
     );
     const applied = [...norm.warnings, ...appliedWiring];
     return ok({
@@ -773,6 +778,7 @@ export async function toolUpdate(
             ? built.patch.ackMessage
             : current.ackMessage
           : null,
+        built.patch.allowedHosts ?? current.allowedHosts,
       );
       const all = [...norm.warnings, ...wiring];
       return ok({
@@ -799,6 +805,7 @@ export async function toolUpdate(
       updated.method,
       toolShapesOf(updated),
       updated.ackEnabled ? updated.ackMessage : null,
+      updated.allowedHosts,
     );
     const applied = [...norm.warnings, ...appliedWiring];
     return ok({

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -1,7 +1,8 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { normalizeExpectedStatuses } from "@/graph/tools/http-status";
 import { AppError } from "@/lib/errors";
-import type { TenantContext } from "@/lib/tenancy";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { configHealthAfterWrite } from "@/modules/agents/config-health-read";
 import type { AgentMode } from "@/modules/agents/mode";
 import {
@@ -34,7 +35,11 @@ import {
   updateMcpConnection,
 } from "@/modules/mcp-connections/service";
 import { unsupportedBodyShape } from "@/modules/tool-definitions/body-shape";
-import { normalizeToolShapes } from "@/modules/tool-definitions/normalize";
+import { unusedCredentialWarning } from "@/modules/tool-definitions/credential-wiring";
+import {
+  normalizeToolShapes,
+  type ToolShapePatch,
+} from "@/modules/tool-definitions/normalize";
 import {
   readResponseTemplateResult,
   storableResponseTemplate,
@@ -49,6 +54,7 @@ import {
   type ToolDefinitionUpdate,
   updateToolDefinition,
 } from "@/modules/tool-definitions/service";
+import { readVaultRefFacts } from "@/modules/vault/service";
 import type { VerifiedToken } from "./oauth/tokens";
 import {
   diffFields,
@@ -522,6 +528,51 @@ export async function buildToolPatch(
   return { patch };
 }
 
+// The five interpolation sites off a row or a patch, as one object. Spelled once because the two
+// writers assemble the same thing from three different shapes (the create input, the update patch,
+// the stored row) and a site dropped from one of those spellings is a warning that fires on a tool
+// that is wired.
+function toolShapesOf(src: {
+  urlTemplate?: string | null;
+  query?: unknown;
+  headers?: unknown;
+  body?: unknown;
+  inputSchema?: unknown;
+}): ToolShapePatch {
+  const out: ToolShapePatch = {};
+  // NOTE: an absent site is OMITTED, never set to `undefined`. These objects are spread over one
+  // another to build the effective row, and a spread key whose value is `undefined` overwrites: the
+  // patch would erase every template it does not mention, and the warning would then fire on the
+  // tool it was reading.
+  if (typeof src.urlTemplate === "string") out.urlTemplate = src.urlTemplate;
+  if (src.query !== undefined) out.query = src.query;
+  if (src.headers !== undefined) out.headers = src.headers;
+  if (src.body !== undefined) out.body = src.body;
+  if (src.inputSchema !== undefined) out.inputSchema = src.inputSchema;
+  return out;
+}
+
+// The unused-credential warning for one tool write, with the vault read it needs. Called once per
+// write and spread into BOTH halves of the answer, like `norm.warnings` beside it: a preview that
+// stays quiet about wiring the apply will not fix is the preview promising something away (#490).
+//
+// `shapes` must be the EFFECTIVE, NORMALIZED templates — what the row will hold — not the raw
+// arguments. A single-brace `{secret}` is rewritten to `{{secret}}` on the way in, so scanning the
+// arguments would warn about a tool that is wired correctly the moment it is stored.
+async function credentialWiringWarning(
+  ctx: TenantContext,
+  base: PrismaClient,
+  credentialRef: string | null | undefined,
+  shapes: ToolShapePatch,
+): Promise<string[]> {
+  if (!credentialRef) return [];
+  const facts = await runScopedOn(base, ctx, (db) =>
+    readVaultRefFacts(db, credentialRef),
+  );
+  const warning = unusedCredentialWarning(facts?.kind ?? null, shapes);
+  return warning ? [warning] : [];
+}
+
 export async function toolCreate(
   principal: VerifiedToken,
   args: ToolWriteArgs & { dry_run?: boolean },
@@ -552,7 +603,12 @@ export async function toolCreate(
     body: input.body,
     inputSchema: input.inputSchema,
   });
-  const warnings = norm.warnings.length > 0 ? { warnings: norm.warnings } : {};
+  const wiring = await credentialWiringWarning(ctx, base, input.credentialRef, {
+    ...toolShapesOf(input),
+    ...norm.shapes,
+  });
+  const all = [...norm.warnings, ...wiring];
+  const warnings = all.length > 0 ? { warnings: all } : {};
   try {
     if (args.dry_run !== false) {
       // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
@@ -626,8 +682,24 @@ export async function toolUpdate(
       ...built.patch,
       ...norm.shapes,
     } as ToolDefinitionUpdate;
-    const warnings =
-      norm.warnings.length > 0 ? { warnings: norm.warnings } : {};
+    // NOTE: the EFFECTIVE row, patch over stored, because a patch that only attaches a credential
+    // says nothing about the templates and a patch that only rewrites a template says nothing about
+    // the credential. Judging either half alone is how this warning would fire on a tool that is
+    // wired and stay silent on one that is not.
+    const wiring = await credentialWiringWarning(
+      ctx,
+      base,
+      built.patch.credentialRef !== undefined
+        ? built.patch.credentialRef
+        : current.credentialRef,
+      {
+        ...toolShapesOf(current),
+        ...toolShapesOf(built.patch),
+        ...norm.shapes,
+      },
+    );
+    const all = [...norm.warnings, ...wiring];
+    const warnings = all.length > 0 ? { warnings: all } : {};
     const keys = Object.keys(built.patch) as (keyof ToolDefinitionUpdate)[];
     const beforeProj: Record<string, unknown> = {};
     const afterProj: Record<string, unknown> = {};

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -571,12 +571,13 @@ async function credentialWiringWarning(
   const facts = await runScopedOn(base, ctx, (db) =>
     readVaultRefFacts(db, credentialRef),
   );
+  // NOTE: a ref that names no row is a DIFFERENT problem — the credential was deleted, and the fix is
+  // to attach one, not to wire the one that is there. Reading the miss as a legacy `generic` handed
+  // that operator remediation for a tool whose credential does not exist. config-health is where the
+  // dangling ref is reported; this stays quiet about it.
+  if (!facts) return [];
   const warning = unusedCredentialWarning(
-    {
-      kind: facts?.kind ?? null,
-      paramName: facts?.paramName ?? null,
-      baseUrl: facts?.baseUrl ?? null,
-    },
+    { kind: facts.kind, paramName: facts.paramName, baseUrl: facts.baseUrl },
     method,
     shapes,
   );
@@ -613,15 +614,6 @@ export async function toolCreate(
     body: input.body,
     inputSchema: input.inputSchema,
   });
-  const wiring = await credentialWiringWarning(
-    ctx,
-    base,
-    input.credentialRef,
-    input.method,
-    toolShapesOf(input),
-  );
-  const all = [...norm.warnings, ...wiring];
-  const warnings = all.length > 0 ? { warnings: all } : {};
   try {
     if (args.dry_run !== false) {
       // NOTE: the core's own question, asked before the preview answers it. It sits INSIDE the
@@ -634,12 +626,23 @@ export async function toolCreate(
       // collision that actually happens (a name the operator already used), and the unique index
       // inside the write remains what guarantees one name to one row (#490).
       await assertToolNameAvailable(ctx, parsed.name, base);
+      // NOTE: INSIDE the branch, like the two checks above it and for a plainer reason: the apply
+      // recomputes this from the row it wrote, so reading the vault out here was a scoped
+      // transaction whose answer that path throws away.
+      const wiring = await credentialWiringWarning(
+        ctx,
+        base,
+        input.credentialRef,
+        input.method,
+        toolShapesOf(input),
+      );
+      const all = [...norm.warnings, ...wiring];
       return ok({
         dryRun: true,
         action: "create",
         resource: "tool",
         preview: { ...input, ...norm.shapes },
-        ...warnings,
+        ...(all.length > 0 ? { warnings: all } : {}),
       });
     }
     const created = await createToolDefinition(ctx, input, base);
@@ -706,21 +709,6 @@ export async function toolUpdate(
       ...built.patch,
       ...norm.shapes,
     } as ToolDefinitionUpdate;
-    // NOTE: the EFFECTIVE row, patch over stored, because a patch that only attaches a credential
-    // says nothing about the templates and a patch that only rewrites a template says nothing about
-    // the credential. Judging either half alone is how this warning would fire on a tool that is
-    // wired and stay silent on one that is not.
-    const wiring = await credentialWiringWarning(
-      ctx,
-      base,
-      built.patch.credentialRef !== undefined
-        ? built.patch.credentialRef
-        : current.credentialRef,
-      built.patch.method ?? current.method,
-      { ...toolShapesOf(current), ...toolShapesOf(built.patch) },
-    );
-    const all = [...norm.warnings, ...wiring];
-    const warnings = all.length > 0 ? { warnings: all } : {};
     const keys = Object.keys(built.patch) as (keyof ToolDefinitionUpdate)[];
     const beforeProj: Record<string, unknown> = {};
     const afterProj: Record<string, unknown> = {};
@@ -730,11 +718,28 @@ export async function toolUpdate(
     }
     const target = `tool:${id}`;
     if (args.dry_run !== false) {
+      // NOTE: the EFFECTIVE row, patch over stored, because a patch that only attaches a credential
+      // says nothing about the templates and a patch that only rewrites a template says nothing
+      // about the credential. Judging either half alone is how this warning would fire on a tool
+      // that is wired and stay silent on one that is not.
+      //
+      // And INSIDE the branch: the apply recomputes it from the row it wrote, so out here it was a
+      // scoped vault transaction whose answer that path throws away.
+      const wiring = await credentialWiringWarning(
+        ctx,
+        base,
+        built.patch.credentialRef !== undefined
+          ? built.patch.credentialRef
+          : current.credentialRef,
+        built.patch.method ?? current.method,
+        { ...toolShapesOf(current), ...toolShapesOf(built.patch) },
+      );
+      const all = [...norm.warnings, ...wiring];
       return ok({
         dryRun: true,
         target,
         diff: diffFields(beforeProj, afterProj),
-        ...warnings,
+        ...(all.length > 0 ? { warnings: all } : {}),
       });
     }
     const updated = await updateToolDefinition(ctx, id, built.patch, base);

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -54,7 +54,7 @@ import {
   type ToolDefinitionUpdate,
   updateToolDefinition,
 } from "@/modules/tool-definitions/service";
-import { readVaultRefFacts } from "@/modules/vault/service";
+import { dialableBaseUrl, readVaultRefFacts } from "@/modules/vault/service";
 import type { VerifiedToken } from "./oauth/tokens";
 import {
   diffFields,
@@ -610,7 +610,14 @@ async function credentialWiringWarning(
   // dangling ref is reported; this stays quiet about it.
   if (!facts) return [];
   const warning = unusedCredentialWarning(
-    { kind: facts.kind, paramName: facts.paramName, baseUrl: facts.baseUrl },
+    // NOTE: the DIALABLE base, like every other reader — the facts carry the row as it is, and a
+    // stray base URL on a kind that has no use for one is not prepended to anything any more. Judging
+    // the stored value would read a relative tool as pointing somewhere it does not.
+    {
+      kind: facts.kind,
+      paramName: facts.paramName,
+      baseUrl: dialableBaseUrl(facts.kind, facts.baseUrl),
+    },
     method,
     shapes,
     { ackMessage, allowedHosts },

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -644,12 +644,23 @@ export async function toolCreate(
     }
     const created = await createToolDefinition(ctx, input, base);
     const target = `tool:${created.id}`;
+    // NOTE: recomputed from the row that was CREATED, for the reason the update path gives: the
+    // preview's vault read happens before the write, and a credential's param name or base URL can
+    // change in between — the response would then describe wiring that is already not the wiring.
+    const appliedWiring = await credentialWiringWarning(
+      ctx,
+      base,
+      created.credentialRef,
+      created.method,
+      toolShapesOf(created),
+    );
+    const applied = [...norm.warnings, ...appliedWiring];
     return ok({
       dryRun: false,
       applied: true,
       target,
       tool: created,
-      ...warnings,
+      ...(applied.length > 0 ? { warnings: applied } : {}),
     });
   } catch (e) {
     return failOf(e);

--- a/src/modules/mcp/write-agents.ts
+++ b/src/modules/mcp/write-agents.ts
@@ -556,20 +556,26 @@ function toolShapesOf(src: {
 // write and spread into BOTH halves of the answer, like `norm.warnings` beside it: a preview that
 // stays quiet about wiring the apply will not fix is the preview promising something away (#490).
 //
-// `shapes` must be the EFFECTIVE, NORMALIZED templates — what the row will hold — not the raw
-// arguments. A single-brace `{secret}` is rewritten to `{{secret}}` on the way in, so scanning the
-// arguments would warn about a tool that is wired correctly the moment it is stored.
+// `shapes` is the EFFECTIVE row — patch over stored — and RAW: `unusedCredentialWarning` runs the
+// normalization itself, because `buildHttpTool` runs it too and a legacy single-brace `{secret}`
+// sitting in a stored template is therefore sent. Normalizing only the patch, as the preview does
+// for its own purposes, would leave the stored half raw and report a working tool as unwired.
 async function credentialWiringWarning(
   ctx: TenantContext,
   base: PrismaClient,
   credentialRef: string | null | undefined,
+  method: string | null | undefined,
   shapes: ToolShapePatch,
 ): Promise<string[]> {
   if (!credentialRef) return [];
   const facts = await runScopedOn(base, ctx, (db) =>
     readVaultRefFacts(db, credentialRef),
   );
-  const warning = unusedCredentialWarning(facts?.kind ?? null, shapes);
+  const warning = unusedCredentialWarning(
+    { kind: facts?.kind ?? null, paramName: facts?.paramName ?? null },
+    method,
+    shapes,
+  );
   return warning ? [warning] : [];
 }
 
@@ -603,10 +609,13 @@ export async function toolCreate(
     body: input.body,
     inputSchema: input.inputSchema,
   });
-  const wiring = await credentialWiringWarning(ctx, base, input.credentialRef, {
-    ...toolShapesOf(input),
-    ...norm.shapes,
-  });
+  const wiring = await credentialWiringWarning(
+    ctx,
+    base,
+    input.credentialRef,
+    input.method,
+    toolShapesOf(input),
+  );
   const all = [...norm.warnings, ...wiring];
   const warnings = all.length > 0 ? { warnings: all } : {};
   try {
@@ -692,11 +701,8 @@ export async function toolUpdate(
       built.patch.credentialRef !== undefined
         ? built.patch.credentialRef
         : current.credentialRef,
-      {
-        ...toolShapesOf(current),
-        ...toolShapesOf(built.patch),
-        ...norm.shapes,
-      },
+      built.patch.method ?? current.method,
+      { ...toolShapesOf(current), ...toolShapesOf(built.patch) },
     );
     const all = [...norm.warnings, ...wiring];
     const warnings = all.length > 0 ? { warnings: all } : {};

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -368,7 +368,11 @@ export function effectiveUrlTemplate(
 // and throws `invalid urlTemplate` when that fails — so a stored `not-a-url`, which the definition
 // schema accepts, is a tool that never reaches a fetch. Same reasoning as the relative-with-no-base
 // case above: there is no unauthenticated request to warn about.
-function buildsARequest(urlTemplate: unknown, shapes: ToolShapePatch): boolean {
+function buildsARequest(
+  urlTemplate: unknown,
+  shapes: ToolShapePatch,
+  ackArg: boolean,
+): boolean {
   if (typeof urlTemplate !== "string") return false;
   // The ORIGIN is pinned: `buildHttpTool` takes it from the neutralized template and throws
   // "interpolation altered the origin" when the real one differs, so a placeholder anywhere in the
@@ -390,6 +394,9 @@ function buildsARequest(urlTemplate: unknown, shapes: ToolShapePatch): boolean {
   const fixed = fixedValuesByName(shapes.inputSchema);
   for (const name of namesIn(urlTemplate)) {
     if (name === "secret") continue;
+    // The ack argument is declared by the RUNTIME, not by the schema, so it is not an orphan on a
+    // tool that has an ack — and is one on a tool that does not.
+    if (ackArg && name === WAIT_MESSAGE_ARG) continue;
     // A prototype name resolves for the same reason it resolves everywhere else here: `valueLookup`
     // asks `n in input` and finds Object.prototype's member. Undeclared, and still not an orphan.
     if (name in {}) continue;
@@ -607,7 +614,10 @@ export function unusedCredentialWarning(
   if (isNonInjectableSecret(facts.kind)) return null;
   const { shapes: normalized } = normalizeToolShapes(raw);
   const effective = effectiveUrlTemplate(normalized.urlTemplate, facts.baseUrl);
-  if (effective === null || !buildsARequest(effective, normalized)) return null;
+  const ackArg = !!opts.ackMessage;
+  if (effective === null || !buildsARequest(effective, normalized, ackArg)) {
+    return null;
+  }
   const shapes: ToolShapePatch = {
     ...normalized,
     urlTemplate: effective as string | undefined,
@@ -619,7 +629,7 @@ export function unusedCredentialWarning(
     facts.paramName,
     m,
     shapes,
-    !!opts.ackMessage,
+    ackArg,
   );
   if (verdict.state === "reaches") return null;
 

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -109,10 +109,11 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-function stringValues(v: unknown): string[] {
-  return isPlainObject(v)
-    ? Object.values(v).filter((x): x is string => typeof x === "string")
-    : [];
+// Header values as the runtime reads them: `interpolate(String(v), …)` on every entry, whatever its
+// JSON type. Filtering to strings dropped an `Authorization: ["Bearer {{secret}}"]` that the
+// executor sends verbatim, and warned about the credential it was carrying.
+function headerTemplates(v: unknown): string[] {
+  return isPlainObject(v) ? Object.values(v).map((x) => String(x)) : [];
 }
 
 // The query map as the runtime reads it (`parseQuery`): a null/undefined value is dropped and
@@ -302,7 +303,7 @@ export function reachableTemplates(
 ): string[] {
   const emitted: string[] = [...transmittedUrl(shapes.urlTemplate)];
   emitted.push(
-    ...stringValues(shapes.headers),
+    ...headerTemplates(shapes.headers),
     ...Object.values(reachingQuery(shapes)),
   );
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -92,14 +92,53 @@ const mentions = (templates: string[], name: string): boolean =>
 //
 // One level, because that is the runtime's: a fixed value interpolates from context and the secret,
 // never from another fixed field.
+// The declared types whose value can never stringify to the empty string: zod gives a number, an
+// integer or a boolean, and `String()` of any of them is at least one character. A `string` field
+// can be `""`, and an enum is only sure when every one of its values is non-empty.
+//
+// A required `string` is the case this cannot answer, and it is deliberately on the quiet side:
+// `zodFor` builds a bare `z.string()` with no `.min(1)`, so the model may send `""` and the runtime
+// then SKIPS that query entry and injects the credential after all. Whether the credential is sent
+// depends on what the model typed, so no executed row can assert it either way — the same shape as
+// the multi-value enum above.
+function neverEmptyByType(spec: Record<string, unknown>): boolean {
+  if (spec.type === "integer" || spec.type === "number") return true;
+  if (spec.type === "boolean") return true;
+  if (spec.type === "enum") {
+    const values = spec.enumValues;
+    return (
+      Array.isArray(values) &&
+      values.length > 0 &&
+      values.every((v) => typeof v === "string" && v !== "")
+    );
+  }
+  return false;
+}
+
+// The REQUIRED ai fields the runtime is sure to receive a non-empty value for. Required is the first
+// half — zod refuses the call without it — and the type is the second: a required `string` may still
+// arrive empty, and an empty query value is one the runtime skips.
+function alwaysFilledAiNames(schema: unknown): Set<string> {
+  const out = new Set<string>();
+  if (typeof schema !== "object" || schema === null) return out;
+  for (const [name, spec] of Object.entries(schema)) {
+    if (!isPlainObject(spec) || spec.source === "fixed") continue;
+    if (!spec.required) continue;
+    if (neverEmptyByType(spec)) out.add(name);
+  }
+  return out;
+}
+
 function alwaysNonEmpty(
   template: string,
   fixed: Map<string, string>,
   resolveFixed = true,
   ackArg = false,
+  alwaysFilled: Set<string> = new Set(),
 ): boolean {
   if (template.replace(PLACEHOLDER, "") !== "") return true;
   if (ackArg && namesIn(template).has(WAIT_MESSAGE_ARG)) return true;
+  for (const name of namesIn(template)) if (alwaysFilled.has(name)) return true;
   // ABOVE the recursion guard, not inside the loop below it: a prototype name resolves to a
   // stringified Object member at ANY depth, so a fixed value of `{{toString}}` is non-empty when it
   // is followed as well as when it is read directly.
@@ -137,6 +176,9 @@ function knownValuesByName(schema: unknown): Map<string, string> {
   for (const [name, spec] of Object.entries(schema)) {
     if (!isPlainObject(spec) || spec.source === "fixed") continue;
     if (!spec.required) continue;
+    // `zodFor` reads `enumValues` only for `type: "enum"`; on a string field it is decoration and
+    // the model may send anything, so the key stays unknowable.
+    if (spec.type !== "enum") continue;
     const values = spec.enumValues;
     if (Array.isArray(values) && values.length === 1) {
       const only = values[0];
@@ -367,6 +409,10 @@ function fixedFields(schema: unknown): { name: string; value: string }[] {
     // gives it `""` — and its NAME is what the legacy query derivation puts on the URL, blocking a
     // query credential of the same name. Dropping it here lost the name, not just the value.
     if (isPlainObject(spec) && spec.source === "fixed") {
+      // `fixedValues[f.name] = …` on a plain `{}` again: a field named `__proto__` reaches the
+      // inherited setter and no value is stored, so every reader of that map gets the prototype
+      // instead. Same swallow as the header of that name, in the map the executor builds for itself.
+      if (name === SWALLOWED_HEADER) continue;
       out.push({
         name,
         value: typeof spec.value === "string" ? spec.value : "",
@@ -405,6 +451,7 @@ function buildsARequest(
   urlTemplate: unknown,
   shapes: ToolShapePatch,
   ackArg: boolean,
+  allowedHosts: string[] | null | undefined,
 ): boolean {
   if (typeof urlTemplate !== "string") return false;
   // The ORIGIN is pinned: `buildHttpTool` takes it from the neutralized template and throws
@@ -414,6 +461,18 @@ function buildsARequest(
   const a = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_A);
   const b = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_B);
   if (!a || !b || a.origin !== b.origin) return false;
+  // The allowlist, which is checked before the fetch and throws. The origins above being equal is
+  // what makes the host literal, so this is a decision and not a guess: a non-empty list that does
+  // not name it refuses every call of this tool. (The credential-base exemption is for RELATIVE
+  // templates, and by here the template is absolute — a relative one was already joined to its base
+  // by `effectiveUrlTemplate`, and that host has to be listed too.)
+  if (
+    allowedHosts &&
+    allowedHosts.length > 0 &&
+    !allowedHosts.includes(a.hostname)
+  ) {
+    return false;
+  }
   try {
     new URL(urlTemplate.replace(PLACEHOLDER, "_"));
   } catch {
@@ -601,7 +660,14 @@ function autoInjectionVerdict(
   }
   const explicit = reachingQuery(shapes)[inj.name];
   const alwaysSet =
-    explicit !== undefined && alwaysNonEmpty(explicit, fixed, true, ackArg);
+    explicit !== undefined &&
+    alwaysNonEmpty(
+      explicit,
+      fixed,
+      true,
+      ackArg,
+      alwaysFilledAiNames(shapes.inputSchema),
+    );
   return alwaysSet ? shadowed("tool") : { state: "reaches" };
 }
 
@@ -647,13 +713,16 @@ export function unusedCredentialWarning(
   // The tool's own ack, when it has one. `buildHttpTool` then DECLARES a required, non-empty
   // `__wait_message` argument of its own, so a query value of `{{__wait_message}}` is set on every
   // executable call and takes its parameter — a field that is in no input schema anywhere.
-  opts: { ackMessage?: string | null } = {},
+  opts: { ackMessage?: string | null; allowedHosts?: string[] | null } = {},
 ): string | null {
   if (isNonInjectableSecret(facts.kind)) return null;
   const { shapes: normalized } = normalizeToolShapes(raw);
   const effective = effectiveUrlTemplate(normalized.urlTemplate, facts.baseUrl);
   const ackArg = !!opts.ackMessage;
-  if (effective === null || !buildsARequest(effective, normalized, ackArg)) {
+  if (
+    effective === null ||
+    !buildsARequest(effective, normalized, ackArg, opts.allowedHosts)
+  ) {
     return null;
   }
   const shapes: ToolShapePatch = {

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -113,15 +113,24 @@ function queryMap(raw: unknown): Record<string, string> {
   return out;
 }
 
-// The URL the runtime will parse, with the placeholders neutralized the way `buildHttpTool` does for
-// its own origin probe. The base is only there so a relative template parses; nothing reads the host.
-function parseUrlTemplate(urlTemplate: unknown): URL | null {
+// The URL the runtime will parse. A placeholder naming a FIXED field is substituted first, because
+// a query KEY can be one — `?{{auth_param}}=constant` over a fixed `auth_param: "token"` is the
+// parameter `token`, and neutralizing it to `_` loses the key the runtime will find there. What is
+// left is neutralized the way `buildHttpTool` does for its own origin probe. The base is only there
+// so a relative template parses; nothing reads the host.
+function parseUrlTemplate(
+  urlTemplate: unknown,
+  fixed: Map<string, string> = new Map(),
+): URL | null {
   if (typeof urlTemplate !== "string") return null;
+  const resolved = urlTemplate.replace(PLACEHOLDER, (_whole, name: string) => {
+    const value = fixed.get(name);
+    // One level, like everywhere else here: a fixed value that is itself a template resolves from
+    // context, which is unknowable, so it stays neutral.
+    return value !== undefined && namesIn(value).size === 0 ? value : "_";
+  });
   try {
-    return new URL(
-      urlTemplate.replace(PLACEHOLDER, "_"),
-      "https://placeholder.invalid",
-    );
+    return new URL(resolved, "https://placeholder.invalid");
   } catch {
     return null;
   }
@@ -134,8 +143,11 @@ function parseUrlTemplate(urlTemplate: unknown): URL | null {
 // Parsed as a URL rather than split on "?", because a query VALUE may hold one of its own — a
 // `redirect=https://a.test/?x=1&token=fixed` keeps everything after the second question mark, which
 // `split("?")[1]` throws away and `searchParams` does not.
-function urlQueryKeys(urlTemplate: unknown): Set<string> {
-  const url = parseUrlTemplate(urlTemplate);
+function urlQueryKeys(
+  urlTemplate: unknown,
+  fixed: Map<string, string> = new Map(),
+): Set<string> {
+  const url = parseUrlTemplate(urlTemplate, fixed);
   return url ? new Set([...url.searchParams.keys()]) : new Set();
 }
 
@@ -150,7 +162,10 @@ function transmittedUrl(urlTemplate: unknown): string[] {
 // The explicit query entries that survive to the request: everything the URL template does not
 // already spell.
 function reachingQuery(shapes: ToolShapePatch): Record<string, string> {
-  const taken = urlQueryKeys(shapes.urlTemplate);
+  const taken = urlQueryKeys(
+    shapes.urlTemplate,
+    fixedValuesByName(shapes.inputSchema),
+  );
   return Object.fromEntries(
     Object.entries(queryMap(shapes.query)).filter(([k]) => !taken.has(k)),
   );
@@ -236,9 +251,16 @@ export function reachableTemplates(
 // the target query param, letting their explicit value win — so a `bearer_token` attached to a tool
 // that sets its own `Authorization` is never sent, which is exactly the shape this file exists to
 // report.
+// The names the URL template interpolates — `pathFields` in the runtime, which excludes them from
+// the legacy query derivation because they are already spent on the path.
+function urlPlaceholderNames(urlTemplate: unknown): Set<string> {
+  return typeof urlTemplate === "string" ? namesIn(urlTemplate) : new Set();
+}
+
 function autoInjectionReaches(
   kind: string | null | undefined,
   paramName: string | null | undefined,
+  method: string,
   shapes: ToolShapePatch,
 ): boolean {
   // The value is a probe, never a secret: `resolveSecretInjection` only needs a non-empty string to
@@ -257,11 +279,23 @@ function autoInjectionReaches(
   // cannot come out empty whatever `id` is, while a bare `{{id}}` can, and only the first is sure to
   // take the parameter. Guessing that a placeholder always resolves would warn about a tool that is
   // wired.
-  if (urlQueryKeys(shapes.urlTemplate).has(inj.name)) return false;
+  const fixed = fixedValuesByName(shapes.inputSchema);
+  if (urlQueryKeys(shapes.urlTemplate, fixed).has(inj.name)) return false;
+  // The legacy derivation: a NON-body method whose body is the legacy `fields` shape and which has no
+  // explicit query copies its non-path input fields into the URL — before auto-injection, and with
+  // `v != null` rather than `v !== ""`, so a fixed field of that name takes the parameter whatever it
+  // holds. An AI field of that name is not counted: the model may omit it, and that is unknowable.
+  if (
+    !BODY_METHODS.has(method) &&
+    isLegacyFieldsBody(shapes.body) &&
+    Object.keys(queryMap(shapes.query)).length === 0 &&
+    fixed.has(inj.name) &&
+    !urlPlaceholderNames(shapes.urlTemplate).has(inj.name)
+  ) {
+    return false;
+  }
   const explicit = reachingQuery(shapes)[inj.name];
-  const alwaysSet =
-    explicit !== undefined &&
-    alwaysNonEmpty(explicit, fixedValuesByName(shapes.inputSchema));
+  const alwaysSet = explicit !== undefined && alwaysNonEmpty(explicit, fixed);
   return !alwaysSet;
 }
 
@@ -272,7 +306,12 @@ export function credentialReachesRequest(
   shapes: ToolShapePatch,
 ): boolean {
   if (mentions(reachableTemplates(method, shapes), "secret")) return true;
-  return autoInjectionReaches(kind, paramName, shapes);
+  return autoInjectionReaches(
+    kind,
+    paramName,
+    (method ?? DEFAULT_HTTP_METHOD).toUpperCase(),
+    shapes,
+  );
 }
 
 // The warning, or null when the wiring is fine. `kind` is the ATTACHED credential's kind, read off

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -428,13 +428,15 @@ function fixedFields(schema: unknown): { name: string; value: string }[] {
 // The template the runtime actually requests. A urlTemplate starting with "/" is RELATIVE and gets
 // the credential's own base URL prepended before anything is interpolated, so a `{{secret}}` stored
 // in that base is sent — the row alone cannot say whether the credential leaves.
+export function isRelativeTemplate(urlTemplate: unknown): boolean {
+  return typeof urlTemplate === "string" && urlTemplate.startsWith("/");
+}
+
 export function effectiveUrlTemplate(
   urlTemplate: unknown,
   credentialBaseUrl: string | null | undefined,
 ): unknown {
-  if (typeof urlTemplate !== "string" || !urlTemplate.startsWith("/")) {
-    return urlTemplate;
-  }
+  if (!isRelativeTemplate(urlTemplate)) return urlTemplate;
   // No base and a relative template is a tool `buildHttpTool` REFUSES to build — it throws "relative
   // urlTemplate requires a credential with a base URL" before there is a request at all. Answering
   // `null` here is what lets the caller stay quiet: a warning that the request goes out
@@ -452,6 +454,7 @@ function buildsARequest(
   shapes: ToolShapePatch,
   ackArg: boolean,
   allowedHosts: string[] | null | undefined,
+  relative: boolean,
 ): boolean {
   if (typeof urlTemplate !== "string") return false;
   // The ORIGIN is pinned: `buildHttpTool` takes it from the neutralized template and throws
@@ -463,10 +466,14 @@ function buildsARequest(
   if (!a || !b || a.origin !== b.origin) return false;
   // The allowlist, which is checked before the fetch and throws. The origins above being equal is
   // what makes the host literal, so this is a decision and not a guess: a non-empty list that does
-  // not name it refuses every call of this tool. (The credential-base exemption is for RELATIVE
-  // templates, and by here the template is absolute — a relative one was already joined to its base
-  // by `effectiveUrlTemplate`, and that host has to be listed too.)
+  // not name it refuses every call of this tool.
+  //
+  // ABSOLUTE templates only. A relative one is explicitly EXEMPT when its host is the credential's
+  // own base — `buildHttpTool` keeps `isRelative` for exactly that — and by here the two have been
+  // joined into one string, so the host looks like any other. Judging it as one would call a working
+  // tool unrunnable and silence a real warning.
   if (
+    !relative &&
     allowedHosts &&
     allowedHosts.length > 0 &&
     !allowedHosts.includes(a.hostname)
@@ -721,7 +728,13 @@ export function unusedCredentialWarning(
   const ackArg = !!opts.ackMessage;
   if (
     effective === null ||
-    !buildsARequest(effective, normalized, ackArg, opts.allowedHosts)
+    !buildsARequest(
+      effective,
+      normalized,
+      ackArg,
+      opts.allowedHosts,
+      isRelativeTemplate(normalized.urlTemplate),
+    )
   ) {
     return null;
   }

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -96,6 +96,12 @@ function alwaysNonEmpty(
   if (template.replace(PLACEHOLDER, "") !== "") return true;
   if (!resolveFixed) return false;
   for (const name of namesIn(template)) {
+    // The prototype names are non-empty for a DIFFERENT reason than the fixed ones, and the two
+    // questions this file asks about them have opposite answers. WHICH key the URL ends up with is
+    // unknowable (it is not the operator's value — see `fixedSubstitution`); whether the value can
+    // come out EMPTY is not: `String(Object.prototype.toString)` and friends are long strings, so a
+    // query value of `{{toString}}` always takes its parameter and always blocks the injection.
+    if (name in {}) return true;
     const value = fixedSubstitution(name, fixed);
     if (value !== undefined && alwaysNonEmpty(value, fixed, false)) return true;
   }
@@ -241,7 +247,7 @@ interface AiFields {
 function aiFields(schema: unknown): AiFields {
   const names = new Set<string>();
   const optional = new Set<string>();
-  if (!isPlainObject(schema)) return { names, optional };
+  if (typeof schema !== "object" || schema === null) return { names, optional };
   for (const [name, spec] of Object.entries(schema)) {
     const s = isPlainObject(spec) ? spec : {};
     if (s.source === "fixed") continue;
@@ -302,7 +308,10 @@ function isLegacyFieldsBody(body: unknown): boolean {
 }
 
 function fixedFields(schema: unknown): { name: string; value: string }[] {
-  if (!isPlainObject(schema)) return [];
+  // ANY object, arrays included: `parseFields` guards on `typeof raw === "object"` like every other
+  // reader in the executor, so a legacy row whose schema is an array has fields named 0, 1, 2 —
+  // fixed values among them.
+  if (typeof schema !== "object" || schema === null) return [];
   const out: { name: string; value: string }[] = [];
   for (const [name, spec] of Object.entries(schema)) {
     // `source === "fixed"` is not a detail: `buildHttpTool` reads `s.source === "fixed" ? "fixed" :
@@ -339,6 +348,21 @@ export function effectiveUrlTemplate(
   // `null` here is what lets the caller stay quiet: a warning that the request goes out
   // unauthenticated diagnoses a failure that cannot happen, and points away from the one that does.
   return credentialBaseUrl ? `${credentialBaseUrl}${urlTemplate}` : null;
+}
+
+// Whether the runtime can build a request from this template at all. It parses the neutralized
+// template with NO base (`new URL(effectiveTemplate.replace(PLACEHOLDER, "_"))`) to pin the origin,
+// and throws `invalid urlTemplate` when that fails — so a stored `not-a-url`, which the definition
+// schema accepts, is a tool that never reaches a fetch. Same reasoning as the relative-with-no-base
+// case above: there is no unauthenticated request to warn about.
+function buildsARequest(urlTemplate: unknown): boolean {
+  if (typeof urlTemplate !== "string") return false;
+  try {
+    new URL(urlTemplate.replace(PLACEHOLDER, "_"));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function reachableTemplates(
@@ -509,7 +533,7 @@ export function unusedCredentialWarning(
   if (isNonInjectableSecret(facts.kind)) return null;
   const { shapes: normalized } = normalizeToolShapes(raw);
   const effective = effectiveUrlTemplate(normalized.urlTemplate, facts.baseUrl);
-  if (effective === null) return null;
+  if (effective === null || !buildsARequest(effective)) return null;
   const shapes: ToolShapePatch = {
     ...normalized,
     urlTemplate: effective as string | undefined,

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -53,12 +53,18 @@ const PLACEHOLDER = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
 // graph/tools/http.ts): a lone AI field the model OMITS makes the runtime skip that row entirely.
 const LONE_PLACEHOLDER = /^\{\{\s*([a-zA-Z0-9_]+)\s*\}\}$/;
 
-// What an UNRESOLVED placeholder becomes while the URL is parsed, and the one thing that matters
-// about it is that NO param name can be this string: `validateParamName` holds those to
-// `[A-Za-z0-9!#$%&'*+.^_`|~-]`, and parentheses are outside it. A key this file could not resolve is
-// UNKNOWN, so a sentinel a real name could equal answers "that parameter is already taken" for a
-// tool where it is not — and it did: `_` was the sentinel, and `paramName: "_"` is legal.
-const UNRESOLVED_KEY = "((unresolved))";
+// TWO sentinels for an unresolved placeholder, and the pair is the mechanism. A query KEY may be a
+// placeholder, and the key it becomes at runtime is unknowable here; a single sentinel puts a made-up
+// key into a space where a real one could equal it, and then answers "that parameter is taken" for a
+// tool where it is not. Both spellings have already cost a round: `_` collided with a legal param
+// name, `((unresolved))` with a legal query-map key.
+//
+// Parsing the same template under both and INTERSECTING the key sets needs no such assumption. A
+// literal key parses identically twice and survives; a placeholder-derived one differs and drops out
+// — including a literal key that happens to equal one of the sentinels, which still parses the same
+// both times.
+const UNRESOLVED_A = "((unresolved-a))";
+const UNRESOLVED_B = "((unresolved-b))";
 
 function namesIn(template: string): Set<string> {
   return new Set(
@@ -131,7 +137,9 @@ function headerTemplates(v: unknown): string[] {
 // parameter the operator has already taken.
 function queryMap(raw: unknown): Record<string, string> {
   const out: Record<string, string> = {};
-  if (!isPlainObject(raw)) return out;
+  // ANY object, arrays included — `parseQuery` guards on `typeof raw === "object"` and nothing else,
+  // so a stored `query: ["{{secret}}"]` is the parameter `0`, exactly as a headers array is.
+  if (typeof raw !== "object" || raw === null) return out;
   for (const [k, v] of Object.entries(raw)) {
     if (v == null) continue;
     out[k] = typeof v === "string" ? v : String(v);
@@ -147,6 +155,7 @@ function queryMap(raw: unknown): Record<string, string> {
 function parseUrlTemplate(
   urlTemplate: unknown,
   fixed: Map<string, string> = new Map(),
+  unresolved: string = UNRESOLVED_A,
 ): URL | null {
   if (typeof urlTemplate !== "string") return null;
   const resolved = urlTemplate.replace(PLACEHOLDER, (_whole, name: string) => {
@@ -159,7 +168,7 @@ function parseUrlTemplate(
     // credential's own parameter as already taken and warn about a tool that injects it.
     return value !== undefined && namesIn(value).size === 0
       ? encodeURIComponent(value)
-      : UNRESOLVED_KEY;
+      : unresolved;
   });
   try {
     return new URL(resolved, "https://placeholder.invalid");
@@ -179,8 +188,11 @@ function urlQueryKeys(
   urlTemplate: unknown,
   fixed: Map<string, string> = new Map(),
 ): Set<string> {
-  const url = parseUrlTemplate(urlTemplate, fixed);
-  return url ? new Set([...url.searchParams.keys()]) : new Set();
+  const a = parseUrlTemplate(urlTemplate, fixed, UNRESOLVED_A);
+  const b = parseUrlTemplate(urlTemplate, fixed, UNRESOLVED_B);
+  if (!a || !b) return new Set();
+  const other = new Set(b.searchParams.keys());
+  return new Set([...a.searchParams.keys()].filter((k) => other.has(k)));
 }
 
 // The URL as far as it is TRANSMITTED. A fragment is not sent to the upstream — measured on a real
@@ -356,16 +368,37 @@ function urlPlaceholderNames(urlTemplate: unknown): Set<string> {
   return typeof urlTemplate === "string" ? namesIn(urlTemplate) : new Set();
 }
 
-function autoInjectionReaches(
+// WHY the credential's own injection does or does not put it on the request, not just whether. The
+// three answers are three different things to tell an operator, and collapsing them to a boolean is
+// how the warning came to advise someone who had already done what it was advising: a `bearer_token`
+// whose `Authorization` header the tool sets itself IS an injecting type, correctly attached, and
+// the fix is the header, not the credential.
+type InjectionVerdict =
+  | { state: "none" }
+  | { state: "reaches" }
+  | {
+      state: "shadowed";
+      target: "header" | "query";
+      name: string;
+      by: "tool" | "runtime";
+    };
+
+function autoInjectionVerdict(
   kind: string | null | undefined,
   paramName: string | null | undefined,
   method: string,
   shapes: ToolShapePatch,
-): boolean {
+): InjectionVerdict {
   // The value is a probe, never a secret: `resolveSecretInjection` only needs a non-empty string to
   // answer WHERE the credential would go.
   const inj = resolveSecretInjection(kind, "probe", paramName);
-  if (!inj) return false;
+  if (!inj) return { state: "none" };
+  const shadowed = (by: "tool" | "runtime"): InjectionVerdict => ({
+    state: "shadowed",
+    target: inj.target,
+    name: inj.name,
+    by,
+  });
   if (inj.target === "header") {
     const names = headerEntries(shapes.headers).map(([name]) => name);
     // The one header the runtime writes ITSELF: a body method with no content-type of its own gets
@@ -376,9 +409,11 @@ function autoInjectionReaches(
       inj.name.toLowerCase() === "content-type" &&
       !names.some((h) => h.toLowerCase() === "content-type")
     ) {
-      return false;
+      return shadowed("runtime");
     }
-    return !names.some((h) => h.toLowerCase() === inj.name.toLowerCase());
+    return names.some((h) => h.toLowerCase() === inj.name.toLowerCase())
+      ? shadowed("tool")
+      : { state: "reaches" };
   }
   // Query: the runtime injects unless the param is already on the URL — spelled in the template, or
   // set from the explicit query map, which it applies first and only for a value that resolves
@@ -387,23 +422,31 @@ function autoInjectionReaches(
   // take the parameter. Guessing that a placeholder always resolves would warn about a tool that is
   // wired.
   const fixed = fixedValuesByName(shapes.inputSchema);
-  if (urlQueryKeys(shapes.urlTemplate, fixed).has(inj.name)) return false;
+  if (urlQueryKeys(shapes.urlTemplate, fixed).has(inj.name)) {
+    return shadowed("tool");
+  }
   // The legacy derivation: a NON-body method whose body is the legacy `fields` shape and which has no
   // explicit query copies its non-path input fields into the URL — before auto-injection, and with
-  // `v != null` rather than `v !== ""`, so a fixed field of that name takes the parameter whatever it
-  // holds. An AI field of that name is not counted: the model may omit it, and that is unknowable.
+  // `v != null` rather than `v !== ""`, so a field of that name takes the parameter whatever it holds.
+  //
+  // A fixed field always, and a REQUIRED ai field too: zod refuses the call without it, so it is on
+  // the URL of every invocation that runs. An OPTIONAL ai field is the one that stays unknowable.
+  const ai = aiFields(shapes.inputSchema);
+  const occupies =
+    fixed.has(inj.name) ||
+    (ai.names.has(inj.name) && !ai.optional.has(inj.name));
   if (
     !BODY_METHODS.has(method) &&
     isLegacyFieldsBody(shapes.body) &&
     Object.keys(queryMap(shapes.query)).length === 0 &&
-    fixed.has(inj.name) &&
+    occupies &&
     !urlPlaceholderNames(shapes.urlTemplate).has(inj.name)
   ) {
-    return false;
+    return shadowed("tool");
   }
   const explicit = reachingQuery(shapes)[inj.name];
   const alwaysSet = explicit !== undefined && alwaysNonEmpty(explicit, fixed);
-  return !alwaysSet;
+  return alwaysSet ? shadowed("tool") : { state: "reaches" };
 }
 
 export function credentialReachesRequest(
@@ -413,11 +456,13 @@ export function credentialReachesRequest(
   shapes: ToolShapePatch,
 ): boolean {
   if (mentions(reachableTemplates(method, shapes), "secret")) return true;
-  return autoInjectionReaches(
-    kind,
-    paramName,
-    (method ?? DEFAULT_HTTP_METHOD).toUpperCase(),
-    shapes,
+  return (
+    autoInjectionVerdict(
+      kind,
+      paramName,
+      (method ?? DEFAULT_HTTP_METHOD).toUpperCase(),
+      shapes,
+    ).state === "reaches"
   );
 }
 
@@ -452,9 +497,27 @@ export function unusedCredentialWarning(
       | string
       | undefined,
   };
-  if (credentialReachesRequest(facts.kind, facts.paramName, method, shapes)) {
-    return null;
-  }
+  const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
+  if (mentions(reachableTemplates(method, shapes), "secret")) return null;
+  const verdict = autoInjectionVerdict(facts.kind, facts.paramName, m, shapes);
+  if (verdict.state === "reaches") return null;
+
   const kind = facts.kind ?? "generic";
-  return `the attached credential is never sent: a "${kind}" credential puts nothing on this request by itself, and {{secret}} appears in none of the templates this ${(method ?? DEFAULT_HTTP_METHOD).toUpperCase()} actually emits — it goes out unauthenticated, and the upstream's 401/403 will look like a bad credential rather than one that was never wired. Write {{secret}} where the API expects it, or attach a credential whose type injects it (${INJECTING_MECHANISM_KIND_IDS.join(", ")}) into a header or query parameter the templates do not already set.`;
+  const consequence = `it goes out unauthenticated, and the upstream's 401/403 will look like a bad credential rather than one that was never wired`;
+  if (verdict.state === "shadowed") {
+    // NOTE: a DIFFERENT sentence, and the reason is that the other one's advice is wrong here. This
+    // operator picked an injecting type and attached it correctly; what stops it is the value the
+    // request already carries at the target, which the runtime deliberately leaves alone. Telling
+    // them to "attach a credential whose type injects it" names something they already did.
+    const where =
+      verdict.target === "header"
+        ? `the "${verdict.name}" header`
+        : `the "${verdict.name}" query parameter`;
+    const who =
+      verdict.by === "runtime"
+        ? `a request with a body always carries that header, so the credential can never take it`
+        : `this tool sets ${where} itself, and the runtime keeps the value you wrote rather than replacing it with the credential`;
+    return `the attached credential is never sent: a "${kind}" credential injects into ${where}, and ${who} — ${consequence}. Write {{secret}} into that value, point the credential at another ${verdict.target === "header" ? "header" : "parameter"}, or remove the one the tool sets.`;
+  }
+  return `the attached credential is never sent: a "${kind}" credential puts nothing on this request by itself, and {{secret}} appears in none of the templates this ${m} actually emits — ${consequence}. Write {{secret}} where the API expects it, or attach a credential whose type injects it (${INJECTING_MECHANISM_KIND_IDS.join(", ")}) into a header or query parameter the templates do not already set.`;
 }

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -4,6 +4,19 @@
 // wire yet — but the failure it produces is unreadable: the request goes out UNAUTHENTICATED and the
 // upstream answers 401/403, which reads as a bad credential rather than as one that was never sent.
 //
+// THIS FILE IS A COPY OF `buildHttpTool`'s ASSEMBLY, AND THAT IS THE ONE THING TO KNOW ABOUT IT.
+// A warning cannot run the request it is warning about — the executor resolves DNS and SSRF-guards
+// the final URL before it would reach a stubbed fetch — so what the credential does has to be read
+// off the row instead. Four review rounds found nine places where the copy was thinner than the
+// original, every one of them confirmed by executing the real tool, and the fence in
+// tests/modules/tool-credential-wiring.test.ts is that same execution: one table, read as a tool
+// definition the executor runs and as the shapes a write would store, asserting the two agree.
+//
+// Where the copy cannot be sure, it errs QUIET — the legacy-fields body counts every fixed field as
+// emitted, a query value that may interpolate empty counts as not shadowing. A gap therefore costs a
+// warning that does not appear, never a warning about a tool that works. That is a property of the
+// choices below, not a proof about the ones nobody has thought of.
+//
 // THE QUESTION IS NOT "does a template mention {{secret}}". It is "does the credential reach the
 // request", and the two come apart in four ways the runtime decides and a text scan does not see: a
 // body is only assembled for POST/PUT/PATCH, a fixed field's value only leaves if something emitted
@@ -40,11 +53,36 @@ function namesIn(template: string): Set<string> {
 const mentions = (templates: string[], name: string): boolean =>
   templates.some((t) => namesIn(t).has(name));
 
-// What is left of a template once every placeholder is gone. Non-empty means the interpolation can
-// never produce the empty string, whatever the placeholders resolve to — which is the difference
-// between a query value the runtime is sure to set and one it may skip.
-const literalPartOf = (template: string): string =>
-  template.replace(PLACEHOLDER, "");
+// Whether interpolating this template can NEVER produce the empty string — the difference between a
+// query value the runtime is sure to set and one it may skip, and therefore between a credential
+// whose auto-injection is blocked and one whose is not.
+//
+// Two ways to be sure, and only two. What is left once every placeholder is gone is the first, and a
+// placeholder naming a FIXED field that is itself sure is the second: the runtime resolves fixed
+// values before it applies the query map, so `{{configured_token}}` over a fixed `abc` always
+// arrives as `abc`. Everything else — AI input the model may omit, a context variable that may be
+// absent — is unknowable here and answers "may be empty", which keeps this file quiet rather than
+// warning about a tool that works.
+//
+// One level, because that is the runtime's: a fixed value interpolates from context and the secret,
+// never from another fixed field.
+function alwaysNonEmpty(
+  template: string,
+  fixed: Map<string, string>,
+  resolveFixed = true,
+): boolean {
+  if (template.replace(PLACEHOLDER, "") !== "") return true;
+  if (!resolveFixed) return false;
+  for (const name of namesIn(template)) {
+    const value = fixed.get(name);
+    if (value !== undefined && alwaysNonEmpty(value, fixed, false)) return true;
+  }
+  return false;
+}
+
+function fixedValuesByName(schema: unknown): Map<string, string> {
+  return new Map(fixedFields(schema).map((f) => [f.name, f.value]));
+}
 
 // Mirrors `isBodyMethod` in graph/tools/http.ts. DELETE is deliberately absent there — a DELETE tool
 // carrying a raw body sends none of it — and a copy of that list which quietly included DELETE would
@@ -122,10 +160,17 @@ function bodyTemplates(body: unknown): string[] {
   if (!isPlainObject(body)) return [];
   if (body.mode === "raw" && typeof body.raw === "string") return [body.raw];
   if (body.mode === "kv" && Array.isArray(body.rows)) {
-    return body.rows
-      .filter((r): r is Record<string, unknown> => isPlainObject(r))
-      .map((r) => r.value)
-      .filter((v): v is string => typeof v === "string");
+    // Collapsed by TRIMMED key, last one winning, because that is what `payload[k] = …` does row by
+    // row: a `{{secret}}` written into a row a later row overwrites is assembled and thrown away.
+    // An empty key is skipped there too, and its row emits nothing at all.
+    const byKey = new Map<string, string>();
+    for (const r of body.rows) {
+      if (!isPlainObject(r) || typeof r.value !== "string") continue;
+      const k = typeof r.key === "string" ? r.key.trim() : "";
+      if (!k) continue;
+      byKey.set(k, r.value);
+    }
+    return [...byKey.values()];
   }
   return [];
 }
@@ -214,7 +259,9 @@ function autoInjectionReaches(
   // wired.
   if (urlQueryKeys(shapes.urlTemplate).has(inj.name)) return false;
   const explicit = reachingQuery(shapes)[inj.name];
-  const alwaysSet = explicit !== undefined && literalPartOf(explicit) !== "";
+  const alwaysSet =
+    explicit !== undefined &&
+    alwaysNonEmpty(explicit, fixedValuesByName(shapes.inputSchema));
   return !alwaysSet;
 }
 

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -36,7 +36,11 @@ import {
   isNonInjectableSecret,
   resolveSecretInjection,
 } from "@/modules/vault/secret-types";
-import { normalizeToolShapes, type ToolShapePatch } from "./normalize";
+import {
+  CONTEXT_VAR_NAMES,
+  normalizeToolShapes,
+  type ToolShapePatch,
+} from "./normalize";
 import { DEFAULT_HTTP_METHOD } from "./service";
 
 // The SAME grammar the runtime interpolates with (`PLACEHOLDER` in graph/tools/http.ts): the braces
@@ -254,7 +258,9 @@ function aiFields(schema: unknown): AiFields {
     const s = isPlainObject(spec) ? spec : {};
     if (s.source === "fixed") continue;
     names.add(name);
-    if (s.required !== true) optional.add(name);
+    // TRUTHY, like `parseFields`' own `!!s.required`: the definition schema lets a field spec carry
+    // anything, and `required: "yes"` is required there.
+    if (!s.required) optional.add(name);
   }
   return { names, optional };
 }
@@ -274,9 +280,12 @@ function bodyTemplates(body: unknown, ai: AiFields): string[] {
     // is the one direction this file must not get wrong.
     const byKey = new Map<string, string[]>();
     for (const r of body.rows) {
-      if (!isPlainObject(r) || typeof r.value !== "string") continue;
+      if (!isPlainObject(r)) continue;
       const k = typeof r.key === "string" ? r.key.trim() : "";
       if (!k) continue;
+      // COERCED, not skipped: `parseBody` turns a non-string value into `""`, and that row still
+      // overwrites the one before it. Skipping it kept a `{{secret}}` the request no longer carries.
+      const rowValue = typeof r.value === "string" ? r.value : "";
       // Two independent questions about one row, and conflating them is how the last two rounds went
       // wrong in both directions.
       //
@@ -287,10 +296,10 @@ function bodyTemplates(body: unknown, ai: AiFields): string[] {
       //
       // WHETHER IT OVERWRITES: only an OPTIONAL one may be omitted, and only then does the earlier
       // row's value survive. A required field is on every executed call, so its row always wins.
-      const lone = r.value.match(LONE_PLACEHOLDER)?.[1];
+      const lone = rowValue.match(LONE_PLACEHOLDER)?.[1];
       const loneAi = lone !== undefined && ai.names.has(lone);
       const mayBeOmitted = lone !== undefined && ai.optional.has(lone);
-      const carried = loneAi ? "" : r.value;
+      const carried = loneAi ? "" : rowValue;
       byKey.set(
         k,
         mayBeOmitted ? [...(byKey.get(k) ?? []), carried] : [carried],
@@ -357,14 +366,26 @@ export function effectiveUrlTemplate(
 // and throws `invalid urlTemplate` when that fails — so a stored `not-a-url`, which the definition
 // schema accepts, is a tool that never reaches a fetch. Same reasoning as the relative-with-no-base
 // case above: there is no unauthenticated request to warn about.
-function buildsARequest(urlTemplate: unknown): boolean {
+function buildsARequest(urlTemplate: unknown, shapes: ToolShapePatch): boolean {
   if (typeof urlTemplate !== "string") return false;
   try {
     new URL(urlTemplate.replace(PLACEHOLDER, "_"));
-    return true;
   } catch {
     return false;
   }
+  // And every URL placeholder has to have SOMEWHERE to come from. `buildHttpTool` collects the ones
+  // it could not resolve and throws for any that the model cannot supply — a `{{order_id}}` naming
+  // no field at all is one of those, on every call. A declared field or a context variable may still
+  // be missing at call time, and that is per-invocation rather than always, so it stays runnable.
+  const ai = aiFields(shapes.inputSchema);
+  const fixed = fixedValuesByName(shapes.inputSchema);
+  for (const name of namesIn(urlTemplate)) {
+    if (name === "secret") continue;
+    if (ai.names.has(name) || fixed.has(name)) continue;
+    if ((CONTEXT_VAR_NAMES as readonly string[]).includes(name)) continue;
+    return false;
+  }
+  return true;
 }
 
 export function reachableTemplates(
@@ -383,6 +404,7 @@ export function reachableTemplates(
 
   const out = [...emitted];
   const legacy = isLegacyFieldsBody(shapes.body);
+  const fixedByName = fixedValuesByName(shapes.inputSchema);
   for (const { name, value } of fixedFields(shapes.inputSchema)) {
     // A fixed value resolves from CONTEXT and the secret only, never from another fixed field, so
     // one level is the whole reach: it leaves if something emitted names it, or if the legacy body
@@ -393,8 +415,15 @@ export function reachableTemplates(
     // the runtime's assembly rules for a case that costs a MISSED warning either way. Over-counting
     // here can only make this file too quiet; under-counting would make it warn about a tool that
     // works.
-    if (legacy || mentions(emitted, name)) {
+    // `fixedSubstitution` and not `value`, for the reason it gives: an emitted `{{toString}}`
+    // resolves off `input`'s prototype, never off this field, so the `{{secret}}` an operator wrote
+    // into a field of that name never leaves. The legacy body is the exception — it reads
+    // `fixedValues[f.name]` directly, with no `in` check, so there the value does arrive.
+    if (legacy) {
       out.push(value);
+    } else if (mentions(emitted, name)) {
+      const substituted = fixedSubstitution(name, fixedByName);
+      if (substituted !== undefined) out.push(substituted);
     }
   }
   return out;
@@ -545,7 +574,7 @@ export function unusedCredentialWarning(
   if (isNonInjectableSecret(facts.kind)) return null;
   const { shapes: normalized } = normalizeToolShapes(raw);
   const effective = effectiveUrlTemplate(normalized.urlTemplate, facts.baseUrl);
-  if (effective === null || !buildsARequest(effective)) return null;
+  if (effective === null || !buildsARequest(effective, normalized)) return null;
   const shapes: ToolShapePatch = {
     ...normalized,
     urlTemplate: effective as string | undefined,

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -53,6 +53,13 @@ const PLACEHOLDER = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
 // graph/tools/http.ts): a lone AI field the model OMITS makes the runtime skip that row entirely.
 const LONE_PLACEHOLDER = /^\{\{\s*([a-zA-Z0-9_]+)\s*\}\}$/;
 
+// What an UNRESOLVED placeholder becomes while the URL is parsed, and the one thing that matters
+// about it is that NO param name can be this string: `validateParamName` holds those to
+// `[A-Za-z0-9!#$%&'*+.^_`|~-]`, and parentheses are outside it. A key this file could not resolve is
+// UNKNOWN, so a sentinel a real name could equal answers "that parameter is already taken" for a
+// tool where it is not — and it did: `_` was the sentinel, and `paramName: "_"` is legal.
+const UNRESOLVED_KEY = "((unresolved))";
+
 function namesIn(template: string): Set<string> {
   return new Set(
     [...template.matchAll(PLACEHOLDER)].map((m) => m[1] as string),
@@ -142,7 +149,7 @@ function parseUrlTemplate(
     // credential's own parameter as already taken and warn about a tool that injects it.
     return value !== undefined && namesIn(value).size === 0
       ? encodeURIComponent(value)
-      : "_";
+      : UNRESOLVED_KEY;
   });
   try {
     return new URL(resolved, "https://placeholder.invalid");

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -21,9 +21,24 @@ import { normalizeToolShapes, type ToolShapePatch } from "./normalize";
 import { DEFAULT_HTTP_METHOD } from "./service";
 
 // The SAME grammar the runtime interpolates with (`PLACEHOLDER` in graph/tools/http.ts): the braces
-// take surrounding whitespace, so a scanner matching only the tight spelling would call a working
+// take surrounding whitespace, so a reader matching only the tight spelling would call a working
 // `{{ secret }}` unused and warn about a tool that is wired correctly.
-const placeholder = (name: string) => new RegExp(`\\{\\{\\s*${name}\\s*\\}\\}`);
+//
+// Read as TOKENS rather than by compiling a regex around each name, and that is not a style choice:
+// an input-schema key is not held to this grammar, so `new RegExp(\`…${name}…\`)` on a field called
+// `a[b` throws — out of `tool_create`, before its try block, as an unhandled error rather than a
+// write result. Extracting the names a template actually carries has no such edge, and it answers
+// the same question the runtime asks: a name outside `[a-zA-Z0-9_]` can never be a placeholder.
+const PLACEHOLDER = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
+
+function namesIn(template: string): Set<string> {
+  return new Set(
+    [...template.matchAll(PLACEHOLDER)].map((m) => m[1] as string),
+  );
+}
+
+const mentions = (templates: string[], name: string): boolean =>
+  templates.some((t) => namesIn(t).has(name));
 
 // Mirrors `isBodyMethod` in graph/tools/http.ts. DELETE is deliberately absent there — a DELETE tool
 // carrying a raw body sends none of it — and a copy of that list which quietly included DELETE would
@@ -38,6 +53,38 @@ function stringValues(v: unknown): string[] {
   return isPlainObject(v)
     ? Object.values(v).filter((x): x is string => typeof x === "string")
     : [];
+}
+
+// The query map as the runtime reads it (`parseQuery`): a null/undefined value is dropped and
+// everything else is STRINGIFIED, so `{ token: 123 }` is a real, non-empty query value. Reading only
+// the strings would call that entry absent and then conclude the credential is auto-injected into a
+// parameter the operator has already taken.
+function queryMap(raw: unknown): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!isPlainObject(raw)) return out;
+  for (const [k, v] of Object.entries(raw)) {
+    if (v == null) continue;
+    out[k] = typeof v === "string" ? v : String(v);
+  }
+  return out;
+}
+
+// The query keys the URL template already carries. The runtime applies the explicit query map with
+// `if (v !== "" && !url.searchParams.has(k))`, so a key the template spells wins and the map's value
+// for it is DISCARDED — never interpolated into anything that leaves.
+function urlQueryKeys(urlTemplate: unknown): Set<string> {
+  if (typeof urlTemplate !== "string") return new Set();
+  const q = urlTemplate.split("?")[1];
+  return q ? new Set([...new URLSearchParams(q).keys()]) : new Set();
+}
+
+// The explicit query entries that survive to the request: everything the URL template does not
+// already spell.
+function reachingQuery(shapes: ToolShapePatch): Record<string, string> {
+  const taken = urlQueryKeys(shapes.urlTemplate);
+  return Object.fromEntries(
+    Object.entries(queryMap(shapes.query)).filter(([k]) => !taken.has(k)),
+  );
 }
 
 function bodyTemplates(body: unknown): string[] {
@@ -83,7 +130,10 @@ export function reachableTemplates(
 ): string[] {
   const emitted: string[] = [];
   if (typeof shapes.urlTemplate === "string") emitted.push(shapes.urlTemplate);
-  emitted.push(...stringValues(shapes.headers), ...stringValues(shapes.query));
+  emitted.push(
+    ...stringValues(shapes.headers),
+    ...Object.values(reachingQuery(shapes)),
+  );
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
   if (BODY_METHODS.has(m)) emitted.push(...bodyTemplates(shapes.body));
 
@@ -99,7 +149,7 @@ export function reachableTemplates(
     // the runtime's assembly rules for a case that costs a MISSED warning either way. Over-counting
     // here can only make this file too quiet; under-counting would make it warn about a tool that
     // works.
-    if (legacy || emitted.some((t) => placeholder(name).test(t))) {
+    if (legacy || mentions(emitted, name)) {
       out.push(value);
     }
   }
@@ -126,20 +176,16 @@ function autoInjectionReaches(
       : [];
     return !names.some((h) => h.toLowerCase() === inj.name.toLowerCase());
   }
-  // Query: the runtime injects unless the param is already on the URL — hand-written in the template,
-  // or set from the explicit query map, which it applies first and only for a value that resolves
-  // NON-EMPTY. A template value may resolve to nothing, and that is unknowable here, so only a
-  // literal counts as shadowing. Guessing the other way would warn about a tool that is wired.
-  const query = isPlainObject(shapes.query) ? shapes.query : {};
-  const explicit = query[inj.name];
+  // Query: the runtime injects unless the param is already on the URL — spelled in the template, or
+  // set from the explicit query map, which it applies first and only for a value that resolves
+  // NON-EMPTY. A value carrying a placeholder may resolve to nothing, and that is unknowable here,
+  // so only a literal counts as shadowing. Guessing the other way would warn about a tool that is
+  // wired.
+  if (urlQueryKeys(shapes.urlTemplate).has(inj.name)) return false;
+  const explicit = reachingQuery(shapes)[inj.name];
   const literalNonEmpty =
-    typeof explicit === "string" &&
-    explicit !== "" &&
-    !/\{\{\s*[a-zA-Z0-9_]+\s*\}\}/.test(explicit);
-  if (literalNonEmpty) return false;
-  const url = typeof shapes.urlTemplate === "string" ? shapes.urlTemplate : "";
-  const q = url.split("?")[1];
-  return !(q && new URLSearchParams(q).has(inj.name));
+    explicit !== undefined && explicit !== "" && namesIn(explicit).size === 0;
+  return !literalNonEmpty;
 }
 
 export function credentialReachesRequest(
@@ -148,13 +194,7 @@ export function credentialReachesRequest(
   method: string | null | undefined,
   shapes: ToolShapePatch,
 ): boolean {
-  if (
-    reachableTemplates(method, shapes).some((t) =>
-      placeholder("secret").test(t),
-    )
-  ) {
-    return true;
-  }
+  if (mentions(reachableTemplates(method, shapes), "secret")) return true;
   return autoInjectionReaches(kind, paramName, shapes);
 }
 

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -186,18 +186,28 @@ function reachingQuery(shapes: ToolShapePatch): Record<string, string> {
   );
 }
 
-// The declared fields the MODEL fills, which is the half of the schema the runtime may not get a
-// value for. `source` absent means "ai" there (`s.source === "fixed" ? "fixed" : "ai"`).
-function aiFieldNames(schema: unknown): Set<string> {
-  if (!isPlainObject(schema)) return new Set();
-  return new Set(
-    Object.entries(schema)
-      .filter(([, spec]) => !isPlainObject(spec) || spec.source !== "fixed")
-      .map(([name]) => name),
-  );
+// The declared fields the MODEL fills, and which of those it may leave out. `source` absent means
+// "ai" (`s.source === "fixed" ? "fixed" : "ai"`), and a REQUIRED one is not optional in any executed
+// call: zod rejects the invocation without it, so its row always overwrites.
+interface AiFields {
+  names: Set<string>;
+  optional: Set<string>;
 }
 
-function bodyTemplates(body: unknown, aiNames: Set<string>): string[] {
+function aiFields(schema: unknown): AiFields {
+  const names = new Set<string>();
+  const optional = new Set<string>();
+  if (!isPlainObject(schema)) return { names, optional };
+  for (const [name, spec] of Object.entries(schema)) {
+    const s = isPlainObject(spec) ? spec : {};
+    if (s.source === "fixed") continue;
+    names.add(name);
+    if (s.required !== true) optional.add(name);
+  }
+  return { names, optional };
+}
+
+function bodyTemplates(body: unknown, ai: AiFields): string[] {
   if (!isPlainObject(body)) return [];
   if (body.mode === "raw" && typeof body.raw === "string") return [body.raw];
   if (body.mode === "kv" && Array.isArray(body.rows)) {
@@ -215,9 +225,24 @@ function bodyTemplates(body: unknown, aiNames: Set<string>): string[] {
       if (!isPlainObject(r) || typeof r.value !== "string") continue;
       const k = typeof r.key === "string" ? r.key.trim() : "";
       if (!k) continue;
+      // Two independent questions about one row, and conflating them is how the last two rounds went
+      // wrong in both directions.
+      //
+      // WHAT IT SENDS: a lone placeholder naming a declared AI field is filled by the MODEL, never
+      // from the vault — `buildHttpTool` takes that branch before any credential interpolation. So a
+      // row of `{{secret}}` on a tool that DECLARES an ai field called `secret` carries the model's
+      // argument, not the credential, and counting it as usage would suppress the warning.
+      //
+      // WHETHER IT OVERWRITES: only an OPTIONAL one may be omitted, and only then does the earlier
+      // row's value survive. A required field is on every executed call, so its row always wins.
       const lone = r.value.match(LONE_PLACEHOLDER)?.[1];
-      const skippable = lone !== undefined && aiNames.has(lone);
-      byKey.set(k, skippable ? [...(byKey.get(k) ?? []), r.value] : [r.value]);
+      const loneAi = lone !== undefined && ai.names.has(lone);
+      const mayBeOmitted = lone !== undefined && ai.optional.has(lone);
+      const carried = loneAi ? "" : r.value;
+      byKey.set(
+        k,
+        mayBeOmitted ? [...(byKey.get(k) ?? []), carried] : [carried],
+      );
     }
     return [...byKey.values()].flat();
   }
@@ -249,6 +274,21 @@ function fixedFields(schema: unknown): { name: string; value: string }[] {
 // Every string the runtime interpolates AND SENDS, for this method and this row. The second half is
 // what a site list alone gets wrong: a template that is assembled and then discarded carries nothing,
 // so counting it as usage silences the warning for a tool whose credential never leaves.
+// The template the runtime actually requests. A urlTemplate starting with "/" is RELATIVE and gets
+// the credential's own base URL prepended before anything is interpolated, so a `{{secret}}` stored
+// in that base is sent — the row alone cannot say whether the credential leaves.
+export function effectiveUrlTemplate(
+  urlTemplate: unknown,
+  credentialBaseUrl: string | null | undefined,
+): unknown {
+  if (typeof urlTemplate !== "string" || !urlTemplate.startsWith("/")) {
+    return urlTemplate;
+  }
+  // No base and a relative template is a tool `buildHttpTool` refuses to build at all; there is no
+  // request to say anything about.
+  return credentialBaseUrl ? `${credentialBaseUrl}${urlTemplate}` : urlTemplate;
+}
+
 export function reachableTemplates(
   method: string | null | undefined,
   shapes: ToolShapePatch,
@@ -260,9 +300,7 @@ export function reachableTemplates(
   );
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
   if (BODY_METHODS.has(m)) {
-    emitted.push(
-      ...bodyTemplates(shapes.body, aiFieldNames(shapes.inputSchema)),
-    );
+    emitted.push(...bodyTemplates(shapes.body, aiFields(shapes.inputSchema)));
   }
 
   const out = [...emitted];
@@ -367,12 +405,22 @@ export function credentialReachesRequest(
 // the raw row would report a working tool as unwired on any update that did not happen to touch that
 // template.
 export function unusedCredentialWarning(
-  facts: { kind: string | null; paramName: string | null },
+  facts: {
+    kind: string | null;
+    paramName: string | null;
+    baseUrl: string | null;
+  },
   method: string | null | undefined,
   raw: ToolShapePatch,
 ): string | null {
   if (isNonInjectableSecret(facts.kind)) return null;
-  const { shapes } = normalizeToolShapes(raw);
+  const { shapes: normalized } = normalizeToolShapes(raw);
+  const shapes: ToolShapePatch = {
+    ...normalized,
+    urlTemplate: effectiveUrlTemplate(normalized.urlTemplate, facts.baseUrl) as
+      | string
+      | undefined,
+  };
   if (credentialReachesRequest(facts.kind, facts.paramName, method, shapes)) {
     return null;
   }

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -12,10 +12,16 @@
 // tests/modules/tool-credential-wiring.test.ts is that same execution: one table, read as a tool
 // definition the executor runs and as the shapes a write would store, asserting the two agree.
 //
-// Where the copy cannot be sure, it errs QUIET — the legacy-fields body counts every fixed field as
-// emitted, a query value that may interpolate empty counts as not shadowing. A gap therefore costs a
-// warning that does not appear, never a warning about a tool that works. That is a property of the
-// choices below, not a proof about the ones nobody has thought of.
+// Where the copy cannot be sure, it is written to err QUIET — the legacy-fields body counts every
+// fixed field as emitted, a query value that may interpolate empty counts as not shadowing, a kv row
+// the model may not overwrite keeps what came before it. The intent is that a gap costs a warning
+// that does not appear rather than a warning about a tool that works.
+//
+// THAT IS AN INTENT, NOT A PROPERTY, and it has been violated twice — both times by a fix for a gap
+// in the other direction. Collapsing kv rows by key (round 4) erased a value the model's silence
+// leaves in the payload; substituting a fixed query key raw (round 5) read `token&x` as two
+// parameters and called the credential's own shadowed. Each new rule here is a chance to warn about
+// a working tool, so a rule that CANNOT be stated in the safe direction does not belong.
 //
 // THE QUESTION IS NOT "does a template mention {{secret}}". It is "does the credential reach the
 // request", and the two come apart in four ways the runtime decides and a text scan does not see: a
@@ -43,6 +49,9 @@ import { DEFAULT_HTTP_METHOD } from "./service";
 // write result. Extracting the names a template actually carries has no such edge, and it answers
 // the same question the runtime asks: a name outside `[a-zA-Z0-9_]` can never be a placeholder.
 const PLACEHOLDER = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
+// A value that is EXACTLY one placeholder, which the kv body treats specially (`LONE_PLACEHOLDER` in
+// graph/tools/http.ts): a lone AI field the model OMITS makes the runtime skip that row entirely.
+const LONE_PLACEHOLDER = /^\{\{\s*([a-zA-Z0-9_]+)\s*\}\}$/;
 
 function namesIn(template: string): Set<string> {
   return new Set(
@@ -127,7 +136,13 @@ function parseUrlTemplate(
     const value = fixed.get(name);
     // One level, like everywhere else here: a fixed value that is itself a template resolves from
     // context, which is unknowable, so it stays neutral.
-    return value !== undefined && namesIn(value).size === 0 ? value : "_";
+    // ENCODED, because the runtime's interpolation is: `encodeURIComponent(v)` on every substituted
+    // value. A fixed key holding a URL metacharacter (`token&x`) is ONE parameter of that name
+    // there, and three separate ones here if the substitution goes in raw — which would read the
+    // credential's own parameter as already taken and warn about a tool that injects it.
+    return value !== undefined && namesIn(value).size === 0
+      ? encodeURIComponent(value)
+      : "_";
   });
   try {
     return new URL(resolved, "https://placeholder.invalid");
@@ -171,21 +186,40 @@ function reachingQuery(shapes: ToolShapePatch): Record<string, string> {
   );
 }
 
-function bodyTemplates(body: unknown): string[] {
+// The declared fields the MODEL fills, which is the half of the schema the runtime may not get a
+// value for. `source` absent means "ai" there (`s.source === "fixed" ? "fixed" : "ai"`).
+function aiFieldNames(schema: unknown): Set<string> {
+  if (!isPlainObject(schema)) return new Set();
+  return new Set(
+    Object.entries(schema)
+      .filter(([, spec]) => !isPlainObject(spec) || spec.source !== "fixed")
+      .map(([name]) => name),
+  );
+}
+
+function bodyTemplates(body: unknown, aiNames: Set<string>): string[] {
   if (!isPlainObject(body)) return [];
   if (body.mode === "raw" && typeof body.raw === "string") return [body.raw];
   if (body.mode === "kv" && Array.isArray(body.rows)) {
     // Collapsed by TRIMMED key, last one winning, because that is what `payload[k] = …` does row by
     // row: a `{{secret}}` written into a row a later row overwrites is assembled and thrown away.
     // An empty key is skipped there too, and its row emits nothing at all.
-    const byKey = new Map<string, string>();
+    //
+    // Except when the later row is a LONE placeholder naming an AI field, which the runtime skips
+    // when the model omits it — leaving the earlier row's value in the payload. That row does not
+    // erase what came before it, it only MAY, so both survive here. Collapsing it unconditionally
+    // warned about a tool that sends the credential on every call where the model stays quiet, which
+    // is the one direction this file must not get wrong.
+    const byKey = new Map<string, string[]>();
     for (const r of body.rows) {
       if (!isPlainObject(r) || typeof r.value !== "string") continue;
       const k = typeof r.key === "string" ? r.key.trim() : "";
       if (!k) continue;
-      byKey.set(k, r.value);
+      const lone = r.value.match(LONE_PLACEHOLDER)?.[1];
+      const skippable = lone !== undefined && aiNames.has(lone);
+      byKey.set(k, skippable ? [...(byKey.get(k) ?? []), r.value] : [r.value]);
     }
-    return [...byKey.values()];
+    return [...byKey.values()].flat();
   }
   return [];
 }
@@ -225,7 +259,11 @@ export function reachableTemplates(
     ...Object.values(reachingQuery(shapes)),
   );
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
-  if (BODY_METHODS.has(m)) emitted.push(...bodyTemplates(shapes.body));
+  if (BODY_METHODS.has(m)) {
+    emitted.push(
+      ...bodyTemplates(shapes.body, aiFieldNames(shapes.inputSchema)),
+    );
+  }
 
   const out = [...emitted];
   const legacy = isLegacyFieldsBody(shapes.body);

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -100,6 +100,10 @@ function alwaysNonEmpty(
 ): boolean {
   if (template.replace(PLACEHOLDER, "") !== "") return true;
   if (ackArg && namesIn(template).has(WAIT_MESSAGE_ARG)) return true;
+  // ABOVE the recursion guard, not inside the loop below it: a prototype name resolves to a
+  // stringified Object member at ANY depth, so a fixed value of `{{toString}}` is non-empty when it
+  // is followed as well as when it is read directly.
+  for (const name of namesIn(template)) if (name in {}) return true;
   if (!resolveFixed) return false;
   for (const name of namesIn(template)) {
     // The prototype names are non-empty for a DIFFERENT reason than the fixed ones, and the two
@@ -118,6 +122,30 @@ function fixedValuesByName(schema: unknown): Map<string, string> {
   return new Map(fixedFields(schema).map((f) => [f.name, f.value]));
 }
 
+// The values that are KNOWN whatever the model does: the operator's fixed fields, plus a required ai
+// field whose enum holds exactly one value — zod accepts nothing else, so every executable call
+// carries it. Used where the substituted text is what matters (which query key the URL ends up with),
+// never where the question is only whether something is non-empty.
+//
+// EXACTLY ONE, and the mutation that widens it to any enum is one the fence cannot judge: with two
+// or more values the key depends on what the model picked, so the executor's answer differs between
+// invocations and no single row can assert it. Unknowable falls to the quiet side, like every other
+// unknown here.
+function knownValuesByName(schema: unknown): Map<string, string> {
+  const out = fixedValuesByName(schema);
+  if (typeof schema !== "object" || schema === null) return out;
+  for (const [name, spec] of Object.entries(schema)) {
+    if (!isPlainObject(spec) || spec.source === "fixed") continue;
+    if (!spec.required) continue;
+    const values = spec.enumValues;
+    if (Array.isArray(values) && values.length === 1) {
+      const only = values[0];
+      if (typeof only === "string") out.set(name, only);
+    }
+  }
+  return out;
+}
+
 // The fixed value the runtime would substitute for this placeholder, or undefined when it would not
 // substitute one. `valueLookup` asks `n in input` FIRST, and `in` walks the prototype: a field named
 // `toString` (or `constructor`, or `valueOf`) resolves to Object.prototype's member, not to the
@@ -129,7 +157,12 @@ function fixedValuesByName(schema: unknown): Map<string, string> {
 function fixedSubstitution(
   name: string,
   fixed: Map<string, string>,
+  ackArg = false,
 ): string | undefined {
+  // The ack argument shadows a fixed field of the same name for the same reason a prototype member
+  // does: `valueLookup` reads `input` first, and on an ack-enabled tool the model always supplies
+  // `__wait_message`. A `{{secret}}` an operator put in a fixed field of that name never leaves.
+  if (ackArg && name === WAIT_MESSAGE_ARG) return undefined;
   return name in {} ? undefined : fixed.get(name);
 }
 
@@ -237,7 +270,7 @@ function transmittedUrl(urlTemplate: unknown): string[] {
 function reachingQuery(shapes: ToolShapePatch): Record<string, string> {
   const taken = urlQueryKeys(
     shapes.urlTemplate,
-    fixedValuesByName(shapes.inputSchema),
+    knownValuesByName(shapes.inputSchema),
   );
   return Object.fromEntries(
     Object.entries(queryMap(shapes.query)).filter(([k]) => !taken.has(k)),
@@ -421,6 +454,7 @@ function buildsARequest(
 export function reachableTemplates(
   method: string | null | undefined,
   shapes: ToolShapePatch,
+  ackArg = false,
 ): string[] {
   const emitted: string[] = [...transmittedUrl(shapes.urlTemplate)];
   emitted.push(
@@ -452,7 +486,7 @@ export function reachableTemplates(
     if (legacy) {
       out.push(value);
     } else if (mentions(emitted, name)) {
-      const substituted = fixedSubstitution(name, fixedByName);
+      const substituted = fixedSubstitution(name, fixedByName, ackArg);
       if (substituted !== undefined) out.push(substituted);
     }
   }
@@ -539,7 +573,11 @@ function autoInjectionVerdict(
   // take the parameter. Guessing that a placeholder always resolves would warn about a tool that is
   // wired.
   const fixed = fixedValuesByName(shapes.inputSchema);
-  if (urlQueryKeys(shapes.urlTemplate, fixed).has(inj.name)) {
+  if (
+    urlQueryKeys(shapes.urlTemplate, knownValuesByName(shapes.inputSchema)).has(
+      inj.name,
+    )
+  ) {
     return shadowed("tool");
   }
   // The legacy derivation: a NON-body method whose body is the legacy `fields` shape and which has no
@@ -623,7 +661,9 @@ export function unusedCredentialWarning(
     urlTemplate: effective as string | undefined,
   };
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
-  if (mentions(reachableTemplates(method, shapes), "secret")) return null;
+  if (mentions(reachableTemplates(method, shapes, ackArg), "secret")) {
+    return null;
+  }
   const verdict = autoInjectionVerdict(
     facts.kind,
     facts.paramName,

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -40,6 +40,12 @@ function namesIn(template: string): Set<string> {
 const mentions = (templates: string[], name: string): boolean =>
   templates.some((t) => namesIn(t).has(name));
 
+// What is left of a template once every placeholder is gone. Non-empty means the interpolation can
+// never produce the empty string, whatever the placeholders resolve to — which is the difference
+// between a query value the runtime is sure to set and one it may skip.
+const literalPartOf = (template: string): string =>
+  template.replace(PLACEHOLDER, "");
+
 // Mirrors `isBodyMethod` in graph/tools/http.ts. DELETE is deliberately absent there — a DELETE tool
 // carrying a raw body sends none of it — and a copy of that list which quietly included DELETE would
 // call such a tool wired.
@@ -69,13 +75,38 @@ function queryMap(raw: unknown): Record<string, string> {
   return out;
 }
 
+// The URL the runtime will parse, with the placeholders neutralized the way `buildHttpTool` does for
+// its own origin probe. The base is only there so a relative template parses; nothing reads the host.
+function parseUrlTemplate(urlTemplate: unknown): URL | null {
+  if (typeof urlTemplate !== "string") return null;
+  try {
+    return new URL(
+      urlTemplate.replace(PLACEHOLDER, "_"),
+      "https://placeholder.invalid",
+    );
+  } catch {
+    return null;
+  }
+}
+
 // The query keys the URL template already carries. The runtime applies the explicit query map with
 // `if (v !== "" && !url.searchParams.has(k))`, so a key the template spells wins and the map's value
 // for it is DISCARDED — never interpolated into anything that leaves.
+//
+// Parsed as a URL rather than split on "?", because a query VALUE may hold one of its own — a
+// `redirect=https://a.test/?x=1&token=fixed` keeps everything after the second question mark, which
+// `split("?")[1]` throws away and `searchParams` does not.
 function urlQueryKeys(urlTemplate: unknown): Set<string> {
-  if (typeof urlTemplate !== "string") return new Set();
-  const q = urlTemplate.split("?")[1];
-  return q ? new Set([...new URLSearchParams(q).keys()]) : new Set();
+  const url = parseUrlTemplate(urlTemplate);
+  return url ? new Set([...url.searchParams.keys()]) : new Set();
+}
+
+// The URL as far as it is TRANSMITTED. A fragment is not sent to the upstream — measured on a real
+// socket, the server reads `/x?a=1` for a request to `/x?a=1#token=…` — so a credential written only
+// there authenticates nothing and produces exactly the 401 this warning exists to explain.
+function transmittedUrl(urlTemplate: unknown): string[] {
+  if (typeof urlTemplate !== "string") return [];
+  return [urlTemplate.split("#")[0] ?? ""];
 }
 
 // The explicit query entries that survive to the request: everything the URL template does not
@@ -128,8 +159,7 @@ export function reachableTemplates(
   method: string | null | undefined,
   shapes: ToolShapePatch,
 ): string[] {
-  const emitted: string[] = [];
-  if (typeof shapes.urlTemplate === "string") emitted.push(shapes.urlTemplate);
+  const emitted: string[] = [...transmittedUrl(shapes.urlTemplate)];
   emitted.push(
     ...stringValues(shapes.headers),
     ...Object.values(reachingQuery(shapes)),
@@ -178,14 +208,14 @@ function autoInjectionReaches(
   }
   // Query: the runtime injects unless the param is already on the URL — spelled in the template, or
   // set from the explicit query map, which it applies first and only for a value that resolves
-  // NON-EMPTY. A value carrying a placeholder may resolve to nothing, and that is unknowable here,
-  // so only a literal counts as shadowing. Guessing the other way would warn about a tool that is
+  // NON-EMPTY. Whether a value resolves empty is knowable from its literal part alone: `prefix-{{id}}`
+  // cannot come out empty whatever `id` is, while a bare `{{id}}` can, and only the first is sure to
+  // take the parameter. Guessing that a placeholder always resolves would warn about a tool that is
   // wired.
   if (urlQueryKeys(shapes.urlTemplate).has(inj.name)) return false;
   const explicit = reachingQuery(shapes)[inj.name];
-  const literalNonEmpty =
-    explicit !== undefined && explicit !== "" && namesIn(explicit).size === 0;
-  return !literalNonEmpty;
+  const alwaysSet = explicit !== undefined && literalPartOf(explicit) !== "";
+  return !alwaysSet;
 }
 
 export function credentialReachesRequest(

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -1,0 +1,84 @@
+// Whether an HTTP tool's request will actually carry the credential attached to it. Issue #504: a
+// tool can reference a `generic` credential while nothing in its templates interpolates `{{secret}}`.
+// Nothing refuses that, and nothing should — a tool may legitimately hold a reference it does not
+// wire yet — but the failure it produces is unreadable: the request goes out UNAUTHENTICATED and the
+// upstream answers 401/403, which reads as a bad credential rather than as a credential that was
+// never sent. A `generic` credential is the one kind with no auto-injection (the catalog says so),
+// so it is also the only one where "attached" and "sent" can come apart silently.
+
+import {
+  INJECTING_MECHANISM_KIND_IDS,
+  isNonInjectableSecret,
+  secretTypeAutoInjects,
+} from "@/modules/vault/secret-types";
+import type { ToolShapePatch } from "./normalize";
+
+// The SAME grammar the runtime interpolates with (`PLACEHOLDER` in graph/tools/http.ts): the braces
+// take surrounding whitespace, so a scanner matching only the tight spelling would call a working
+// `{{ secret }}` unused and warn about a tool that is wired correctly.
+const SECRET_PLACEHOLDER = /\{\{\s*secret\s*\}\}/;
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// Every string the runtime interpolates `{{secret}}` into, and nothing else. Five sites, and they are
+// the same five `normalizeToolShapes` rewrites: the URL, header values, query values, the body (raw
+// text, or the kv rows' values) and a FIXED input field's value.
+//
+// `source === "fixed"` is not a detail. `buildHttpTool` reads `s.source === "fixed" ? "fixed" : "ai"`
+// and precomputes only the fixed values with the secret in scope; a `{{secret}}` written into an AI
+// field's `value` is never interpolated, so counting it as usage would silence the warning for a
+// tool whose credential genuinely never leaves.
+export function toolSecretTemplates(shapes: ToolShapePatch): string[] {
+  const out: string[] = [];
+  if (typeof shapes.urlTemplate === "string") out.push(shapes.urlTemplate);
+  for (const key of ["headers", "query"] as const) {
+    const value = shapes[key];
+    if (!isPlainObject(value)) continue;
+    for (const v of Object.values(value)) {
+      if (typeof v === "string") out.push(v);
+    }
+  }
+  const body = shapes.body;
+  if (isPlainObject(body)) {
+    if (body.mode === "raw" && typeof body.raw === "string") out.push(body.raw);
+    if (body.mode === "kv" && Array.isArray(body.rows)) {
+      for (const row of body.rows) {
+        if (isPlainObject(row) && typeof row.value === "string") {
+          out.push(row.value);
+        }
+      }
+    }
+  }
+  const schema = shapes.inputSchema;
+  if (isPlainObject(schema)) {
+    for (const spec of Object.values(schema)) {
+      if (isPlainObject(spec) && spec.source === "fixed") {
+        if (typeof spec.value === "string") out.push(spec.value);
+      }
+    }
+  }
+  return out;
+}
+
+export function toolUsesSecretPlaceholder(shapes: ToolShapePatch): boolean {
+  return toolSecretTemplates(shapes).some((t) => SECRET_PLACEHOLDER.test(t));
+}
+
+// The warning, or null when the wiring is fine. `kind` is the ATTACHED credential's kind, read off
+// the vault entry; null (or a kind this build does not know) is the legacy `generic` and answers the
+// same way, because that is how every other reader treats it.
+//
+// Scoped to kinds that CAN be sent: a `neverOutbound` credential on an HTTP tool is a worse problem
+// with a different answer (it must not be sent at all, and the write boundary does not yet refuse
+// it), and telling its operator to "write {{secret}} where the API expects it" would be advice to
+// mail their stdio token to a third party.
+export function unusedCredentialWarning(
+  kind: string | null | undefined,
+  shapes: ToolShapePatch,
+): string | null {
+  if (secretTypeAutoInjects(kind) || isNonInjectableSecret(kind)) return null;
+  if (toolUsesSecretPlaceholder(shapes)) return null;
+  return `the attached credential is never sent: a "${kind ?? "generic"}" credential is not auto-injected, and {{secret}} appears in none of url_template, headers, query, body or a fixed field value — this request goes out unauthenticated, and the upstream's 401/403 will look like a bad credential rather than one that was never wired. Write {{secret}} where the API expects it, or attach a credential whose type injects it (${INJECTING_MECHANISM_KIND_IDS.join(", ")}).`;
+}

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -461,6 +461,16 @@ function buildsARequest(
   // "interpolation altered the origin" when the real one differs, so a placeholder anywhere in the
   // scheme, host or port is a tool that never fetches. The two sentinels answer where it sits — the
   // origins differ only if a placeholder is inside one.
+  // The protocol the SSRF guard will accept. It runs on the FINAL URL, immediately before the fetch,
+  // and refuses anything that is not https — http only where the deployment allows it, which this
+  // boundary cannot know and therefore does not claim. An `ftp://` template parses, stores, and never
+  // leaves.
+  const scheme = parseUrlTemplate(
+    urlTemplate,
+    new Map(),
+    UNRESOLVED_A,
+  )?.protocol;
+  if (scheme !== "https:") return false;
   const a = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_A);
   const b = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_B);
   if (!a || !b || a.origin !== b.origin) return false;

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -112,8 +112,17 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 // Header values as the runtime reads them: `interpolate(String(v), …)` on every entry, whatever its
 // JSON type. Filtering to strings dropped an `Authorization: ["Bearer {{secret}}"]` that the
 // executor sends verbatim, and warned about the credential it was carrying.
+// The header entries as the runtime walks them: `Object.entries(headerTemplates)` over whatever is
+// in the column, ARRAY included — a stored `headers: ["{{secret}}"]` sends the credential under the
+// header named `0`. `isPlainObject` excludes arrays, so reading them through it reported that tool
+// as unwired.
+function headerEntries(v: unknown): [string, string][] {
+  if (typeof v !== "object" || v === null) return [];
+  return Object.entries(v).map(([k, x]) => [k, String(x)]);
+}
+
 function headerTemplates(v: unknown): string[] {
-  return isPlainObject(v) ? Object.values(v).map((x) => String(x)) : [];
+  return headerEntries(v).map(([, value]) => value);
 }
 
 // The query map as the runtime reads it (`parseQuery`): a null/undefined value is dropped and
@@ -358,9 +367,7 @@ function autoInjectionReaches(
   const inj = resolveSecretInjection(kind, "probe", paramName);
   if (!inj) return false;
   if (inj.target === "header") {
-    const names = isPlainObject(shapes.headers)
-      ? Object.keys(shapes.headers)
-      : [];
+    const names = headerEntries(shapes.headers).map(([name]) => name);
     // The one header the runtime writes ITSELF: a body method with no content-type of its own gets
     // `Content-Type: application/json` added before auto-injection, which occupies that target the
     // same way an operator's own header does.

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -145,7 +145,9 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 // as unwired.
 function headerEntries(v: unknown): [string, string][] {
   if (typeof v !== "object" || v === null) return [];
-  return Object.entries(v).map(([k, x]) => [k, String(x)]);
+  return Object.entries(v)
+    .filter(([k]) => k !== SWALLOWED_HEADER)
+    .map(([k, x]) => [k, String(x)]);
 }
 
 function headerTemplates(v: unknown): string[] {
@@ -417,12 +419,20 @@ function urlPlaceholderNames(urlTemplate: unknown): Set<string> {
 type InjectionVerdict =
   | { state: "none" }
   | { state: "reaches" }
+  | { state: "swallowed"; name: string }
   | {
       state: "shadowed";
       target: "header" | "query";
       name: string;
       by: "tool" | "runtime";
     };
+
+// A header name that CANNOT be set on the request, however it is written. `buildHttpTool` builds its
+// header map as a plain `{}`, so `headers["__proto__"] = v` reaches the inherited setter: the
+// assignment succeeds, no own property is created, and the header is silently absent. Exactly the
+// loss issue #150 fixed for the body payload with `Object.create(null)` — the headers map was not
+// given the same treatment, and mirroring that here is what agrees with the runtime as it is.
+const SWALLOWED_HEADER = "__proto__";
 
 function autoInjectionVerdict(
   kind: string | null | undefined,
@@ -441,6 +451,8 @@ function autoInjectionVerdict(
     by,
   });
   if (inj.target === "header") {
+    if (inj.name === SWALLOWED_HEADER)
+      return { state: "swallowed", name: inj.name };
     const names = headerEntries(shapes.headers).map(([name]) => name);
     // The one header the runtime writes ITSELF: a body method with no content-type of its own gets
     // `Content-Type: application/json` added before auto-injection, which occupies that target the
@@ -545,6 +557,9 @@ export function unusedCredentialWarning(
 
   const kind = facts.kind ?? "generic";
   const consequence = `it goes out unauthenticated, and the upstream's 401/403 will look like a bad credential rather than one that was never wired`;
+  if (verdict.state === "swallowed") {
+    return `the attached credential is never sent: a "${kind}" credential injects into the "${verdict.name}" header, and that name cannot be set on a request — the assignment reaches an inherited setter and creates no header at all, silently. Give the credential another param name; nothing about this tool can make that one arrive.`;
+  }
   if (verdict.state === "shadowed") {
     // NOTE: a DIFFERENT sentence, and the reason is that the other one's advice is wrong here. This
     // operator picked an injecting type and attached it correctly; what stops it is the value the

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -96,8 +96,10 @@ function alwaysNonEmpty(
   template: string,
   fixed: Map<string, string>,
   resolveFixed = true,
+  ackArg = false,
 ): boolean {
   if (template.replace(PLACEHOLDER, "") !== "") return true;
+  if (ackArg && namesIn(template).has(WAIT_MESSAGE_ARG)) return true;
   if (!resolveFixed) return false;
   for (const name of namesIn(template)) {
     // The prototype names are non-empty for a DIFFERENT reason than the fixed ones, and the two
@@ -368,6 +370,13 @@ export function effectiveUrlTemplate(
 // case above: there is no unauthenticated request to warn about.
 function buildsARequest(urlTemplate: unknown, shapes: ToolShapePatch): boolean {
   if (typeof urlTemplate !== "string") return false;
+  // The ORIGIN is pinned: `buildHttpTool` takes it from the neutralized template and throws
+  // "interpolation altered the origin" when the real one differs, so a placeholder anywhere in the
+  // scheme, host or port is a tool that never fetches. The two sentinels answer where it sits — the
+  // origins differ only if a placeholder is inside one.
+  const a = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_A);
+  const b = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_B);
+  if (!a || !b || a.origin !== b.origin) return false;
   try {
     new URL(urlTemplate.replace(PLACEHOLDER, "_"));
   } catch {
@@ -477,11 +486,16 @@ type InjectionVerdict =
 // given the same treatment, and mirroring that here is what agrees with the runtime as it is.
 const SWALLOWED_HEADER = "__proto__";
 
+// The argument `buildHttpTool` adds for itself when the tool has an ack: required, and rejected by
+// zod when empty, so it is present and non-empty on every call that runs.
+const WAIT_MESSAGE_ARG = "__wait_message";
+
 function autoInjectionVerdict(
   kind: string | null | undefined,
   paramName: string | null | undefined,
   method: string,
   shapes: ToolShapePatch,
+  ackArg = false,
 ): InjectionVerdict {
   // The value is a probe, never a secret: `resolveSecretInjection` only needs a non-empty string to
   // answer WHERE the credential would go.
@@ -541,7 +555,8 @@ function autoInjectionVerdict(
     return shadowed("tool");
   }
   const explicit = reachingQuery(shapes)[inj.name];
-  const alwaysSet = explicit !== undefined && alwaysNonEmpty(explicit, fixed);
+  const alwaysSet =
+    explicit !== undefined && alwaysNonEmpty(explicit, fixed, true, ackArg);
   return alwaysSet ? shadowed("tool") : { state: "reaches" };
 }
 
@@ -584,6 +599,10 @@ export function unusedCredentialWarning(
   },
   method: string | null | undefined,
   raw: ToolShapePatch,
+  // The tool's own ack, when it has one. `buildHttpTool` then DECLARES a required, non-empty
+  // `__wait_message` argument of its own, so a query value of `{{__wait_message}}` is set on every
+  // executable call and takes its parameter — a field that is in no input schema anywhere.
+  opts: { ackMessage?: string | null } = {},
 ): string | null {
   if (isNonInjectableSecret(facts.kind)) return null;
   const { shapes: normalized } = normalizeToolShapes(raw);
@@ -595,7 +614,13 @@ export function unusedCredentialWarning(
   };
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
   if (mentions(reachableTemplates(method, shapes), "secret")) return null;
-  const verdict = autoInjectionVerdict(facts.kind, facts.paramName, m, shapes);
+  const verdict = autoInjectionVerdict(
+    facts.kind,
+    facts.paramName,
+    m,
+    shapes,
+    !!opts.ackMessage,
+  );
   if (verdict.state === "reaches") return null;
 
   const kind = facts.kind ?? "generic";

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -272,8 +272,14 @@ function fixedFields(schema: unknown): { name: string; value: string }[] {
     // `source === "fixed"` is not a detail: `buildHttpTool` reads `s.source === "fixed" ? "fixed" :
     // "ai"` and precomputes only the fixed values with the secret in scope, so a `{{secret}}` written
     // into an AI field's `value` is never interpolated.
+    // A fixed field whose `value` is absent or not a string is still a fixed field — `parseFields`
+    // gives it `""` — and its NAME is what the legacy query derivation puts on the URL, blocking a
+    // query credential of the same name. Dropping it here lost the name, not just the value.
     if (isPlainObject(spec) && spec.source === "fixed") {
-      if (typeof spec.value === "string") out.push({ name, value: spec.value });
+      out.push({
+        name,
+        value: typeof spec.value === "string" ? spec.value : "",
+      });
     }
   }
   return out;
@@ -355,6 +361,16 @@ function autoInjectionReaches(
     const names = isPlainObject(shapes.headers)
       ? Object.keys(shapes.headers)
       : [];
+    // The one header the runtime writes ITSELF: a body method with no content-type of its own gets
+    // `Content-Type: application/json` added before auto-injection, which occupies that target the
+    // same way an operator's own header does.
+    if (
+      BODY_METHODS.has(method) &&
+      inj.name.toLowerCase() === "content-type" &&
+      !names.some((h) => h.toLowerCase() === "content-type")
+    ) {
+      return false;
+    }
     return !names.some((h) => h.toLowerCase() === inj.name.toLowerCase());
   }
   // Query: the runtime injects unless the param is already on the URL — spelled in the template, or

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -31,6 +31,9 @@
 // does reach. Each of those was a wrong answer in the first draft of this file, and each is fenced by
 // executing the real tool rather than by a list written here.
 
+import { isIP } from "node:net";
+import config from "@/config";
+import { isBlockedIp } from "@/lib/ssrf";
 import {
   INJECTING_MECHANISM_KIND_IDS,
   isNonInjectableSecret,
@@ -170,11 +173,19 @@ function fixedValuesByName(schema: unknown): Map<string, string> {
 // or more values the key depends on what the model picked, so the executor's answer differs between
 // invocations and no single row can assert it. Unknowable falls to the quiet side, like every other
 // unknown here.
-function knownValuesByName(schema: unknown): Map<string, string> {
+function knownValuesByName(
+  schema: unknown,
+  ackArg = false,
+): Map<string, string> {
   const out = fixedValuesByName(schema);
+  if (ackArg) out.delete(WAIT_MESSAGE_ARG);
   if (typeof schema !== "object" || schema === null) return out;
   for (const [name, spec] of Object.entries(schema)) {
     if (!isPlainObject(spec) || spec.source === "fixed") continue;
+    // NOTE: on an ack tool the executor REPLACES this field's schema with its own unrestricted
+    // non-empty argument, so a `__wait_message` declared as a singleton enum binds nothing: whatever
+    // the model writes as the wait message is what the key becomes.
+    if (ackArg && name === WAIT_MESSAGE_ARG) continue;
     if (!spec.required) continue;
     // `zodFor` reads `enumValues` only for `type: "enum"`; on a string field it is decoration and
     // the model may send anything, so the key stays unknowable.
@@ -309,10 +320,13 @@ function transmittedUrl(urlTemplate: unknown): string[] {
 
 // The explicit query entries that survive to the request: everything the URL template does not
 // already spell.
-function reachingQuery(shapes: ToolShapePatch): Record<string, string> {
+function reachingQuery(
+  shapes: ToolShapePatch,
+  ackArg = false,
+): Record<string, string> {
   const taken = urlQueryKeys(
     shapes.urlTemplate,
-    knownValuesByName(shapes.inputSchema),
+    knownValuesByName(shapes.inputSchema, ackArg),
   );
   return Object.fromEntries(
     Object.entries(queryMap(shapes.query)).filter(([k]) => !taken.has(k)),
@@ -455,22 +469,27 @@ function buildsARequest(
   ackArg: boolean,
   allowedHosts: string[] | null | undefined,
   relative: boolean,
+  // The deployment's SSRF policy, read from config by default and overridable so the branch below is
+  // testable: where private targets are allowed the guard lifts BOTH of its decidable refusals, and
+  // the suite runs with them on.
+  privateAllowed: boolean,
 ): boolean {
   if (typeof urlTemplate !== "string") return false;
   // The ORIGIN is pinned: `buildHttpTool` takes it from the neutralized template and throws
   // "interpolation altered the origin" when the real one differs, so a placeholder anywhere in the
   // scheme, host or port is a tool that never fetches. The two sentinels answer where it sits — the
   // origins differ only if a placeholder is inside one.
-  // The protocol the SSRF guard will accept. It runs on the FINAL URL, immediately before the fetch,
-  // and refuses anything that is not https — http only where the deployment allows it, which this
-  // boundary cannot know and therefore does not claim. An `ftp://` template parses, stores, and never
-  // leaves.
-  const scheme = parseUrlTemplate(
-    urlTemplate,
-    new Map(),
-    UNRESOLVED_A,
-  )?.protocol;
-  if (scheme !== "https:") return false;
+  // The SSRF guard, which runs on the FINAL URL immediately before the fetch. Two of its refusals are
+  // decidable here: a protocol that is not https (http only where the deployment allows it, which is
+  // also a per-call flag this boundary cannot see), and a literal address in a blocked range. Both
+  // are lifted wholesale when the deployment allows private targets, and THAT is readable — it is
+  // the same `config.ssrf.allowPrivateTargets` the guard itself reads.
+  const probe = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_A);
+  if (!privateAllowed) {
+    if (probe?.protocol !== "https:") return false;
+    const host = probe.hostname.replace(/^\[|\]$/g, "");
+    if (isIP(host) && isBlockedIp(host)) return false;
+  }
   const a = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_A);
   const b = parseUrlTemplate(urlTemplate, new Map(), UNRESOLVED_B);
   if (!a || !b || a.origin !== b.origin) return false;
@@ -535,7 +554,7 @@ export function reachableTemplates(
   const emitted: string[] = [...transmittedUrl(shapes.urlTemplate)];
   emitted.push(
     ...headerTemplates(shapes.headers),
-    ...Object.values(reachingQuery(shapes)),
+    ...Object.values(reachingQuery(shapes, ackArg)),
   );
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
   if (BODY_METHODS.has(m)) {
@@ -675,7 +694,7 @@ function autoInjectionVerdict(
   ) {
     return shadowed("tool");
   }
-  const explicit = reachingQuery(shapes)[inj.name];
+  const explicit = reachingQuery(shapes, ackArg)[inj.name];
   const alwaysSet =
     explicit !== undefined &&
     alwaysNonEmpty(
@@ -730,7 +749,11 @@ export function unusedCredentialWarning(
   // The tool's own ack, when it has one. `buildHttpTool` then DECLARES a required, non-empty
   // `__wait_message` argument of its own, so a query value of `{{__wait_message}}` is set on every
   // executable call and takes its parameter — a field that is in no input schema anywhere.
-  opts: { ackMessage?: string | null; allowedHosts?: string[] | null } = {},
+  opts: {
+    ackMessage?: string | null;
+    allowedHosts?: string[] | null;
+    privateAllowed?: boolean;
+  } = {},
 ): string | null {
   if (isNonInjectableSecret(facts.kind)) return null;
   const { shapes: normalized } = normalizeToolShapes(raw);
@@ -744,6 +767,7 @@ export function unusedCredentialWarning(
       ackArg,
       opts.allowedHosts,
       isRelativeTemplate(normalized.urlTemplate),
+      opts.privateAllowed ?? config.ssrf.allowPrivateTargets,
     )
   ) {
     return null;

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -2,68 +2,160 @@
 // tool can reference a `generic` credential while nothing in its templates interpolates `{{secret}}`.
 // Nothing refuses that, and nothing should — a tool may legitimately hold a reference it does not
 // wire yet — but the failure it produces is unreadable: the request goes out UNAUTHENTICATED and the
-// upstream answers 401/403, which reads as a bad credential rather than as a credential that was
-// never sent. A `generic` credential is the one kind with no auto-injection (the catalog says so),
-// so it is also the only one where "attached" and "sent" can come apart silently.
+// upstream answers 401/403, which reads as a bad credential rather than as one that was never sent.
+//
+// THE QUESTION IS NOT "does a template mention {{secret}}". It is "does the credential reach the
+// request", and the two come apart in four ways the runtime decides and a text scan does not see: a
+// body is only assembled for POST/PUT/PATCH, a fixed field's value only leaves if something emitted
+// references it, a typed credential's auto-injection is skipped when the operator already wrote its
+// target header or query param, and a stored single-brace `{secret}` is normalized at BUILD time and
+// does reach. Each of those was a wrong answer in the first draft of this file, and each is fenced by
+// executing the real tool rather than by a list written here.
 
 import {
   INJECTING_MECHANISM_KIND_IDS,
   isNonInjectableSecret,
-  secretTypeAutoInjects,
+  resolveSecretInjection,
 } from "@/modules/vault/secret-types";
-import type { ToolShapePatch } from "./normalize";
+import { normalizeToolShapes, type ToolShapePatch } from "./normalize";
+import { DEFAULT_HTTP_METHOD } from "./service";
 
 // The SAME grammar the runtime interpolates with (`PLACEHOLDER` in graph/tools/http.ts): the braces
 // take surrounding whitespace, so a scanner matching only the tight spelling would call a working
 // `{{ secret }}` unused and warn about a tool that is wired correctly.
-const SECRET_PLACEHOLDER = /\{\{\s*secret\s*\}\}/;
+const placeholder = (name: string) => new RegExp(`\\{\\{\\s*${name}\\s*\\}\\}`);
+
+// Mirrors `isBodyMethod` in graph/tools/http.ts. DELETE is deliberately absent there — a DELETE tool
+// carrying a raw body sends none of it — and a copy of that list which quietly included DELETE would
+// call such a tool wired.
+const BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-// Every string the runtime interpolates `{{secret}}` into, and nothing else. Five sites, and they are
-// the same five `normalizeToolShapes` rewrites: the URL, header values, query values, the body (raw
-// text, or the kv rows' values) and a FIXED input field's value.
-//
-// `source === "fixed"` is not a detail. `buildHttpTool` reads `s.source === "fixed" ? "fixed" : "ai"`
-// and precomputes only the fixed values with the secret in scope; a `{{secret}}` written into an AI
-// field's `value` is never interpolated, so counting it as usage would silence the warning for a
-// tool whose credential genuinely never leaves.
-export function toolSecretTemplates(shapes: ToolShapePatch): string[] {
-  const out: string[] = [];
-  if (typeof shapes.urlTemplate === "string") out.push(shapes.urlTemplate);
-  for (const key of ["headers", "query"] as const) {
-    const value = shapes[key];
-    if (!isPlainObject(value)) continue;
-    for (const v of Object.values(value)) {
-      if (typeof v === "string") out.push(v);
-    }
+function stringValues(v: unknown): string[] {
+  return isPlainObject(v)
+    ? Object.values(v).filter((x): x is string => typeof x === "string")
+    : [];
+}
+
+function bodyTemplates(body: unknown): string[] {
+  if (!isPlainObject(body)) return [];
+  if (body.mode === "raw" && typeof body.raw === "string") return [body.raw];
+  if (body.mode === "kv" && Array.isArray(body.rows)) {
+    return body.rows
+      .filter((r): r is Record<string, unknown> => isPlainObject(r))
+      .map((r) => r.value)
+      .filter((v): v is string => typeof v === "string");
   }
-  const body = shapes.body;
-  if (isPlainObject(body)) {
-    if (body.mode === "raw" && typeof body.raw === "string") out.push(body.raw);
-    if (body.mode === "kv" && Array.isArray(body.rows)) {
-      for (const row of body.rows) {
-        if (isPlainObject(row) && typeof row.value === "string") {
-          out.push(row.value);
-        }
-      }
-    }
-  }
-  const schema = shapes.inputSchema;
-  if (isPlainObject(schema)) {
-    for (const spec of Object.values(schema)) {
-      if (isPlainObject(spec) && spec.source === "fixed") {
-        if (typeof spec.value === "string") out.push(spec.value);
-      }
+  return [];
+}
+
+// A legacy `fields` body (mode absent, or anything that is not raw/kv) assembles its payload from the
+// declared fields, so EVERY non-path fixed field is emitted without being referenced. Read from the
+// same shape `parseBody` reads.
+function isLegacyFieldsBody(body: unknown): boolean {
+  if (!isPlainObject(body)) return true;
+  return body.mode !== "raw" && body.mode !== "kv";
+}
+
+function fixedFields(schema: unknown): { name: string; value: string }[] {
+  if (!isPlainObject(schema)) return [];
+  const out: { name: string; value: string }[] = [];
+  for (const [name, spec] of Object.entries(schema)) {
+    // `source === "fixed"` is not a detail: `buildHttpTool` reads `s.source === "fixed" ? "fixed" :
+    // "ai"` and precomputes only the fixed values with the secret in scope, so a `{{secret}}` written
+    // into an AI field's `value` is never interpolated.
+    if (isPlainObject(spec) && spec.source === "fixed") {
+      if (typeof spec.value === "string") out.push({ name, value: spec.value });
     }
   }
   return out;
 }
 
-export function toolUsesSecretPlaceholder(shapes: ToolShapePatch): boolean {
-  return toolSecretTemplates(shapes).some((t) => SECRET_PLACEHOLDER.test(t));
+// Every string the runtime interpolates AND SENDS, for this method and this row. The second half is
+// what a site list alone gets wrong: a template that is assembled and then discarded carries nothing,
+// so counting it as usage silences the warning for a tool whose credential never leaves.
+export function reachableTemplates(
+  method: string | null | undefined,
+  shapes: ToolShapePatch,
+): string[] {
+  const emitted: string[] = [];
+  if (typeof shapes.urlTemplate === "string") emitted.push(shapes.urlTemplate);
+  emitted.push(...stringValues(shapes.headers), ...stringValues(shapes.query));
+  const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
+  if (BODY_METHODS.has(m)) emitted.push(...bodyTemplates(shapes.body));
+
+  const out = [...emitted];
+  const legacy = isLegacyFieldsBody(shapes.body);
+  for (const { name, value } of fixedFields(shapes.inputSchema)) {
+    // A fixed value resolves from CONTEXT and the secret only, never from another fixed field, so
+    // one level is the whole reach: it leaves if something emitted names it, or if the legacy body
+    // assembles it without being asked.
+    //
+    // The legacy arm OVER-counts on purpose. `buildHttpTool` derives the query from those fields
+    // only when there is no explicit query, and reproducing that condition would be a third copy of
+    // the runtime's assembly rules for a case that costs a MISSED warning either way. Over-counting
+    // here can only make this file too quiet; under-counting would make it warn about a tool that
+    // works.
+    if (legacy || emitted.some((t) => placeholder(name).test(t))) {
+      out.push(value);
+    }
+  }
+  return out;
+}
+
+// Whether the kind's own injection puts the credential on the request. Not `injection !== "none"`:
+// the runtime SKIPS auto-injection when the operator already wrote the target header (any casing) or
+// the target query param, letting their explicit value win — so a `bearer_token` attached to a tool
+// that sets its own `Authorization` is never sent, which is exactly the shape this file exists to
+// report.
+function autoInjectionReaches(
+  kind: string | null | undefined,
+  paramName: string | null | undefined,
+  shapes: ToolShapePatch,
+): boolean {
+  // The value is a probe, never a secret: `resolveSecretInjection` only needs a non-empty string to
+  // answer WHERE the credential would go.
+  const inj = resolveSecretInjection(kind, "probe", paramName);
+  if (!inj) return false;
+  if (inj.target === "header") {
+    const names = isPlainObject(shapes.headers)
+      ? Object.keys(shapes.headers)
+      : [];
+    return !names.some((h) => h.toLowerCase() === inj.name.toLowerCase());
+  }
+  // Query: the runtime injects unless the param is already on the URL — hand-written in the template,
+  // or set from the explicit query map, which it applies first and only for a value that resolves
+  // NON-EMPTY. A template value may resolve to nothing, and that is unknowable here, so only a
+  // literal counts as shadowing. Guessing the other way would warn about a tool that is wired.
+  const query = isPlainObject(shapes.query) ? shapes.query : {};
+  const explicit = query[inj.name];
+  const literalNonEmpty =
+    typeof explicit === "string" &&
+    explicit !== "" &&
+    !/\{\{\s*[a-zA-Z0-9_]+\s*\}\}/.test(explicit);
+  if (literalNonEmpty) return false;
+  const url = typeof shapes.urlTemplate === "string" ? shapes.urlTemplate : "";
+  const q = url.split("?")[1];
+  return !(q && new URLSearchParams(q).has(inj.name));
+}
+
+export function credentialReachesRequest(
+  kind: string | null | undefined,
+  paramName: string | null | undefined,
+  method: string | null | undefined,
+  shapes: ToolShapePatch,
+): boolean {
+  if (
+    reachableTemplates(method, shapes).some((t) =>
+      placeholder("secret").test(t),
+    )
+  ) {
+    return true;
+  }
+  return autoInjectionReaches(kind, paramName, shapes);
 }
 
 // The warning, or null when the wiring is fine. `kind` is the ATTACHED credential's kind, read off
@@ -74,11 +166,22 @@ export function toolUsesSecretPlaceholder(shapes: ToolShapePatch): boolean {
 // with a different answer (it must not be sent at all, and the write boundary does not yet refuse
 // it), and telling its operator to "write {{secret}} where the API expects it" would be advice to
 // mail their stdio token to a third party.
+//
+// `shapes` is NORMALIZED here rather than by the caller, and that is the difference between reading
+// the row and reading what the runtime reads: `buildHttpTool` runs the same normalization at BUILD
+// time, so a legacy single-brace `{secret}` in a stored header is sent — and a caller that scanned
+// the raw row would report a working tool as unwired on any update that did not happen to touch that
+// template.
 export function unusedCredentialWarning(
-  kind: string | null | undefined,
-  shapes: ToolShapePatch,
+  facts: { kind: string | null; paramName: string | null },
+  method: string | null | undefined,
+  raw: ToolShapePatch,
 ): string | null {
-  if (secretTypeAutoInjects(kind) || isNonInjectableSecret(kind)) return null;
-  if (toolUsesSecretPlaceholder(shapes)) return null;
-  return `the attached credential is never sent: a "${kind ?? "generic"}" credential is not auto-injected, and {{secret}} appears in none of url_template, headers, query, body or a fixed field value — this request goes out unauthenticated, and the upstream's 401/403 will look like a bad credential rather than one that was never wired. Write {{secret}} where the API expects it, or attach a credential whose type injects it (${INJECTING_MECHANISM_KIND_IDS.join(", ")}).`;
+  if (isNonInjectableSecret(facts.kind)) return null;
+  const { shapes } = normalizeToolShapes(raw);
+  if (credentialReachesRequest(facts.kind, facts.paramName, method, shapes)) {
+    return null;
+  }
+  const kind = facts.kind ?? "generic";
+  return `the attached credential is never sent: a "${kind}" credential puts nothing on this request by itself, and {{secret}} appears in none of the templates this ${(method ?? DEFAULT_HTTP_METHOD).toUpperCase()} actually emits — it goes out unauthenticated, and the upstream's 401/403 will look like a bad credential rather than one that was never wired. Write {{secret}} where the API expects it, or attach a credential whose type injects it (${INJECTING_MECHANISM_KIND_IDS.join(", ")}) into a header or query parameter the templates do not already set.`;
 }

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -381,9 +381,23 @@ function buildsARequest(urlTemplate: unknown, shapes: ToolShapePatch): boolean {
   const fixed = fixedValuesByName(shapes.inputSchema);
   for (const name of namesIn(urlTemplate)) {
     if (name === "secret") continue;
-    if (ai.names.has(name) || fixed.has(name)) continue;
+    // A prototype name resolves for the same reason it resolves everywhere else here: `valueLookup`
+    // asks `n in input` and finds Object.prototype's member. Undeclared, and still not an orphan.
+    if (name in {}) continue;
+    if (ai.names.has(name)) continue;
     if ((CONTEXT_VAR_NAMES as readonly string[]).includes(name)) continue;
-    return false;
+    const value = fixed.get(name);
+    if (value === undefined) return false;
+    // A FIXED field brings its own dependencies, and the runtime tracks them: a `path` whose value is
+    // `{{missing}}` resolves to "" with `missing` recorded, and the URL guard then throws for the
+    // dependency rather than fetching an incomplete segment. So the field existing is not enough —
+    // what it needs has to be available too.
+    for (const dep of namesIn(value)) {
+      if (dep === "secret") continue;
+      if (dep in {}) continue;
+      if ((CONTEXT_VAR_NAMES as readonly string[]).includes(dep)) continue;
+      return false;
+    }
   }
   return true;
 }

--- a/src/modules/tool-definitions/credential-wiring.ts
+++ b/src/modules/tool-definitions/credential-wiring.ts
@@ -96,7 +96,7 @@ function alwaysNonEmpty(
   if (template.replace(PLACEHOLDER, "") !== "") return true;
   if (!resolveFixed) return false;
   for (const name of namesIn(template)) {
-    const value = fixed.get(name);
+    const value = fixedSubstitution(name, fixed);
     if (value !== undefined && alwaysNonEmpty(value, fixed, false)) return true;
   }
   return false;
@@ -104,6 +104,21 @@ function alwaysNonEmpty(
 
 function fixedValuesByName(schema: unknown): Map<string, string> {
   return new Map(fixedFields(schema).map((f) => [f.name, f.value]));
+}
+
+// The fixed value the runtime would substitute for this placeholder, or undefined when it would not
+// substitute one. `valueLookup` asks `n in input` FIRST, and `in` walks the prototype: a field named
+// `toString` (or `constructor`, or `valueOf`) resolves to Object.prototype's member, not to the
+// operator's fixed value, whatever the schema says. Reading the map for those names claimed a URL
+// key the request does not carry — and, on a query credential of that name, called it shadowed.
+//
+// The runtime's `in` is the defect; this is not the place to change it, and treating those names as
+// unresolvable is the reading that agrees with what it does today.
+function fixedSubstitution(
+  name: string,
+  fixed: Map<string, string>,
+): string | undefined {
+  return name in {} ? undefined : fixed.get(name);
 }
 
 // Mirrors `isBodyMethod` in graph/tools/http.ts. DELETE is deliberately absent there — a DELETE tool
@@ -159,7 +174,7 @@ function parseUrlTemplate(
 ): URL | null {
   if (typeof urlTemplate !== "string") return null;
   const resolved = urlTemplate.replace(PLACEHOLDER, (_whole, name: string) => {
-    const value = fixed.get(name);
+    const value = fixedSubstitution(name, fixed);
     // One level, like everywhere else here: a fixed value that is itself a template resolves from
     // context, which is unknowable, so it stays neutral.
     // ENCODED, because the runtime's interpolation is: `encodeURIComponent(v)` on every substituted
@@ -319,9 +334,11 @@ export function effectiveUrlTemplate(
   if (typeof urlTemplate !== "string" || !urlTemplate.startsWith("/")) {
     return urlTemplate;
   }
-  // No base and a relative template is a tool `buildHttpTool` refuses to build at all; there is no
-  // request to say anything about.
-  return credentialBaseUrl ? `${credentialBaseUrl}${urlTemplate}` : urlTemplate;
+  // No base and a relative template is a tool `buildHttpTool` REFUSES to build — it throws "relative
+  // urlTemplate requires a credential with a base URL" before there is a request at all. Answering
+  // `null` here is what lets the caller stay quiet: a warning that the request goes out
+  // unauthenticated diagnoses a failure that cannot happen, and points away from the one that does.
+  return credentialBaseUrl ? `${credentialBaseUrl}${urlTemplate}` : null;
 }
 
 export function reachableTemplates(
@@ -491,11 +508,11 @@ export function unusedCredentialWarning(
 ): string | null {
   if (isNonInjectableSecret(facts.kind)) return null;
   const { shapes: normalized } = normalizeToolShapes(raw);
+  const effective = effectiveUrlTemplate(normalized.urlTemplate, facts.baseUrl);
+  if (effective === null) return null;
   const shapes: ToolShapePatch = {
     ...normalized,
-    urlTemplate: effectiveUrlTemplate(normalized.urlTemplate, facts.baseUrl) as
-      | string
-      | undefined,
+    urlTemplate: effective as string | undefined,
   };
   const m = (method ?? DEFAULT_HTTP_METHOD).toUpperCase();
   if (mentions(reachableTemplates(method, shapes), "secret")) return null;

--- a/src/modules/tool-definitions/test-run.ts
+++ b/src/modules/tool-definitions/test-run.ts
@@ -40,7 +40,11 @@ import {
 } from "@/lib/outbound";
 import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { resolveInjectableCredential } from "@/modules/vault/injectable";
-import { formatVaultRef, readVaultRefId } from "@/modules/vault/service";
+import {
+  dialableBaseUrl,
+  formatVaultRef,
+  readVaultRefId,
+} from "@/modules/vault/service";
 import { unsupportedBodyShape } from "./body-shape";
 import { CONTEXT_VAR_NAMES } from "./normalize";
 import { readResponseTemplateResult } from "./response-template";
@@ -366,7 +370,7 @@ async function readCredentialMeta(
     return {
       kind: entry.kind,
       paramName: entry.paramName,
-      baseUrl: entry.baseUrl,
+      baseUrl: dialableBaseUrl(entry.kind, entry.baseUrl),
     };
   });
 }

--- a/src/modules/vault/secret-types.ts
+++ b/src/modules/vault/secret-types.ts
@@ -58,8 +58,16 @@ export interface SecretType {
   service?: string;
   // Optional connectivity test (test-on-save). Absent ⇒ the type is not testable.
   test?: SecretTestSpec;
-  // When true, a non-empty baseUrl is required to create or update this credential kind.
-  requiresBaseUrl?: boolean;
+  // Whether this kind carries a persistent base URL (VaultEntry.baseUrl), and whether it can be
+  // created without one. ONE declaration rather than a supports/requires pair, because "required
+  // but not supported" is not a state any kind can be in and a pair lets it be written: the
+  // console's own mirror kept the two as separate booleans and the server declared only half of
+  // them, which is how every kind ended up storing a base URL nine of them never show (#504).
+  // Absent ⇒ the kind has no use for one, and a non-empty baseUrl on it is REFUSED at the write
+  // boundary — the field is read straight off the entry by the model, vision, STT, TTS and MCP
+  // paths (`credentialBaseUrl ?? cfg.baseURL`), so a value stored on a kind whose form never shows
+  // it silently redirects where the credential is sent.
+  baseUrl?: "required" | "optional";
   // When true, the VALUE is a server-managed JSON blob (created empty, populated by a connect flow
   // like OAuth DCR + consent). Exempt from validateVaultValue's field/string shape check — only
   // "must be an object" is enforced. The operator never types the secret value directly.
@@ -69,13 +77,23 @@ export interface SecretType {
 // Order is the UI display order. Keep `generic` first (the default); generic mechanisms, then the
 // service-specific types (which carry a logo + a connectivity test).
 export const SECRET_TYPES: SecretType[] = [
-  { id: "generic", injection: "none" },
-  { id: "bearer_token", injection: "bearer" },
+  { id: "generic", injection: "none", baseUrl: "optional" },
+  { id: "bearer_token", injection: "bearer", baseUrl: "optional" },
   // Generic header injection — the operator names the header in VaultEntry.paramName.
-  { id: "header", injection: "header", needsParamName: true },
-  { id: "basic_auth", injection: "basic" },
+  {
+    id: "header",
+    injection: "header",
+    needsParamName: true,
+    baseUrl: "optional",
+  },
+  { id: "basic_auth", injection: "basic", baseUrl: "optional" },
   // Generic query injection — the operator names the query parameter in VaultEntry.paramName.
-  { id: "query", injection: "query", needsParamName: true },
+  {
+    id: "query",
+    injection: "query",
+    needsParamName: true,
+    baseUrl: "optional",
+  },
   {
     id: "openai",
     injection: "bearer",
@@ -119,7 +137,7 @@ export const SECRET_TYPES: SecretType[] = [
     id: "openai_compatible",
     injection: "bearer",
     service: "openai_compatible",
-    requiresBaseUrl: true,
+    baseUrl: "required",
     // Base is the operator's API root (typically ending in /v1); the probe hits {base}/models.
     test: { needsBase: true, path: "/models" },
   },
@@ -158,7 +176,7 @@ export const SECRET_TYPES: SecretType[] = [
     // with the SAME header; hyphenated to survive proxies that drop underscores (chatwoot/constants.ts).
     name: CHATWOOT_AUTH_HEADER,
     service: "chatwoot",
-    requiresBaseUrl: true,
+    baseUrl: "required",
     // Self-hosted: the operator's Chatwoot base. Probes the user-scoped profile endpoint.
     test: { needsBase: true, path: "/api/v1/profile" },
   },
@@ -183,7 +201,7 @@ export const SECRET_TYPES: SecretType[] = [
     id: "mcp_oauth",
     injection: "bearer",
     service: "mcp",
-    requiresBaseUrl: true,
+    baseUrl: "required",
     managedBlob: true,
   },
   // Environment variable for a stdio MCP server (many stdio servers read their token from an env var,
@@ -206,7 +224,7 @@ export const SECRET_TYPES: SecretType[] = [
     injection: "none",
     neverOutbound: true,
     service: "langfuse",
-    requiresBaseUrl: true,
+    baseUrl: "required",
     fields: [{ key: "publicKey" }, { key: "secretKey", masked: true }],
   },
 ];
@@ -260,10 +278,58 @@ export function secretTypeRefusesParamName(
   return type != null && !type.needsParamName;
 }
 
+// Whether the kind puts the credential on the outbound request BY ITSELF. False for `generic` — the
+// escape hatch whose whole contract is that the operator writes `{{secret}}` where the API wants it —
+// and for a kind this build does not know, which is treated as `generic` everywhere else.
+export function secretTypeAutoInjects(id: string | null | undefined): boolean {
+  const type = getSecretType(id);
+  return type != null && type.injection !== "none";
+}
+
+// The kinds that inject a credential without naming a service: bearer/header/basic/query. Derived
+// rather than listed, and the two conditions are both load-bearing — a kind that injects but names a
+// service (`openai`, `asaas`, …) is not an alternative for an arbitrary HTTP tool, it is a different
+// API. This is what the unused-credential warning offers instead of only saying the credential is dead.
+export const INJECTING_MECHANISM_KIND_IDS: string[] = SECRET_TYPES.filter(
+  (s) => s.injection !== "none" && !s.service,
+).map((s) => s.id);
+
 export function secretTypeRequiresBaseUrl(
   id: string | null | undefined,
 ): boolean {
-  return !!getSecretType(id)?.requiresBaseUrl;
+  return getSecretType(id)?.baseUrl === "required";
+}
+
+// Whether the kind has any use for a base URL at all. Required implies supported by construction —
+// that is the whole reason the catalog declares one field and not two.
+export function secretTypeSupportsBaseUrl(
+  id: string | null | undefined,
+): boolean {
+  return getSecretType(id)?.baseUrl != null;
+}
+
+// The kinds that carry a base URL, in catalog order — the same shape `PARAM_NAME_KIND_IDS` has, and
+// for the same reason: the refusal below can NAME the alternatives instead of only saying no.
+export const BASE_URL_KIND_IDS: string[] = SECRET_TYPES.filter(
+  (s) => s.baseUrl != null,
+).map((s) => s.id);
+
+// Whether a non-empty `baseUrl` on this kind must be REFUSED at the write boundary. Not the negation
+// of `secretTypeSupportsBaseUrl`, and the difference is the same carve-out `secretTypeRefusesParamName`
+// makes: a kind this build does not know answers false, so an entry written by a build whose catalog
+// had a kind this one dropped stays editable.
+//
+// The field is read straight off the resolved entry by the model path (`credentialBaseUrl ?? mc.baseURL`
+// in prepare.ts), vision, STT, TTS, the HTTP-tool base and the MCP connection URL — none of them
+// asking the kind. So a base URL stored on a kind whose console form never renders the input is a
+// redirect nobody can see: the operator's provider key goes to that host on the next turn, and the
+// only surface that already asks the question is the embedding path, which honours the entry's
+// baseUrl for `openai_compatible` and nothing else (rag/documents.ts, and it says why).
+export function secretTypeRefusesBaseUrl(
+  id: string | null | undefined,
+): boolean {
+  const type = getSecretType(id);
+  return type != null && type.baseUrl == null;
 }
 
 // True for kinds whose VALUE is a server-managed JSON blob (created empty; see SecretType.managedBlob).

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -17,6 +17,7 @@ import {
   type SecretTestResult,
 } from "./secret-test";
 import {
+  BASE_URL_KIND_IDS,
   type CredentialUse,
   credentialServes,
   getSecretTypeFields,
@@ -27,6 +28,7 @@ import {
   secretTypeFits,
   secretTypeIsManagedBlob,
   secretTypeNeedsParamName,
+  secretTypeRefusesBaseUrl,
   secretTypeRefusesParamName,
   secretTypeRequiresBaseUrl,
   secretValueFitsKind,
@@ -862,7 +864,9 @@ export interface CreateVaultEntryInput {
 // Its RETURN is part of the verdict, not a convenience: `kind` defaults to "generic" and `baseUrl`
 // normalizes, and a caller that re-derives either from the raw input will disagree with what gets
 // stored.
-// The base URL a write would STORE, refusing when the kind requires one and this is not it.
+
+// The base URL a write would STORE, refusing both ways the kind can disagree with it: required and
+// absent, and present on a kind that has no use for one.
 //
 // It exists because the check has to sit after the normalization, and `updateVaultEntry` had it
 // before: it asked `secretTypeRequiresBaseUrl` only on the `null`/`""` branch, while the other
@@ -871,17 +875,43 @@ export interface CreateVaultEntryInput {
 // updated to `baseUrl: null` — a state its own create path rejects. Found by the MCP preview
 // answering the question the apply did not (#490), and it is the inverse of every other divergence
 // in that issue: the preview refused and the apply succeeded, leaving invalid configuration behind.
-function normalizeRequiredBaseUrl(
+//
+// The second half is issue #504, and it is the `paramName` story of #488 with a sharper ending. The
+// catalog declares which kinds carry a base URL; the console renders the input for exactly those
+// nine of the eighteen and for no other. The other nine STORED one anyway — every one of them,
+// measured — and the runtime then USED it: `prepare.ts` hands the model client `credentialBaseUrl ?? mc.baseURL`
+// straight off the resolved entry, and vision, STT, TTS, the HTTP-tool base and the MCP connection
+// URL do the same, none of them asking the kind. So an `openai` credential could carry a host the
+// console never shows, never lists and cannot edit, and the provider key went there on the next
+// turn. The kind that legitimately points an OpenAI API somewhere else is `openai_compatible`, and
+// naming it is the difference between a refusal and a dead end.
+//
+// Empty stays empty, for the reason `validateParamName` gives: the console submits the field on
+// every kind whose form has no input, and refusing that would refuse every save it makes.
+function normalizeBaseUrlForKind(
   raw: string | null | undefined,
   kind: string,
 ): string | null {
   const normalized =
     raw == null || raw === "" ? null : validateBaseUrl(raw) || null;
-  if (normalized === null && secretTypeRequiresBaseUrl(kind)) {
+  if (normalized === null) {
+    if (secretTypeRequiresBaseUrl(kind)) {
+      throw new AppError(
+        "baseUrl is required for this credential type",
+        400,
+        "errors.vaultBaseUrlRequired",
+      );
+    }
+    return null;
+  }
+  if (secretTypeRefusesBaseUrl(kind)) {
+    const kinds = BASE_URL_KIND_IDS.join(", ");
     throw new AppError(
-      "baseUrl is required for this credential type",
+      `the "${kind}" credential type does not use a base URL. The types that do are: ${kinds}.`,
       400,
-      "errors.vaultBaseUrlRequired",
+      "errors.vaultBaseUrlNotApplicable",
+      { kind, kinds },
+      "baseUrl",
     );
   }
   return normalized;
@@ -900,7 +930,7 @@ export function assertVaultEntryCreatable(input: CreateVaultEntryInput): {
   const kind = input.kind ?? "generic";
   validateVaultValue(kind, input.value);
 
-  const baseUrl = normalizeRequiredBaseUrl(input.baseUrl, kind);
+  const baseUrl = normalizeBaseUrlForKind(input.baseUrl, kind);
 
   const paramName =
     input.paramName != null
@@ -1158,17 +1188,13 @@ export function assertPendingVaultEntryCreatable(
     );
   }
 
-  let normalizedBaseUrl: string | null = null;
-  if (input.baseUrl != null && input.baseUrl !== "") {
-    normalizedBaseUrl = validateBaseUrl(input.baseUrl) || null;
-  }
-  if (secretTypeRequiresBaseUrl(normalizedKind) && !normalizedBaseUrl) {
-    throw new AppError(
-      "baseUrl is required for this credential type",
-      400,
-      "errors.vaultBaseUrlRequired",
-    );
-  }
+  // NOTE: the SAME helper the create path uses, not a second spelling of it. The two were written
+  // separately and the copy here already lagged once — it is where #490 found the required-baseUrl
+  // check sitting before the normalization instead of after.
+  const normalizedBaseUrl = normalizeBaseUrlForKind(
+    input.baseUrl,
+    normalizedKind,
+  );
   const normalizedParamName =
     input.paramName != null
       ? validateParamName(input.paramName, normalizedKind)
@@ -1329,7 +1355,7 @@ export async function updateVaultEntry(
     }
 
     if (patch.baseUrl !== undefined) {
-      data.baseUrl = normalizeRequiredBaseUrl(patch.baseUrl, entry.kind);
+      data.baseUrl = normalizeBaseUrlForKind(patch.baseUrl, entry.kind);
     }
 
     if (patch.paramName !== undefined) {

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -500,6 +500,10 @@ function vaultValueFits(kind: string | null, encrypted: string): boolean {
 export interface VaultEntryFacts {
   kind: string;
   valueFitsKind: boolean;
+  // The operator-supplied header/query name, for the two kinds that read one. Part of the facts and
+  // not a second lookup because WHERE the credential lands is as much a property of the entry as
+  // whether it fits — the tool write asks both in one breath (#504).
+  paramName: string | null;
 }
 
 export async function readVaultRefFacts(
@@ -508,13 +512,14 @@ export async function readVaultRefFacts(
 ): Promise<VaultEntryFacts | null> {
   const row = await db.vaultEntry.findFirst({
     where: vaultRefWhere(ref),
-    select: { kind: true, status: true, secret: true },
+    select: { kind: true, status: true, secret: true, paramName: true },
   });
   if (!row) return null;
   return {
     kind: row.kind,
     valueFitsKind:
       row.status === "pending" || vaultValueFits(row.kind, row.secret),
+    paramName: row.paramName,
   };
 }
 

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -500,10 +500,12 @@ function vaultValueFits(kind: string | null, encrypted: string): boolean {
 export interface VaultEntryFacts {
   kind: string;
   valueFitsKind: boolean;
-  // The operator-supplied header/query name, for the two kinds that read one. Part of the facts and
-  // not a second lookup because WHERE the credential lands is as much a property of the entry as
-  // whether it fits — the tool write asks both in one breath (#504).
+  // The operator-supplied header/query name, for the two kinds that read one, and the base URL a
+  // relative tool template is resolved against. Part of the facts and not a second lookup because
+  // WHERE the credential lands is as much a property of the entry as whether it fits, and the base
+  // is part of the URL the tool actually requests — placeholders in it included (#504).
   paramName: string | null;
+  baseUrl: string | null;
 }
 
 export async function readVaultRefFacts(
@@ -512,7 +514,13 @@ export async function readVaultRefFacts(
 ): Promise<VaultEntryFacts | null> {
   const row = await db.vaultEntry.findFirst({
     where: vaultRefWhere(ref),
-    select: { kind: true, status: true, secret: true, paramName: true },
+    select: {
+      kind: true,
+      status: true,
+      secret: true,
+      paramName: true,
+      baseUrl: true,
+    },
   });
   if (!row) return null;
   return {
@@ -520,6 +528,7 @@ export async function readVaultRefFacts(
     valueFitsKind:
       row.status === "pending" || vaultValueFits(row.kind, row.secret),
     paramName: row.paramName,
+    baseUrl: row.baseUrl,
   };
 }
 

--- a/src/modules/vault/service.ts
+++ b/src/modules/vault/service.ts
@@ -205,6 +205,23 @@ export type VaultEntryResolution<T> =
   | { state: "pending" }
   | { state: "not_found" };
 
+// The base URL a consumer may DIAL, which is not always the one in the row.
+//
+// The write boundary refuses a base URL on a kind that has no use for one (#504), and refusing only
+// there leaves every row an older build wrote still redirecting: the model path, vision, STT, TTS,
+// the HTTP-tool base and the MCP connection URL all read this field off the RESOLVED entry without
+// asking the kind. A rule that only covers new writes is a rule that does not cover the installs it
+// was written for.
+//
+// The row is not touched. `listVaultInfos` still reports the stored value, so the console can show an
+// operator what is sitting in a field its own form never rendered — and nothing dials it.
+export function dialableBaseUrl(
+  kind: string | null,
+  baseUrl: string | null,
+): string | null {
+  return secretTypeRefusesBaseUrl(kind) ? null : baseUrl;
+}
+
 // State-aware variant for callers that need both operator-facing pending/not-found diagnostics and
 // active-entry metadata such as baseUrl. Keeping this separate avoids changing the generic
 // resolveVaultRefState value contract used by existing secret-only consumers.
@@ -230,7 +247,7 @@ export async function resolveVaultEntryState<T = unknown>(
     entry: {
       secret: decryptJson<T>(entry.secret),
       kind: entry.kind,
-      baseUrl: entry.baseUrl,
+      baseUrl: dialableBaseUrl(entry.kind, entry.baseUrl),
       paramName: entry.paramName,
       name: entry.name,
     },
@@ -257,7 +274,7 @@ export async function resolveVaultEntry<T = unknown>(
   return {
     secret: decryptJson<T>(entry.secret),
     kind: entry.kind,
-    baseUrl: entry.baseUrl,
+    baseUrl: dialableBaseUrl(entry.kind, entry.baseUrl),
     paramName: entry.paramName,
     name: entry.name,
   };
@@ -289,7 +306,7 @@ export async function tryResolveVaultEntry(
   return {
     secret: decryptJson(entry.secret),
     kind: entry.kind,
-    baseUrl: entry.baseUrl,
+    baseUrl: dialableBaseUrl(entry.kind, entry.baseUrl),
     paramName: entry.paramName,
     name: entry.name,
   };
@@ -328,7 +345,11 @@ export async function tryResolveApiKeyEntry(
   ) {
     return { state: "unusable", kind: entry.kind };
   }
-  return { state: "ok", secret: entry.secret, baseUrl: entry.baseUrl };
+  return {
+    state: "ok",
+    secret: entry.secret,
+    baseUrl: dialableBaseUrl(entry.kind, entry.baseUrl),
+  };
 }
 
 // The MCP surface speaks vault entry NAMES (agent-friendly: the operator tells the agent a name);

--- a/tests/client/lib/vaultCache.test.ts
+++ b/tests/client/lib/vaultCache.test.ts
@@ -164,7 +164,10 @@ describe("useVaultBaseUrls", () => {
       {
         id: "7",
         name: "llama",
-        kind: "openai",
+        // NOTE: `openai_compatible` and not `openai`, since #504: this hook answers with the base URL
+        // the runtime will DIAL, and a base stored on a kind whose form never offered the field is no
+        // longer one. `llama` behind an OpenAI-compatible endpoint is what this fixture always meant.
+        kind: "openai_compatible",
         baseUrl: "http://llama:8080/v1",
       },
       { id: "8", name: "openai", kind: "openai" },
@@ -190,7 +193,10 @@ describe("useVaultBaseUrls", () => {
       {
         id: "7",
         name: "llama",
-        kind: "openai",
+        // NOTE: `openai_compatible` and not `openai`, since #504: this hook answers with the base URL
+        // the runtime will DIAL, and a base stored on a kind whose form never offered the field is no
+        // longer one. `llama` behind an OpenAI-compatible endpoint is what this fixture always meant.
+        kind: "openai_compatible",
         baseUrl: "http://llama:8080/v1",
       },
     ];
@@ -282,7 +288,10 @@ describe("useVaultBaseUrls with a noncanonical ref", () => {
       {
         id: "7",
         name: "llama",
-        kind: "openai",
+        // NOTE: `openai_compatible` and not `openai`, since #504: this hook answers with the base URL
+        // the runtime will DIAL, and a base stored on a kind whose form never offered the field is no
+        // longer one. `llama` behind an OpenAI-compatible endpoint is what this fixture always meant.
+        kind: "openai_compatible",
         baseUrl: "http://llama:8080/v1",
       },
     ];

--- a/tests/modules/secret-types-mirror.test.ts
+++ b/tests/modules/secret-types-mirror.test.ts
@@ -39,4 +39,23 @@ describe("secret-types client mirror", () => {
       expect(!!meta?.needsParamName).toBe(!!type.needsParamName);
     }
   });
+
+  // NOTE: the base-URL pair, load-bearing since issue #504 for the same reason `needsParamName`
+  // became load-bearing with #488: the write now REFUSES a base URL on a kind that declares none,
+  // and the form is what keeps the console from ever sending one — it submits the field only when
+  // its own copy says the kind takes one. Drift here is a save the operator cannot fix, because the
+  // form renders no input for a kind it thinks takes no URL, and the refusal would name a field with
+  // nowhere to go.
+  //
+  // The client keeps the pair as two booleans because that is what the form asks (render the input /
+  // mark it required); the SERVER holds one field, so "required but not supported" cannot be
+  // written there. This test is what stops the client from writing it.
+  test("the client base-URL pair matches the server's single declaration", () => {
+    for (const type of SECRET_TYPES) {
+      const meta = SECRET_TYPE_META[type.id as keyof typeof SECRET_TYPE_META];
+      expect(!!meta?.supportsBaseUrl).toBe(type.baseUrl != null);
+      expect(!!meta?.requiresBaseUrl).toBe(type.baseUrl === "required");
+      if (meta?.requiresBaseUrl) expect(meta.supportsBaseUrl).toBe(true);
+    }
+  });
 });

--- a/tests/modules/secret-types-mirror.test.ts
+++ b/tests/modules/secret-types-mirror.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   SECRET_TYPE_IDS as CLIENT_SECRET_TYPE_IDS,
+  dialableBaseUrl as clientDialable,
   SECRET_TYPE_META,
 } from "@/client/lib/secretTypes";
 import {
   SECRET_TYPES,
   SECRET_TYPE_IDS as SERVER_SECRET_TYPE_IDS,
 } from "@/modules/vault/secret-types";
+import { dialableBaseUrl as serverDialable } from "@/modules/vault/service";
 
 // The client mirror (src/client/lib/secretTypes.ts) must stay in lockstep with the server catalog
 // (src/modules/vault/secret-types.ts) — otherwise a new credential kind is usable server-side but
@@ -50,6 +52,33 @@ describe("secret-types client mirror", () => {
   // The client keeps the pair as two booleans because that is what the form asks (render the input /
   // mark it required); the SERVER holds one field, so "required but not supported" cannot be
   // written there. This test is what stops the client from writing it.
+  // NOTE: the two GATES, not just the two declarations. The console decides with this — the tool
+  // editor accepts a relative url_template only when a credential supplies a base — and the runtime
+  // dials with it, so the day they disagree an operator saves a tool the runtime refuses to build.
+  // The unknown kind is in here on purpose: both sides refuse nothing for a kind they do not know,
+  // and a client that gated it would blank a base URL a newer build wrote.
+  test("the two dialableBaseUrl agree, kind by kind and past the catalog", () => {
+    const BASE = "https://elsewhere.invalid";
+    for (const id of SERVER_SECRET_TYPE_IDS) {
+      expect([id, clientDialable(id, BASE)]).toEqual([
+        id,
+        serverDialable(id, BASE),
+      ]);
+    }
+    for (const unknown of [null, "kind_from_a_future_build", "toString"]) {
+      expect([unknown, clientDialable(unknown, BASE)]).toEqual([
+        unknown,
+        serverDialable(unknown, BASE),
+      ]);
+    }
+    // NOTE: a floor — an assertion that both sides answered `null` for everything would pass while
+    // proving nothing about the kinds that DO carry one.
+    expect(
+      SERVER_SECRET_TYPE_IDS.filter((id) => clientDialable(id, BASE) === BASE)
+        .length,
+    ).toBe(9);
+  });
+
   test("the client base-URL pair matches the server's single declaration", () => {
     for (const type of SECRET_TYPES) {
       const meta = SECRET_TYPE_META[type.id as keyof typeof SECRET_TYPE_META];

--- a/tests/modules/stt-baseurl.test.ts
+++ b/tests/modules/stt-baseurl.test.ts
@@ -53,8 +53,12 @@ describe.skipIf(!dbUp)("stt: vault entry baseUrl precedence", () => {
     const e1 = await suDb.vaultEntry.create({
       data: {
         tenantId,
+        // NOTE: `openai_compatible` and not `openai`, since #504: a base URL is only DIALLED for a
+        // kind whose catalog entry declares one, so a row with `kind: "openai"` and a base URL is a
+        // stray value the resolve now answers `null` for. What this file is about — the entry's base
+        // winning over the config's — is unchanged, and this is the kind that can carry one.
         name: "stt-with-base",
-        kind: "openai",
+        kind: "openai_compatible",
         secret: encryptJson("sk-stt"),
         baseUrl: "https://custom.openai-proxy.com/v1",
       },

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -818,6 +818,15 @@ const CASES: Wiring[] = [
     ),
   },
 
+  {
+    label:
+      "a RELATIVE tool is exempt from its own allowlist at the credential host",
+    reaches: false,
+    urlTemplate: "/v1/thing",
+    credentialBaseUrl: "https://1.1.1.1/api",
+    allowedHosts: [PUBLIC],
+  },
+
   // ── spelling ──
   {
     label:
@@ -1097,7 +1106,7 @@ describe("the scanner answers what the runtime does", () => {
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
     expect(reaching).toBeGreaterThan(27);
-    expect(CASES.length - reaching).toBeGreaterThan(31);
+    expect(CASES.length - reaching).toBeGreaterThan(32);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -102,9 +102,10 @@ async function secretLeft(w: Wiring): Promise<boolean> {
   // omission branch the table is reading.
   const input: Record<string, unknown> = {};
   for (const [name, spec] of Object.entries(
-    (w.inputSchema ?? {}) as Record<string, { required?: boolean }>,
+    (w.inputSchema ?? {}) as Record<string, { required?: unknown }>,
   )) {
-    if (spec?.required === true) input[name] = "model-value";
+    // TRUTHY, like `parseFields`' own `!!s.required` — a spec may carry anything there.
+    if (spec?.required) input[name] = "model-value";
   }
   (await tool.invoke(input)) as unknown as ToolMessage;
   const headers = captured.init?.headers as Record<string, string> | undefined;
@@ -605,6 +606,72 @@ const CASES: Wiring[] = [
     headers: JSON.parse('{"__proto__":"{{secret}}"}'),
   },
 
+  {
+    label:
+      "a fixed field named toString does not carry its value into a header",
+    reaches: false,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+    headers: { "X-Auth": "{{toString}}" },
+    inputSchema: {
+      toString: { type: "string", source: "fixed", value: "{{secret}}" },
+    },
+  },
+  {
+    label: "…though the legacy body assembles it directly, with no `in` check",
+    reaches: true,
+    method: "POST",
+    headers: { "X-Auth": "{{toString}}" },
+    inputSchema: {
+      toString: { type: "string", source: "fixed", value: "{{secret}}" },
+    },
+  },
+  {
+    label: "…and an ordinary field name carries it either way",
+    reaches: true,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+    headers: { "X-Auth": "{{tok}}" },
+    inputSchema: {
+      tok: { type: "string", source: "fixed", value: "{{secret}}" },
+    },
+  },
+  {
+    label:
+      "a lone AI row whose `required` is merely truthy still always overwrites",
+    reaches: false,
+    method: "POST",
+    body: {
+      mode: "kv",
+      rows: [
+        { key: "auth", value: "{{secret}}" },
+        { key: "auth", value: "{{ov}}" },
+      ],
+    },
+    inputSchema: { ov: { type: "string", required: "yes" } },
+  },
+  {
+    label:
+      "a kv row whose value is not a string is coerced to empty, and overwrites",
+    reaches: false,
+    method: "POST",
+    body: {
+      mode: "kv",
+      rows: [
+        { key: "auth", value: "{{secret}}" },
+        { key: "auth", value: 42 },
+      ],
+    },
+  },
+
+  {
+    label:
+      "a URL placeholder naming a declared field still runs, and is judged",
+    reaches: false,
+    urlTemplate: `https://${PUBLIC}/v1/{{order_id}}`,
+    inputSchema: { order_id: { type: "string", required: true } },
+  },
+
   // ── spelling ──
   {
     label:
@@ -688,6 +755,31 @@ describe("the scanner answers what the runtime does", () => {
       ),
     ).toBeNull();
 
+    // NOTE: and the third shape the executor refuses: a URL placeholder naming no field, no fixed
+    // value and no context variable. It throws on every call, for every model input.
+    const orphan = buildHttpTool(
+      asDef({
+        label: "",
+        reaches: false,
+        urlTemplate: `https://${PUBLIC}/v1/{{order_id}}`,
+      }),
+      { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+    );
+    await expect(orphan.invoke({})).rejects.toThrow(
+      "no value available for URL placeholder",
+    );
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        {
+          urlTemplate: `https://${PUBLIC}/v1/{{order_id}}`,
+          headers: {},
+          inputSchema: {},
+        },
+      ),
+    ).toBeNull();
+
     // NOTE: the control — with a base, the same tool is judged normally.
     expect(
       unusedCredentialWarning(
@@ -734,8 +826,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(22);
-    expect(CASES.length - reaching).toBeGreaterThan(20);
+    expect(reaching).toBeGreaterThan(24);
+    expect(CASES.length - reaching).toBeGreaterThan(24);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -348,6 +348,43 @@ const CASES: Wiring[] = [
     },
   },
 
+  {
+    label:
+      "a query kind shadowed by the legacy query derivation, on a non-body method",
+    reaches: false,
+    method: "GET",
+    kind: "query",
+    paramName: "token",
+    inputSchema: { token: { type: "string", source: "fixed", value: "xyz" } },
+  },
+  {
+    label: "…not when that field is spent on the path instead",
+    reaches: true,
+    method: "GET",
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/{{token}}`,
+    inputSchema: { token: { type: "string", source: "fixed", value: "xyz" } },
+  },
+  {
+    label: "…and not on a POST, which assembles a body instead of a query",
+    reaches: true,
+    method: "POST",
+    kind: "query",
+    paramName: "token",
+    inputSchema: { token: { type: "string", source: "fixed", value: "xyz" } },
+  },
+  {
+    label:
+      "a URL query KEY that is a fixed placeholder still takes the parameter",
+    reaches: false,
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{auth_param}}=constant`,
+    query: { token: "{{secret}}" },
+    inputSchema: {
+      auth_param: { type: "string", source: "fixed", value: "token" },
+    },
+  },
+
   // ── spelling ──
   {
     label:
@@ -415,8 +452,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(10);
-    expect(CASES.length - reaching).toBeGreaterThan(10);
+    expect(reaching).toBeGreaterThan(12);
+    expect(CASES.length - reaching).toBeGreaterThan(12);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -82,6 +82,9 @@ const asShapes = (w: Wiring): ToolShapePatch => ({
   inputSchema: w.inputSchema ?? {},
 });
 
+// Invoked with NO model input, which is the reading the warning has to take: a credential that
+// leaves on some invocations is a credential that leaves. One row below depends on exactly that —
+// the runtime skips a lone AI placeholder the model omits, and the earlier row's `{{secret}}` stays.
 async function secretLeft(w: Wiring): Promise<boolean> {
   const captured: Captured = {};
   const tool = buildHttpTool(asDef(w), {
@@ -385,6 +388,47 @@ const CASES: Wiring[] = [
     },
   },
 
+  {
+    label: "a kv row a later LONE AI placeholder may not overwrite",
+    reaches: true,
+    method: "POST",
+    body: {
+      mode: "kv",
+      rows: [
+        { key: "auth", value: "{{secret}}" },
+        { key: "auth", value: "{{override}}" },
+      ],
+    },
+    inputSchema: { override: { type: "string" } },
+  },
+  {
+    label:
+      "…but a lone FIXED placeholder always resolves, so it always overwrites",
+    reaches: false,
+    method: "POST",
+    body: {
+      mode: "kv",
+      rows: [
+        { key: "auth", value: "{{secret}}" },
+        { key: "auth", value: "{{override}}" },
+      ],
+    },
+    inputSchema: {
+      override: { type: "string", source: "fixed", value: "constant" },
+    },
+  },
+  {
+    label:
+      "a fixed query key holding a URL metacharacter is ONE parameter, not two",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{auth_param}}=constant`,
+    inputSchema: {
+      auth_param: { type: "string", source: "fixed", value: "token&x" },
+    },
+  },
+
   // ── spelling ──
   {
     label:
@@ -452,8 +496,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(12);
-    expect(CASES.length - reaching).toBeGreaterThan(12);
+    expect(reaching).toBeGreaterThan(13);
+    expect(CASES.length - reaching).toBeGreaterThan(13);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -58,6 +58,7 @@ interface Wiring {
   kind?: string;
   paramName?: string | null;
   credentialBaseUrl?: string;
+  ackMessage?: string;
   urlTemplate?: string;
   headers?: Record<string, unknown>;
   query?: Record<string, unknown>;
@@ -78,6 +79,7 @@ const asDef = (w: Wiring): HttpToolDef => ({
   credentialKind: w.kind ?? "generic",
   credentialParamName: w.paramName ?? null,
   credentialBaseUrl: w.credentialBaseUrl ?? null,
+  ackMessage: w.ackMessage ?? null,
 });
 
 const asShapes = (w: Wiring): ToolShapePatch => ({
@@ -107,6 +109,9 @@ async function secretLeft(w: Wiring): Promise<boolean> {
     // TRUTHY, like `parseFields`' own `!!s.required` — a spec may carry anything there.
     if (spec?.required) input[name] = "model-value";
   }
+  // NOTE: the runtime declares this one for itself when the tool has an ack, and zod rejects the
+  // call without it — so a row with an ack has to supply it, exactly like a required field.
+  if (w.ackMessage) input.__wait_message = "one moment";
   (await tool.invoke(input)) as unknown as ToolMessage;
   const headers = captured.init?.headers as Record<string, string> | undefined;
   return [
@@ -130,6 +135,7 @@ const scannerSaysReaches = (w: Wiring): boolean =>
     },
     w.method ?? "GET",
     asShapes(w),
+    { ackMessage: w.ackMessage ?? null },
   ) === null;
 
 const CASES: Wiring[] = [
@@ -678,6 +684,22 @@ const CASES: Wiring[] = [
     urlTemplate: `https://${PUBLIC}/v1/{{toString}}`,
   },
 
+  {
+    label: "a query kind shadowed by the ack argument the runtime declares",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{__wait_message}}" },
+    ackMessage: "one moment",
+  },
+  {
+    label: "…and not shadowed by it when the tool has no ack",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{__wait_message}}" },
+  },
+
   // ── spelling ──
   {
     label:
@@ -817,6 +839,37 @@ describe("the scanner answers what the runtime does", () => {
       ),
     ).toBeNull();
 
+    // NOTE: and the fifth: a placeholder inside the ORIGIN. The runtime pins the origin from the
+    // neutralized template and throws when the real one differs, so this template never fetches
+    // however the field resolves.
+    const moving = buildHttpTool(
+      {
+        name: "t",
+        method: "GET",
+        urlTemplate: "https://{{region}}.example.com/x",
+        allowedHosts: ["us.example.com"],
+        headers: {},
+        inputSchema: { region: { type: "string", required: true } },
+        credentialRef: "vault:1",
+        credentialKind: "generic",
+      },
+      { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+    );
+    await expect(moving.invoke({ region: "us" })).rejects.toThrow(
+      "interpolation altered the origin",
+    );
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        {
+          urlTemplate: "https://{{region}}.example.com/x",
+          headers: {},
+          inputSchema: { region: { type: "string", required: true } },
+        },
+      ),
+    ).toBeNull();
+
     // NOTE: the control — with a base, the same tool is judged normally.
     expect(
       unusedCredentialWarning(
@@ -864,7 +917,7 @@ describe("the scanner answers what the runtime does", () => {
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
     expect(reaching).toBeGreaterThan(24);
-    expect(CASES.length - reaching).toBeGreaterThan(25);
+    expect(CASES.length - reaching).toBeGreaterThan(26);
   });
 });
 
@@ -1308,6 +1361,52 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
     );
     expect(r.ok).toBe(true);
     expect(wiringWarning(r)).toHaveLength(0);
+  });
+
+  test("a post-commit read that fails does not undo the write", async () => {
+    // NOTE: the warning is recomputed AFTER `createToolDefinition` commits, and that read is a
+    // scoped vault transaction like any other — a pool timeout or a transient error there would
+    // otherwise answer `ok: false` for a tool that exists, and the caller's retry would meet a name
+    // conflict. docs/mcp.md states the rule for config-health, and it is the same rule.
+    let created = false;
+    const failing = appDb.$extends({
+      query: {
+        toolDefinition: {
+          async create({ args, query }) {
+            const r = await query(args);
+            created = true;
+            return r;
+          },
+        },
+        vaultEntry: {
+          async findFirst({ args, query }) {
+            if (created) throw new Error("pool timeout");
+            return query(args);
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+
+    n += 1;
+    const name = `wiring_postcommit_${n}`;
+    const r = await toolCreate(
+      principal(),
+      {
+        name,
+        url_template: `https://${PUBLIC}/v1/thing`,
+        allowed_hosts: [PUBLIC],
+        credential_ref: genericRef,
+        dry_run: false,
+      } as Parameters<typeof toolCreate>[1],
+      { base: failing },
+    );
+    expect(created).toBe(true);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect((r.data as { applied?: boolean }).applied).toBe(true);
+    // NOTE: and the row is really there — which is the whole point of not raising.
+    expect(await suDb.toolDefinition.count({ where: { tenantId, name } })).toBe(
+      1,
+    );
   });
 
   test("no credential attached, no warning", async () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -53,6 +53,7 @@ interface Wiring {
   method?: string;
   kind?: string;
   paramName?: string | null;
+  credentialBaseUrl?: string;
   urlTemplate?: string;
   headers?: Record<string, string>;
   query?: Record<string, unknown>;
@@ -72,6 +73,7 @@ const asDef = (w: Wiring): HttpToolDef => ({
   credentialRef: "vault:1",
   credentialKind: w.kind ?? "generic",
   credentialParamName: w.paramName ?? null,
+  credentialBaseUrl: w.credentialBaseUrl ?? null,
 });
 
 const asShapes = (w: Wiring): ToolShapePatch => ({
@@ -91,7 +93,16 @@ async function secretLeft(w: Wiring): Promise<boolean> {
     resolveCredential: async () => SECRET,
     fetchImpl: stubFetch(captured),
   });
-  (await tool.invoke({})) as unknown as ToolMessage;
+  // NOTE: a REQUIRED ai field is supplied, because zod refuses the call without it — which is the
+  // very reason its row always overwrites. Everything optional is left out, so the runtime takes the
+  // omission branch the table is reading.
+  const input: Record<string, unknown> = {};
+  for (const [name, spec] of Object.entries(
+    (w.inputSchema ?? {}) as Record<string, { required?: boolean }>,
+  )) {
+    if (spec?.required === true) input[name] = "model-value";
+  }
+  (await tool.invoke(input)) as unknown as ToolMessage;
   const headers = captured.init?.headers as Record<string, string> | undefined;
   return [
     // The URL as far as it is TRANSMITTED. A stub fetch is handed the whole string, fragment and
@@ -107,7 +118,11 @@ async function secretLeft(w: Wiring): Promise<boolean> {
 
 const scannerSaysReaches = (w: Wiring): boolean =>
   unusedCredentialWarning(
-    { kind: w.kind ?? "generic", paramName: w.paramName ?? null },
+    {
+      kind: w.kind ?? "generic",
+      paramName: w.paramName ?? null,
+      baseUrl: w.credentialBaseUrl ?? null,
+    },
     w.method ?? "GET",
     asShapes(w),
   ) === null;
@@ -429,6 +444,41 @@ const CASES: Wiring[] = [
     },
   },
 
+  {
+    label:
+      "{{secret}} stored in the credential's own base, under a relative template",
+    reaches: true,
+    urlTemplate: "/v1/thing",
+    credentialBaseUrl: `https://${PUBLIC}/{{secret}}`,
+  },
+  {
+    label: "…and an absolute template ignores that base entirely",
+    reaches: false,
+    urlTemplate: `https://${PUBLIC}/v1/thing`,
+    credentialBaseUrl: `https://${PUBLIC}/{{secret}}`,
+  },
+  {
+    label:
+      "a lone {{secret}} row on a tool that DECLARES an ai field called secret",
+    reaches: false,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "auth", value: "{{secret}}" }] },
+    inputSchema: { secret: { type: "string" } },
+  },
+  {
+    label: "a later lone AI row that is REQUIRED always overwrites",
+    reaches: false,
+    method: "POST",
+    body: {
+      mode: "kv",
+      rows: [
+        { key: "auth", value: "{{secret}}" },
+        { key: "auth", value: "{{override}}" },
+      ],
+    },
+    inputSchema: { override: { type: "string", required: true } },
+  },
+
   // ── spelling ──
   {
     label:
@@ -496,15 +546,19 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(13);
-    expect(CASES.length - reaching).toBeGreaterThan(13);
+    expect(reaching).toBeGreaterThan(14);
+    expect(CASES.length - reaching).toBeGreaterThan(14);
   });
 });
 
 describe("which kinds the warning is about", () => {
   const bare: ToolShapePatch = { urlTemplate: `https://${PUBLIC}/v1/thing` };
   const warn = (kind: string | null) =>
-    unusedCredentialWarning({ kind, paramName: "X-Probe" }, "GET", bare);
+    unusedCredentialWarning(
+      { kind, paramName: "X-Probe", baseUrl: null },
+      "GET",
+      bare,
+    );
 
   test("only the kinds that put nothing on the request by themselves", () => {
     const warned = SECRET_TYPE_IDS.filter((id) => warn(id) !== null);
@@ -570,6 +624,7 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
   let genericRef = "";
   let bearerRef = "";
   let headerRef = "";
+  let basedRef = "";
   let n = 0;
 
   const principal = (): VerifiedToken =>
@@ -620,6 +675,20 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
           value: "abc123TOKEN",
           kind: "header",
           paramName: "X-Api-Key",
+        },
+        undefined,
+        undefined,
+        appDb,
+      )
+    ).ref;
+    basedRef = (
+      await createVaultEntry(
+        ctx,
+        {
+          name: "wiring-based",
+          value: "abc123TOKEN",
+          kind: "generic",
+          baseUrl: `https://${PUBLIC}/{{secret}}`,
         },
         undefined,
         undefined,
@@ -712,6 +781,25 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
     });
     expect(shadowed.ok).toBe(true);
     expect(wiringWarning(shadowed)).toHaveLength(1);
+  });
+
+  test("the credential's own base URL is part of the request, and is read off the entry", async () => {
+    // NOTE: a RELATIVE template gets that base prepended before anything is interpolated, so a
+    // {{secret}} stored in the base is sent — and the tool row alone cannot say so. Without the base
+    // in the facts the writer reports a working tool as unwired, which a mutation of exactly that
+    // line survived until this test existed.
+    const relative = await create({
+      credential_ref: basedRef,
+      url_template: "/v1/thing",
+    });
+    expect(relative.ok).toBe(true);
+    expect(wiringWarning(relative)).toHaveLength(0);
+
+    // NOTE: the control — an ABSOLUTE template ignores the base entirely, so the same credential is
+    // dead on this tool.
+    const absolute = await create({ credential_ref: basedRef });
+    expect(absolute.ok).toBe(true);
+    expect(wiringWarning(absolute)).toHaveLength(1);
   });
 
   test("no credential attached, no warning", async () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -10,7 +10,11 @@ import { toolCreate, toolUpdate } from "@/modules/mcp/write-agents";
 import { unusedCredentialWarning } from "@/modules/tool-definitions/credential-wiring";
 import type { ToolShapePatch } from "@/modules/tool-definitions/normalize";
 import { SECRET_TYPE_IDS } from "@/modules/vault/secret-types";
-import { createVaultEntry } from "@/modules/vault/service";
+import {
+  createVaultEntry,
+  readVaultRefId,
+  updateVaultEntry,
+} from "@/modules/vault/service";
 
 // Issue #504, second half: an HTTP tool can reference a `generic` credential while nothing in its
 // templates interpolates {{secret}}. Nothing refuses it and nothing should — a tool may hold a
@@ -518,6 +522,12 @@ const CASES: Wiring[] = [
     inputSchema: { token: { type: "string", source: "fixed" } },
   },
 
+  {
+    label: "a legacy headers ARRAY, which the runtime still walks",
+    reaches: true,
+    headers: ["{{secret}}"] as unknown as Record<string, unknown>,
+  },
+
   // ── spelling ──
   {
     label:
@@ -585,7 +595,7 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(17);
+    expect(reaching).toBeGreaterThan(18);
     expect(CASES.length - reaching).toBeGreaterThan(16);
   });
 });
@@ -891,6 +901,58 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
     expect(fired).toBe(true);
     expect(r.ok).toBe(true);
     expect(wiringWarning(r)).toHaveLength(1);
+  });
+
+  test("the create's warning describes the credential as it was WRITTEN against", async () => {
+    // NOTE: the same window as the update above, on the other write. The preview resolves the
+    // credential's facts before `createToolDefinition` runs, and a second administrator can rename
+    // the param that decides whether this tool's own header shadows the injection. Opened
+    // deliberately: the extension fires on the create itself, after the vault has been read.
+    let fired = false;
+    n += 1;
+    const racing = appDb.$extends({
+      query: {
+        toolDefinition: {
+          async create({ args, query }) {
+            if (!fired) {
+              fired = true;
+              await updateVaultEntry(
+                { tenantId, userId: null, role: "TENANT_ADMIN" },
+                readVaultRefId(headerRef) as bigint,
+                { paramName: "X-Other" },
+                appDb,
+              );
+            }
+            return query(args);
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+
+    // Shadowed while the param name is `X-Api-Key`; not shadowed once it is `X-Other`.
+    const r = await toolCreate(
+      principal(),
+      {
+        name: `wiring_race_${n}`,
+        url_template: `https://${PUBLIC}/v1/thing`,
+        allowed_hosts: [PUBLIC],
+        credential_ref: headerRef,
+        headers: { "x-api-key": "constant" },
+        dry_run: false,
+      } as Parameters<typeof toolCreate>[1],
+      { base: racing },
+    );
+    expect(fired).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
+
+    // NOTE: put back, because the header credential is shared with the tests above.
+    await updateVaultEntry(
+      { tenantId, userId: null, role: "TENANT_ADMIN" },
+      readVaultRefId(headerRef) as bigint,
+      { paramName: "X-Api-Key" },
+      appDb,
+    );
   });
 
   test("no credential attached, no warning", async () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -1,0 +1,437 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { ToolMessage } from "@langchain/core/messages";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { buildHttpTool, type HttpToolDef } from "@/graph/tools/http";
+import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
+import { toolCreate, toolUpdate } from "@/modules/mcp/write-agents";
+import {
+  toolUsesSecretPlaceholder,
+  unusedCredentialWarning,
+} from "@/modules/tool-definitions/credential-wiring";
+import type { ToolShapePatch } from "@/modules/tool-definitions/normalize";
+import { SECRET_TYPE_IDS } from "@/modules/vault/secret-types";
+import { createVaultEntry } from "@/modules/vault/service";
+
+// Issue #504, second half: an HTTP tool can reference a `generic` credential while nothing in its
+// templates interpolates {{secret}}. Nothing refuses it and nothing should — a tool may hold a
+// reference it has not wired yet — but the request then goes out UNAUTHENTICATED and the upstream
+// answers 401/403, which reads as a bad credential rather than one that was never sent.
+//
+// The warning is only as good as its site list, so the list is not asserted against a list written
+// here: each site is placed in a REAL tool and executed, and the same placement is put to the
+// scanner. A site the runtime interpolates and the scanner misses shows up as a secret in the
+// captured request with `toolUsesSecretPlaceholder` saying false.
+
+const PUBLIC = "8.8.8.8";
+const SECRET = "SECRET123";
+
+interface Captured {
+  url?: string;
+  init?: RequestInit;
+}
+
+const stubFetch = (captured: Captured) =>
+  (async (url: string, init: RequestInit) => {
+    captured.url = url;
+    captured.init = init;
+    return new Response('{"ok":true}', {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+function def(over: Partial<HttpToolDef> = {}): HttpToolDef {
+  return {
+    name: "thing",
+    method: "GET",
+    urlTemplate: `https://${PUBLIC}/v1/thing`,
+    allowedHosts: [PUBLIC],
+    headers: {},
+    inputSchema: {},
+    credentialRef: "vault:1",
+    credentialKind: "generic",
+    ...over,
+  };
+}
+
+// What the request actually carried, as one string: the URL, every header value and the body. The
+// question is only ever "did the secret leave", so where it left is not part of the assertion.
+async function sent(over: Partial<HttpToolDef>): Promise<string> {
+  const captured: Captured = {};
+  const tool = buildHttpTool(def(over), {
+    resolveCredential: async () => SECRET,
+    fetchImpl: stubFetch(captured),
+  });
+  (await tool.invoke({})) as unknown as ToolMessage;
+  const headers = captured.init?.headers as Record<string, string> | undefined;
+  return [
+    captured.url ?? "",
+    ...Object.values(headers ?? {}),
+    String(captured.init?.body ?? ""),
+  ].join(" | ");
+}
+
+// Each of the five sites the runtime interpolates {{secret}} into, as a tool definition the executor
+// accepts and as the shapes a write would store. The two halves are the SAME placement, which is
+// what makes this a fence and not two independent lists.
+const SITES: {
+  site: string;
+  def: Partial<HttpToolDef>;
+  shapes: ToolShapePatch;
+}[] = [
+  {
+    site: "url_template",
+    def: { urlTemplate: `https://${PUBLIC}/v1/{{secret}}` },
+    shapes: { urlTemplate: `https://${PUBLIC}/v1/{{secret}}` },
+  },
+  {
+    site: "headers",
+    def: { headers: { "X-Auth": "{{secret}}" } },
+    shapes: { headers: { "X-Auth": "{{secret}}" } },
+  },
+  {
+    site: "query",
+    def: { query: { token: "{{secret}}" } },
+    shapes: { query: { token: "{{secret}}" } },
+  },
+  {
+    site: "body.raw",
+    def: {
+      method: "POST",
+      body: { mode: "raw", raw: '{"t":"{{secret}}"}' },
+    },
+    shapes: { body: { mode: "raw", raw: '{"t":"{{secret}}"}' } },
+  },
+  {
+    site: "body.kv",
+    def: {
+      method: "POST",
+      body: { mode: "kv", rows: [{ key: "t", value: "{{secret}}" }] },
+    },
+    shapes: {
+      body: { mode: "kv", rows: [{ key: "t", value: "{{secret}}" }] },
+    },
+  },
+  {
+    site: "a fixed input field",
+    def: {
+      urlTemplate: `https://${PUBLIC}/v1/{{tok}}`,
+      inputSchema: {
+        tok: { type: "string", source: "fixed", value: "{{secret}}" },
+      },
+    },
+    shapes: {
+      urlTemplate: `https://${PUBLIC}/v1/{{tok}}`,
+      inputSchema: {
+        tok: { type: "string", source: "fixed", value: "{{secret}}" },
+      },
+    },
+  },
+];
+
+describe("the scanner covers exactly what the runtime interpolates", () => {
+  for (const { site, def: over, shapes } of SITES) {
+    test(`{{secret}} in ${site} is sent, and counts as wired`, async () => {
+      expect(await sent(over)).toContain(SECRET);
+      expect(toolUsesSecretPlaceholder(shapes)).toBe(true);
+      expect(unusedCredentialWarning("generic", shapes)).toBeNull();
+    });
+  }
+
+  test("the same tool with no placeholder sends nothing, and is warned about", async () => {
+    // NOTE: the control the six above need. Without it they would all pass on a scanner that
+    // answered true unconditionally, and the executor half would pass on a runtime that leaked the
+    // credential everywhere.
+    const shapes: ToolShapePatch = {
+      urlTemplate: `https://${PUBLIC}/v1/thing`,
+      headers: { "X-Other": "constant" },
+      query: { page: "1" },
+      inputSchema: { note: { type: "string" } },
+    };
+    expect(
+      await sent({
+        headers: { "X-Other": "constant" },
+        query: { page: "1" },
+        inputSchema: { note: { type: "string" } },
+      }),
+    ).not.toContain(SECRET);
+    expect(toolUsesSecretPlaceholder(shapes)).toBe(false);
+    expect(unusedCredentialWarning("generic", shapes)).toContain("never sent");
+  });
+
+  test("{{secret}} in an AI field's value is not interpolated, and does not count", async () => {
+    // NOTE: `buildHttpTool` reads `source === "fixed" ? "fixed" : "ai"` and precomputes only the
+    // fixed values with the secret in scope. A scanner that took any field `value` would call this
+    // tool wired, and the operator would get no warning about a request that carries nothing.
+    const inputSchema = {
+      tok: { type: "string", value: "{{secret}}" },
+    };
+    const out = await sent({
+      urlTemplate: `https://${PUBLIC}/v1/thing`,
+      inputSchema,
+    });
+    expect(out).not.toContain(SECRET);
+    expect(
+      toolUsesSecretPlaceholder({
+        urlTemplate: `https://${PUBLIC}/v1/thing`,
+        inputSchema,
+      }),
+    ).toBe(false);
+  });
+
+  test("the spacing the runtime accepts is the spacing the scanner accepts", async () => {
+    // NOTE: the runtime's PLACEHOLDER takes whitespace inside the braces. A scanner matching only
+    // the tight spelling would warn about a tool that works.
+    const headers = { "X-Auth": "{{ secret }}" };
+    expect(await sent({ headers })).toContain(SECRET);
+    expect(toolUsesSecretPlaceholder({ headers })).toBe(true);
+  });
+});
+
+describe("which kinds the warning is about", () => {
+  const bare: ToolShapePatch = { urlTemplate: `https://${PUBLIC}/v1/thing` };
+
+  test("only the kinds that auto-inject nothing and may still be sent", () => {
+    const warned = SECRET_TYPE_IDS.filter(
+      (id) => unusedCredentialWarning(id, bare) !== null,
+    );
+    // NOTE: `generic` is the whole point — the escape hatch whose contract IS that the operator
+    // writes {{secret}} by hand, so it is the one kind where attached and sent come apart silently.
+    // `mcp_env` and `langfuse` also inject nothing, and are deliberately NOT warned about: their
+    // catalog entry says the value must never travel outbound, so "write {{secret}} where the API
+    // expects it" would be advice to mail an stdio token to a third party. That they can be attached
+    // to an HTTP tool at all is a separate defect, and a refusal rather than a warning.
+    expect(warned).toEqual(["generic"]);
+  });
+
+  test("a kind this build does not know is the legacy generic, and is warned about", () => {
+    expect(unusedCredentialWarning(null, bare)).not.toBeNull();
+    expect(
+      unusedCredentialWarning("kind_from_a_future_build", bare),
+    ).not.toBeNull();
+  });
+
+  test("the sentence names a way out, and the ways out come from the catalog", () => {
+    const w = unusedCredentialWarning("generic", bare) ?? "";
+    for (const id of ["bearer_token", "header", "basic_auth", "query"]) {
+      expect(w).toContain(id);
+    }
+    // NOTE: a service kind is not an alternative for an arbitrary HTTP tool — it is a different API,
+    // with a header name fixed to that vendor.
+    expect(w).not.toContain("anthropic");
+  });
+});
+
+// ── the write surface ──
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+
+afterAll(async () => {
+  await su?.$disconnect();
+  await app?.$disconnect();
+});
+
+const appDb = app as PrismaClient;
+
+describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
+  let tenantId = 0n;
+  let genericRef = "";
+  let bearerRef = "";
+  let n = 0;
+
+  const principal = (): VerifiedToken =>
+    ({
+      userId: null,
+      tenantId,
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:read", "mcp:write"],
+      clientId: "c",
+      jti: "j",
+    }) as unknown as VerifiedToken;
+
+  const warningsOf = (r: Awaited<ReturnType<typeof toolCreate>>): string[] =>
+    r.ok ? ((r.data as { warnings?: string[] }).warnings ?? []) : [];
+  const wiringWarning = (r: Awaited<ReturnType<typeof toolCreate>>): string[] =>
+    warningsOf(r).filter((w) => w.includes("never sent"));
+
+  beforeAll(async () => {
+    if (!su) return;
+    const t = await su.tenant.create({
+      data: { name: "ToolWiring", slug: `toolwiring-${process.pid}` },
+    });
+    tenantId = t.id;
+    const ctx = { tenantId, userId: null, role: "TENANT_ADMIN" as const };
+    genericRef = (
+      await createVaultEntry(
+        ctx,
+        { name: "wiring-generic", value: "abc123TOKEN", kind: "generic" },
+        undefined,
+        undefined,
+        appDb,
+      )
+    ).ref;
+    bearerRef = (
+      await createVaultEntry(
+        ctx,
+        { name: "wiring-bearer", value: "abc123TOKEN", kind: "bearer_token" },
+        undefined,
+        undefined,
+        appDb,
+      )
+    ).ref;
+  });
+
+  afterAll(async () => {
+    if (su && tenantId) {
+      await su.$executeRawUnsafe(
+        `DELETE FROM tool_definitions WHERE tenant_id = ${tenantId}`,
+      );
+      await su.$executeRawUnsafe(
+        `DELETE FROM vault_entries WHERE tenant_id = ${tenantId}`,
+      );
+      await su.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+    }
+  });
+
+  const create = (over: Record<string, unknown> = {}) => {
+    n += 1;
+    return toolCreate(
+      principal(),
+      {
+        name: `wiring_${n}`,
+        url_template: `https://${PUBLIC}/v1/thing`,
+        allowed_hosts: [PUBLIC],
+        ...over,
+      } as Parameters<typeof toolCreate>[1],
+      { base: appDb },
+    );
+  };
+
+  test("a generic credential nothing sends is reported, in the preview AND in the apply", async () => {
+    // NOTE: both halves, because the preview is what the caller reads before deciding. A warning the
+    // apply adds and the dry run withholds is the preview promising a clean write (#490).
+    for (const dry_run of [undefined, false]) {
+      const r = await create({ credential_ref: genericRef, dry_run });
+      expect(r.ok).toBe(true);
+      expect(wiringWarning(r)).toHaveLength(1);
+      expect(wiringWarning(r)[0]).toContain("unauthenticated");
+    }
+  });
+
+  test("the same tool with {{secret}} in a header is not warned about", async () => {
+    const r = await create({
+      credential_ref: genericRef,
+      headers: { "X-Auth": "{{secret}}" },
+    });
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
+  });
+
+  test("a single-brace {secret} is judged AFTER normalization, not before", async () => {
+    // NOTE: the write stores `{{secret}}` here — `normalizeToolShapes` rewrites the single brace
+    // because "secret" is a name it knows. Scanning the raw argument would warn about a tool that
+    // is wired the instant it is stored, and the operator would have nothing to fix.
+    const r = await create({
+      credential_ref: genericRef,
+      headers: { "X-Auth": "{secret}" },
+    });
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
+  });
+
+  test("a typed credential is auto-injected, so silence is right", async () => {
+    const r = await create({ credential_ref: bearerRef });
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
+  });
+
+  test("no credential attached, no warning", async () => {
+    // NOTE: most tools need none. A warning here would fire on nearly every write.
+    const r = await create({});
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
+  });
+
+  test("attaching the credential to a stored tool judges the STORED templates", async () => {
+    // NOTE: the patch says nothing about the templates. Judging the patch alone would find no
+    // {{secret}} in an empty object and warn about every tool, or find none to judge and warn about
+    // nothing — which is the same bug read from either end.
+    const created = await create({ dry_run: false });
+    expect(created.ok).toBe(true);
+    const id = created.ok
+      ? (created.data as { target: string }).target.split(":")[1]
+      : "";
+    const r = await toolUpdate(
+      principal(),
+      { tool_id: id as string, credential_ref: genericRef },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(1);
+  });
+
+  test("rewriting a template away from {{secret}} judges the STORED credential", async () => {
+    // NOTE: the mirror of the case above, and the reason the effective row is patch-over-stored
+    // rather than either one: here the patch carries the templates and the credential is the half
+    // that only exists in the row.
+    const created = await create({
+      credential_ref: genericRef,
+      headers: { "X-Auth": "{{secret}}" },
+      dry_run: false,
+    });
+    expect(created.ok).toBe(true);
+    expect(wiringWarning(created)).toHaveLength(0);
+    const id = created.ok
+      ? (created.data as { target: string }).target.split(":")[1]
+      : "";
+    const r = await toolUpdate(
+      principal(),
+      { tool_id: id as string, headers: { "X-Other": "constant" } },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(1);
+  });
+
+  test("a patch that touches neither still reads the row, and stays quiet on a wired tool", async () => {
+    // NOTE: the control for the two above. A rename must not start warning about a tool whose
+    // wiring nobody touched.
+    const created = await create({
+      credential_ref: genericRef,
+      headers: { "X-Auth": "{{secret}}" },
+      dry_run: false,
+    });
+    const id = created.ok
+      ? (created.data as { target: string }).target.split(":")[1]
+      : "";
+    const r = await toolUpdate(
+      principal(),
+      { tool_id: id as string, label: "Renamed" },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
+  });
+});

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import type { ToolMessage } from "@langchain/core/messages";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
 import { buildHttpTool, type HttpToolDef } from "@/graph/tools/http";
 import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
 import { toolCreate, toolUpdate } from "@/modules/mcp/write-agents";
@@ -1059,6 +1060,31 @@ describe("the scanner answers what the runtime does", () => {
       ),
     ).not.toBeNull();
 
+    // NOTE: and the seventh: a protocol the SSRF guard refuses. `ftp://` parses, the schema stores
+    // it, and the guard runs on the final URL immediately before the fetch.
+    const wrongScheme = buildHttpTool(
+      {
+        name: "t",
+        method: "GET",
+        urlTemplate: "ftp://example.com/x",
+        allowedHosts: ["example.com"],
+        headers: {},
+        inputSchema: {},
+        credentialRef: "vault:1",
+        credentialKind: "generic",
+      },
+      { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+    );
+    await expect(wrongScheme.invoke({})).rejects.toThrow("protocol ftp:");
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        { urlTemplate: "ftp://example.com/x", headers: {}, inputSchema: {} },
+        { allowedHosts: ["example.com"] },
+      ),
+    ).toBeNull();
+
     // NOTE: the control — with a base, the same tool is judged normally.
     expect(
       unusedCredentialWarning(
@@ -1635,6 +1661,33 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
       { tool_id: id as string, ack_message: null },
       { base: appDb },
     );
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
+  });
+
+  test("a legacy base URL is not prepended, so the relative tool it fed is not judged", async () => {
+    // NOTE: the write can no longer create this row, and an upgraded database has them. The gate
+    // makes the resolve answer `null`, so a RELATIVE tool wired to one builds no request at all —
+    // and a warning about an unauthenticated request would describe something that cannot happen.
+    // Reading the STORED value here instead put the old host back and judged the tool against it.
+    const legacy = await suDb.vaultEntry.create({
+      data: {
+        tenantId,
+        name: "wiring-legacy-base",
+        secret: encryptJson("abc123TOKEN"),
+        kind: "openai",
+        baseUrl: `https://${PUBLIC}/api`,
+      },
+      select: { id: true },
+    });
+    // NOTE: the tool sets its own `Authorization`, which is what makes an `openai` credential
+    // reportable at all — it injects a bearer, and the operator's own header wins. Without that the
+    // credential is wired whatever the base is, and the row proves nothing.
+    const r = await create({
+      credential_ref: `vault:${legacy.id}`,
+      url_template: "/v1/thing",
+      headers: { Authorization: "constant" },
+    });
     expect(r.ok).toBe(true);
     expect(wiringWarning(r)).toHaveLength(0);
   });

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -55,7 +55,7 @@ interface Wiring {
   paramName?: string | null;
   credentialBaseUrl?: string;
   urlTemplate?: string;
-  headers?: Record<string, string>;
+  headers?: Record<string, unknown>;
   query?: Record<string, unknown>;
   body?: unknown;
   inputSchema?: unknown;
@@ -66,7 +66,7 @@ const asDef = (w: Wiring): HttpToolDef => ({
   method: w.method ?? "GET",
   urlTemplate: w.urlTemplate ?? `https://${PUBLIC}/v1/thing`,
   allowedHosts: [PUBLIC],
-  headers: w.headers ?? {},
+  headers: (w.headers ?? {}) as Record<string, string>,
   query: w.query,
   body: w.body,
   inputSchema: w.inputSchema ?? {},
@@ -488,6 +488,12 @@ const CASES: Wiring[] = [
     inputSchema: { field: { type: "string", required: true } },
   },
 
+  {
+    label: "a header value the runtime String()s before interpolating",
+    reaches: true,
+    headers: { "X-Auth": ["Bearer {{secret}}"] },
+  },
+
   // ── spelling ──
   {
     label:
@@ -555,7 +561,7 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(15);
+    expect(reaching).toBeGreaterThan(16);
     expect(CASES.length - reaching).toBeGreaterThan(14);
   });
 });

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -53,7 +53,7 @@ interface Wiring {
   paramName?: string | null;
   urlTemplate?: string;
   headers?: Record<string, string>;
-  query?: Record<string, string>;
+  query?: Record<string, unknown>;
   body?: unknown;
   inputSchema?: unknown;
 }
@@ -228,6 +228,38 @@ const CASES: Wiring[] = [
     kind: "query",
     paramName: "token",
     urlTemplate: `https://${PUBLIC}/v1/thing?token=constant`,
+  },
+
+  // ── the query map, which the runtime reads on its own terms ──
+  {
+    label: "a query value the URL template already spells is discarded",
+    reaches: false,
+    urlTemplate: `https://${PUBLIC}/v1/thing?token=fixed`,
+    query: { token: "{{secret}}" },
+  },
+  {
+    label:
+      "a query kind shadowed by a NON-string literal the runtime stringifies",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: 123 },
+  },
+  {
+    label: "…and not shadowed by an empty one, which the runtime skips",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    query: { token: "" },
+  },
+  {
+    label: "a fixed field whose NAME cannot be a placeholder reaches nothing",
+    reaches: false,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+    inputSchema: {
+      "a[b": { type: "string", source: "fixed", value: "{{secret}}" },
+    },
   },
 
   // ── spelling ──

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -59,6 +59,7 @@ interface Wiring {
   paramName?: string | null;
   credentialBaseUrl?: string;
   ackMessage?: string;
+  allowedHosts?: string[];
   urlTemplate?: string;
   headers?: Record<string, unknown>;
   query?: Record<string, unknown>;
@@ -70,7 +71,7 @@ const asDef = (w: Wiring): HttpToolDef => ({
   name: "thing",
   method: w.method ?? "GET",
   urlTemplate: w.urlTemplate ?? `https://${PUBLIC}/v1/thing`,
-  allowedHosts: [PUBLIC],
+  allowedHosts: w.allowedHosts ?? [PUBLIC],
   headers: (w.headers ?? {}) as Record<string, string>,
   query: w.query,
   body: w.body,
@@ -106,17 +107,24 @@ async function secretLeft(w: Wiring): Promise<boolean> {
   for (const [name, spec] of Object.entries(
     (w.inputSchema ?? {}) as Record<
       string,
-      { required?: unknown; enumValues?: unknown }
+      { required?: unknown; enumValues?: unknown; type?: unknown }
     >,
   )) {
-    // TRUTHY, like `parseFields`' own `!!s.required` — a spec may carry anything there. An enum
-    // takes one of its own values, since zod refuses anything else.
+    // TRUTHY, like `parseFields`' own `!!s.required` — a spec may carry anything there. The VALUE
+    // follows the declared type, because that is what zod enforces: an enum takes one of its own
+    // values, a number a number, and a `string` carrying an `enumValues` decoration takes anything,
+    // which is the whole point of one of the rows below.
     if (!spec?.required) continue;
     const values = spec.enumValues;
-    input[name] =
-      Array.isArray(values) && typeof values[0] === "string"
-        ? values[0]
-        : "model-value";
+    if (spec.type === "enum" && Array.isArray(values)) {
+      input[name] = values[0];
+    } else if (spec.type === "integer" || spec.type === "number") {
+      input[name] = 7;
+    } else if (spec.type === "boolean") {
+      input[name] = true;
+    } else {
+      input[name] = "model-value";
+    }
   }
   // NOTE: the runtime declares this one for itself when the tool has an ack, and zod rejects the
   // call without it — so a row with an ack has to supply it, exactly like a required field.
@@ -144,7 +152,10 @@ const scannerSaysReaches = (w: Wiring): boolean =>
     },
     w.method ?? "GET",
     asShapes(w),
-    { ackMessage: w.ackMessage ?? null },
+    {
+      ackMessage: w.ackMessage ?? null,
+      allowedHosts: w.allowedHosts ?? [PUBLIC],
+    },
   ) === null;
 
 const CASES: Wiring[] = [
@@ -776,6 +787,37 @@ const CASES: Wiring[] = [
     },
   },
 
+  {
+    label:
+      "enumValues on a plain string field binds nothing, so the key is unknown",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{authParam}}=fixed`,
+    query: { token: "{{secret}}" },
+    inputSchema: {
+      authParam: { type: "string", required: true, enumValues: ["token"] },
+    },
+  },
+  {
+    label:
+      "a required integer in a query value can never be empty, so it shadows",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{count}}" },
+    inputSchema: { count: { type: "integer", required: true } },
+  },
+  {
+    label:
+      "a fixed field named __proto__ is swallowed by the runtime's own map",
+    reaches: false,
+    method: "POST",
+    inputSchema: JSON.parse(
+      '{"__proto__":{"type":"string","source":"fixed","value":"{{secret}}"}}',
+    ),
+  },
+
   // ── spelling ──
   {
     label:
@@ -971,6 +1013,43 @@ describe("the scanner answers what the runtime does", () => {
       ),
     ).toBeNull();
 
+    // NOTE: and the sixth: a host the tool's own allowlist does not name. The check runs before the
+    // fetch and throws, so no request leaves however the credential is wired.
+    const blocked = buildHttpTool(
+      asDef({
+        label: "",
+        reaches: false,
+        urlTemplate: "https://other.example/x",
+      }),
+      { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+    );
+    await expect(blocked.invoke({})).rejects.toThrow("not in allowlist");
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        {
+          urlTemplate: "https://other.example/x",
+          headers: {},
+          inputSchema: {},
+        },
+        { allowedHosts: [PUBLIC] },
+      ),
+    ).toBeNull();
+    // NOTE: and an EMPTY allowlist blocks nothing, so that tool is judged.
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        {
+          urlTemplate: "https://other.example/x",
+          headers: {},
+          inputSchema: {},
+        },
+        { allowedHosts: [] },
+      ),
+    ).not.toBeNull();
+
     // NOTE: the control — with a base, the same tool is judged normally.
     expect(
       unusedCredentialWarning(
@@ -1017,8 +1096,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(26);
-    expect(CASES.length - reaching).toBeGreaterThan(29);
+    expect(reaching).toBeGreaterThan(27);
+    expect(CASES.length - reaching).toBeGreaterThan(31);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -571,6 +571,26 @@ const CASES: Wiring[] = [
     },
   },
 
+  {
+    label:
+      "a query value naming an Object member is never empty, so it shadows",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{toString}}" },
+    inputSchema: {
+      toString: { type: "string", source: "fixed", value: "abc" },
+    },
+  },
+  {
+    label: "a legacy inputSchema ARRAY, whose fields are named 0, 1, 2",
+    reaches: true,
+    method: "POST",
+    inputSchema: [
+      { type: "string", source: "fixed", value: "{{secret}}" },
+    ] as unknown as Record<string, unknown>,
+  },
+
   // ── spelling ──
   {
     label:
@@ -602,7 +622,7 @@ describe("the scanner answers what the runtime does", () => {
     });
   }
 
-  test("a relative template with no base builds no request, so it gets no warning", async () => {
+  test("a template that builds no request gets no warning", async () => {
     // NOTE: not a row of the table, because there is nothing to execute: `buildHttpTool` refuses the
     // pairing outright. A warning that the request goes out unauthenticated would diagnose a failure
     // that cannot happen and point away from the one that does.
@@ -626,6 +646,31 @@ describe("the scanner answers what the runtime does", () => {
           headers: {},
           inputSchema: {},
         },
+      ),
+    ).toBeNull();
+
+    // NOTE: the same reasoning, for the other template the executor refuses. The definition schema
+    // accepts `not-a-url`; the throw comes at CALL time, where the origin is pinned — which is still
+    // before any request, and is why this pairing gets no warning either.
+    const broken = buildHttpTool(
+      {
+        name: "t",
+        method: "GET",
+        urlTemplate: "not-a-url",
+        allowedHosts: ["x"],
+        headers: {},
+        inputSchema: {},
+        credentialRef: "vault:1",
+        credentialKind: "generic",
+      },
+      { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+    );
+    await expect(broken.invoke({})).rejects.toThrow("invalid urlTemplate");
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        { urlTemplate: "not-a-url", headers: {}, inputSchema: {} },
       ),
     ).toBeNull();
 
@@ -675,8 +720,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(21);
-    expect(CASES.length - reaching).toBeGreaterThan(17);
+    expect(reaching).toBeGreaterThan(22);
+    expect(CASES.length - reaching).toBeGreaterThan(18);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -104,10 +104,19 @@ async function secretLeft(w: Wiring): Promise<boolean> {
   // omission branch the table is reading.
   const input: Record<string, unknown> = {};
   for (const [name, spec] of Object.entries(
-    (w.inputSchema ?? {}) as Record<string, { required?: unknown }>,
+    (w.inputSchema ?? {}) as Record<
+      string,
+      { required?: unknown; enumValues?: unknown }
+    >,
   )) {
-    // TRUTHY, like `parseFields`' own `!!s.required` — a spec may carry anything there.
-    if (spec?.required) input[name] = "model-value";
+    // TRUTHY, like `parseFields`' own `!!s.required` — a spec may carry anything there. An enum
+    // takes one of its own values, since zod refuses anything else.
+    if (!spec?.required) continue;
+    const values = spec.enumValues;
+    input[name] =
+      Array.isArray(values) && typeof values[0] === "string"
+        ? values[0]
+        : "model-value";
   }
   // NOTE: the runtime declares this one for itself when the tool has an ack, and zod rejects the
   // call without it — so a row with an ack has to supply it, exactly like a required field.
@@ -710,6 +719,63 @@ const CASES: Wiring[] = [
     ackMessage: "one moment",
   },
 
+  {
+    label:
+      "an ack tool's fixed __wait_message loses to the model's own argument",
+    reaches: false,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+    headers: { "X-Auth": "{{__wait_message}}" },
+    inputSchema: {
+      __wait_message: { type: "string", source: "fixed", value: "{{secret}}" },
+    },
+    ackMessage: "hold on",
+  },
+  {
+    label:
+      "…though the legacy body still assembles that fixed value into the query",
+    reaches: true,
+    headers: { "X-Auth": "{{__wait_message}}" },
+    inputSchema: {
+      __wait_message: { type: "string", source: "fixed", value: "{{secret}}" },
+    },
+    ackMessage: "hold on",
+  },
+  {
+    label:
+      "…and with no ack, that same fixed field is the only source there is",
+    reaches: true,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+    headers: { "X-Auth": "{{__wait_message}}" },
+    inputSchema: {
+      __wait_message: { type: "string", source: "fixed", value: "{{secret}}" },
+    },
+  },
+  {
+    label:
+      "a required singleton-enum field resolves its query key on every call",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{authParam}}=fixed`,
+    query: { token: "{{secret}}" },
+    inputSchema: {
+      authParam: { type: "enum", required: true, enumValues: ["token"] },
+    },
+  },
+  {
+    label:
+      "a fixed value that is itself a prototype name is never empty either",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{f}}" },
+    inputSchema: {
+      f: { type: "string", source: "fixed", value: "{{toString}}" },
+    },
+  },
+
   // ── spelling ──
   {
     label:
@@ -951,8 +1017,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(24);
-    expect(CASES.length - reaching).toBeGreaterThan(27);
+    expect(reaching).toBeGreaterThan(26);
+    expect(CASES.length - reaching).toBeGreaterThan(29);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -479,6 +479,15 @@ const CASES: Wiring[] = [
     inputSchema: { override: { type: "string", required: true } },
   },
 
+  {
+    label: "a query key nothing here can resolve is unknown, not a literal `_`",
+    reaches: true,
+    kind: "query",
+    paramName: "_",
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{field}}=constant`,
+    inputSchema: { field: { type: "string", required: true } },
+  },
+
   // ── spelling ──
   {
     label:
@@ -546,7 +555,7 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(14);
+    expect(reaching).toBeGreaterThan(15);
     expect(CASES.length - reaching).toBeGreaterThan(14);
   });
 });

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -494,6 +494,30 @@ const CASES: Wiring[] = [
     headers: { "X-Auth": ["Bearer {{secret}}"] },
   },
 
+  {
+    label: "a header kind aimed at the Content-Type the runtime writes itself",
+    reaches: false,
+    method: "POST",
+    kind: "header",
+    paramName: "Content-Type",
+    body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+  },
+  {
+    label: "…which a GET does not write, so there it injects",
+    reaches: true,
+    method: "GET",
+    kind: "header",
+    paramName: "Content-Type",
+  },
+  {
+    label: "a fixed field with no value still takes its query parameter",
+    reaches: false,
+    method: "GET",
+    kind: "query",
+    paramName: "token",
+    inputSchema: { token: { type: "string", source: "fixed" } },
+  },
+
   // ── spelling ──
   {
     label:
@@ -561,8 +585,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(16);
-    expect(CASES.length - reaching).toBeGreaterThan(14);
+    expect(reaching).toBeGreaterThan(17);
+    expect(CASES.length - reaching).toBeGreaterThan(16);
   });
 });
 
@@ -815,6 +839,58 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
     const absolute = await create({ credential_ref: basedRef });
     expect(absolute.ok).toBe(true);
     expect(wiringWarning(absolute)).toHaveLength(1);
+  });
+
+  test("the apply's warning describes the row it WROTE, not the row it read", async () => {
+    // NOTE: the preview reads outside the write's transaction. A second administrator landing in
+    // that window changes what the write lands on, and the response would otherwise report a diff of
+    // the row that was written next to a warning about the row that was read.
+    //
+    // The window is opened deliberately: a Prisma extension fires ONCE, after `getToolDefinition`s
+    // read returns and before `updateToolDefinition` runs, and unwires the tool from another
+    // connection. The label-only update then has to come back warning.
+    const created = await create({
+      credential_ref: genericRef,
+      headers: { "X-Auth": "{{secret}}" },
+      dry_run: false,
+    });
+    const id = created.ok
+      ? (created.data as { target: string }).target.split(":")[1]
+      : "";
+    expect(wiringWarning(created)).toHaveLength(0);
+
+    let fired = false;
+    const racing = appDb.$extends({
+      query: {
+        toolDefinition: {
+          async findUnique({ args, query }) {
+            const result = await query(args);
+            if (!fired) {
+              fired = true;
+              await toolUpdate(
+                principal(),
+                {
+                  tool_id: id as string,
+                  headers: { "X-Other": "constant" },
+                  dry_run: false,
+                },
+                { base: appDb },
+              );
+            }
+            return result;
+          },
+        },
+      },
+    }) as unknown as PrismaClient;
+
+    const r = await toolUpdate(
+      principal(),
+      { tool_id: id as string, label: "Renamed", dry_run: false },
+      { base: racing },
+    );
+    expect(fired).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(1);
   });
 
   test("no credential attached, no warning", async () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -5,10 +5,7 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { buildHttpTool, type HttpToolDef } from "@/graph/tools/http";
 import type { VerifiedToken } from "@/modules/mcp/oauth/tokens";
 import { toolCreate, toolUpdate } from "@/modules/mcp/write-agents";
-import {
-  toolUsesSecretPlaceholder,
-  unusedCredentialWarning,
-} from "@/modules/tool-definitions/credential-wiring";
+import { unusedCredentialWarning } from "@/modules/tool-definitions/credential-wiring";
 import type { ToolShapePatch } from "@/modules/tool-definitions/normalize";
 import { SECRET_TYPE_IDS } from "@/modules/vault/secret-types";
 import { createVaultEntry } from "@/modules/vault/service";
@@ -18,10 +15,15 @@ import { createVaultEntry } from "@/modules/vault/service";
 // reference it has not wired yet — but the request then goes out UNAUTHENTICATED and the upstream
 // answers 401/403, which reads as a bad credential rather than one that was never sent.
 //
-// The warning is only as good as its site list, so the list is not asserted against a list written
-// here: each site is placed in a REAL tool and executed, and the same placement is put to the
-// scanner. A site the runtime interpolates and the scanner misses shows up as a secret in the
-// captured request with `toolUsesSecretPlaceholder` saying false.
+// THE FENCE IS EXECUTION, NOT A LIST. Every row below is built ONCE and read two ways: as a tool
+// definition the real executor runs against a captured fetch, and as the shapes a write would store.
+// The assertion is that the two agree. A rule the runtime has and this file does not shows up as a
+// secret in the captured request with the warning saying it was never sent, or the reverse.
+//
+// Four of these rows were wrong answers in the first draft, and none of them is a site the scan
+// missed: the body of a GET is assembled and discarded, a fixed field only leaves if something
+// emitted names it, a typed credential's auto-injection is SKIPPED when the operator already wrote
+// its target header, and a stored single-brace `{secret}` is normalized at build time and does reach.
 
 const PUBLIC = "8.8.8.8";
 const SECRET = "SECRET123";
@@ -41,25 +43,46 @@ const stubFetch = (captured: Captured) =>
     });
   }) as unknown as typeof fetch;
 
-function def(over: Partial<HttpToolDef> = {}): HttpToolDef {
-  return {
-    name: "thing",
-    method: "GET",
-    urlTemplate: `https://${PUBLIC}/v1/thing`,
-    allowedHosts: [PUBLIC],
-    headers: {},
-    inputSchema: {},
-    credentialRef: "vault:1",
-    credentialKind: "generic",
-    ...over,
-  };
+// One row, and the two projections of it. Written once so the executor and the scanner cannot be
+// given different tools by accident, which is the only way a fence like this lies.
+interface Wiring {
+  label: string;
+  reaches: boolean;
+  method?: string;
+  kind?: string;
+  paramName?: string | null;
+  urlTemplate?: string;
+  headers?: Record<string, string>;
+  query?: Record<string, string>;
+  body?: unknown;
+  inputSchema?: unknown;
 }
 
-// What the request actually carried, as one string: the URL, every header value and the body. The
-// question is only ever "did the secret leave", so where it left is not part of the assertion.
-async function sent(over: Partial<HttpToolDef>): Promise<string> {
+const asDef = (w: Wiring): HttpToolDef => ({
+  name: "thing",
+  method: w.method ?? "GET",
+  urlTemplate: w.urlTemplate ?? `https://${PUBLIC}/v1/thing`,
+  allowedHosts: [PUBLIC],
+  headers: w.headers ?? {},
+  query: w.query,
+  body: w.body,
+  inputSchema: w.inputSchema ?? {},
+  credentialRef: "vault:1",
+  credentialKind: w.kind ?? "generic",
+  credentialParamName: w.paramName ?? null,
+});
+
+const asShapes = (w: Wiring): ToolShapePatch => ({
+  urlTemplate: w.urlTemplate ?? `https://${PUBLIC}/v1/thing`,
+  headers: w.headers ?? {},
+  query: w.query,
+  body: w.body,
+  inputSchema: w.inputSchema ?? {},
+});
+
+async function secretLeft(w: Wiring): Promise<boolean> {
   const captured: Captured = {};
-  const tool = buildHttpTool(def(over), {
+  const tool = buildHttpTool(asDef(w), {
     resolveCredential: async () => SECRET,
     fetchImpl: stubFetch(captured),
   });
@@ -69,151 +92,207 @@ async function sent(over: Partial<HttpToolDef>): Promise<string> {
     captured.url ?? "",
     ...Object.values(headers ?? {}),
     String(captured.init?.body ?? ""),
-  ].join(" | ");
+  ]
+    .join(" | ")
+    .includes(SECRET);
 }
 
-// Each of the five sites the runtime interpolates {{secret}} into, as a tool definition the executor
-// accepts and as the shapes a write would store. The two halves are the SAME placement, which is
-// what makes this a fence and not two independent lists.
-const SITES: {
-  site: string;
-  def: Partial<HttpToolDef>;
-  shapes: ToolShapePatch;
-}[] = [
+const scannerSaysReaches = (w: Wiring): boolean =>
+  unusedCredentialWarning(
+    { kind: w.kind ?? "generic", paramName: w.paramName ?? null },
+    w.method ?? "GET",
+    asShapes(w),
+  ) === null;
+
+const CASES: Wiring[] = [
+  // ── the five interpolation sites ──
   {
-    site: "url_template",
-    def: { urlTemplate: `https://${PUBLIC}/v1/{{secret}}` },
-    shapes: { urlTemplate: `https://${PUBLIC}/v1/{{secret}}` },
+    label: "{{secret}} in url_template",
+    reaches: true,
+    urlTemplate: `https://${PUBLIC}/v1/{{secret}}`,
   },
   {
-    site: "headers",
-    def: { headers: { "X-Auth": "{{secret}}" } },
-    shapes: { headers: { "X-Auth": "{{secret}}" } },
+    label: "{{secret}} in a header",
+    reaches: true,
+    headers: { "X-Auth": "{{secret}}" },
   },
   {
-    site: "query",
-    def: { query: { token: "{{secret}}" } },
-    shapes: { query: { token: "{{secret}}" } },
+    label: "{{secret}} in a query value",
+    reaches: true,
+    query: { token: "{{secret}}" },
   },
   {
-    site: "body.raw",
-    def: {
-      method: "POST",
-      body: { mode: "raw", raw: '{"t":"{{secret}}"}' },
-    },
-    shapes: { body: { mode: "raw", raw: '{"t":"{{secret}}"}' } },
+    label: "{{secret}} in a raw body, on a POST",
+    reaches: true,
+    method: "POST",
+    body: { mode: "raw", raw: '{"t":"{{secret}}"}' },
   },
   {
-    site: "body.kv",
-    def: {
-      method: "POST",
-      body: { mode: "kv", rows: [{ key: "t", value: "{{secret}}" }] },
+    label: "{{secret}} in a kv body row, on a POST",
+    reaches: true,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "t", value: "{{secret}}" }] },
+  },
+  {
+    label: "{{secret}} in a fixed field the URL names",
+    reaches: true,
+    urlTemplate: `https://${PUBLIC}/v1/{{tok}}`,
+    inputSchema: {
+      tok: { type: "string", source: "fixed", value: "{{secret}}" },
     },
-    shapes: {
-      body: { mode: "kv", rows: [{ key: "t", value: "{{secret}}" }] },
+  },
+
+  // ── a template that is assembled and discarded ──
+  {
+    label: "a raw body on a GET is never sent",
+    reaches: false,
+    method: "GET",
+    body: { mode: "raw", raw: '{"t":"{{secret}}"}' },
+  },
+  {
+    label: "a raw body on a DELETE is never sent either",
+    reaches: false,
+    method: "DELETE",
+    body: { mode: "raw", raw: '{"t":"{{secret}}"}' },
+  },
+  {
+    label: "a fixed field nothing references, with a kv body",
+    reaches: false,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+    inputSchema: {
+      tok: { type: "string", source: "fixed", value: "{{secret}}" },
     },
   },
   {
-    site: "a fixed input field",
-    def: {
-      urlTemplate: `https://${PUBLIC}/v1/{{tok}}`,
-      inputSchema: {
-        tok: { type: "string", source: "fixed", value: "{{secret}}" },
-      },
+    label: "the same fixed field, with a legacy fields body that assembles it",
+    reaches: true,
+    method: "POST",
+    inputSchema: {
+      tok: { type: "string", source: "fixed", value: "{{secret}}" },
     },
-    shapes: {
-      urlTemplate: `https://${PUBLIC}/v1/{{tok}}`,
-      inputSchema: {
-        tok: { type: "string", source: "fixed", value: "{{secret}}" },
-      },
-    },
+  },
+  {
+    label: "{{secret}} in an AI field's value is not interpolated",
+    reaches: false,
+    inputSchema: { tok: { type: "string", value: "{{secret}}" } },
+  },
+
+  // ── auto-injection, and the operator's value winning over it ──
+  {
+    label: "bearer_token injects on its own",
+    reaches: true,
+    kind: "bearer_token",
+  },
+  {
+    label: "bearer_token whose Authorization header the operator already wrote",
+    reaches: false,
+    kind: "bearer_token",
+    headers: { Authorization: "constant" },
+  },
+  {
+    label: "…unless what they wrote is {{secret}}",
+    reaches: true,
+    kind: "bearer_token",
+    headers: { Authorization: "Bearer {{secret}}" },
+  },
+  {
+    label: "a header kind injects into its own param name",
+    reaches: true,
+    kind: "header",
+    paramName: "X-Api-Key",
+  },
+  {
+    label: "…and is shadowed by that header in any casing",
+    reaches: false,
+    kind: "header",
+    paramName: "X-Api-Key",
+    headers: { "x-api-key": "constant" },
+  },
+  {
+    label: "a query kind injects its param",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+  },
+  {
+    label: "…and is shadowed by an explicit query value",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: "constant" },
+  },
+  {
+    label: "…and by one hand-written into the URL",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?token=constant`,
+  },
+
+  // ── spelling ──
+  {
+    label:
+      "a stored single-brace {secret} is normalized at build time and does reach",
+    reaches: true,
+    headers: { "X-Auth": "{secret}" },
+  },
+  {
+    label: "the spacing the runtime accepts",
+    reaches: true,
+    headers: { "X-Auth": "{{ secret }}" },
+  },
+
+  // ── the control every row above needs ──
+  {
+    label: "a generic credential and no wiring at all",
+    reaches: false,
+    headers: { "X-Other": "constant" },
+    query: { page: "1" },
+    inputSchema: { note: { type: "string" } },
   },
 ];
 
-describe("the scanner covers exactly what the runtime interpolates", () => {
-  for (const { site, def: over, shapes } of SITES) {
-    test(`{{secret}} in ${site} is sent, and counts as wired`, async () => {
-      expect(await sent(over)).toContain(SECRET);
-      expect(toolUsesSecretPlaceholder(shapes)).toBe(true);
-      expect(unusedCredentialWarning("generic", shapes)).toBeNull();
+describe("the scanner answers what the runtime does", () => {
+  for (const w of CASES) {
+    test(`${w.reaches ? "reaches" : "never reaches"}: ${w.label}`, async () => {
+      expect(await secretLeft(w)).toBe(w.reaches);
+      expect(scannerSaysReaches(w)).toBe(w.reaches);
     });
   }
 
-  test("the same tool with no placeholder sends nothing, and is warned about", async () => {
-    // NOTE: the control the six above need. Without it they would all pass on a scanner that
-    // answered true unconditionally, and the executor half would pass on a runtime that leaked the
-    // credential everywhere.
-    const shapes: ToolShapePatch = {
-      urlTemplate: `https://${PUBLIC}/v1/thing`,
-      headers: { "X-Other": "constant" },
-      query: { page: "1" },
-      inputSchema: { note: { type: "string" } },
-    };
-    expect(
-      await sent({
-        headers: { "X-Other": "constant" },
-        query: { page: "1" },
-        inputSchema: { note: { type: "string" } },
-      }),
-    ).not.toContain(SECRET);
-    expect(toolUsesSecretPlaceholder(shapes)).toBe(false);
-    expect(unusedCredentialWarning("generic", shapes)).toContain("never sent");
-  });
-
-  test("{{secret}} in an AI field's value is not interpolated, and does not count", async () => {
-    // NOTE: `buildHttpTool` reads `source === "fixed" ? "fixed" : "ai"` and precomputes only the
-    // fixed values with the secret in scope. A scanner that took any field `value` would call this
-    // tool wired, and the operator would get no warning about a request that carries nothing.
-    const inputSchema = {
-      tok: { type: "string", value: "{{secret}}" },
-    };
-    const out = await sent({
-      urlTemplate: `https://${PUBLIC}/v1/thing`,
-      inputSchema,
-    });
-    expect(out).not.toContain(SECRET);
-    expect(
-      toolUsesSecretPlaceholder({
-        urlTemplate: `https://${PUBLIC}/v1/thing`,
-        inputSchema,
-      }),
-    ).toBe(false);
-  });
-
-  test("the spacing the runtime accepts is the spacing the scanner accepts", async () => {
-    // NOTE: the runtime's PLACEHOLDER takes whitespace inside the braces. A scanner matching only
-    // the tight spelling would warn about a tool that works.
-    const headers = { "X-Auth": "{{ secret }}" };
-    expect(await sent({ headers })).toContain(SECRET);
-    expect(toolUsesSecretPlaceholder({ headers })).toBe(true);
+  test("the table is not all one answer", () => {
+    // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
+    // single verdict would still pass while proving nothing about the boundary between them.
+    const reaching = CASES.filter((c) => c.reaches).length;
+    expect(reaching).toBeGreaterThan(5);
+    expect(CASES.length - reaching).toBeGreaterThan(5);
   });
 });
 
 describe("which kinds the warning is about", () => {
   const bare: ToolShapePatch = { urlTemplate: `https://${PUBLIC}/v1/thing` };
+  const warn = (kind: string | null) =>
+    unusedCredentialWarning({ kind, paramName: "X-Probe" }, "GET", bare);
 
-  test("only the kinds that auto-inject nothing and may still be sent", () => {
-    const warned = SECRET_TYPE_IDS.filter(
-      (id) => unusedCredentialWarning(id, bare) !== null,
-    );
+  test("only the kinds that put nothing on the request by themselves", () => {
+    const warned = SECRET_TYPE_IDS.filter((id) => warn(id) !== null);
     // NOTE: `generic` is the whole point — the escape hatch whose contract IS that the operator
-    // writes {{secret}} by hand, so it is the one kind where attached and sent come apart silently.
-    // `mcp_env` and `langfuse` also inject nothing, and are deliberately NOT warned about: their
-    // catalog entry says the value must never travel outbound, so "write {{secret}} where the API
-    // expects it" would be advice to mail an stdio token to a third party. That they can be attached
-    // to an HTTP tool at all is a separate defect, and a refusal rather than a warning.
+    // writes {{secret}} by hand. `mcp_env` and `langfuse` also inject nothing and are deliberately
+    // NOT warned about: their catalog entry says the value must never travel outbound, so "write
+    // {{secret}} where the API expects it" would be advice to mail an stdio token to a third party.
+    // That they can be attached to an HTTP tool at all is a separate defect, and a refusal rather
+    // than a warning.
     expect(warned).toEqual(["generic"]);
   });
 
   test("a kind this build does not know is the legacy generic, and is warned about", () => {
-    expect(unusedCredentialWarning(null, bare)).not.toBeNull();
-    expect(
-      unusedCredentialWarning("kind_from_a_future_build", bare),
-    ).not.toBeNull();
+    expect(warn(null)).not.toBeNull();
+    expect(warn("kind_from_a_future_build")).not.toBeNull();
   });
 
   test("the sentence names a way out, and the ways out come from the catalog", () => {
-    const w = unusedCredentialWarning("generic", bare) ?? "";
+    const w = warn("generic") ?? "";
     for (const id of ["bearer_token", "header", "basic_auth", "query"]) {
       expect(w).toContain(id);
     }
@@ -222,7 +301,6 @@ describe("which kinds the warning is about", () => {
     expect(w).not.toContain("anthropic");
   });
 });
-
 // ── the write surface ──
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
@@ -254,11 +332,13 @@ afterAll(async () => {
 });
 
 const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
 
 describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
   let tenantId = 0n;
   let genericRef = "";
   let bearerRef = "";
+  let headerRef = "";
   let n = 0;
 
   const principal = (): VerifiedToken =>
@@ -296,6 +376,20 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
       await createVaultEntry(
         ctx,
         { name: "wiring-bearer", value: "abc123TOKEN", kind: "bearer_token" },
+        undefined,
+        undefined,
+        appDb,
+      )
+    ).ref;
+    headerRef = (
+      await createVaultEntry(
+        ctx,
+        {
+          name: "wiring-header",
+          value: "abc123TOKEN",
+          kind: "header",
+          paramName: "X-Api-Key",
+        },
         undefined,
         undefined,
         appDb,
@@ -367,6 +461,28 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
     expect(wiringWarning(r)).toHaveLength(0);
   });
 
+  test("where a header credential lands is read off the ENTRY, not guessed", async () => {
+    // NOTE: `header` is the one kind whose injection target is operator-supplied, so the answer to
+    // "does this credential reach the request" is in the vault row and nowhere else. Without the
+    // stored param name the writer cannot resolve an injection at all, and every tool holding one of
+    // these credentials would be reported as unwired — the shape a mutation of exactly that line
+    // survived until this test existed.
+    const clean = await create({ credential_ref: headerRef });
+    expect(clean.ok).toBe(true);
+    expect(wiringWarning(clean)).toHaveLength(0);
+
+    // NOTE: and the other side of the same read — the operator wrote that header themselves, so the
+    // runtime leaves their value alone and the credential never leaves. Different casing, because
+    // the runtime compares case-insensitively and a warning that missed this would be a warning
+    // about a header the operator can see.
+    const shadowed = await create({
+      credential_ref: headerRef,
+      headers: { "x-api-key": "constant" },
+    });
+    expect(shadowed.ok).toBe(true);
+    expect(wiringWarning(shadowed)).toHaveLength(1);
+  });
+
   test("no credential attached, no warning", async () => {
     // NOTE: most tools need none. A warning here would fire on nearly every write.
     const r = await create({});
@@ -413,6 +529,30 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
     );
     expect(r.ok).toBe(true);
     expect(wiringWarning(r)).toHaveLength(1);
+  });
+
+  test("a legacy single-brace {secret} in the stored row is not reported as unwired", async () => {
+    // NOTE: the write normalizes, so this row cannot be produced through the write — it is what a
+    // build older than that normalization left behind. `buildHttpTool` normalizes at BUILD time, so
+    // the secret IS sent; a warning here would tell the operator to fix a tool that works, on an
+    // update that never touched the template.
+    const created = await create({
+      credential_ref: genericRef,
+      dry_run: false,
+    });
+    const id = created.ok
+      ? (created.data as { target: string }).target.split(":")[1]
+      : "";
+    await suDb.$executeRawUnsafe(
+      `UPDATE tool_definitions SET headers = '{"X-Auth":"{secret}"}'::jsonb WHERE id = ${id}`,
+    );
+    const r = await toolUpdate(
+      principal(),
+      { tool_id: id as string, label: "Renamed" },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
   });
 
   test("a patch that touches neither still reads the row, and stays quiet on a wired tool", async () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -700,6 +700,16 @@ const CASES: Wiring[] = [
     query: { token: "{{__wait_message}}" },
   },
 
+  {
+    label:
+      "the ack argument in the URL is declared by the runtime, so the tool runs",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?token={{__wait_message}}`,
+    ackMessage: "one moment",
+  },
+
   // ── spelling ──
   {
     label:
@@ -870,6 +880,31 @@ describe("the scanner answers what the runtime does", () => {
       ),
     ).toBeNull();
 
+    // NOTE: and the ack argument is the runtime's ONLY when the tool has an ack. Without one it is
+    // a name nothing declares, and the call throws like any other orphan.
+    const noAck = buildHttpTool(
+      asDef({
+        label: "",
+        reaches: false,
+        urlTemplate: `https://${PUBLIC}/v1/thing?token={{__wait_message}}`,
+      }),
+      { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+    );
+    await expect(noAck.invoke({})).rejects.toThrow(
+      "no value available for URL placeholder",
+    );
+    expect(
+      unusedCredentialWarning(
+        { kind: "query", paramName: "token", baseUrl: null },
+        "GET",
+        {
+          urlTemplate: `https://${PUBLIC}/v1/thing?token={{__wait_message}}`,
+          headers: {},
+          inputSchema: {},
+        },
+      ),
+    ).toBeNull();
+
     // NOTE: the control — with a base, the same tool is judged normally.
     expect(
       unusedCredentialWarning(
@@ -917,7 +952,7 @@ describe("the scanner answers what the runtime does", () => {
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
     expect(reaching).toBeGreaterThan(24);
-    expect(CASES.length - reaching).toBeGreaterThan(26);
+    expect(CASES.length - reaching).toBeGreaterThan(27);
   });
 });
 
@@ -1050,6 +1085,7 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
   let bearerRef = "";
   let headerRef = "";
   let basedRef = "";
+  let queryRef = "";
   let n = 0;
 
   const principal = (): VerifiedToken =>
@@ -1114,6 +1150,20 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
           value: "abc123TOKEN",
           kind: "generic",
           baseUrl: `https://${PUBLIC}/{{secret}}`,
+        },
+        undefined,
+        undefined,
+        appDb,
+      )
+    ).ref;
+    queryRef = (
+      await createVaultEntry(
+        ctx,
+        {
+          name: "wiring-query",
+          value: "abc123TOKEN",
+          kind: "query",
+          paramName: "token",
         },
         undefined,
         undefined,
@@ -1407,6 +1457,32 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
     expect(await suDb.toolDefinition.count({ where: { tenantId, name } })).toBe(
       1,
     );
+  });
+
+  test("clearing the ack message is not the same as leaving it alone", async () => {
+    // NOTE: `ack_message: null` CLEARS it, and the applied row then declares no `__wait_message` at
+    // all. Reading the cleared field as "unchanged" restored an ack the write is removing, and the
+    // preview reported a credential shadowed by an argument that will not exist.
+    const created = await create({
+      credential_ref: queryRef,
+      query: { token: "{{__wait_message}}" },
+      ack_enabled: true,
+      ack_message: "one moment",
+      dry_run: false,
+    });
+    expect(created.ok).toBe(true);
+    expect(wiringWarning(created)).toHaveLength(1);
+    const id = created.ok
+      ? (created.data as { target: string }).target.split(":")[1]
+      : "";
+
+    const r = await toolUpdate(
+      principal(),
+      { tool_id: id as string, ack_message: null },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
   });
 
   test("no credential attached, no warning", async () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -672,6 +672,12 @@ const CASES: Wiring[] = [
     inputSchema: { order_id: { type: "string", required: true } },
   },
 
+  {
+    label: "an undeclared URL placeholder that IS a prototype name still runs",
+    reaches: false,
+    urlTemplate: `https://${PUBLIC}/v1/{{toString}}`,
+  },
+
   // ── spelling ──
   {
     label:
@@ -780,6 +786,37 @@ describe("the scanner answers what the runtime does", () => {
       ),
     ).toBeNull();
 
+    // NOTE: and the fourth: a URL that names a FIXED field whose own value depends on something
+    // unavailable. The field exists, so it looks resolvable, and the runtime still throws — it
+    // records the dependency and refuses to fetch an incomplete segment.
+    const orphanDep = buildHttpTool(
+      asDef({
+        label: "",
+        reaches: false,
+        urlTemplate: `https://${PUBLIC}/v1/{{path}}`,
+        inputSchema: {
+          path: { type: "string", source: "fixed", value: "{{missing}}" },
+        },
+      }),
+      { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+    );
+    await expect(orphanDep.invoke({})).rejects.toThrow(
+      "no value available for URL placeholder",
+    );
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        {
+          urlTemplate: `https://${PUBLIC}/v1/{{path}}`,
+          headers: {},
+          inputSchema: {
+            path: { type: "string", source: "fixed", value: "{{missing}}" },
+          },
+        },
+      ),
+    ).toBeNull();
+
     // NOTE: the control — with a base, the same tool is judged normally.
     expect(
       unusedCredentialWarning(
@@ -827,7 +864,7 @@ describe("the scanner answers what the runtime does", () => {
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
     expect(reaching).toBeGreaterThan(24);
-    expect(CASES.length - reaching).toBeGreaterThan(24);
+    expect(CASES.length - reaching).toBeGreaterThan(25);
   });
 });
 
@@ -1239,6 +1276,38 @@ describe.skipIf(!dbUp)("tool_create / tool_update say so", () => {
       { paramName: "X-Api-Key" },
       appDb,
     );
+  });
+
+  test("a credential ref that names no row gets no wiring advice", async () => {
+    // NOTE: the entry was deleted after the tool was wired to it. Reading the miss as a legacy
+    // `generic` handed the operator remediation for the wrong problem — the credential is not
+    // unwired, it is gone, and config-health is what reports that.
+    const gone = (
+      await createVaultEntry(
+        { tenantId, userId: null, role: "TENANT_ADMIN" },
+        { name: "wiring-gone", value: "abc123TOKEN", kind: "generic" },
+        undefined,
+        undefined,
+        appDb,
+      )
+    ).ref;
+    const created = await create({ credential_ref: gone, dry_run: false });
+    expect(created.ok).toBe(true);
+    const id = created.ok
+      ? (created.data as { target: string }).target.split(":")[1]
+      : "";
+    expect(wiringWarning(created)).toHaveLength(1);
+
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM vault_entries WHERE id = ${readVaultRefId(gone)}`,
+    );
+    const r = await toolUpdate(
+      principal(),
+      { tool_id: id as string, label: "Renamed" },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    expect(wiringWarning(r)).toHaveLength(0);
   });
 
   test("no credential attached, no warning", async () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createServer, request } from "node:http";
+import type { AddressInfo } from "node:net";
 import type { ToolMessage } from "@langchain/core/messages";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
@@ -89,7 +91,10 @@ async function secretLeft(w: Wiring): Promise<boolean> {
   (await tool.invoke({})) as unknown as ToolMessage;
   const headers = captured.init?.headers as Record<string, string> | undefined;
   return [
-    captured.url ?? "",
+    // The URL as far as it is TRANSMITTED. A stub fetch is handed the whole string, fragment and
+    // all, and the wire is not — the test below measures that against a real socket, and without
+    // this cut a credential written into a fragment would read here as sent.
+    (captured.url ?? "").split("#")[0] ?? "",
     ...Object.values(headers ?? {}),
     String(captured.init?.body ?? ""),
   ]
@@ -262,6 +267,32 @@ const CASES: Wiring[] = [
     },
   },
 
+  {
+    label: "a query key the URL spells past a value that carries its own '?'",
+    reaches: false,
+    urlTemplate: `https://${PUBLIC}/v1/thing?redirect=https://a.test/?x=1&token=fixed`,
+    query: { token: "{{secret}}" },
+  },
+  {
+    label: "a query kind shadowed by a value that cannot interpolate empty",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: "prefix-{{contact_name}}" },
+  },
+  {
+    label: "…and not shadowed by one that can",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{contact_name}}" },
+  },
+  {
+    label: "{{secret}} in a URL fragment is written and never transmitted",
+    reaches: false,
+    urlTemplate: `https://${PUBLIC}/v1/thing#token={{secret}}`,
+  },
+
   // ── spelling ──
   {
     label:
@@ -293,12 +324,44 @@ describe("the scanner answers what the runtime does", () => {
     });
   }
 
+  test("a fragment does not reach the upstream, which is why the table cuts it", async () => {
+    // NOTE: the PREMISE behind the row above, measured rather than assumed, because the stub fetch
+    // the table runs on cannot show it: `fetchImpl` is handed the whole URL string. A real socket is
+    // what says whether the bytes leave, and `req.url` on the server side is the request TARGET the
+    // client put on the wire.
+    //
+    // node:http on both ends, not `fetch`/`Bun.serve`: this suite preloads happy-dom, and under it
+    // that pair answers `Parse Error: Duplicate Content-Length`. The client still builds its own
+    // request line from a real URL, which is the thing under measurement.
+    let seen = "";
+    const srv = createServer((req, res) => {
+      seen = req.url ?? "";
+      res.end("ok");
+    });
+    await new Promise<void>((r) => srv.listen(0, "127.0.0.1", r));
+    const { port } = srv.address() as AddressInfo;
+    await new Promise<void>((resolve, reject) => {
+      const req = request(
+        `http://127.0.0.1:${port}/x?a=1#token=${SECRET}`,
+        (res) => {
+          res.resume();
+          res.on("end", () => resolve());
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+    await new Promise<void>((r) => srv.close(() => r()));
+    expect(seen).toBe("/x?a=1");
+    expect(seen).not.toContain(SECRET);
+  });
+
   test("the table is not all one answer", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(5);
-    expect(CASES.length - reaching).toBeGreaterThan(5);
+    expect(reaching).toBeGreaterThan(8);
+    expect(CASES.length - reaching).toBeGreaterThan(8);
   });
 });
 

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -528,6 +528,37 @@ const CASES: Wiring[] = [
     headers: ["{{secret}}"] as unknown as Record<string, unknown>,
   },
 
+  {
+    label:
+      "a query kind shadowed by a REQUIRED ai field in the legacy derivation",
+    reaches: false,
+    method: "GET",
+    kind: "query",
+    paramName: "token",
+    inputSchema: { token: { type: "string", required: true } },
+  },
+  {
+    label: "…and not by an optional one, which the model may omit",
+    reaches: true,
+    method: "GET",
+    kind: "query",
+    paramName: "token",
+    inputSchema: { token: { type: "string" } },
+  },
+  {
+    label: "a legacy query ARRAY, which the runtime still walks",
+    reaches: true,
+    query: ["{{secret}}"] as unknown as Record<string, unknown>,
+  },
+  {
+    label:
+      "an explicit query key that happens to look like the unresolved marker",
+    reaches: true,
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{field}}=x`,
+    query: { "((unresolved-a))": "{{secret}}" },
+    inputSchema: { field: { type: "string", required: true } },
+  },
+
   // ── spelling ──
   {
     label:
@@ -595,8 +626,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(18);
-    expect(CASES.length - reaching).toBeGreaterThan(16);
+    expect(reaching).toBeGreaterThan(20);
+    expect(CASES.length - reaching).toBeGreaterThan(17);
   });
 });
 
@@ -618,6 +649,42 @@ describe("which kinds the warning is about", () => {
     // That they can be attached to an HTTP tool at all is a separate defect, and a refusal rather
     // than a warning.
     expect(warned).toEqual(["generic"]);
+  });
+
+  test("a shadowed injection gets its OWN sentence, not the generic advice", () => {
+    // NOTE: the operator already did what the other sentence advises — picked an injecting type and
+    // attached it. What stops the credential is the value the request carries at the target, and a
+    // warning that names the credential instead of the header sends them to fix the wrong thing.
+    const w =
+      unusedCredentialWarning(
+        { kind: "bearer_token", paramName: null, baseUrl: null },
+        "GET",
+        {
+          urlTemplate: `https://${PUBLIC}/v1/thing`,
+          headers: { Authorization: "constant" },
+          inputSchema: {},
+        },
+      ) ?? "";
+    expect(w).toContain("Authorization");
+    expect(w).toContain("keeps the value you wrote");
+    // NOTE: and it must NOT recommend attaching an injecting type, which is the other sentence.
+    expect(w).not.toContain("attach a credential whose type injects it");
+  });
+
+  test("the Content-Type a body method always carries is named as the runtime's, not the tool's", () => {
+    const w =
+      unusedCredentialWarning(
+        { kind: "header", paramName: "Content-Type", baseUrl: null },
+        "POST",
+        {
+          urlTemplate: `https://${PUBLIC}/v1/thing`,
+          headers: {},
+          body: { mode: "kv", rows: [{ key: "a", value: "1" }] },
+          inputSchema: {},
+        },
+      ) ?? "";
+    expect(w).toContain("a request with a body always carries that header");
+    expect(w).not.toContain("this tool sets");
   });
 
   test("a kind this build does not know is the legacy generic, and is warned about", () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -559,6 +559,18 @@ const CASES: Wiring[] = [
     inputSchema: { field: { type: "string", required: true } },
   },
 
+  {
+    label:
+      "a fixed field named like an Object member does not resolve a URL key",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{toString}}=x`,
+    inputSchema: {
+      toString: { type: "string", source: "fixed", value: "token" },
+    },
+  },
+
   // ── spelling ──
   {
     label:
@@ -589,6 +601,43 @@ describe("the scanner answers what the runtime does", () => {
       expect(scannerSaysReaches(w)).toBe(w.reaches);
     });
   }
+
+  test("a relative template with no base builds no request, so it gets no warning", async () => {
+    // NOTE: not a row of the table, because there is nothing to execute: `buildHttpTool` refuses the
+    // pairing outright. A warning that the request goes out unauthenticated would diagnose a failure
+    // that cannot happen and point away from the one that does.
+    expect(() =>
+      buildHttpTool(
+        asDef({
+          label: "",
+          reaches: false,
+          urlTemplate: "/v1/thing",
+        }),
+        { resolveCredential: async () => SECRET, fetchImpl: stubFetch({}) },
+      ),
+    ).toThrow("relative urlTemplate requires a credential with a base URL");
+
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        {
+          urlTemplate: "/v1/thing",
+          headers: {},
+          inputSchema: {},
+        },
+      ),
+    ).toBeNull();
+
+    // NOTE: the control — with a base, the same tool is judged normally.
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: `https://${PUBLIC}` },
+        "GET",
+        { urlTemplate: "/v1/thing", headers: {}, inputSchema: {} },
+      ),
+    ).not.toBeNull();
+  });
 
   test("a fragment does not reach the upstream, which is why the table cuts it", async () => {
     // NOTE: the PREMISE behind the row above, measured rather than assumed, because the stub fetch
@@ -626,7 +675,7 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(20);
+    expect(reaching).toBeGreaterThan(21);
     expect(CASES.length - reaching).toBeGreaterThan(17);
   });
 });

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -828,6 +828,37 @@ const CASES: Wiring[] = [
     allowedHosts: [PUBLIC],
   },
 
+  {
+    label:
+      "an ack replaces a declared __wait_message, so its enum binds no key",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{__wait_message}}=fixed`,
+    query: { token: "{{secret}}" },
+    inputSchema: {
+      __wait_message: {
+        type: "enum",
+        required: true,
+        enumValues: ["token"],
+      },
+    },
+    ackMessage: "one moment",
+  },
+
+  {
+    label: "…and an ack replaces a FIXED __wait_message the same way",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    urlTemplate: `https://${PUBLIC}/v1/thing?{{__wait_message}}=fixed`,
+    query: { token: "{{secret}}" },
+    inputSchema: {
+      __wait_message: { type: "string", source: "fixed", value: "token" },
+    },
+    ackMessage: "one moment",
+  },
+
   // ── spelling ──
   {
     label:
@@ -1085,6 +1116,37 @@ describe("the scanner answers what the runtime does", () => {
       ),
     ).toBeNull();
 
+    // NOTE: and the eighth: a literal address the SSRF guard blocks. Decidable here because the
+    // deployment's own `allowPrivateTargets` is the same value the guard reads — where it is ON,
+    // every one of these checks is lifted and this boundary claims nothing.
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        { urlTemplate: "https://127.0.0.1/x", headers: {}, inputSchema: {} },
+        { allowedHosts: ["127.0.0.1"] },
+      ),
+    ).toBeNull();
+
+    // NOTE: and where the deployment ALLOWS private targets, the guard lifts both of those
+    // refusals — so this boundary claims nothing about either, and judges the tool normally.
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        { urlTemplate: "https://127.0.0.1/x", headers: {}, inputSchema: {} },
+        { allowedHosts: ["127.0.0.1"], privateAllowed: true },
+      ),
+    ).not.toBeNull();
+    expect(
+      unusedCredentialWarning(
+        { kind: "generic", paramName: null, baseUrl: null },
+        "GET",
+        { urlTemplate: "http://example.com/x", headers: {}, inputSchema: {} },
+        { allowedHosts: ["example.com"], privateAllowed: true },
+      ),
+    ).not.toBeNull();
+
     // NOTE: the control — with a base, the same tool is judged normally.
     expect(
       unusedCredentialWarning(
@@ -1131,7 +1193,7 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(27);
+    expect(reaching).toBeGreaterThan(29);
     expect(CASES.length - reaching).toBeGreaterThan(32);
   });
 });

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -591,6 +591,20 @@ const CASES: Wiring[] = [
     ] as unknown as Record<string, unknown>,
   },
 
+  {
+    label:
+      "a header credential aimed at __proto__, which no assignment can create",
+    reaches: false,
+    kind: "header",
+    paramName: "__proto__",
+  },
+  {
+    label:
+      "…and {{secret}} written into a header of that name is lost the same way",
+    reaches: false,
+    headers: JSON.parse('{"__proto__":"{{secret}}"}'),
+  },
+
   // ── spelling ──
   {
     label:
@@ -721,7 +735,7 @@ describe("the scanner answers what the runtime does", () => {
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
     expect(reaching).toBeGreaterThan(22);
-    expect(CASES.length - reaching).toBeGreaterThan(18);
+    expect(CASES.length - reaching).toBeGreaterThan(20);
   });
 });
 
@@ -743,6 +757,25 @@ describe("which kinds the warning is about", () => {
     // That they can be attached to an HTTP tool at all is a separate defect, and a refusal rather
     // than a warning.
     expect(warned).toEqual(["generic"]);
+  });
+
+  test("a header name nothing can set gets a sentence of its own", () => {
+    // NOTE: neither of the other two fits. The credential DOES inject, and nothing shadows it — the
+    // assignment reaches an inherited setter and creates no header. Telling this operator to remove
+    // a conflicting header names one that does not exist.
+    const w =
+      unusedCredentialWarning(
+        { kind: "header", paramName: "__proto__", baseUrl: null },
+        "GET",
+        {
+          urlTemplate: `https://${PUBLIC}/v1/thing`,
+          headers: {},
+          inputSchema: {},
+        },
+      ) ?? "";
+    expect(w).toContain("cannot be set on a request");
+    expect(w).not.toContain("keeps the value you wrote");
+    expect(w).not.toContain("attach a credential whose type injects it");
   });
 
   test("a shadowed injection gets its OWN sentence, not the generic advice", () => {

--- a/tests/modules/tool-credential-wiring.test.ts
+++ b/tests/modules/tool-credential-wiring.test.ts
@@ -293,6 +293,61 @@ const CASES: Wiring[] = [
     urlTemplate: `https://${PUBLIC}/v1/thing#token={{secret}}`,
   },
 
+  {
+    label: "a kv row a later row overwrites is assembled and discarded",
+    reaches: false,
+    method: "POST",
+    body: {
+      mode: "kv",
+      rows: [
+        { key: "auth", value: "{{secret}}" },
+        { key: "auth", value: "fixed" },
+      ],
+    },
+  },
+  {
+    label: "…and the row that wins is the one that counts",
+    reaches: true,
+    method: "POST",
+    body: {
+      mode: "kv",
+      rows: [
+        { key: "auth", value: "fixed" },
+        { key: "auth", value: "{{secret}}" },
+      ],
+    },
+  },
+  {
+    label: "a kv row with a blank key emits nothing",
+    reaches: false,
+    method: "POST",
+    body: { mode: "kv", rows: [{ key: "  ", value: "{{secret}}" }] },
+  },
+  {
+    label: "a query kind shadowed through a fixed field that is always set",
+    reaches: false,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{configured}}" },
+    inputSchema: {
+      configured: { type: "string", source: "fixed", value: "abc" },
+    },
+  },
+  {
+    label: "…and not shadowed through one that may resolve empty",
+    reaches: true,
+    kind: "query",
+    paramName: "token",
+    query: { token: "{{configured}}" },
+    inputSchema: {
+      configured: {
+        type: "string",
+        source: "fixed",
+        value: "{{contact_name}}",
+      },
+    },
+  },
+
   // ── spelling ──
   {
     label:
@@ -360,8 +415,8 @@ describe("the scanner answers what the runtime does", () => {
     // NOTE: the floor. Every assertion above is `toBe(w.reaches)`, so a table that drifted to a
     // single verdict would still pass while proving nothing about the boundary between them.
     const reaching = CASES.filter((c) => c.reaches).length;
-    expect(reaching).toBeGreaterThan(8);
-    expect(CASES.length - reaching).toBeGreaterThan(8);
+    expect(reaching).toBeGreaterThan(10);
+    expect(CASES.length - reaching).toBeGreaterThan(10);
   });
 });
 

--- a/tests/modules/tts-baseurl.test.ts
+++ b/tests/modules/tts-baseurl.test.ts
@@ -43,8 +43,12 @@ describe.skipIf(!dbUp)("tts: vault entry baseUrl precedence", () => {
     const e1 = await suDb.vaultEntry.create({
       data: {
         tenantId,
+        // NOTE: `openai_compatible` and not `openai`, since #504: a base URL is only DIALLED for a
+        // kind whose catalog entry declares one, so a row with `kind: "openai"` and a base URL is a
+        // stray value the resolve now answers `null` for. What this file is about — the entry's base
+        // winning over the config's — is unchanged, and this is the kind that can carry one.
         name: "tts-with-base",
-        kind: "openai",
+        kind: "openai_compatible",
         secret: encryptJson("sk-tts"),
         baseUrl: "https://custom.tts-proxy.com/v1",
       },

--- a/tests/modules/vault/base-url-applicability.test.ts
+++ b/tests/modules/vault/base-url-applicability.test.ts
@@ -119,6 +119,54 @@ describe("nothing writes a base URL past the rule", () => {
   });
 });
 
+describe("nothing reads a base URL past the gate", () => {
+  // NOTE: the write-side sweep above has a read-side twin, and it exists because the first version of
+  // the gate missed two readers: `assemble.ts` and `test-run.ts` build their OWN vault query and copy
+  // `baseUrl` straight into `credentialBaseUrl`, so a relative HTTP tool kept dialling the stray host
+  // after the resolvers had stopped. A ledger rather than a rule, because two of these files are
+  // supposed to read the row raw — the audit projection and the console listing — and the point is
+  // that a NEW reader has to be looked at rather than silently join either side.
+  const SELECTS = /baseUrl:\s*true/g;
+  const LEDGER: Record<string, "gated" | "raw by design"> = {
+    "src/api/v1/oauth-mcp.controller.ts": "gated",
+    "src/graph/tools/assemble.ts": "gated",
+    "src/modules/tool-definitions/test-run.ts": "gated",
+    // The four resolvers, the audit projection (the row as it was), `listVaultInfos` (the row as the
+    // console shows it) and `readVaultRefFacts` (which hands the tool writer the stored value on
+    // purpose — the wiring warning judges what the ROW says, and its own gate is the resolve).
+    "src/modules/vault/service.ts": "gated",
+  };
+
+  test("every file that selects a vault base URL is in the ledger", async () => {
+    const files = new Glob("src/**/*.ts").scanSync(".");
+    const found = new Set<string>();
+    for (const file of files) {
+      const code = codeOnly(await Bun.file(file).text());
+      // NOTE: the Chatwoot deployment has a `baseUrl` of its own and is not this column.
+      if (!/vaultEntry\./.test(code)) continue;
+      for (const _ of code.matchAll(SELECTS)) found.add(file);
+    }
+    expect([...found].sort()).toEqual(Object.keys(LEDGER).sort());
+    // NOTE: a FLOOR, so a sweep that stops matching cannot pass as "nothing reads it".
+    expect(found.size).toBeGreaterThan(3);
+  });
+
+  test("every gated file CALLS the gate, not merely imports it", async () => {
+    // NOTE: the call and not the name. Both mutations that put a raw `entry.baseUrl` back left the
+    // import untouched, so a file-contains-the-word check passed while the read was ungated again.
+    //
+    // What this fences is that the gate is present in the file, not that it wraps the right read —
+    // the placement is what the resolve-level tests above measure, and these two readers build their
+    // own query, so a behavioural test of them means an agent, a tool and a grant apiece.
+    for (const [file, how] of Object.entries(LEDGER)) {
+      if (how !== "gated") continue;
+      const code = codeOnly(await Bun.file(file).text());
+      const calls = [...code.matchAll(/dialableBaseUrl\(/g)].length;
+      expect([file, calls > 0]).toEqual([file, true]);
+    }
+  });
+});
+
 describe("the catalog is the rule", () => {
   test("exactly the kinds that declare a base URL take one", () => {
     const takes = SECRET_TYPE_IDS.filter(secretTypeSupportsBaseUrl);

--- a/tests/modules/vault/base-url-applicability.test.ts
+++ b/tests/modules/vault/base-url-applicability.test.ts
@@ -2,8 +2,9 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Glob } from "bun";
 import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
 import { AppError } from "@/lib/errors";
-import type { TenantContext } from "@/lib/tenancy";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
 import { credentialCreate } from "@/modules/mcp/write";
 import {
   BASE_URL_KIND_IDS,
@@ -19,6 +20,9 @@ import {
 import {
   createPendingVaultEntry,
   createVaultEntry,
+  listVaultInfos,
+  tryResolveApiKeyEntry,
+  tryResolveVaultEntry,
   updateVaultEntry,
 } from "@/modules/vault/service";
 import { codeOnly } from "@/tests/utils/source-text";
@@ -369,6 +373,71 @@ describe.skipIf(!dbUp)("vault: a base URL the kind cannot use", () => {
       select: { baseUrl: true },
     });
     expect(row?.baseUrl).toBeNull();
+  });
+
+  test("a row that already carries a dead base URL is KEPT and never dialled", async () => {
+    // NOTE: the refusal covers what a write introduces, and covering only that would leave every
+    // install the rule was written for still redirecting — the model path, vision, STT, TTS, the
+    // HTTP-tool base and the MCP connection URL read this field off the RESOLVED entry without
+    // asking the kind. So the resolve is gated too.
+    //
+    // The row is not touched, and that half is the point: `listVaultInfos` still reports the stored
+    // value, so the console can show an operator what is sitting in a field its own form never
+    // rendered. What the runtime dials is `null`.
+    const row = await suDb.vaultEntry.create({
+      data: {
+        tenantId,
+        name: "bu-dialled",
+        secret: encryptJson("sk-legacy"),
+        kind: "openai",
+        baseUrl: ELSEWHERE,
+      },
+      select: { id: true },
+    });
+    const ref = `vault:${row.id}`;
+    const resolved = await runScopedOn(appDb, ctx(), (db) =>
+      tryResolveApiKeyEntry(db, ref),
+    );
+    expect(resolved.state).toBe("ok");
+    if (resolved.state === "ok") expect(resolved.baseUrl).toBeNull();
+    const entry = await runScopedOn(appDb, ctx(), (db) =>
+      tryResolveVaultEntry(db, ref),
+    );
+    expect(entry?.baseUrl).toBeNull();
+    // NOTE: and the listing — the surface an operator reads — still shows it.
+    const listed = await runScopedOn(appDb, ctx(), (db) => listVaultInfos(db));
+    expect(listed.find((e) => e.name === "bu-dialled")?.baseUrl).toBe(
+      ELSEWHERE,
+    );
+    expect(
+      (
+        await suDb.vaultEntry.findUnique({
+          where: { id: row.id },
+          select: { baseUrl: true },
+        })
+      )?.baseUrl,
+    ).toBe(ELSEWHERE);
+  });
+
+  test("a kind that DOES take one keeps dialling it", async () => {
+    // NOTE: the control for the gate above. It has to cut the dead field and nothing else.
+    const { id } = await createVaultEntry(
+      ctx(),
+      {
+        name: "bu-dialled-ok",
+        value: "sk-abc123",
+        kind: "openai_compatible",
+        baseUrl: ELSEWHERE,
+      },
+      undefined,
+      undefined,
+      appDb,
+    );
+    const resolved = await runScopedOn(appDb, ctx(), (db) =>
+      tryResolveApiKeyEntry(db, `vault:${id}`),
+    );
+    expect(resolved.state).toBe("ok");
+    if (resolved.state === "ok") expect(resolved.baseUrl).toBe(ELSEWHERE);
   });
 
   test("a row that already carries a dead base URL stays editable, and can be cleared", async () => {

--- a/tests/modules/vault/base-url-applicability.test.ts
+++ b/tests/modules/vault/base-url-applicability.test.ts
@@ -151,6 +151,49 @@ describe("nothing reads a base URL past the gate", () => {
     expect(found.size).toBeGreaterThan(3);
   });
 
+  // NOTE: the CLIENT half, and it exists because the gate reached the console one reader at a time —
+  // the tool editor in one round, the MCP editor in the next. A page that DECIDES with this value
+  // (locking a field, enabling Save, accepting a relative template) has to use the dialable one; a
+  // page that DISPLAYS the row, or edits the row itself, keeps the raw value on purpose.
+  const CLIENT_LEDGER: Record<
+    string,
+    "gated" | "via the hook" | "raw by design"
+  > = {
+    // Displays what the picker holds, and hands the raw value to the credential form, which edits
+    // the row itself.
+    "src/client/components/CredentialPicker.tsx": "raw by design",
+    "src/client/lib/vaultCache.ts": "gated",
+    "src/client/pages/resources/McpEditModal.tsx": "gated",
+    "src/client/pages/resources/ToolEditModal.tsx": "gated",
+    // The credential listing: the row as it is, which is the one surface that must keep showing a
+    // base URL sitting on a kind whose form never rendered the field.
+    "src/client/pages/resources/VaultPanel.tsx": "raw by design",
+    // Asks `useVaultBaseUrls`, which is gated above — it never touches an entry itself.
+    "src/client/pages/agents/AgentEditorPage.tsx": "via the hook",
+  };
+
+  test("every client reader of a vault base URL is in the ledger", async () => {
+    const files = new Glob("src/client/**/*.{ts,tsx}").scanSync(".");
+    const found = new Set<string>();
+    for (const file of files) {
+      if (file.endsWith("secretTypes.ts")) continue;
+      const code = codeOnly(await Bun.file(file).text());
+      if (!/\bVaultEntry\b|loadVault|vault\.get/.test(code)) continue;
+      if (/\.baseUrl\b|baseUrl:/.test(code)) found.add(file);
+    }
+    expect([...found].sort()).toEqual(Object.keys(CLIENT_LEDGER).sort());
+    expect(found.size).toBeGreaterThan(4);
+  });
+
+  test("every gated client file CALLS the gate", async () => {
+    for (const [file, how] of Object.entries(CLIENT_LEDGER)) {
+      if (how !== "gated") continue;
+      const code = codeOnly(await Bun.file(file).text());
+      const calls = [...code.matchAll(/dialableBaseUrl\(/g)].length;
+      expect([file, calls > 0]).toEqual([file, true]);
+    }
+  });
+
   test("every gated file CALLS the gate, not merely imports it", async () => {
     // NOTE: the call and not the name. Both mutations that put a raw `entry.baseUrl` back left the
     // import untouched, so a file-contains-the-word check passed while the read was ungated again.

--- a/tests/modules/vault/base-url-applicability.test.ts
+++ b/tests/modules/vault/base-url-applicability.test.ts
@@ -1,0 +1,403 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Glob } from "bun";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { AppError } from "@/lib/errors";
+import type { TenantContext } from "@/lib/tenancy";
+import { credentialCreate } from "@/modules/mcp/write";
+import {
+  BASE_URL_KIND_IDS,
+  getSecretType,
+  getSecretTypeFields,
+  SECRET_TYPE_IDS,
+  secretTypeIsManagedBlob,
+  secretTypeNeedsParamName,
+  secretTypeRefusesBaseUrl,
+  secretTypeRequiresBaseUrl,
+  secretTypeSupportsBaseUrl,
+} from "@/modules/vault/secret-types";
+import {
+  createPendingVaultEntry,
+  createVaultEntry,
+  updateVaultEntry,
+} from "@/modules/vault/service";
+import { codeOnly } from "@/tests/utils/source-text";
+
+// A `baseUrl` is only meaningful for the kinds whose catalog entry declares one. Every other kind
+// STORED it anyway and the runtime then USED it: the model path reads `credentialBaseUrl ?? mc.baseURL`
+// straight off the resolved entry, and so do vision, STT, TTS, the HTTP-tool base and the MCP
+// connection URL — none of them asking the kind. So an `openai` credential could carry a base URL
+// the console never renders, never shows and cannot edit, and the operator's provider key went to
+// that host on the next turn with nothing anywhere saying so. That is issue #504, and the count is
+// not a sample: all NINE kinds whose form hides the input accepted one.
+//
+// The rule is the CATALOG, not a list written here, and a kind this build does not know keeps
+// passing — the same carve-out `secretTypeRefusesParamName` makes (#488), so a row written by an
+// older build stays editable.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+
+// OUTSIDE the skipIf: a superuser probe that connects while the app one does not leaves an open
+// pool nothing else closes.
+afterAll(async () => {
+  await su?.$disconnect();
+  await app?.$disconnect();
+});
+
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+let tenantId = 0n;
+
+const refusal = async (run: () => Promise<unknown>): Promise<AppError> => {
+  try {
+    await run();
+  } catch (e) {
+    if (e instanceof AppError) return e;
+    throw e;
+  }
+  throw new Error("expected the write to be refused, and it was not");
+};
+
+// A value and a param name this kind accepts, so the baseUrl decision is the ONLY thing under test.
+// `createVaultEntry` validates value, then baseUrl, then paramName — a kind whose value shape is
+// wrong never reaches the rule, and the test would pass on the wrong refusal.
+const validValue = (kind: string): string | Record<string, string> => {
+  if (secretTypeIsManagedBlob(kind)) return {};
+  const fields = getSecretTypeFields(kind);
+  if (fields) return Object.fromEntries(fields.map((f) => [f.key, "abc123"]));
+  return "abc123TOKEN";
+};
+const validParamName = (kind: string): string | undefined =>
+  secretTypeNeedsParamName(kind) ? "X-Probe" : undefined;
+
+const ELSEWHERE = "https://elsewhere.invalid";
+
+describe("nothing writes a base URL past the rule", () => {
+  // NOTE: the rule is a helper, and a helper only holds the sites that call it. This counts the
+  // vault-entry WRITES in `src/` and pins them to the one file the helper lives in: a fourth write
+  // path — an OAuth callback storing a discovered endpoint, an import restoring an export — would
+  // set `baseUrl` without ever passing the kind, and no test of the three current boundaries would
+  // notice. `codeOnly` because a comment naming `vaultEntry.update` is prose, not a write (#424).
+  const WRITE = /\bvaultEntry\.(create|update|updateMany|upsert|createMany)\b/g;
+
+  test("every vaultEntry write lives in the vault service", async () => {
+    const files = new Glob("src/**/*.ts").scanSync(".");
+    const sites: string[] = [];
+    for (const file of files) {
+      const code = codeOnly(await Bun.file(file).text());
+      for (const _ of code.matchAll(WRITE)) sites.push(file);
+    }
+    // NOTE: a FLOOR, not an equality: a sweep that silently stops matching (a rename, a Prisma
+    // extension, a moved file) reports zero sites and passes as "nothing bypasses the rule".
+    expect(sites.length).toBeGreaterThan(3);
+    expect([...new Set(sites)]).toEqual(["src/modules/vault/service.ts"]);
+  });
+});
+
+describe("the catalog is the rule", () => {
+  test("exactly the kinds that declare a base URL take one", () => {
+    const takes = SECRET_TYPE_IDS.filter(secretTypeSupportsBaseUrl);
+    expect(takes).toEqual([
+      "generic",
+      "bearer_token",
+      "header",
+      "basic_auth",
+      "query",
+      "openai_compatible",
+      "chatwoot_api_token",
+      "mcp_oauth",
+      "langfuse",
+    ]);
+    expect(BASE_URL_KIND_IDS).toEqual(takes);
+    // NOTE: The other side of the same count, spelled out so a kind added to the catalog without a
+    // decision about this field shows up here instead of silently joining the refusing majority.
+    expect(SECRET_TYPE_IDS.filter(secretTypeRefusesBaseUrl).length).toBe(
+      SECRET_TYPE_IDS.length - takes.length,
+    );
+  });
+
+  test("required implies supported, for every kind, by construction", () => {
+    // NOTE: The state a supports/requires PAIR would let someone write — required and not
+    // supported — which the write boundary would read as "must have one" and "must not have one" at
+    // the same time, refusing every create of that kind. One field cannot express it.
+    for (const id of SECRET_TYPE_IDS) {
+      if (secretTypeRequiresBaseUrl(id))
+        expect(secretTypeSupportsBaseUrl(id)).toBe(true);
+      expect(secretTypeRefusesBaseUrl(id)).toBe(!secretTypeSupportsBaseUrl(id));
+    }
+  });
+
+  test("a kind this build does not know refuses nothing", () => {
+    expect(getSecretType("kind_from_a_future_build")).toBeNull();
+    expect(secretTypeRefusesBaseUrl("kind_from_a_future_build")).toBe(false);
+    expect(secretTypeRefusesBaseUrl(null)).toBe(false);
+    expect(secretTypeRefusesBaseUrl(undefined)).toBe(false);
+  });
+});
+
+describe.skipIf(!dbUp)("vault: a base URL the kind cannot use", () => {
+  const ctx = (): TenantContext => ({
+    tenantId,
+    userId: null,
+    role: "TENANT_ADMIN",
+  });
+
+  beforeAll(async () => {
+    if (!su) return;
+    const t = await su.tenant.create({
+      data: { name: "VaultBaseUrl", slug: `vaultbu-${process.pid}` },
+    });
+    tenantId = t.id;
+  });
+
+  afterAll(async () => {
+    if (su && tenantId) {
+      await su.$executeRawUnsafe(
+        `DELETE FROM vault_entries WHERE tenant_id = ${tenantId}`,
+      );
+      await su.$executeRawUnsafe(`DELETE FROM tenants WHERE id = ${tenantId}`);
+    }
+  });
+
+  // NOTE: The matrix: every kind in the catalog, against the same base URL. Enumerating it instead
+  // of sampling is what makes the rule the catalog's — a kind added later is covered the day it is
+  // added, on whichever side its own entry puts it.
+  for (const kind of SECRET_TYPE_IDS) {
+    const takes = secretTypeSupportsBaseUrl(kind);
+    test(`createVaultEntry ${takes ? "stores" : "refuses"} a base URL on ${kind}`, async () => {
+      const input = {
+        name: `bu-create-${kind}`,
+        value: validValue(kind),
+        kind,
+        baseUrl: ELSEWHERE,
+        paramName: validParamName(kind),
+      };
+      if (!takes) {
+        const e = await refusal(() =>
+          createVaultEntry(ctx(), input, undefined, undefined, appDb),
+        );
+        expect(e.statusCode).toBe(400);
+        expect(e.translationKey).toBe("errors.vaultBaseUrlNotApplicable");
+        // NOTE: The refusal is ABOUT the field, by the name the server uses for it, so the console
+        // and the MCP caller key on the same string.
+        expect(e.field).toBe("baseUrl");
+        // NOTE: The door: the sentence has to say which kinds do take one, or the operator learns
+        // only that this one does not.
+        for (const id of BASE_URL_KIND_IDS) expect(e.message).toContain(id);
+        const rows = await suDb.vaultEntry.count({
+          where: { tenantId, name: input.name },
+        });
+        expect(rows).toBe(0);
+        return;
+      }
+      const { id } = await createVaultEntry(
+        ctx(),
+        input,
+        undefined,
+        undefined,
+        appDb,
+      );
+      const row = await suDb.vaultEntry.findUnique({
+        where: { id },
+        select: { baseUrl: true },
+      });
+      expect(row?.baseUrl).toBe(ELSEWHERE);
+    });
+  }
+
+  test("the redirect the issue describes is refused, and the kind that exists for it is not", async () => {
+    // NOTE: Issue #504 verbatim, on the sharpest of the nine: an `openai` credential carrying a base
+    // URL the console never shows. `prepare.ts` hands `credentialBaseUrl ?? mc.baseURL` to the model
+    // client, so every turn's API key went to that host. The kind that legitimately does this is
+    // `openai_compatible`, which is why the refusal names it.
+    const e = await refusal(() =>
+      createVaultEntry(
+        ctx(),
+        {
+          name: "bu-openai-redirect",
+          value: "sk-abc123",
+          kind: "openai",
+          baseUrl: ELSEWHERE,
+        },
+        undefined,
+        undefined,
+        appDb,
+      ),
+    );
+    expect(e.translationKey).toBe("errors.vaultBaseUrlNotApplicable");
+    expect(e.message).toContain("openai_compatible");
+
+    const { id } = await createVaultEntry(
+      ctx(),
+      {
+        name: "bu-openai-compatible",
+        value: "sk-abc123",
+        kind: "openai_compatible",
+        baseUrl: ELSEWHERE,
+      },
+      undefined,
+      undefined,
+      appDb,
+    );
+    const row = await suDb.vaultEntry.findUnique({
+      where: { id },
+      select: { kind: true, baseUrl: true },
+    });
+    expect(row).toEqual({ kind: "openai_compatible", baseUrl: ELSEWHERE });
+  });
+
+  test("an empty base URL still means none, on a kind that cannot use one", async () => {
+    // NOTE: A client that always sends the field must not be refused for sending nothing in it: the
+    // console submits `baseUrl: null` on every kind whose form has no input, and "" reaches
+    // `validateBaseUrl` as the empty string it already returned before this rule existed.
+    for (const baseUrl of [null, "", "   "]) {
+      const { id } = await createVaultEntry(
+        ctx(),
+        {
+          name: `bu-empty-${String(baseUrl).length}`,
+          value: "sk-abc123",
+          kind: "openai",
+          baseUrl,
+        },
+        undefined,
+        undefined,
+        appDb,
+      );
+      const row = await suDb.vaultEntry.findUnique({
+        where: { id },
+        select: { baseUrl: true },
+      });
+      expect(row?.baseUrl).toBeNull();
+    }
+  });
+
+  test("the MCP dry run refuses it too, so the preview cannot promise what apply rejects", async () => {
+    // NOTE: `credential_create` defaults to dry_run and answers BEFORE reaching the core, so a rule
+    // the core learns later is a rule the preview promises away. Both halves have to refuse, and the
+    // apply half must not create a row.
+    const p = {
+      tenantId,
+      userId: null,
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:write"],
+    } as unknown as Parameters<typeof credentialCreate>[0];
+    for (const dry_run of [undefined, false]) {
+      const r = await credentialCreate(
+        p,
+        { name: "bu-mcp", kind: "gemini", base_url: ELSEWHERE, dry_run },
+        { base: appDb },
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.error).toContain("does not use a base URL");
+        for (const id of BASE_URL_KIND_IDS) expect(r.error).toContain(id);
+      }
+    }
+    expect(
+      await suDb.vaultEntry.count({ where: { tenantId, name: "bu-mcp" } }),
+    ).toBe(0);
+  });
+
+  test("the MCP dry run still previews the config that works", async () => {
+    // NOTE: the control for the case above — the guard has to refuse the dead field and nothing
+    // else, or it is the preview lying in the other direction.
+    const p = {
+      tenantId,
+      userId: null,
+      role: "TENANT_ADMIN",
+      scopes: ["mcp:write"],
+    } as unknown as Parameters<typeof credentialCreate>[0];
+    const r = await credentialCreate(
+      p,
+      { name: "bu-mcp-ok", kind: "openai_compatible", base_url: ELSEWHERE },
+      { base: appDb },
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.dryRun).toBe(true);
+  });
+
+  test("createPendingVaultEntry refuses it too — the surface the MCP tool writes through", async () => {
+    const e = await refusal(() =>
+      createPendingVaultEntry(
+        ctx(),
+        { name: "bu-pending", kind: "anthropic", baseUrl: ELSEWHERE },
+        appDb,
+      ),
+    );
+    expect(e.statusCode).toBe(400);
+    expect(e.translationKey).toBe("errors.vaultBaseUrlNotApplicable");
+    expect(
+      await suDb.vaultEntry.count({ where: { tenantId, name: "bu-pending" } }),
+    ).toBe(0);
+  });
+
+  test("updateVaultEntry refuses it against the STORED kind, which is immutable", async () => {
+    const { id } = await createVaultEntry(
+      ctx(),
+      { name: "bu-update", value: "sk-abc123", kind: "openai" },
+      undefined,
+      undefined,
+      appDb,
+    );
+    const e = await refusal(() =>
+      updateVaultEntry(ctx(), id, { baseUrl: ELSEWHERE }, appDb),
+    );
+    expect(e.translationKey).toBe("errors.vaultBaseUrlNotApplicable");
+    const row = await suDb.vaultEntry.findUnique({
+      where: { id },
+      select: { baseUrl: true },
+    });
+    expect(row?.baseUrl).toBeNull();
+  });
+
+  test("a row that already carries a dead base URL stays editable, and can be cleared", async () => {
+    // NOTE: The refusal covers what a write INTRODUCES. Rows written before it exists keep their
+    // stray value, and a save that does not touch the field must still go through, or the rule
+    // strands exactly the entries it was written for. Clearing it has to work for the same reason:
+    // it is the only repair a caller has.
+    const row = await suDb.vaultEntry.create({
+      data: {
+        tenantId,
+        name: "bu-legacy",
+        secret: "x",
+        kind: "gemini",
+        baseUrl: ELSEWHERE,
+      },
+      select: { id: true },
+    });
+    await updateVaultEntry(ctx(), row.id, { name: "bu-legacy-renamed" }, appDb);
+    const kept = await suDb.vaultEntry.findUnique({
+      where: { id: row.id },
+      select: { name: true, baseUrl: true },
+    });
+    expect(kept).toEqual({ name: "bu-legacy-renamed", baseUrl: ELSEWHERE });
+
+    await updateVaultEntry(ctx(), row.id, { baseUrl: null }, appDb);
+    const cleared = await suDb.vaultEntry.findUnique({
+      where: { id: row.id },
+      select: { baseUrl: true },
+    });
+    expect(cleared?.baseUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
Two loose ends in credential validation, both at the write boundary and both the same question: what is this boundary responsible for checking about the credential it is storing.

## 1. A base URL on a type whose form never shows one

`supportsBaseUrl` lived only in the **client** mirror (`src/client/lib/secretTypes.ts`), where it decides whether the credential form renders the base-URL input. The server catalog declared `requiresBaseUrl` and nothing else, so the write boundary had no way to ask the question — and did not.

Measured over the whole catalog, not sampled: the console renders the input for **9 of the 18** kinds, and **all 9 of the others stored one anyway**.

```
generic            console=shows  STORED       openai       console=HIDES  STORED
bearer_token       console=shows  STORED       anthropic    console=HIDES  STORED
header             console=shows  STORED       gemini       console=HIDES  STORED
basic_auth         console=shows  STORED       deepseek     console=HIDES  STORED
query              console=shows  STORED       openrouter   console=HIDES  STORED
openai_compatible  console=shows  STORED       elevenlabs   console=HIDES  STORED
chatwoot_api_token console=shows  STORED       asaas        console=HIDES  STORED
mcp_oauth          console=shows  STORED       google_oauth console=HIDES  STORED
langfuse           console=shows  STORED       mcp_env      console=HIDES  STORED
```

The stored value is not inert. It is read off the resolved entry by the model path (`credentialBaseUrl ?? mc.baseURL` in `graph/prepare.ts`), by vision, STT and TTS, by an HTTP tool's relative-URL base and by the MCP connection URL — none of them asking the kind. The one surface that did ask is the embedding path, and `rag/documents.ts` says why: without the kind test, "an operator who picks the Chatwoot credential here does not get a 401 from OpenAI any more — they get every chunk of their knowledge base POSTed at the Chatwoot host."

**The catalog gains the declaration** — as ONE field, `baseUrl?: "required" | "optional"` replacing `requiresBaseUrl`, because "required but not supported" is a state a supports/requires pair lets someone write and no kind can be in. Then:

- **the write refuses** a non-empty base URL on a kind that declares none, naming the kinds that do. Empty stays empty; a kind this build does not know refuses nothing (the `paramName` carve-out from #488);
- **the resolve refuses to dial one**, through a single `dialableBaseUrl` the four resolvers, config-health, tool assembly, the editor's test run and the MCP OAuth callback share. Refusing only at the write would have left every install the rule was written for still redirecting;
- **the console decides with the dialable value too** — the tool editor accepts a relative `url_template` only when a credential supplies a base, and the MCP editor locks its URL field on one.

The **row keeps its value**: `listVaultInfos` still reports it, so an operator can see what is sitting in a field their own form never rendered. Two ledgers fence the gate — one over every server file selecting a vault `baseUrl`, one over every client reader — and each gated file must CALL the gate, not merely import it.

`assertPendingVaultEntryCreatable` had its own copy of the base-URL normalization; it now calls the same helper. That copy is where #490 found the required-check sitting before the normalization instead of after.

## 2. A generic credential no template interpolates

An HTTP tool can reference a `generic` credential while nothing in its request writes `{{secret}}`. `generic` is the one kind with no auto-injection — that is its whole contract — so the request goes out **unauthenticated** and the upstream's 401/403 reads as a bad credential rather than one that was never sent.

Not a refusal: a tool may legitimately hold a reference it has not wired yet. `tool_create` and `tool_update` say so through the `warnings` channel they already return.

**The question is not "does a template mention `{{secret}}`" — it is "does the credential reach the request".** This file is a copy of `buildHttpTool`'s assembly, and that is the one thing to know about it: a warning cannot run the request it is warning about (the executor resolves DNS and SSRF-guards the URL before a stubbed fetch would see it), so what the credential does is read off the row. Twenty-five review rounds found where the copy was thinner than the original; every one was confirmed by executing the real tool first.

What it now knows, in one list:

| | |
| --- | --- |
| **what is emitted** | a body only on POST/PUT/PATCH; a fixed field only when something emitted names it, or the legacy `fields` body assembles it; a kv row only until a later row of the same trimmed key overwrites it — unless that row is a lone OPTIONAL ai placeholder, which the model may omit; a URL minus its fragment, which is not transmitted |
| **what the runtime resolves** | `n in input` walks the prototype, so `{{toString}}` is Object's member and not the operator's field; the ack's `__wait_message` replaces any declared field of that name; `String(v)` on non-string headers and query values; single braces normalized at build time |
| **whether injection lands** | shadowed by the operator's own header (any casing) or query parameter, by the `Content-Type` a body method always carries, or swallowed entirely when the target is `__proto__` |
| **whether there is a request at all** | eight shapes that never fetch: a relative template with no base, an unparseable one, a placeholder in the origin, an orphan placeholder (or a fixed field whose own dependency is one), a host outside the allowlist, a non-https protocol, a blocked IP literal — the last two only where the deployment's own `allowPrivateTargets` says the guard will enforce them |

A shadowed injection gets its **own sentence**, and so does a swallowed one: an operator who picked an injecting type and attached it correctly should be sent to the header, not to the credential.

## Validation scope

**By test**, ~140 assertions across three files:

- `tests/modules/vault/base-url-applicability.test.ts` — the full 18-kind matrix on `createVaultEntry`, `createPendingVaultEntry`, `updateVaultEntry` and the MCP `credential_create` dry run *and* apply; the empty/whitespace carve-out; a legacy row kept, unread and clearable; and the four sweeps (writes, server readers, client readers, gate-is-called) with floors.
- `tests/modules/tool-credential-wiring.test.ts` — **one table read two ways**: 47 rows, each built once and projected into a tool definition the real `buildHttpTool` runs against a captured fetch, and into the shapes a write would store. The assertion is that the executor and the warning agree. Then the shapes that build no request (asserted by executing them), and the MCP write surface end to end — including both write races, opened deliberately with a Prisma extension.
- `tests/modules/secret-types-mirror.test.ts` — the client's `supportsBaseUrl`/`requiresBaseUrl` pair against the server's single declaration, and the two `dialableBaseUrl` **gates** against each other, kind by kind and past the catalog.

**Mutation battery: 111 mutants, 109 killed.** The two survivors are recorded at their sites: a multi-value enum as a query key, and a required `string` in a query value. In both, what the runtime does depends on what the model sent, so no executed row can assert either way.

**Live**, against a real Postgres, the real `loadAgentConfig`, the real OpenAI SDK and a real socket:

| | base | with this change |
| --- | --- | --- |
| `createVaultEntry(kind: "openai", baseUrl: …)` | `STORED as vault:1464` | `REFUSED: the "openai" credential type does not use a base URL. The types that do are: …` |
| a legacy row already in the table, same kind | `loadAgentConfig → http://127.0.0.1:63134/v1`, and the local host received `POST /v1/chat/completions` with `Authorization: Bearer sk-LIVEKEY123` | `loadAgentConfig → null`, the local host received **nothing** |
| control: `kind: "openai_compatible"` | dials it | dials it — `/v1/chat/completions` with the bearer, unchanged |

**Behaviour this changes, deliberately:**

- **An agent that depended on a stray base URL stops working, loudly.** Measured in the arm above: with the credential's base gone and no `modelConfig.baseURL` of its own, an `openai-compatible` agent now fails to build its model — `openai-compatible provider requires baseURL`, logged, agent cannot reply — where before it silently dialled the hidden host. The fix is to set the agent's own base URL or use an `openai_compatible` credential. A loud failure over a hidden redirect is the trade this makes.
- **Five test fixtures across four files seeded exactly that row** (`kind: "openai"` with a `baseUrl`) and failed on the way in. They are `openai_compatible` now, which is what they always meant.

**Not covered:**

- **The console still cannot clear a stray base URL**, because it renders no input for those kinds. The REST and MCP surfaces accept `baseUrl: null` and there is a test; the listing keeps showing the value so the operator can see there is one.
- **The wiring warning is MCP-only.** `warnings` is that channel; the REST tool create/update returns the row. A tool wired through the console with a dead `generic` credential is still silent.
- **`neverOutbound` credentials on an HTTP tool.** `mcp_env` and `langfuse` declare that their value must never travel outbound, and `createToolDefinition` calls `requireVaultRef`, not `requireVaultRefFor(..., "injectable")` — so one can be attached. Outside this change: the answer there is a refusal, and telling that operator to "write {{secret}}" would be advice to do the harmful thing.
- **Two runtime defects this mirrors rather than fixes**, both found by the review and both the same shape as #150: `valueLookup` uses `n in input`, so an ai field named `toString` gets `String(Object.prototype.toString)` in its place; and `buildHttpTool` builds its header map as a plain `{}`, so a header named `__proto__` is written and never exists. Each has its own issue coming.
- **The scan mirrors the executor's assembly**, and a change to `buildHttpTool` that no table row covers can still drift them apart. The fence is that every row is the executor's own verdict, not a list.

Fixes #504
