### PR TITLE
Prove the renewal with both halves measured on the same run

### DIFF
--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -178,41 +178,90 @@ describe("runSandboxedCode", () => {
   // value the body finished building with the deadline nearly spent would otherwise have its render
   // interrupted and come back as "[object Object]".
   //
-  // The budget is MEASURED here, not written down. The first version spent 250 ms of a fixed 300 ms
-  // and then built 60k objects, which is an assertion about how fast the machine is: it passed on a
-  // developer laptop and failed on every CI runner for four consecutive commits (#518). What the
-  // renewal is for does not depend on the machine — so the build is timed on THIS machine first,
-  // and the deadline is then set just past it. The body finishes with a sliver left, far less than
-  // its own render needs (rendering the array costs several times building it), so without the
-  // renewal the render is interrupted and with it the value comes back whole.
+  // WHAT THE BODY SPENDS IS PINNED TO THE CLOCK, NOT TO THE WORK. Two earlier versions of this test
+  // asserted how fast this machine is, and both kept the shard red (#518). The first spent 250 ms of
+  // a fixed 300 ms budget and then built 60k objects: it passed on a laptop and failed on every CI
+  // runner, deterministically. The second measured the build and set the deadline just past it --
+  // better, because it no longer wrote the machine down, but it still asked the SECOND run to finish
+  // the same build within 1.5x of what the FIRST one took, and one scheduler preemption on a shared
+  // runner is wider than that margin (measured here: the build varies 1.2x over 25 runs, and the
+  // whole margin is ~12 ms).
+  //
+  // So the body no longer races its own budget. It builds the value with the budget wide open, then
+  // SPINS on `Date.now()` until a chosen instant, which puts the end of the body at a wall-clock
+  // point that does not move with how fast the build was. A stall during the build is absorbed by
+  // the spin instead of being fatal.
+  //
+  // The leftover the render then has to live on is `setup + render/2`, and both halves are measured
+  // rather than written down, because the safe window is `(setup, setup + render)` and BOTH of its
+  // ends scale with the machine:
+  //
+  //   - above `setup`, or the BODY is interrupted (setup is the span from the deadline starting in
+  //     `open()` to the snippet's first statement -- 16-23 ms here, and it is not zero);
+  //   - below `setup + render`, or the render fits anyway and the renewal guards nothing.
+  //
+  // Halfway between them satisfies both by ALGEBRA, on any machine: the leftover is
+  // `leftMs - setupMs = render/2`, which is positive and less than `render` whatever those numbers
+  // turn out to be. Nothing here is a margin that a slower machine can exhaust.
+  //
+  // What that buys, measured by shrinking the budget, which is exactly what losing time to a stall
+  // does: the previous shape survives a stall of 14 ms and fails at 15; this one survives 89 and
+  // fails at 90. The factor matters less than WHICH quantity it is a fraction of -- the old margin
+  // was half the BUILD, which the second run had to beat, and this one is half the RENDER, which
+  // grows on exactly the machines where the old one ran out.
   test("a value built with the last of the budget is still rendered whole", async () => {
-    const BUILD = "Array.from({ length: 20000 }, (_, i) => ({ i }))";
+    const N = 100_000;
+    const BUILD = `Array.from({ length: ${N} }, (_, i) => ({ i }))`;
+    const CHARS = 20_000_000;
+
+    // SETUP: the deadline starts in `open()`, and the interpreter's prelude runs inside it, so the
+    // snippet's own first reading of the clock is already this far past the start.
+    const before = Date.now();
+    const clock = await runSandboxedCode("Date.now()", { timeoutMs: 30_000 });
+    expect(clock.kind).toBe("value");
+    const setupMs = Number((clock as { value: string }).value) - before;
+
+    // RENDER: wall minus the span `ms` covers, which ends before the render begins.
     const t0 = performance.now();
     const baseline = await runSandboxedCode(BUILD, {
       timeoutMs: 30_000,
-      maxChars: 2_000_000,
+      maxChars: CHARS,
     });
     const wall = performance.now() - t0;
     expect(baseline.kind).toBe("value");
-    // `ms` is measured through the evaluation and BEFORE the render, so it is the span the deadline
-    // covers: opening the context, the prelude and the build. What is left of `wall` is the render
-    // (plus the reply hop), the part that runs on the renewed deadline.
-    const evalMs = (baseline as { ms: number }).ms;
-    const renderMs = wall - evalMs;
-    // Half the measured span again, so a second run slower than the baseline still FINISHES its
-    // build — the interruption this test is about is the render's, not the body's.
-    const slack = Math.ceil(evalMs * 0.5) + 5;
-    // The premise, asserted instead of assumed: rendering has to cost more than the slack, or this
-    // test would pass with the renewal gone and guard nothing. It held by ~3x when written.
-    expect(renderMs).toBeGreaterThan(slack);
-    const out = await runSandboxedCode(BUILD, {
-      timeoutMs: evalMs + slack,
-      maxChars: 2_000_000,
+    const buildMs = (baseline as { ms: number }).ms;
+    const renderMs = wall - buildMs;
+    // The premise, asserted rather than assumed: there has to BE a render to interrupt.
+    expect(renderMs).toBeGreaterThan(1);
+
+    const leftMs = setupMs + Math.floor(renderMs / 2);
+    // THE SIZING IS THE TEST, so it is asserted and not merely computed. Both bounds were shown to
+    // matter by mutation: with the leftover at 3x the render, and with the spin below removed, this
+    // test PASSES while the renewal is gone -- it would guard nothing and say so to nobody.
+    const leftoverMs = leftMs - setupMs;
+    expect(leftoverMs).toBeGreaterThan(0);
+    expect(leftoverMs).toBeLessThan(renderMs);
+    // The budget is the leftover plus room the build cannot plausibly need, scaled to the build this
+    // machine actually does rather than to a number from mine: the spin absorbs whatever is left.
+    const budgetMs = leftMs + Math.max(500, buildMs * 20);
+    const spun = `const t0 = Date.now(); const v = ${BUILD}; while (Date.now() - t0 < ${budgetMs - leftMs}) {} v`;
+
+    const out = await runSandboxedCode(spun, {
+      timeoutMs: budgetMs,
+      maxChars: CHARS,
     });
+    // Not `limit`: the body ends `render/2` before the deadline by construction, so a body that was
+    // interrupted means the arithmetic above is wrong, not that the machine was slow.
     expect(out.kind).toBe("value");
+    // ...and the body really did spend the budget, which is the other half the mutation found: with
+    // the spin gone the body returns after the build, the render inherits a budget it never needed
+    // renewed, and this test passes while guarding nothing. `ms` covers the setup and the body.
+    expect((out as { ms: number }).ms).toBeGreaterThanOrEqual(
+      budgetMs - leftMs,
+    );
     const v = (out as { value: string }).value;
     expect(v.startsWith('[{"i":0},{"i":1}')).toBe(true);
-    expect(v.endsWith('{"i":19999}]')).toBe(true);
+    expect(v.endsWith(`{"i":${N - 1}}]`)).toBe(true);
   });
 
   // A value can still run the body's code AFTER the body returned: a getter, a proxy trap. The

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -229,8 +229,25 @@ describe("runSandboxedCode", () => {
     // unrenewed render through; halving it would buy ceiling headroom that the precondition below
     // already guards, and spend margin that nothing guards.
     const N = 40_000;
-    const BUILD = `Array.from({ length: ${N} }, (_, i) => ({ i }))`;
     const CHARS = 20_000_000;
+    // NOTE: THE RENDER IS MEASURED FROM INSIDE, by the only clock that is not contaminated: its own.
+    // A getter runs when the renderer reaches it (the test below this one is the fence for that), so
+    // a getter on the first element and one on the last bracket the walk, and their `console.log`
+    // comes back in the reply. Nothing host-side is in the span -- not the worker spawn, not the
+    // dispatch, not the transfer, not the disposal -- which is what four earlier rounds each failed
+    // to subtract out of `wall - ms`. Measured: 43-45 ms here, stable over 4 runs.
+    const BUILD = `(() => {
+      const v = Array.from({ length: ${N} }, (_, i) => ({ i }));
+      v[0] = { get i() { console.log("A" + Date.now()); return 0 } };
+      v[${N - 1}] = { get i() { console.log("B" + Date.now()); return ${N - 1} } };
+      return v;
+    })()`;
+    const renderMsOf = (out: SandboxOutcome) => {
+      const logs = "logs" in out ? (out.logs as string[]) : [];
+      const a = logs.find((l) => l.startsWith("A"));
+      const b = logs.find((l) => l.startsWith("B"));
+      return a && b ? Number(b.slice(1)) - Number(a.slice(1)) : null;
+    };
 
     // NOTE: The ceiling is a production constant and the render is machine work, so a slow enough
     // machine cannot render this fixture at all -- and it would fail as `InternalError`, which is
@@ -332,6 +349,18 @@ describe("runSandboxedCode", () => {
     // machine the same way: rendering 40k objects is the same interpreter doing the same kind of
     // work as setting one up. Measured, the two ends stay a factor of 3.6 apart.
     expect(leftoverMs as number).toBeLessThanOrEqual(TOL_MS);
+    // NOTE: AND THIS IS THE PROOF, both halves off the same run. `leftMs` is the exact upper bound of
+    // what the render could have had on the ORIGINAL deadline -- exact because the prefix cancels:
+    //
+    //     real leftover = prefix + leftoverMs <= setup + leftoverMs = leftMs,  since prefix <= setup
+    //
+    // and `renderMs` is what the render actually took, on the interpreter's own clock. One being
+    // larger than the other says the render could not have finished on the deadline it inherited, so
+    // the whole value coming back is the renewal and nothing else. No proportionality argument, no
+    // timing carried between workers, no host clock. Measured: 11 against 44, a factor of 4.
+    const renderMs = renderMsOf(out);
+    expect(renderMs).not.toBeNull();
+    expect(renderMs as number).toBeGreaterThan(leftMs);
     const v = (out as { value: string }).value;
     expect(v.startsWith('[{"i":0},{"i":1}')).toBe(true);
     expect(v.endsWith(`{"i":${N - 1}}]`)).toBe(true);

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -211,101 +211,74 @@ describe("runSandboxedCode", () => {
   // grows on exactly the machines where the old one ran out.
   test("a value built with the last of the budget is still rendered whole", async () => {
     // N IS BOUNDED FROM ABOVE BY A DEADLINE THIS TEST DOES NOT CONTROL. The renewal installs a
-    // FIXED `RENDER_BUDGET_MS`, so a value too big to render inside it fails even on the baseline
-    // call, whatever `timeoutMs` says -- which would put the machine's speed back into the test by
-    // the other door. Measured here by walking N up: 200k still renders whole, 300k does not, so the
-    // ceiling is between them and 40k leaves about 6x. The first draft of this rewrite used 100k,
-    // which leaves 2-3x, and a runner that slow is exactly the one this test exists for.
+    // FIXED `RENDER_BUDGET_MS`, so a value too big to render inside it fails even on a call with a
+    // 30-second timeout, which would put the machine's speed back in by the other door. Measured by
+    // walking N up: 200k still renders whole here, 300k does not, so 40k leaves about 6x.
     const N = 40_000;
     const BUILD = `Array.from({ length: ${N} }, (_, i) => ({ i }))`;
     const CHARS = 20_000_000;
 
-    // SETUP: the deadline starts in `open()`, and the interpreter's prelude runs inside it, so the
-    // snippet's own first statement is already this far past the start.
+    // NOTHING HERE ESTIMATES THE RENDER, and that is the point. Four review rounds each found a
+    // different contaminant in the same host-side estimate of it -- worker startup, dispatch,
+    // result transfer, per-call jitter, disposal after the render -- because `wall - ms` is not the
+    // render and no correction term makes it into one. So the leftover is not sized against it: it
+    // is made SMALL ENOUGH that any render at all exceeds it, and the body is protected by what the
+    // run itself reports rather than by a figure guessed beforehand.
     //
-    // Read from the WORKER's own `ms`, which starts at the top of `run()` — a hair before `open()`
-    // — and not from this side of the call. Measuring it here would fold in spawning the worker and
-    // dispatching to it, which happen BEFORE the deadline exists: measured, 16-25 ms from here
-    // against 9 ms of deadline-covered setup, an inflation the same size as the leftover itself.
-    // Overstating it inflates `leftMs` by the same amount, which leaves the render enough real time
-    // to finish WITHOUT the renewal — and the assertions below cannot see it, because they subtract
-    // the same overstated number.
-    // EACH NUMBER IS SAMPLED, AND EACH END IS CHOSEN FOR THE DIRECTION IT PROTECTS. One reading of
-    // one call is one draw from a loaded machine, and the three quantities below do not jitter the
-    // same way: measured over 8 rounds here, the worker-side setup sits at 9-11 ms and the gross
-    // figure at 67-73, while the round-trip overhead swings 8.5-18.3 — a 2x spread on the very term
-    // that is subtracted from the other one. Mixing a slow probe with a fast baseline is what round
-    // 3 of this review is about, and it breaks in BOTH directions: over-subtract and `renderMs` goes
-    // non-positive, under-subtract and the leftover grows until the render fits without the renewal.
-    const SAMPLES = 3;
-    const setupSamples: number[] = [];
-    const overheadSamples: number[] = [];
-    const grossSamples: number[] = [];
-    let buildMs = 0;
-    for (let i = 0; i < SAMPLES; i++) {
-      const clockT0 = performance.now();
-      const clock = await runSandboxedCode("Date.now()", { timeoutMs: 30_000 });
-      const clockWall = performance.now() - clockT0;
-      expect(clock.kind).toBe("value");
-      const clockMs = (clock as { ms: number }).ms;
-      setupSamples.push(clockMs);
-      // What a round trip costs when the value is one number: spawning the worker and dispatching to
-      // it, which happen before `run()` starts its own clock and render nothing.
-      overheadSamples.push(clockWall - clockMs);
-
-      const t0 = performance.now();
-      const baseline = await runSandboxedCode(BUILD, {
-        timeoutMs: 30_000,
+    // The two ways this can end are distinguishable, which is what makes the correction below safe
+    // (measured, both shapes):
+    //
+    //   body interrupted   -> kind "limit", limit "time", and NO `ms`
+    //   render interrupted -> kind "error", name "InternalError", WITH `ms`
+    //
+    // So a `limit` means the leftover was too small and the arithmetic is corrected by the amount
+    // the run itself gives up; an `error` is the defect this test exists to catch and is never
+    // retried past. A retry loop that could not tell them apart would grow the leftover until the
+    // render fits and report green.
+    const attempt = async (leftMs: number) => {
+      const budgetMs = leftMs + 500;
+      const spun = `const t0 = Date.now(); const v = ${BUILD}; while (Date.now() - t0 < ${budgetMs - leftMs}) {} v`;
+      const out = await runSandboxedCode(spun, {
+        timeoutMs: budgetMs,
         maxChars: CHARS,
       });
-      expect(baseline.kind).toBe("value");
-      buildMs = (baseline as { ms: number }).ms;
-      grossSamples.push(performance.now() - t0 - buildMs);
+      // `ms` covers the setup plus the body, so what is left of the budget when the body returned is
+      // exactly this -- measured on the run that matters, not carried over from another one.
+      const leftoverMs =
+        "ms" in out ? budgetMs - (out as { ms: number }).ms : null;
+      return { out, leftoverMs };
+    };
+
+    // Three milliseconds, which is below any render of 40,000 objects on any machine. Where it is
+    // too small, the body is interrupted and says by how much.
+    let leftMs = 3;
+    let r = await attempt(leftMs);
+    for (let i = 0; i < 4 && r.out.kind === "limit"; i++) {
+      // The body needed more than it had. Give it exactly the shortfall the run reports, plus a
+      // millisecond, and no more: every millisecond added here is one the render gets for free.
+      leftMs += 1 + (r.leftoverMs === null ? 3 : Math.ceil(-r.leftoverMs));
+      r = await attempt(leftMs);
     }
+    const { out, leftoverMs } = r;
 
-    // The HIGHEST setup seen, because understating it is what leaves the body itself interrupted.
-    const setupMs = Math.max(...setupSamples);
-    // The LOWEST overhead and the LOWEST gross, because both are subtracted or divided into the
-    // leftover: the floor of each is the reading least contaminated by a stall, and erring low here
-    // makes the leftover smaller, which is the side that keeps this test honest rather than green.
-    const renderMs = Math.min(...grossSamples) - Math.min(...overheadSamples);
-    // The premise, asserted rather than assumed: there has to BE a render to interrupt.
-    expect(renderMs).toBeGreaterThan(1);
-
-    const leftMs = setupMs + Math.floor(renderMs / 4);
-    // THE SIZING IS THE TEST, so it is asserted and not merely computed. Both bounds were shown to
-    // matter by mutation: with the leftover at 3x the render, and with the spin below removed, this
-    // test PASSES while the renewal is gone -- it would guard nothing and say so to nobody.
-    const leftoverMs = leftMs - setupMs;
-    expect(leftoverMs).toBeGreaterThan(0);
-    expect(leftoverMs).toBeLessThan(renderMs);
-    // The budget is the leftover plus room the build cannot plausibly need, scaled to the build this
-    // machine actually does rather than to a number from mine: the spin absorbs whatever is left.
-    // ...and CAPPED, because this number is a busy spin the test itself has to sit through. A
-    // baseline preempted into a 240 ms build would make `buildMs * 20` a 4.8-second spin, and Bun's
-    // own per-test deadline is 5 s: the test would then fail by timing out on exactly the stalled
-    // runner it is meant to survive.
-    const budgetMs = leftMs + Math.min(2_000, Math.max(500, buildMs * 20));
-    const spun = `const t0 = Date.now(); const v = ${BUILD}; while (Date.now() - t0 < ${budgetMs - leftMs}) {} v`;
-
-    const out = await runSandboxedCode(spun, {
-      timeoutMs: budgetMs,
-      maxChars: CHARS,
-    });
-    // Not `limit`: the body ends `render/2` before the deadline by construction, so a body that was
-    // interrupted means the arithmetic above is wrong, not that the machine was slow.
+    // Not `limit`: after the corrections above, a body still being interrupted is not a slow machine
+    // but arithmetic that does not converge.
     expect(out.kind).toBe("value");
-    // ...and the body really did spend the budget, which is the other half the mutation found: with
-    // the spin gone the body returns after the build, the render inherits a budget it never needed
-    // renewed, and this test passes while guarding nothing. `ms` covers the setup and the body.
-    expect((out as { ms: number }).ms).toBeGreaterThanOrEqual(
-      budgetMs - leftMs,
-    );
+    // ...and the leftover the render actually had is a couple of milliseconds, which no render of
+    // this value fits into. Measured here: the loop settles at 1-3 ms from a starting 3.
+    //
+    // ONLY THE UPPER BOUND IS ASSERTED. `ms` is rounded to the millisecond and the deadline is a
+    // poll, so a body that finished perfectly well reports a leftover of 0 or -1 often enough to
+    // matter -- measured, 2 runs in 5 of a HEALTHY build failed a `> 0` assertion here, which is the
+    // same disease this PR is treating. What says the body was interrupted is `kind`, and the loop
+    // above already acts on it.
+    expect(leftoverMs).not.toBeNull();
+    expect(leftoverMs as number).toBeLessThan(15);
     const v = (out as { value: string }).value;
     expect(v.startsWith('[{"i":0},{"i":1}')).toBe(true);
     expect(v.endsWith(`{"i":${N - 1}}]`)).toBe(true);
-    // Comfortably above the cap plus the three calls that precede the spin, so the cap is what
-    // bounds this test and not a default nobody here chose.
+    // Comfortably above the five round trips this can take, so nothing here is bounded by a default
+    // nobody chose.
   }, 20_000);
 
   // A value can still run the body's code AFTER the body returned: a getter, a proxy trap. The

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -230,43 +230,48 @@ describe("runSandboxedCode", () => {
     // Overstating it inflates `leftMs` by the same amount, which leaves the render enough real time
     // to finish WITHOUT the renewal — and the assertions below cannot see it, because they subtract
     // the same overstated number.
-    const clockT0 = performance.now();
-    const clock = await runSandboxedCode("Date.now()", { timeoutMs: 30_000 });
-    const clockWall = performance.now() - clockT0;
-    expect(clock.kind).toBe("value");
-    const setupMs = (clock as { ms: number }).ms;
-    // ...and the same call answers a SECOND question: what a round trip costs when the value is
-    // tiny. `wall - ms` on any call folds in spawning the worker and dispatching to it, which happen
-    // before `run()` starts its own clock and are not rendering anything. Measured, that is 9-14 ms
-    // here and it is the term the round-2 finding is about: on a runner where startup drags, it
-    // inflates the render figure below without the render getting any slower.
-    const overheadMs = clockWall - setupMs;
-    expect(overheadMs).toBeGreaterThan(0);
+    // EACH NUMBER IS SAMPLED, AND EACH END IS CHOSEN FOR THE DIRECTION IT PROTECTS. One reading of
+    // one call is one draw from a loaded machine, and the three quantities below do not jitter the
+    // same way: measured over 8 rounds here, the worker-side setup sits at 9-11 ms and the gross
+    // figure at 67-73, while the round-trip overhead swings 8.5-18.3 — a 2x spread on the very term
+    // that is subtracted from the other one. Mixing a slow probe with a fast baseline is what round
+    // 3 of this review is about, and it breaks in BOTH directions: over-subtract and `renderMs` goes
+    // non-positive, under-subtract and the leftover grows until the render fits without the renewal.
+    const SAMPLES = 3;
+    const setupSamples: number[] = [];
+    const overheadSamples: number[] = [];
+    const grossSamples: number[] = [];
+    let buildMs = 0;
+    for (let i = 0; i < SAMPLES; i++) {
+      const clockT0 = performance.now();
+      const clock = await runSandboxedCode("Date.now()", { timeoutMs: 30_000 });
+      const clockWall = performance.now() - clockT0;
+      expect(clock.kind).toBe("value");
+      const clockMs = (clock as { ms: number }).ms;
+      setupSamples.push(clockMs);
+      // What a round trip costs when the value is one number: spawning the worker and dispatching to
+      // it, which happen before `run()` starts its own clock and render nothing.
+      overheadSamples.push(clockWall - clockMs);
 
-    // RENDER: wall minus the span `ms` covers, which ends before the render begins.
-    const t0 = performance.now();
-    const baseline = await runSandboxedCode(BUILD, {
-      timeoutMs: 30_000,
-      maxChars: CHARS,
-    });
-    const wall = performance.now() - t0;
-    expect(baseline.kind).toBe("value");
-    const buildMs = (baseline as { ms: number }).ms;
-    // NET of the round-trip cost above, so what is left is the render plus carrying its result back
-    // — and no longer moves with how long the worker took to come up. Measured at this N: 66-74 ms
-    // gross, 9-14 ms of that being startup, 52-64 ms net, against an interpreter render the sweep
-    // below puts at 30-40 ms.
-    const renderMs = wall - buildMs - overheadMs;
+      const t0 = performance.now();
+      const baseline = await runSandboxedCode(BUILD, {
+        timeoutMs: 30_000,
+        maxChars: CHARS,
+      });
+      expect(baseline.kind).toBe("value");
+      buildMs = (baseline as { ms: number }).ms;
+      grossSamples.push(performance.now() - t0 - buildMs);
+    }
+
+    // The HIGHEST setup seen, because understating it is what leaves the body itself interrupted.
+    const setupMs = Math.max(...setupSamples);
+    // The LOWEST overhead and the LOWEST gross, because both are subtracted or divided into the
+    // leftover: the floor of each is the reading least contaminated by a stall, and erring low here
+    // makes the leftover smaller, which is the side that keeps this test honest rather than green.
+    const renderMs = Math.min(...grossSamples) - Math.min(...overheadSamples);
     // The premise, asserted rather than assumed: there has to BE a render to interrupt.
     expect(renderMs).toBeGreaterThan(1);
 
-    // A QUARTER of that, because even net of the round trip it is the render PLUS carrying the
-    // result back. Swept with the renewal removed, which is the only way to see the interpreter's
-    // half alone: at 20k the render is interrupted with 20 ms left and fits with 25, and at 40k it
-    // is interrupted with 30 and fits with 40. Against the 52-64 ms net that is a ratio near 0.6, so
-    // sizing the leftover at HALF would land on the threshold — measured, the mutation this test
-    // exists to catch survived 2 runs in 5 that way. A quarter is 13-16 ms against a threshold of
-    // 30, and the two ends of that margin are the sweep and the measurement, not a guess.
     const leftMs = setupMs + Math.floor(renderMs / 4);
     // THE SIZING IS THE TEST, so it is asserted and not merely computed. Both bounds were shown to
     // matter by mutation: with the leftover at 3x the render, and with the spin below removed, this

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -210,16 +210,29 @@ describe("runSandboxedCode", () => {
   // was half the BUILD, which the second run had to beat, and this one is half the RENDER, which
   // grows on exactly the machines where the old one ran out.
   test("a value built with the last of the budget is still rendered whole", async () => {
-    const N = 100_000;
+    // N IS BOUNDED FROM ABOVE BY A DEADLINE THIS TEST DOES NOT CONTROL. The renewal installs a
+    // FIXED `RENDER_BUDGET_MS`, so a value too big to render inside it fails even on the baseline
+    // call, whatever `timeoutMs` says -- which would put the machine's speed back into the test by
+    // the other door. Measured here by walking N up: 200k still renders whole, 300k does not, so the
+    // ceiling is between them and 40k leaves about 6x. The first draft of this rewrite used 100k,
+    // which leaves 2-3x, and a runner that slow is exactly the one this test exists for.
+    const N = 40_000;
     const BUILD = `Array.from({ length: ${N} }, (_, i) => ({ i }))`;
     const CHARS = 20_000_000;
 
     // SETUP: the deadline starts in `open()`, and the interpreter's prelude runs inside it, so the
-    // snippet's own first reading of the clock is already this far past the start.
-    const before = Date.now();
+    // snippet's own first statement is already this far past the start.
+    //
+    // Read from the WORKER's own `ms`, which starts at the top of `run()` — a hair before `open()`
+    // — and not from this side of the call. Measuring it here would fold in spawning the worker and
+    // dispatching to it, which happen BEFORE the deadline exists: measured, 16-25 ms from here
+    // against 9 ms of deadline-covered setup, an inflation the same size as the leftover itself.
+    // Overstating it inflates `leftMs` by the same amount, which leaves the render enough real time
+    // to finish WITHOUT the renewal — and the assertions below cannot see it, because they subtract
+    // the same overstated number.
     const clock = await runSandboxedCode("Date.now()", { timeoutMs: 30_000 });
     expect(clock.kind).toBe("value");
-    const setupMs = Number((clock as { value: string }).value) - before;
+    const setupMs = (clock as { ms: number }).ms;
 
     // RENDER: wall minus the span `ms` covers, which ends before the render begins.
     const t0 = performance.now();
@@ -234,7 +247,14 @@ describe("runSandboxedCode", () => {
     // The premise, asserted rather than assumed: there has to BE a render to interrupt.
     expect(renderMs).toBeGreaterThan(1);
 
-    const leftMs = setupMs + Math.floor(renderMs / 2);
+    // A QUARTER of the wall figure, not half of it, because `renderMs` is not the render: it is the
+    // render PLUS carrying the result back across the thread boundary. Swept with the renewal
+    // removed, which is the only way to see the interpreter's half alone: at 20k the render is
+    // interrupted with 20 ms left and fits with 25, and at 40k it is interrupted with 30 and fits
+    // with 40 — about half of what the wall reports either way. Sizing the leftover at half the wall
+    // therefore lands ON that threshold: measured, the mutation this test exists to catch survived
+    // 2 runs in 5. A quarter is half the interpreter's own render, with the sweep either side of it.
+    const leftMs = setupMs + Math.floor(renderMs / 4);
     // THE SIZING IS THE TEST, so it is asserted and not merely computed. Both bounds were shown to
     // matter by mutation: with the leftover at 3x the render, and with the spin below removed, this
     // test PASSES while the renewal is gone -- it would guard nothing and say so to nobody.
@@ -243,7 +263,11 @@ describe("runSandboxedCode", () => {
     expect(leftoverMs).toBeLessThan(renderMs);
     // The budget is the leftover plus room the build cannot plausibly need, scaled to the build this
     // machine actually does rather than to a number from mine: the spin absorbs whatever is left.
-    const budgetMs = leftMs + Math.max(500, buildMs * 20);
+    // ...and CAPPED, because this number is a busy spin the test itself has to sit through. A
+    // baseline preempted into a 240 ms build would make `buildMs * 20` a 4.8-second spin, and Bun's
+    // own per-test deadline is 5 s: the test would then fail by timing out on exactly the stalled
+    // runner it is meant to survive.
+    const budgetMs = leftMs + Math.min(2_000, Math.max(500, buildMs * 20));
     const spun = `const t0 = Date.now(); const v = ${BUILD}; while (Date.now() - t0 < ${budgetMs - leftMs}) {} v`;
 
     const out = await runSandboxedCode(spun, {
@@ -262,7 +286,9 @@ describe("runSandboxedCode", () => {
     const v = (out as { value: string }).value;
     expect(v.startsWith('[{"i":0},{"i":1}')).toBe(true);
     expect(v.endsWith(`{"i":${N - 1}}]`)).toBe(true);
-  });
+    // Comfortably above the cap plus the three calls that precede the spin, so the cap is what
+    // bounds this test and not a default nobody here chose.
+  }, 20_000);
 
   // A value can still run the body's code AFTER the body returned: a getter, a proxy trap. The
   // renderer used to swallow that and answer "[object Object]" as a successful value, so the agent

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -212,13 +212,38 @@ describe("runSandboxedCode", () => {
   // before the deadline does, which the assertion at the end handles by bounding the leftover from
   // the other side.
   test("a value built with the last of the budget is still rendered whole", async () => {
-    // N IS BOUNDED FROM ABOVE BY A DEADLINE THIS TEST DOES NOT CONTROL. The renewal installs a
-    // FIXED `RENDER_BUDGET_MS`, so a value too big to render inside it fails even on a call with a
-    // 30-second timeout, which would put the machine's speed back in by the other door. Measured by
-    // walking N up: 200k still renders whole here, 300k does not, so 40k leaves about 6x.
+    // N IS SQUEEZED FROM BOTH SIDES, AND NEITHER SIDE IS FREE. Above, the renewal installs a FIXED
+    // `RENDER_BUDGET_MS`, so a value too big to render inside it fails even on a call with a
+    // 30-second timeout -- the machine's speed back in by the other door. Below, the leftover this
+    // test grants the render is about one setup, which does NOT shrink with N, so a smaller fixture
+    // narrows the very gap the test lives in. Both ends measured here, on the nominal leftover the
+    // loop below controls:
+    //
+    //            renders inside the fixed ceiling   defect hides from a leftover of
+    //     20k    yes                                30 ms   (test lands at 11-14)
+    //     40k    yes                                50 ms
+    //    200k    yes                                --
+    //    240k    NO                                 --
+    //
+    // So 40k sits about 5x under the ceiling and about 3.6x under the leftover that would let an
+    // unrenewed render through; halving it would buy ceiling headroom that the precondition below
+    // already guards, and spend margin that nothing guards.
     const N = 40_000;
     const BUILD = `Array.from({ length: ${N} }, (_, i) => ({ i }))`;
     const CHARS = 20_000_000;
+
+    // NOTE: The ceiling is a production constant and the render is machine work, so a slow enough
+    // machine cannot render this fixture at all -- and it would fail as `InternalError`, which is
+    // exactly what the defect looks like. Ask first, with the budget wide open so only the ceiling
+    // can bite, and let a machine that cannot host the fixture say so in those words.
+    const roomy = await runSandboxedCode(BUILD, {
+      timeoutMs: 30_000,
+      maxChars: CHARS,
+    });
+    expect(
+      roomy.kind,
+      `${N} objects must render inside the fixed RENDER_BUDGET_MS on this machine`,
+    ).toBe("value");
 
     const attempt = async (leftMs: number) => {
       const budgetMs = leftMs + 500;
@@ -260,12 +285,13 @@ describe("runSandboxedCode", () => {
     const firstSetupMs = await calibrate();
     const setupMs = Math.min(firstSetupMs, await calibrate());
 
-    // Now the setup plus a sliver. The sliver is allowed to be a constant BECAUSE it no longer
-    // covers the setup, which is measured above: it covers only how much that setup moves between
-    // two runs on the same machine, which is small and does not grow with how slow the machine is
-    // (measured here: 10-12 ms over 8 runs, a spread of 2). Three retries walk it from 2 ms to 5,
-    // and a run still coming back `limit` after that is arithmetic that does not converge rather
-    // than a runner having a bad day.
+    // Now the setup plus a sliver, and then a CONTROLLER rather than a ladder, because the two ways
+    // of being wrong carry different amounts of information. Overshooting is measured exactly -- the
+    // run reports its own leftover -- so it is corrected by exactly that much. Undershooting is only
+    // a direction, because an interrupted run reports nothing at all, so it takes a step. Every
+    // worker is spawned fresh and sets itself up at its own pace, so the calibration above cannot
+    // promise anything about this one; what makes that harmless is that the assertion reads the
+    // asserted run's own clock, which lets the steps be generous without ever buying a green.
     //
     // The two ways this can end are distinguishable, which is what makes retrying on one of them
     // safe (measured, both shapes):
@@ -276,39 +302,43 @@ describe("runSandboxedCode", () => {
     // So `limit` means the sliver lost to jitter and is retried; `error` is the defect this test
     // exists to catch and is never retried past. A retry loop blind to the difference would grow the
     // leftover until the render fits and report green.
+    const TOL_MS = 5;
     let leftMs = setupMs + 2;
     let r = await attempt(leftMs);
-    for (let i = 1; i <= 3 && r.out.kind === "limit"; i++) {
-      leftMs = setupMs + 2 + i;
+    for (let i = 0; i < 8; i++) {
+      if (r.out.kind === "limit") {
+        leftMs += 4;
+      } else if (r.out.kind === "value" && (r.leftoverMs as number) > TOL_MS) {
+        leftMs = Math.max(1, leftMs - ((r.leftoverMs as number) - TOL_MS));
+      } else {
+        break;
+      }
       r = await attempt(leftMs);
     }
-    const { out } = r;
+    const { out, leftoverMs } = r;
 
     expect(out.kind).toBe("value");
-    // NOTE: WHAT THE RENDER ACTUALLY HAD IS BOUNDED ABOVE BY `leftMs`, and that is the quantity
-    // asserted -- not the leftover the reply implies. The deadline starts a little way INTO `open()`,
-    // after the runtime is built, while `ms` is clocked from the top of `run()`, so `budgetMs - ms`
-    // UNDERSTATES the real leftover by that prefix (measured: 0.4 ms of an 8-9 ms setup here).
-    // Asserting an understatement leaves the prefix unwatched, and a render that fits because the
-    // prefix was generous is indistinguishable from one that fits because the deadline was renewed.
-    // The prefix cancels instead, because it is a prefix of exactly what `ms` measures:
+    // NOTE: EVERY TERM OF THIS BOUND COMES OFF THE RUN BEING ASSERTED. `leftoverMs` is
+    // `leftMs - (ms - 500)`, and `ms - 500` is that worker's OWN setup, so the calibration above is
+    // only a starting point for the search: a worker slower or faster than the ones that calibrated
+    // cannot move this number, because it never enters it. What it bounds is:
     //
-    //     real leftover = prefix + leftMs - setup <= leftMs,  since prefix <= setup
+    //     real leftover = prefix + leftoverMs <= setup(this run) + TOL,  since prefix <= setup
     //
-    // on any machine, with nothing about the prefix left to measure.
-    //
-    // AND THE BOUND IS WRITTEN AGAINST THE MEASURED SETUP, not in milliseconds, because what it has
-    // to stay under scales with the machine too: rendering 40k objects is the same interpreter doing
-    // the same kind of work as setting one up. Swept with the defect present, a leftover of 30 ms
-    // still interrupts the render at this N and 40 ms lets it through -- roughly four times the
-    // setup here, and a slower machine grows both ends together.
-    expect(leftMs).toBeLessThanOrEqual(setupMs + 5);
+    // The prefix is the sliver between `ms` starting at the top of `run()` and the deadline starting
+    // partway into `open()`, once the runtime is built -- measured at 0.4 ms of an 8-9 ms setup, and
+    // bounded rather than measured because it is a prefix of exactly what `ms` covers. So the real
+    // leftover is about one setup of this very worker, and what it has to stay under scales with the
+    // machine the same way: rendering 40k objects is the same interpreter doing the same kind of
+    // work as setting one up. Measured, the two ends stay a factor of 3.6 apart.
+    expect(leftoverMs as number).toBeLessThanOrEqual(TOL_MS);
     const v = (out as { value: string }).value;
     expect(v.startsWith('[{"i":0},{"i":1}')).toBe(true);
     expect(v.endsWith(`{"i":${N - 1}}]`)).toBe(true);
-    // NOTE: The 20 s below is comfortably above the six round trips this can take, so nothing here is
-    // bounded by a default nobody chose. Measured end to end, it settles at `setupMs + 2` with no
-    // retry in 5 tries.
+    // NOTE: The 20 s below is comfortably above the twelve round trips this can take (one
+    // precondition, two calibrations, up to nine controlled attempts, ~0.6 s each), so nothing here
+    // is bounded by a default nobody chose. Measured end to end, the controller settles on its first
+    // attempt and the whole test takes about 2 s.
   }, 20_000);
 
   // A value can still run the body's code AFTER the body returned: a getter, a proxy trap. The

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -189,26 +189,26 @@ describe("runSandboxedCode", () => {
   //
   // So the body no longer races its own budget. It builds the value with the budget wide open, then
   // SPINS on `Date.now()` until a chosen instant, which puts the end of the body at a wall-clock
-  // point that does not move with how fast the build was. A stall during the build is absorbed by
-  // the spin instead of being fatal.
+  // point that does not move with how fast the build was. A stall during the build is absorbed
+  // whole, because the spin targets an absolute instant and not a duration.
   //
-  // The leftover the render then has to live on is `setup + render/2`, and both halves are measured
-  // rather than written down, because the safe window is `(setup, setup + render)` and BOTH of its
-  // ends scale with the machine:
+  // WHAT IS LEFT WHEN THE BODY RETURNS IS MEASURED, ON THIS MACHINE, FROM THE REPLY. One quantity
+  // decides the whole test: the span between the deadline starting in `open()` and the snippet's
+  // first statement -- call it the setup. Ask for a leftover below it and the BODY is interrupted;
+  // ask for one above `setup + render` and the render fits anyway and the renewal guards nothing.
+  // Four review rounds each found a different contaminant in a host-side ESTIMATE of that span
+  // (worker startup, dispatch, result transfer, per-call jitter, disposal after the render), because
+  // `wall - ms` is not the setup and no correction term turns it into one.
   //
-  //   - above `setup`, or the BODY is interrupted (setup is the span from the deadline starting in
-  //     `open()` to the snippet's first statement -- 16-23 ms here, and it is not zero);
-  //   - below `setup + render`, or the render fits anyway and the renewal guards nothing.
+  // It does not have to be estimated. On a run that came back at all, `ms` covers the setup plus the
+  // body, and the body ends at an instant this test chose, so the setup falls straight out of the
+  // reply:
   //
-  // Halfway between them satisfies both by ALGEBRA, on any machine: the leftover is
-  // `leftMs - setupMs = render/2`, which is positive and less than `render` whatever those numbers
-  // turn out to be. Nothing here is a margin that a slower machine can exhaust.
+  //     setupMs = leftMs - (budgetMs - ms)
   //
-  // What that buys, measured by shrinking the budget, which is exactly what losing time to a stall
-  // does: the previous shape survives a stall of 14 ms and fails at 15; this one survives 89 and
-  // fails at 90. The factor matters less than WHICH quantity it is a fraction of -- the old margin
-  // was half the BUILD, which the second run had to beat, and this one is half the RENDER, which
-  // grows on exactly the machines where the old one ran out.
+  // A calibration run with a leftover nothing could exhaust reads it off; the run that is asserted
+  // on then asks for that plus a sliver. A machine three times slower measures three times more and
+  // asks for three times more, and no constant written here has to cover it.
   test("a value built with the last of the budget is still rendered whole", async () => {
     // N IS BOUNDED FROM ABOVE BY A DEADLINE THIS TEST DOES NOT CONTROL. The renewal installs a
     // FIXED `RENDER_BUDGET_MS`, so a value too big to render inside it fails even on a call with a
@@ -218,23 +218,6 @@ describe("runSandboxedCode", () => {
     const BUILD = `Array.from({ length: ${N} }, (_, i) => ({ i }))`;
     const CHARS = 20_000_000;
 
-    // NOTHING HERE ESTIMATES THE RENDER, and that is the point. Four review rounds each found a
-    // different contaminant in the same host-side estimate of it -- worker startup, dispatch,
-    // result transfer, per-call jitter, disposal after the render -- because `wall - ms` is not the
-    // render and no correction term makes it into one. So the leftover is not sized against it: it
-    // is made SMALL ENOUGH that any render at all exceeds it, and the body is protected by what the
-    // run itself reports rather than by a figure guessed beforehand.
-    //
-    // The two ways this can end are distinguishable, which is what makes the correction below safe
-    // (measured, both shapes):
-    //
-    //   body interrupted   -> kind "limit", limit "time", and NO `ms`
-    //   render interrupted -> kind "error", name "InternalError", WITH `ms`
-    //
-    // So a `limit` means the leftover was too small and the arithmetic is corrected by the amount
-    // the run itself gives up; an `error` is the defect this test exists to catch and is never
-    // retried past. A retry loop that could not tell them apart would grow the leftover until the
-    // render fits and report green.
     const attempt = async (leftMs: number) => {
       const budgetMs = leftMs + 500;
       const spun = `const t0 = Date.now(); const v = ${BUILD}; while (Date.now() - t0 < ${budgetMs - leftMs}) {} v`;
@@ -242,30 +225,66 @@ describe("runSandboxedCode", () => {
         timeoutMs: budgetMs,
         maxChars: CHARS,
       });
-      // `ms` covers the setup plus the body, so what is left of the budget when the body returned is
-      // exactly this -- measured on the run that matters, not carried over from another one.
+      // What the run itself says was left of the budget when the body returned -- measured on the run
+      // that matters, never carried over from another one. A `limit` reply carries no `ms` at all
+      // (the host drops it), so nothing here can read a number off an interrupted run by accident.
       const leftoverMs =
         "ms" in out ? budgetMs - (out as { ms: number }).ms : null;
       return { out, leftoverMs };
     };
 
-    // Three milliseconds, which is below any render of 40,000 objects on any machine. Where it is
-    // too small, the body is interrupted and says by how much.
-    let leftMs = 3;
-    let r = await attempt(leftMs);
-    for (let i = 0; i < 4 && r.out.kind === "limit"; i++) {
-      // The body needed more than it had. Give it exactly the shortfall the run reports, plus a
-      // millisecond, and no more: every millisecond added here is one the render gets for free.
-      leftMs += 1 + (r.leftoverMs === null ? 3 : Math.ceil(-r.leftoverMs));
-      r = await attempt(leftMs);
+    // 64 ms is six times the setup measured here (10-12 ms), and its job is only to be survivable,
+    // not to be right: whatever the leftover turns out to be, the subtraction gives the setup. A
+    // machine slow enough to spend more than that measures itself at 128, then 256; the ceiling is a
+    // runaway guard, not a budget, and hitting it fails on the null rather than inventing a number.
+    let calMs = 64;
+    const calibrate = async () => {
+      let probe = await attempt(calMs);
+      while (probe.out.kind === "limit" && calMs < 1024) {
+        calMs *= 2;
+        probe = await attempt(calMs);
+      }
+      expect(probe.leftoverMs).not.toBeNull();
+      return calMs - (probe.leftoverMs as number);
+    };
+    // TWICE, KEEPING THE SMALLER, because the two directions of error are not symmetric. A setup
+    // read too small makes the asserted run ask for less than it needs, which comes back `limit` and
+    // the loop below corrects. One read too large hands the render a leftover it should never have
+    // had, and a render that fits is exactly what this test cannot tell from a render that was
+    // renewed -- it would report green over the defect. So the estimate is biased to the recoverable
+    // side. The first call is also what warms the interpreter, which running this test alone would
+    // otherwise pay inside the only measurement it has.
+    const firstSetupMs = await calibrate();
+    const setupMs = Math.min(firstSetupMs, await calibrate());
+
+    // Now the setup plus a sliver. The sliver is allowed to be a constant BECAUSE it no longer
+    // covers the setup, which is measured above: it covers only how much that setup moves between
+    // two runs on the same machine, which is small and does not grow with how slow the machine is
+    // (measured here: 10-12 ms over 8 runs, a spread of 2). Three retries walk it from 2 ms to 5,
+    // and a run still coming back `limit` after that is arithmetic that does not converge rather
+    // than a runner having a bad day.
+    //
+    // The two ways this can end are distinguishable, which is what makes retrying on one of them
+    // safe (measured, both shapes):
+    //
+    //   body interrupted   -> kind "limit", limit "time", and NO `ms`
+    //   render interrupted -> kind "error", name "InternalError", WITH `ms`
+    //
+    // So `limit` means the sliver lost to jitter and is retried; `error` is the defect this test
+    // exists to catch and is never retried past. A retry loop blind to the difference would grow the
+    // leftover until the render fits and report green.
+    let r = await attempt(setupMs + 2);
+    for (let i = 1; i <= 3 && r.out.kind === "limit"; i++) {
+      r = await attempt(setupMs + 2 + i);
     }
     const { out, leftoverMs } = r;
 
-    // Not `limit`: after the corrections above, a body still being interrupted is not a slow machine
-    // but arithmetic that does not converge.
     expect(out.kind).toBe("value");
-    // ...and the leftover the render actually had is a couple of milliseconds, which no render of
-    // this value fits into. Measured here: the loop settles at 1-3 ms from a starting 3.
+    // ...and the leftover that render actually had is a couple of milliseconds, far under any
+    // render of this value: swept with the defect present, a leftover of 30 ms still interrupts the
+    // render at this N and 40 ms lets it through, so 15 keeps a factor of two under the boundary.
+    // Measured end to end, the whole shape above settles at a leftover of 1-2 ms and needed no retry
+    // in 5 tries.
     //
     // ONLY THE UPPER BOUND IS ASSERTED. `ms` is rounded to the millisecond and the deadline is a
     // poll, so a body that finished perfectly well reports a leftover of 0 or -1 often enough to
@@ -277,7 +296,7 @@ describe("runSandboxedCode", () => {
     const v = (out as { value: string }).value;
     expect(v.startsWith('[{"i":0},{"i":1}')).toBe(true);
     expect(v.endsWith(`{"i":${N - 1}}]`)).toBe(true);
-    // Comfortably above the five round trips this can take, so nothing here is bounded by a default
+    // Comfortably above the six round trips this can take, so nothing here is bounded by a default
     // nobody chose.
   }, 20_000);
 

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -230,9 +230,18 @@ describe("runSandboxedCode", () => {
     // Overstating it inflates `leftMs` by the same amount, which leaves the render enough real time
     // to finish WITHOUT the renewal — and the assertions below cannot see it, because they subtract
     // the same overstated number.
+    const clockT0 = performance.now();
     const clock = await runSandboxedCode("Date.now()", { timeoutMs: 30_000 });
+    const clockWall = performance.now() - clockT0;
     expect(clock.kind).toBe("value");
     const setupMs = (clock as { ms: number }).ms;
+    // ...and the same call answers a SECOND question: what a round trip costs when the value is
+    // tiny. `wall - ms` on any call folds in spawning the worker and dispatching to it, which happen
+    // before `run()` starts its own clock and are not rendering anything. Measured, that is 9-14 ms
+    // here and it is the term the round-2 finding is about: on a runner where startup drags, it
+    // inflates the render figure below without the render getting any slower.
+    const overheadMs = clockWall - setupMs;
+    expect(overheadMs).toBeGreaterThan(0);
 
     // RENDER: wall minus the span `ms` covers, which ends before the render begins.
     const t0 = performance.now();
@@ -243,17 +252,21 @@ describe("runSandboxedCode", () => {
     const wall = performance.now() - t0;
     expect(baseline.kind).toBe("value");
     const buildMs = (baseline as { ms: number }).ms;
-    const renderMs = wall - buildMs;
+    // NET of the round-trip cost above, so what is left is the render plus carrying its result back
+    // — and no longer moves with how long the worker took to come up. Measured at this N: 66-74 ms
+    // gross, 9-14 ms of that being startup, 52-64 ms net, against an interpreter render the sweep
+    // below puts at 30-40 ms.
+    const renderMs = wall - buildMs - overheadMs;
     // The premise, asserted rather than assumed: there has to BE a render to interrupt.
     expect(renderMs).toBeGreaterThan(1);
 
-    // A QUARTER of the wall figure, not half of it, because `renderMs` is not the render: it is the
-    // render PLUS carrying the result back across the thread boundary. Swept with the renewal
-    // removed, which is the only way to see the interpreter's half alone: at 20k the render is
-    // interrupted with 20 ms left and fits with 25, and at 40k it is interrupted with 30 and fits
-    // with 40 — about half of what the wall reports either way. Sizing the leftover at half the wall
-    // therefore lands ON that threshold: measured, the mutation this test exists to catch survived
-    // 2 runs in 5. A quarter is half the interpreter's own render, with the sweep either side of it.
+    // A QUARTER of that, because even net of the round trip it is the render PLUS carrying the
+    // result back. Swept with the renewal removed, which is the only way to see the interpreter's
+    // half alone: at 20k the render is interrupted with 20 ms left and fits with 25, and at 40k it
+    // is interrupted with 30 and fits with 40. Against the 52-64 ms net that is a ratio near 0.6, so
+    // sizing the leftover at HALF would land on the threshold — measured, the mutation this test
+    // exists to catch survived 2 runs in 5 that way. A quarter is 13-16 ms against a threshold of
+    // 30, and the two ends of that margin are the sweep and the measurement, not a guess.
     const leftMs = setupMs + Math.floor(renderMs / 4);
     // THE SIZING IS THE TEST, so it is asserted and not merely computed. Both bounds were shown to
     // matter by mutation: with the leftover at 3x the render, and with the spin below removed, this

--- a/tests/graph/code-sandbox.test.ts
+++ b/tests/graph/code-sandbox.test.ts
@@ -208,7 +208,9 @@ describe("runSandboxedCode", () => {
   //
   // A calibration run with a leftover nothing could exhaust reads it off; the run that is asserted
   // on then asks for that plus a sliver. A machine three times slower measures three times more and
-  // asks for three times more, and no constant written here has to cover it.
+  // asks for three times more, and no constant written here has to cover it. `ms` starts marginally
+  // before the deadline does, which the assertion at the end handles by bounding the leftover from
+  // the other side.
   test("a value built with the last of the budget is still rendered whole", async () => {
     // N IS BOUNDED FROM ABOVE BY A DEADLINE THIS TEST DOES NOT CONTROL. The renewal installs a
     // FIXED `RENDER_BUDGET_MS`, so a value too big to render inside it fails even on a call with a
@@ -253,7 +255,8 @@ describe("runSandboxedCode", () => {
     // had, and a render that fits is exactly what this test cannot tell from a render that was
     // renewed -- it would report green over the defect. So the estimate is biased to the recoverable
     // side. The first call is also what warms the interpreter, which running this test alone would
-    // otherwise pay inside the only measurement it has.
+    // otherwise pay inside the only measurement it has. Measured: a single read lands at 10-12 ms
+    // here, the smaller of two at 8-9.
     const firstSetupMs = await calibrate();
     const setupMs = Math.min(firstSetupMs, await calibrate());
 
@@ -273,31 +276,39 @@ describe("runSandboxedCode", () => {
     // So `limit` means the sliver lost to jitter and is retried; `error` is the defect this test
     // exists to catch and is never retried past. A retry loop blind to the difference would grow the
     // leftover until the render fits and report green.
-    let r = await attempt(setupMs + 2);
+    let leftMs = setupMs + 2;
+    let r = await attempt(leftMs);
     for (let i = 1; i <= 3 && r.out.kind === "limit"; i++) {
-      r = await attempt(setupMs + 2 + i);
+      leftMs = setupMs + 2 + i;
+      r = await attempt(leftMs);
     }
-    const { out, leftoverMs } = r;
+    const { out } = r;
 
     expect(out.kind).toBe("value");
-    // ...and the leftover that render actually had is a couple of milliseconds, far under any
-    // render of this value: swept with the defect present, a leftover of 30 ms still interrupts the
-    // render at this N and 40 ms lets it through, so 15 keeps a factor of two under the boundary.
-    // Measured end to end, the whole shape above settles at a leftover of 1-2 ms and needed no retry
-    // in 5 tries.
+    // NOTE: WHAT THE RENDER ACTUALLY HAD IS BOUNDED ABOVE BY `leftMs`, and that is the quantity
+    // asserted -- not the leftover the reply implies. The deadline starts a little way INTO `open()`,
+    // after the runtime is built, while `ms` is clocked from the top of `run()`, so `budgetMs - ms`
+    // UNDERSTATES the real leftover by that prefix (measured: 0.4 ms of an 8-9 ms setup here).
+    // Asserting an understatement leaves the prefix unwatched, and a render that fits because the
+    // prefix was generous is indistinguishable from one that fits because the deadline was renewed.
+    // The prefix cancels instead, because it is a prefix of exactly what `ms` measures:
     //
-    // ONLY THE UPPER BOUND IS ASSERTED. `ms` is rounded to the millisecond and the deadline is a
-    // poll, so a body that finished perfectly well reports a leftover of 0 or -1 often enough to
-    // matter -- measured, 2 runs in 5 of a HEALTHY build failed a `> 0` assertion here, which is the
-    // same disease this PR is treating. What says the body was interrupted is `kind`, and the loop
-    // above already acts on it.
-    expect(leftoverMs).not.toBeNull();
-    expect(leftoverMs as number).toBeLessThan(15);
+    //     real leftover = prefix + leftMs - setup <= leftMs,  since prefix <= setup
+    //
+    // on any machine, with nothing about the prefix left to measure.
+    //
+    // AND THE BOUND IS WRITTEN AGAINST THE MEASURED SETUP, not in milliseconds, because what it has
+    // to stay under scales with the machine too: rendering 40k objects is the same interpreter doing
+    // the same kind of work as setting one up. Swept with the defect present, a leftover of 30 ms
+    // still interrupts the render at this N and 40 ms lets it through -- roughly four times the
+    // setup here, and a slower machine grows both ends together.
+    expect(leftMs).toBeLessThanOrEqual(setupMs + 5);
     const v = (out as { value: string }).value;
     expect(v.startsWith('[{"i":0},{"i":1}')).toBe(true);
     expect(v.endsWith(`{"i":${N - 1}}]`)).toBe(true);
-    // Comfortably above the six round trips this can take, so nothing here is bounded by a default
-    // nobody chose.
+    // NOTE: The 20 s below is comfortably above the six round trips this can take, so nothing here is
+    // bounded by a default nobody chose. Measured end to end, it settles at `setupMs + 2` with no
+    // retry in 5 tries.
   }, 20_000);
 
   // A value can still run the body's code AFTER the body returned: a getter, a proxy trap. The


### PR DESCRIPTION
Prove the renewal with both halves measured on the same run

The test in #518 kept the shard red because it asserted how fast the machine is. Two rewrites tried to stop doing that and did not: the first spent 250 ms of a fixed 300 ms budget and then built 60k objects; the second measured the build and asked the second run to repeat it within 1.5x, which one scheduler preemption is wider than.

What the test needs is a run where the body finishes with almost nothing left of its budget, so that a value coming back whole can only be the renewal. Getting there means knowing two numbers, and every earlier attempt guessed at least one of them.

## The body no longer races its own budget

It builds the value with the budget wide open, then spins on `Date.now()` until an absolute instant. A stall during the build is absorbed completely instead of being fatal, because the end of the body is a wall-clock point rather than a duration added to whatever the build cost.

## The setup is measured, not searched for

The span between the deadline starting in `open()` and the snippet's first statement is what decides how small the leftover can be. On any run that came back, `ms` covers that span plus the body, and the body ends at an instant the test chose, so

    setupMs = leftMs - (budgetMs - ms)

reads it straight off the reply. A calibration run with a leftover nothing can exhaust reads it; the run being asserted asks for that plus a sliver. A machine three times slower measures three times more and asks for three times more.

The search that follows is a controller rather than a ladder, because the two ways of being wrong carry different amounts of information. Overshooting is measured exactly, since the run reports its own leftover, and is corrected by exactly that much. Undershooting is only a direction, since an interrupted run carries no `ms` at all, and takes a step. Measured: starting the search 60 ms too high, or 10 ms too low, both converge and both still catch the defect.

## The render is measured from inside

Four attempts to estimate it host-side each turned out to fold in something different: worker startup, dispatch, result transfer, per-call jitter, disposal after the render. `wall - ms` is not the render and no correction term makes it into one.

It does not have to be estimated either. A getter runs when the renderer reaches it, so a getter on the first element and one on the last bracket the walk, and their `console.log` comes back in the reply. The span holds no host work at all. Measured: 43-45 ms for 40k objects, stable over four runs.

## So the proof is one run, both halves

    leftMs   the exact ceiling on what the render had on the ORIGINAL deadline
    renderMs what the render actually took, on the interpreter's own clock

`leftMs` is exact because the prefix cancels: `ms` starts at the top of `run()` and the deadline starts partway into `open()`, so `budgetMs - ms` understates the real leftover by that prefix, and the prefix is a prefix of exactly what `ms` covers, so `real leftover = prefix + leftoverMs <= leftMs`. Measured here: 11 against 44.

Nothing in that is carried between workers, and nothing in it is a host clock.

## N, squeezed from both sides

|  | renders inside the fixed ceiling | defect hides from a nominal leftover of |
| --- | --- | --- |
| 20k | yes | 30 ms (the test lands at 11-14) |
| 40k | yes | 50 ms |
| 200k | yes | — |
| 240k | **no** | — |

The leftover granted to the render is about one setup, and the setup does not shrink with N, so a smaller fixture buys ceiling headroom and spends defect margin — 3.6x down to 2.1x. The ceiling is a production constant while the render is machine work, so a slow enough machine genuinely cannot host the fixture; a precondition with the budget wide open now asks that first, so such a machine says so in those words instead of failing as `InternalError`, which is exactly what the defect looks like.

## Battery

| | with the defect | healthy |
| --- | --- | --- |
| as written | 5/5 caught | 10/10 |
| `TOL_MS` 5 → 60, search starting 60 high | 3/3 caught | — |
| search starting below the setup | 3/3 caught | 3/3 |

Nine review rounds, eight of them landing a real defect in this test; each round's reasoning is in the comments.

The other test named in #518, the burst of fifty, was fixed in #517 and is green.

Fixes #518
