### PR TITLE
Reset the walk while rendering, not a commit later

### DIFF
--- a/src/client/pages/AuditPage.tsx
+++ b/src/client/pages/AuditPage.tsx
@@ -500,14 +500,25 @@ export function AuditPage() {
   // that does not match the URL on screen — and pagination would then walk from the wrong place.
   const reqRef = useRef(0);
 
-  // NOTE: THE SCOPE IS ON THIS LIST BECAUSE IT CHOOSES THE TRAIL, not because it is another filter.
-  // A keyset cursor is an id cut from the page before, and it only means "continue" against the rows
-  // it was cut from; handed to a different trail it still means `id < N` and silently drops
-  // everything newer, under a pager that goes on saying "Page 2".
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on filter change only
-  useEffect(() => {
+  // WHAT THE WALK BELONGS TO. A keyset cursor is an id cut from the page before, and it only means
+  // "continue" against the rows it was cut from; handed to a different trail it still means
+  // `id < N` and silently drops everything newer, under a pager that goes on saying "Page 2". THE
+  // SCOPE IS ON THIS LIST because it chooses the trail, not because it is another filter.
+  const filterKey = [action, actorType, from, to, scope].join("\u0000");
+
+  // RESET DURING RENDER, NOT IN AN EFFECT, and that is the whole of issue #532. As an effect this
+  // ran after the same commit as the load, so one render's worth of requests went out pairing the
+  // NEW filter with the PREVIOUS walk's cursor before the reset landed -- measured: changing the
+  // scope on page two sent `?scope=fleet&cursor=42` and only then `?scope=fleet`. `reqRef` discarded
+  // the answer, so the screen was always right, which is exactly why it went unnoticed; what it cost
+  // was a scoped transaction against a table that only grows, run under the fleet role on the wider
+  // scopes. Adjusting state during render is React's own answer for this, and it re-renders before
+  // committing, so `load` is never created holding the mismatched pair.
+  const [stackKey, setStackKey] = useState(filterKey);
+  if (stackKey !== filterKey) {
+    setStackKey(filterKey);
     setCursorStack([null]);
-  }, [action, actorType, from, to, scope]);
+  }
 
   const setFilter = (key: string, value: string) => {
     setSearchParams(

--- a/tests/client/audit-cursor-reset.test.tsx
+++ b/tests/client/audit-cursor-reset.test.tsx
@@ -1,0 +1,155 @@
+/// <reference lib="dom" />
+
+// THE WALK RESTARTS WHENEVER THE QUESTION CHANGES (issue #532).
+//
+// A keyset cursor is an id cut from the page before, and it only means "continue" against the rows
+// it was cut from. Every filter on this page changes which rows those are, so every one of them has
+// to restart the walk -- and the reset has to be visible on the render that recreates the load, not
+// one commit later.
+//
+// WHAT MAKES THESE TESTS DIFFERENT from the ones already in `audit-scope-control.test.tsx` is not
+// the filter they drive, it is that they assert EVERY request the change produced. The page has
+// always ended up on the right rows, because `reqRef` discards the answer to the stale pair; the
+// defect was only ever visible in the requests that were made and thrown away. A test that reads
+// the last URL is green against both the bug and the fix.
+
+import {
+  afterEach,
+  beforeEach,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
+import { TooltipProvider } from "@radix-ui/react-tooltip";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { ToastProvider } from "@/client/components";
+
+const mockUser = { role: "SUPER_ADMIN" as string };
+
+mock.module("@/client/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: mockUser }),
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+const { AuditPage } = await import("@/client/pages/AuditPage");
+
+const ROWS = [
+  {
+    id: "200",
+    tenantId: null,
+    actorId: "1",
+    actorType: "user",
+    action: "agent.update",
+    target: "t:1",
+    before: null,
+    after: { name: "Ana" },
+    createdAt: "2026-09-03T12:00:00.000Z",
+  },
+];
+
+const realFetch = globalThis.fetch;
+let sent: string[] = [];
+
+beforeEach(() => {
+  sent = [];
+  mockUser.role = "SUPER_ADMIN";
+  setSystemTime(new Date(2026, 8, 3, 12, 0));
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    sent.push(String(input));
+    // A live next cursor, so the pager works and page two can be reached at all.
+    return new Response(
+      JSON.stringify({ entries: ROWS, nextCursor: "42", latestAt: null }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  setSystemTime();
+});
+
+function mount() {
+  const view = render(
+    <ToastProvider>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/audit"]}>
+          <AuditPage />
+        </MemoryRouter>
+      </TooltipProvider>
+    </ToastProvider>,
+  );
+  return {
+    ...view,
+    selects: () => Array.from(view.container.querySelectorAll("select")),
+  };
+}
+
+const asked = () => sent.at(-1) ?? "";
+
+// Walks to page two, so there is a cursor to carry over in the first place. On page one the cursor
+// is null and any reset looks correct: the assertion would hold against the bug.
+async function toPageTwo(view: ReturnType<typeof mount>) {
+  await waitFor(() => expect(sent.length).toBeGreaterThan(0));
+  const next = view.getByRole("button", { name: /next/i });
+  act(() => {
+    fireEvent.click(next);
+  });
+  await waitFor(() => expect(asked()).toContain("cursor=42"));
+  return sent.length;
+}
+
+async function changing(
+  label: RegExp,
+  value: string,
+): Promise<{ after: string[]; text: string }> {
+  const view = mount();
+  const mark = await toPageTwo(view);
+  const select = (await waitFor(() =>
+    view.getByLabelText(label),
+  )) as HTMLSelectElement;
+  act(() => {
+    fireEvent.change(select, { target: { value } });
+  });
+  await waitFor(() => expect(sent.length).toBeGreaterThan(mark));
+  return { after: sent.slice(mark), text: view.container.textContent ?? "" };
+}
+
+for (const [name, label, value] of [
+  ["the door", /authenticated as/i, "mcp"],
+  ["the trail", /trail/i, "fleet"],
+  ["the period", /period/i, "yesterday"],
+] as const) {
+  test(`changing ${name} on page two makes no request carrying the old cursor`, async () => {
+    const { after, text } = await changing(label, value);
+    expect(after.length).toBeGreaterThan(0);
+    expect(after.filter((u) => u.includes("cursor="))).toEqual([]);
+    expect(text).toContain("Page 1");
+  });
+}
+
+// The action filter is not a <select>, it is set from a row's own action chip -- the same reset has
+// to happen there, and it is the path an operator actually takes.
+test("filtering by an action from the table restarts the walk too", async () => {
+  const view = mount();
+  const mark = await toPageTwo(view);
+  const chip = await waitFor(() =>
+    view.getByLabelText(/show only agent\.update/i),
+  );
+  act(() => {
+    fireEvent.click(chip);
+  });
+  await waitFor(() => expect(asked()).toContain("action=agent.update"));
+  expect(sent.slice(mark).filter((u) => u.includes("cursor="))).toEqual([]);
+  expect(view.container.textContent).toContain("Page 1");
+});

--- a/tests/client/audit-scope-control.test.tsx
+++ b/tests/client/audit-scope-control.test.tsx
@@ -202,12 +202,19 @@ test("switching scope restarts the walk instead of carrying the cursor over", as
   expect(view.container.textContent).toContain("Page 2");
 
   const scopeSelect = view.selects()[0] as HTMLSelectElement;
+  const mark = sent.length;
   act(() => {
     fireEvent.change(scopeSelect, { target: { value: "fleet" } });
   });
   await waitFor(() => expect(asked()).toContain("scope=fleet"));
   expect(asked()).not.toContain("cursor=");
   expect(view.container.textContent).toContain("Page 1");
+  // EVERY REQUEST THE CHANGE PRODUCED, and not just the one that won. Asserting the last request
+  // only is what let the old cursor be fired at the new trail unnoticed: the reset lived in an
+  // effect, so a render's worth of requests went out with the new filter and the previous walk's
+  // cursor still paired together. `reqRef` then discarded the answer, which is why the screen was
+  // right and the round trip was still made -- against a growing table, and under the fleet role.
+  expect(sent.slice(mark).filter((u) => u.includes("cursor="))).toEqual([]);
 });
 
 // THE EMPTY STATE HAS TO SAY WHAT WAS SEARCHED. On a tenant's trail a fleet-level action can only


### PR DESCRIPTION
Changing any filter on the audit page while past page one fired **two** requests: the first pairing the NEW filter with the PREVIOUS walk's cursor, the second the correct reset one. Measured on page two, switching the trail:

```
GET /api/v1/audit?scope=fleet&cursor=42   <- the stale pair
GET /api/v1/audit?scope=fleet
```

The reset lived in an effect keyed on the filters, while `load` is a `useCallback` that already had the new filter and the old cursor in its dependency list. Both ran after the same commit, so a render's worth of requests went out before the reset landed.

## Why it went unnoticed

The page was never wrong. `reqRef` makes only the newest load own the state, so the stale answer was discarded whichever order the two returned in. What it cost was a round trip per filter change — a scoped transaction against a table that only grows, and on `fleet`/`all` one that runs under the fleet role.

That is also why the test that catches it has to assert **every** request the change produced rather than the last one. `tests/client/audit-scope-control.test.tsx` asserted the last URL and was green against the bug; it now asserts the whole burst.

## The fix

Reset during render, which is React's own answer for adjusting state when something changes. The re-render happens before the commit, so `load` is never created holding the mismatched pair.

## Coverage

The defect was common to all five filters, so the coverage is too: the door, the trail, the period, and the action chip in the table, each asserted on the whole burst rather than on the winning request. Verified both ways — all five go red with the effect restored, and a seven-mutation battery (dropping the reset, dropping the key write, and dropping each of the four filter terms from the key) dies completely.

Fixes #532