### PR TITLE
Take the agent's own lock before binding an inbox to it

### DIFF
--- a/src/modules/agents/service.ts
+++ b/src/modules/agents/service.ts
@@ -726,10 +726,18 @@ export async function updateAgent(
     if (hasBh) updateData.businessHoursId = bhId;
     if (hasFuh) updateData.followUpHoursId = fuhId;
     // NOTE: Arm the follow-up backlog fence on the OFF→ON transition of the effective state. The row
-    // lock (FOR UPDATE, held to commit — runScopedOn is one interactive transaction) serializes the
+    // lock (held to commit — runScopedOn is one interactive transaction) serializes the
     // read-compute-write against concurrent saves: without it, a save that read the old ON state
     // could land last after another save turned follow-up OFF, restoring ON with the STALE watermark
     // and re-exposing the pre-arm backlog to the sweep. RLS still applies to the raw read.
+    //
+    // NO KEY UPDATE rather than FOR UPDATE, and the difference is who else waits. Both conflict with
+    // each other and with the `FOR UPDATE` that `deleteAgent` takes, so the serialization this note
+    // is about is unchanged; what NO KEY UPDATE stops conflicting with is `FOR KEY SHARE`, which is
+    // the lock a foreign key takes to REFERENCE this row. A save that also blocked references would
+    // block `bindInbox`, which holds the Chatwoot account row while it asks (#546), so renaming an
+    // agent would stall binds, syncs and disconnects for an account it has nothing to do with. This
+    // statement changes no key, which is exactly the case the weaker mode exists for.
     const beforeRows = await db.$queryRaw<
       Array<{
         enabled: boolean;
@@ -738,7 +746,7 @@ export async function updateAgent(
         model_config: unknown;
         updated_at: Date;
       }>
-    >`SELECT enabled, mode, settings, model_config, updated_at FROM agents WHERE id = ${id} FOR UPDATE`;
+    >`SELECT enabled, mode, settings, model_config, updated_at FROM agents WHERE id = ${id} FOR NO KEY UPDATE`;
     const before = beforeRows[0];
     // NOTE: read AFTER the lock, and that order is the whole point. The raw lock above reads the
     // four columns the follow-up fence needs; the trail answers for every column an operator can
@@ -2001,8 +2009,12 @@ export async function replaceAgentToolSelections(
     // wait while another commits B, and then write A back while its audit row claims A→A. The
     // agent is also what `expectedUpdatedAt` is checked against, so the precondition and the
     // snapshot now answer for the same instant. RLS still applies to the raw read.
+    //
+    // NO KEY UPDATE for the reason `updateAgent` gives above: it serializes replacements and still
+    // conflicts with the delete, and it stops conflicting with the `FOR KEY SHARE` a reference to
+    // this agent takes, which is what keeps a grant save out of the way of `bindInbox` (#546).
     const locked = await db.$queryRaw<Array<{ updated_at: Date }>>`
-      SELECT updated_at FROM agents WHERE id = ${agentId} FOR UPDATE`;
+      SELECT updated_at FROM agents WHERE id = ${agentId} FOR NO KEY UPDATE`;
     const agent = locked[0] ? { updatedAt: locked[0].updated_at } : null;
     if (!agent) {
       throw new NotFoundError("agent not found", "errors.agentNotFound");

--- a/src/modules/chatwoot/management.ts
+++ b/src/modules/chatwoot/management.ts
@@ -1922,15 +1922,29 @@ export async function bindInbox(
   try {
     return await persistBinding();
   } catch (err) {
-    logger.error(
-      {
-        err,
-        tenantId: String(tenantId),
-        inboxId: String(inboxId),
-        agentId: agentId === null ? null : String(agentId),
-      },
-      "chatwoot: the bot was attached in Chatwoot and the binding was not saved — retry the bind",
-    );
+    // Two different states reach here and only one of them is a repair away. A FAILURE (the audit
+    // insert, a lock) left a binding that a retry writes; a REFUSAL decided inside the transaction
+    // (the account disconnected under us, the agent deleted under us) answered the operator, and a
+    // retry refuses the same way for the same reason. Both leave the bot attached upstream, which is
+    // why both are logged, and only one of them may say "retry".
+    const refused = err instanceof AppError;
+    const line = {
+      err,
+      tenantId: String(tenantId),
+      inboxId: String(inboxId),
+      agentId: agentId === null ? null : String(agentId),
+    };
+    if (refused) {
+      logger.warn(
+        line,
+        "chatwoot: the bot was attached in Chatwoot and the write refused the binding; a retry refuses the same way",
+      );
+    } else {
+      logger.error(
+        line,
+        "chatwoot: the bot was attached in Chatwoot and the binding was not saved — retry the bind",
+      );
+    }
     throw err;
   }
 
@@ -1956,6 +1970,41 @@ export async function bindInbox(
           409,
           "errors.chatwootAccountDisconnected",
         );
+      }
+      // NOTE: The AGENT next, and LOCKED, with the lock a foreign key would have taken. `Inbox.agentId`
+      // is a plain column with no `@relation`, so nothing has ever refused a binding to an agent that
+      // is gone, and the reading step 1 took predates the Chatwoot calls: `deleteAgent` takes the
+      // agent `FOR UPDATE`, nulls every inbox pointing at it (this one does not yet), deletes it, and
+      // this transaction would then commit a binding to a row that no longer exists. What is left is
+      // an inbox the console shows as bound, with a bot still attached upstream, that nothing answers.
+      //
+      // `FOR KEY SHARE` is what an FK's referencing write takes: among the row-lock modes it conflicts
+      // only with `FOR UPDATE`, so two binds on the same agent do not serialise against each other and
+      // a child insert (which takes KEY SHARE too) cannot be blocked by one. That it also leaves an
+      // ordinary SAVE of the agent alone is NOT free: `updateAgent` and `replaceAgentToolSelections`
+      // took `FOR UPDATE` until #546 and were weakened to `FOR NO KEY UPDATE` for exactly this, since
+      // a bind that waits here is waiting while HOLDING the Chatwoot account row, and would stall
+      // every other bind, sync and disconnect on that account behind an unrelated agent edit. Deleting
+      // is the one that still takes `FOR UPDATE`, which is the conflict this read wants.
+      //
+      // BEFORE the inbox row, which is the half that is not about existence: `deleteAgent` takes the
+      // agent and then the inboxes that point at it, so taking them in the other order here is a
+      // deadlock between two writes that are each individually correct. Measured rather than argued,
+      // on a re-bind of the agent an inbox already names (what re-submitting the editor does, and the
+      // one shape where the two transactions want each other's row): with this read moved below the
+      // inbox lock, Postgres answers `40P01 deadlock detected` and kills the bind; in the order
+      // written here, both transactions commit. Same argument and same order as `updateExperiment`,
+      // which answered this shape for `Experiment.agentId` in #501. An unbind names no agent and
+      // makes no reference, so it takes nothing here.
+      if (agentId !== null) {
+        const alive = await db.$queryRaw<Array<{ id: bigint }>>`
+      SELECT id
+        FROM agents
+       WHERE id = ${agentId}
+         FOR KEY SHARE`;
+        if (alive.length === 0) {
+          throw new NotFoundError("agent not found", "errors.agentNotFound");
+        }
       }
       // NOTE: Read INSIDE the transaction and with the row LOCKED, because it is what the audit
       // compares against. The reading taken at the top predates the Chatwoot calls, which are a window

--- a/tests/modules/audit-agent-family.test.ts
+++ b/tests/modules/audit-agent-family.test.ts
@@ -121,7 +121,12 @@ export function lockedBeforeSnapshot(
     .split("\n")
     .filter((l) => !l.trim().startsWith("//"))
     .join("\n");
-  const lock = code.indexOf("FOR UPDATE");
+  // The UPDATE family, both spellings, because what this fence is about is a lock that SERIALIZES
+  // the write, and `FOR NO KEY UPDATE` conflicts with itself exactly like `FOR UPDATE` does (#546
+  // weakened two of these writers to it so a bind's `FOR KEY SHARE` would stop waiting on them).
+  // The SHARE family deliberately does NOT count: two writers can hold it at once, so a snapshot
+  // read under one is the same race as a snapshot read under nothing.
+  const lock = code.search(/FOR (?:NO KEY )?UPDATE/);
   const snap = code.indexOf(snapshot);
   if (lock < 0 || snap < 0) return "not found";
   return lock < snap ? "locked" : "unlocked";
@@ -146,6 +151,19 @@ describe("the audit snapshot is read under the write's lock", () => {
     expect(lockedBeforeSnapshot(wrong, "SNAP")).toBe("unlocked");
     expect(lockedBeforeSnapshot(right, "SNAP")).toBe("locked");
     expect(lockedBeforeSnapshot("nothing here", "SNAP")).toBe("not found");
+    // NO KEY UPDATE serializes and counts; a share lock does not, and must read as no lock at all.
+    expect(
+      lockedBeforeSnapshot(
+        "await sql`… FOR NO KEY UPDATE`;\nconst before = read(SNAP);",
+        "SNAP",
+      ),
+    ).toBe("locked");
+    expect(
+      lockedBeforeSnapshot(
+        "await sql`… FOR KEY SHARE`;\nconst before = read(SNAP);",
+        "SNAP",
+      ),
+    ).toBe("not found");
     // And the prose that broke the first version of this fence.
     const commented = `// the FOR UPDATE below serializes it\n${wrong}`;
     expect(lockedBeforeSnapshot(commented, "SNAP")).toBe("unlocked");

--- a/tests/modules/audit-channel-family.test.ts
+++ b/tests/modules/audit-channel-family.test.ts
@@ -975,6 +975,13 @@ describe.skipIf(!dbUp)("the channel family records its own changes", () => {
   // Every lock in the module, in one place, because the mode is a property of the MODULE and not of
   // whichever path happened to need one first: a new `FOR UPDATE` added later deadlocks against the
   // mirror exactly the same way, and a deadlock has no green test that can catch it.
+  //
+  // TWO modes are admissible, not one, and the second is the reason this matches every row-lock
+  // spelling rather than only the UPDATE family. `FOR KEY SHARE` is exactly what a child insert's
+  // foreign key takes, so it cannot be the lock that blocks one; `bindInbox` takes it on the AGENT
+  // (#546) to stand in for the foreign key `Inbox.agentId` does not have. `FOR UPDATE` and
+  // `FOR SHARE` stay out: the first is the mirror deadlock above, and the second conflicts with the
+  // NO KEY UPDATE this module takes everywhere, which would serialise paths that have no reason to.
   test("no path in the module takes a lock strong enough to block a child insert", async () => {
     const src = await Bun.file(
       new URL("../../src/modules/chatwoot/management.ts", import.meta.url),
@@ -982,9 +989,12 @@ describe.skipIf(!dbUp)("the channel family records its own changes", () => {
     // Comments stripped first: this very file's NOTEs discuss `FOR UPDATE` by name, and a fence that
     // counts prose as code fails on its own explanation.
     const code = src.replace(/^\s*\/\/.*$/gm, "");
-    const locks = code.match(/FOR (?:NO KEY )?UPDATE/g) ?? [];
-    expect(locks.length).toBeGreaterThanOrEqual(11);
-    expect(new Set(locks)).toEqual(new Set(["FOR NO KEY UPDATE"]));
+    const locks =
+      code.match(/FOR (?:NO KEY )?UPDATE|FOR (?:KEY )?SHARE/g) ?? [];
+    expect(locks.length).toBeGreaterThanOrEqual(12);
+    expect(new Set(locks)).toEqual(
+      new Set(["FOR NO KEY UPDATE", "FOR KEY SHARE"]),
+    );
   });
 
   // The bot IS attached in Chatwoot by the time the binding is persisted, and this transaction can

--- a/tests/modules/chatwoot-bind-agent-race.test.ts
+++ b/tests/modules/chatwoot-bind-agent-race.test.ts
@@ -1,0 +1,388 @@
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import logger from "@/api/lib/logger";
+import { runScopedOn, type TenantContext } from "@/lib/tenancy";
+import { deleteAgent } from "@/modules/agents/service";
+import type { ChatwootClient } from "@/modules/chatwoot/client";
+import { bindInbox } from "@/modules/chatwoot/management";
+import { seedChatwootInstance } from "../utils/chatwoot";
+
+// #546. `Inbox.agentId` is a plain column with no `@relation`, so no foreign key ever refused a
+// binding to an agent that is gone, and `persistBinding` referenced the row without holding any lock
+// on it. `deleteAgent` is the writer that fits in the window: it takes the agent `FOR UPDATE`, nulls
+// every inbox pointing at it (this one is not yet), deletes it, and the bind then commits the
+// dangling reference. The window is not a millisecond either: step 2 of `bindInbox` is the round trip
+// to Chatwoot, made deliberately OUTSIDE the transaction.
+//
+// Sibling of #501, which answered the same shape on `Experiment.agentId`.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+let tenantId = 0n;
+const ctx = (): TenantContext => ({
+  tenantId,
+  userId: null,
+  role: "TENANT_ADMIN",
+});
+
+// Personifies only what `bindInbox` calls on the way to persisting: the bot has to exist in Chatwoot
+// and be attached before the row means anything. `onAttach` is the SEAM this file is about, because
+// the attach is the last thing that happens outside the transaction.
+function stubClient(onAttach?: () => Promise<void>) {
+  const calls: string[] = [];
+  const client = {
+    listAgentBots: async () => {
+      calls.push("listAgentBots");
+      return [];
+    },
+    createAgentBot: async () => {
+      calls.push("createAgentBot");
+      return { id: 900, access_token: "bot-token", secret: "bot-secret" };
+    },
+    updateAgentBot: async () => {
+      calls.push("updateAgentBot");
+      return {};
+    },
+    setInboxAgentBot: async () => {
+      calls.push("setInboxAgentBot");
+      await onAttach?.();
+      return {};
+    },
+  } as unknown as ChatwootClient;
+  return { calls, makeClient: async () => client };
+}
+
+describe.skipIf(!dbUp)("#546 binding an agent that is being deleted", () => {
+  let instanceId = 0n;
+  let nextInbox = 5460;
+
+  beforeAll(async () => {
+    const t = await suDb.tenant.create({
+      data: { name: "BIND546", slug: `bind546-${process.pid}` },
+    });
+    tenantId = t.id;
+    // A real blob, not the seed's "enc" marker: `loadChatwootClient` decrypts the deployment's admin
+    // token before it ever reaches `deps.makeClient`, so a stubbed client does not spare the fixture
+    // from having a decryptable one.
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 5460,
+      accountName: "BIND546",
+      adminToken: encryptJson("admin-token"),
+    });
+    instanceId = inst.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  // A fresh unbound inbox and a fresh agent per test: the binding this file measures is the write,
+  // and a fixture shared between tests would carry the previous one's.
+  async function pair(label: string) {
+    const agent = await suDb.agent.create({
+      data: { tenantId, name: `Ag ${label}`, systemPrompt: "x" },
+      select: { id: true },
+    });
+    nextInbox += 1;
+    const inbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: nextInbox,
+        name: `Inbox ${label}`,
+        agentId: null,
+      },
+      select: { id: true },
+    });
+    return { agentId: agent.id, inboxId: inbox.id };
+  }
+
+  const boundAgentOf = async (inboxId: bigint) =>
+    (
+      await suDb.inbox.findUniqueOrThrow({
+        where: { id: inboxId },
+        select: { agentId: true },
+      })
+    ).agentId;
+
+  // THE EFFECT, driven through the real write and through the real window: the agent is deleted from
+  // inside the Chatwoot call, which is where a concurrent delete actually lands. Nothing here is
+  // timed, and nothing simulates the race by reaching into the service.
+  test("an agent deleted during the Chatwoot call leaves no binding to it", async () => {
+    const { agentId, inboxId } = await pair("deleted");
+    const stub = stubClient(async () => {
+      await deleteAgent(ctx(), agentId, appDb);
+    });
+
+    // The line this leaves behind, because the bot IS attached upstream and the operator reads the
+    // log to know what to do about it. A refusal decided inside the transaction is not the state a
+    // retry repairs, and saying "retry the bind" here sends them at a loop that cannot close.
+    const warn = spyOn(logger, "warn");
+    const error = spyOn(logger, "error");
+    try {
+      await expect(
+        bindInbox(
+          ctx(),
+          inboxId,
+          agentId,
+          { makeClient: stub.makeClient },
+          appDb,
+        ),
+      ).rejects.toThrow(/agent/i);
+      const said = (calls: unknown[][]) =>
+        calls.map((c) => String((c as unknown[])[1] ?? ""));
+      expect(
+        said(warn.mock.calls as unknown[][]).some((m: string) =>
+          m.includes("refuses the same way"),
+        ),
+      ).toBe(true);
+      expect(
+        said(error.mock.calls as unknown[][]).some((m: string) =>
+          m.includes("retry the bind"),
+        ),
+      ).toBe(false);
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+
+    // The delete DID happen inside the window: without this the refusal above could be about an
+    // agent that was never there, which is a different test passing for the wrong reason.
+    expect(stub.calls).toContain("setInboxAgentBot");
+    expect(await suDb.agent.count({ where: { tenantId, id: agentId } })).toBe(
+      0,
+    );
+    expect(await boundAgentOf(inboxId)).toBeNull();
+  });
+
+  // THE CONTROL for the test above, in the same shape: with nobody deleting anything, the same call
+  // binds. Without it, a refusal that came from the stub, from the fixture or from the account would
+  // read exactly like the one the rule produces.
+  test("the same call with nobody deleting anything binds", async () => {
+    const { agentId, inboxId } = await pair("plain");
+    const stub = stubClient();
+    await bindInbox(
+      ctx(),
+      inboxId,
+      agentId,
+      { makeClient: stub.makeClient },
+      appDb,
+    );
+    expect(stub.calls).toContain("setInboxAgentBot");
+    expect(await boundAgentOf(inboxId)).toBe(agentId);
+  });
+
+  type Holder = { pid: number; release: () => void; done: Promise<unknown> };
+
+  // Takes a lock on the agent and resolves once it HAS it. The mode is the parameter because the
+  // point of two of the tests below is which OTHER writer this bind waits for: `FOR UPDATE` is what
+  // `deleteAgent` takes, `FOR NO KEY UPDATE` is what an ordinary save takes.
+  async function holdAgentLock(
+    agentId: bigint,
+    mode: "FOR UPDATE" | "FOR NO KEY UPDATE" = "FOR UPDATE",
+  ): Promise<Holder> {
+    let release!: () => void;
+    const held = new Promise<void>((r) => {
+      release = r;
+    });
+    let announce!: (pid: number) => void;
+    const gotIt = new Promise<number>((r) => {
+      announce = r;
+    });
+    const done = runScopedOn(appDb, ctx(), async (db) => {
+      await db.$queryRawUnsafe(
+        `SELECT id FROM agents WHERE id = ${agentId} ${mode}`,
+      );
+      const [me] = await db.$queryRaw<Array<{ pid: number }>>`
+        SELECT pg_backend_pid()::int AS pid`;
+      announce(me?.pid as number);
+      await held;
+    });
+    // A holder that failed would otherwise hang this on a promise nobody resolves, and the failure
+    // would read as a timeout with no cause.
+    return {
+      pid: await Promise.race([gotIt, done.then(() => -1)]),
+      release,
+      done,
+    };
+  }
+
+  // Polls Postgres rather than the clock: on a fast machine it returns in one round trip, and on a
+  // slow one it keeps asking instead of concluding.
+  async function someoneBlockedBy(pid: number, ms = 5000): Promise<boolean> {
+    const until = Date.now() + ms;
+    while (Date.now() < until) {
+      const rows = await suDb.$queryRaw<Array<{ pid: number }>>`
+        SELECT pid FROM pg_stat_activity WHERE ${pid} = ANY(pg_blocking_pids(pid))`;
+      if (rows.length > 0) return true;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    return false;
+  }
+
+  // THE MECHANISM, and why the lookup LOCKS instead of reading. Driven through the real write rather
+  // than by re-issuing the lock here: a test that takes its own lock proves Postgres works and says
+  // nothing about the guard. Nothing is timed: the holder signals its backend pid from inside the
+  // transaction, and Postgres is asked who is blocking whom.
+  test("the write waits for the agent's own lock", async () => {
+    const { agentId, inboxId } = await pair("waits");
+    // Provision the bot FIRST, and then re-bind through a client that reports it alive. Otherwise
+    // `ensureAgentBot` inserts `chatwoot_agent_bots`, whose foreign key takes KEY SHARE on the agent
+    // and blocks against the holder all by itself: the assertion below would be green with no guard
+    // in the write at all, which is how this test passed before it was written properly.
+    await bindInbox(
+      ctx(),
+      inboxId,
+      agentId,
+      { makeClient: stubClient().makeClient },
+      appDb,
+    );
+    await bindInbox(
+      ctx(),
+      inboxId,
+      null,
+      { makeClient: stubClient().makeClient },
+      appDb,
+    );
+    const provisioned = stubClient();
+    (
+      provisioned.makeClient() as unknown as {
+        listAgentBots: () => Promise<unknown>;
+      }
+    ).listAgentBots = async () => [{ id: 900 }];
+
+    const holder = await holdAgentLock(agentId);
+    expect(holder.pid).toBeGreaterThan(0);
+
+    let settled = false;
+    const stub = provisioned;
+    const write = bindInbox(
+      ctx(),
+      inboxId,
+      agentId,
+      { makeClient: stub.makeClient },
+      appDb,
+    ).then(() => {
+      settled = true;
+    });
+    expect(await someoneBlockedBy(holder.pid)).toBe(true);
+    expect(settled).toBe(false);
+
+    // The ORDER, which a blocking assertion cannot see and which is what keeps this off a deadlock
+    // with `deleteAgent` (it takes the agent, then the inboxes that point at it). Read from the
+    // effect: parked on the AGENT, this write has not taken the inbox row, so a second transaction
+    // can still take it. Under a statement timeout, because the wrong order makes this WAIT, and a
+    // test that hangs reports nothing.
+    await runScopedOn(appDb, ctx(), async (db) => {
+      await db.$executeRawUnsafe("SET LOCAL statement_timeout = '2000ms'");
+      await db.$queryRaw`SELECT id FROM inboxes WHERE id = ${inboxId} FOR UPDATE`;
+    });
+
+    holder.release();
+    await holder.done;
+    await write;
+    expect(settled).toBe(true);
+    expect(await boundAgentOf(inboxId)).toBe(agentId);
+  });
+
+  // The other half of the mode, and the one a future edit is most likely to break: an ordinary SAVE
+  // of the agent must NOT hold the bind up. `FOR KEY SHARE` conflicts with `FOR UPDATE` and with
+  // nothing else, so this holds true only while the non-deleting writers take `FOR NO KEY UPDATE`
+  // (`updateAgent` and `replaceAgentToolSelections`, weakened for exactly this in #546). If one of
+  // them goes back to `FOR UPDATE`, this test does not fail with a message: it HANGS until the
+  // runner kills it, which is the loud version of the stall it is about, since a bind that waits
+  // here is holding the Chatwoot account row while it does.
+  test("an ordinary save of the same agent does not hold the bind up", async () => {
+    const { agentId, inboxId } = await pair("saved");
+    const holder = await holdAgentLock(agentId, "FOR NO KEY UPDATE");
+    expect(holder.pid).toBeGreaterThan(0);
+    await bindInbox(
+      ctx(),
+      inboxId,
+      agentId,
+      { makeClient: stubClient().makeClient },
+      appDb,
+    );
+    expect(await boundAgentOf(inboxId)).toBe(agentId);
+    holder.release();
+    await holder.done;
+  });
+
+  // An unbind names no agent to lock, and has no dangling reference to make: it must not start
+  // waiting on a row it is not going to write.
+  test("an unbind does not wait on the agent it is removing", async () => {
+    const { agentId, inboxId } = await pair("unbind");
+    await bindInbox(
+      ctx(),
+      inboxId,
+      agentId,
+      { makeClient: stubClient().makeClient },
+      appDb,
+    );
+    const holder = await holdAgentLock(agentId);
+    expect(holder.pid).toBeGreaterThan(0);
+    await bindInbox(
+      ctx(),
+      inboxId,
+      null,
+      { makeClient: stubClient().makeClient },
+      appDb,
+    );
+    expect(await boundAgentOf(inboxId)).toBeNull();
+    holder.release();
+    await holder.done;
+  });
+
+  // The test above proves the two modes are compatible; this one proves the agents module still
+  // SPEAKS the weak one. They are different claims, and only the second survives a writer being
+  // added: a new `FOR UPDATE` in some third agent write would stall the bind exactly like the two
+  // weakened in #546 did, and the test above would go on passing because it takes its own lock. The
+  // delete is the single admissible strong lock, and it is the conflict the bind wants.
+  test("only the delete takes a lock on the agent strong enough to stall a bind", async () => {
+    const src = await Bun.file(
+      new URL("../../src/modules/agents/service.ts", import.meta.url),
+    ).text();
+    // Comments stripped first, for the reason the same fence in `audit-channel-family` gives: the
+    // NOTEs in that file name `FOR UPDATE` while explaining why they do not take it.
+    const code = src.replace(/^\s*\/\/.*$/gm, "");
+    const strong = [...code.matchAll(/FOR UPDATE/g)].map((m) => m.index);
+    const del = code.indexOf("export async function deleteAgent(");
+    const next = code.indexOf("\nexport async function", del + 1);
+    expect(del).toBeGreaterThan(-1);
+    expect(next).toBeGreaterThan(del);
+    expect(strong).toHaveLength(1);
+    expect(strong[0]).toBeGreaterThan(del);
+    expect(strong[0]).toBeLessThan(next);
+    expect(code.match(/FOR NO KEY UPDATE/g) ?? []).not.toHaveLength(0);
+  });
+});


### PR DESCRIPTION
`bindInbox` wrote `inboxes.agent_id` without holding any lock on the agent it names, so a `deleteAgent` that committed during the call left an inbox bound to an agent row that no longer exists. Measured against the local Chatwoot fork, not argued: the base tree commits the dangling binding, this one refuses it.

## Why nothing caught it

`Inbox.agentId` is a plain `BigInt?` with no `@relation` (`prisma/schema.prisma`, `model Inbox`), so Postgres takes no `FOR KEY SHARE` on the referenced row on our behalf. The delete side was already answered: `deleteAgent` locks the agent `FOR UPDATE` and nulls every `inboxes.agent_id` that points at it before deleting, deliberately. What was missing is the write side.

The window is not a millisecond. `bindInbox` reads the agent in step 1, then makes its Chatwoot calls (`ensureAgentBot`, `setInboxAgentBot`) OUTSIDE any transaction, which is the correct design and also the width of the race. Measured against the local fork below: 94 to 162 ms of real round trip per bind.

The interleaving needs nothing exotic. `deleteAgent` runs `UPDATE inboxes SET agent_id = NULL WHERE agent_id = A`, which does not reach an inbox that is not bound to A **yet**, so it takes no lock this write would wait on. It deletes and commits; `persistBinding` then locks the account row and the inbox row, neither of which serialises against any of that, and commits `agent_id = A`.

What is left is an inbox the console reads as bound, with the bot still attached upstream in Chatwoot, that nothing answers.

## The fix

One locked read in `persistBinding`, refusing when it comes back empty:

```sql
SELECT id FROM agents WHERE id = ${agentId} FOR KEY SHARE
```

`FOR KEY SHARE` is what an FK's referencing write takes: among the row-lock modes it conflicts only with `FOR UPDATE`, so two binds on the same agent do not serialise against each other. It is also, deliberately, weak enough for this module's own fence on lock modes: a child insert takes KEY SHARE too, so this cannot be the lock that blocks one. That fence now matches every row-lock spelling instead of only the UPDATE family, and admits exactly the two modes the module uses, with the reason each is admissible written next to it.

### The other half: the ordinary agent writes had to get out of the way

Round 2 caught what "conflicts only with `FOR UPDATE`" glosses over: two writes that are not deletes were taking `FOR UPDATE` on the agent anyway — `updateAgent` and `replaceAgentToolSelections`, i.e. saving the agent and saving its tool selection. A bind overlapping either of those would have waited, and it would have waited **while holding the Chatwoot account row**, so an unrelated agent edit would stall every other bind, sync and disconnect on that account behind it. A guard against a rare delete is not worth a lock convoy on the common save.

Both were weakened to `FOR NO KEY UPDATE`. Nothing they serialise is lost: `FOR NO KEY UPDATE` conflicts with itself and with `FOR UPDATE`, so the two saves still exclude each other and still exclude `deleteAgent`, which is the whole reason either took a lock. What it stops conflicting with is the `FOR KEY SHARE` a reference takes, which is this guard and every foreign key into `agents`. `deleteAgent` keeps `FOR UPDATE`: it is the conflict the guard is asking for.

It goes BEFORE the inbox row and AFTER the account row. Before the inbox, because `deleteAgent` takes the agent and then the inboxes that point at it, so the other order is a deadlock between two writes that are each individually correct. That sentence was a claim with no number behind it, so round 2 went and measured it: driving `deleteAgent`'s own two steps by hand against a re-bind of the agent an inbox already names (what re-submitting the editor does, and the one shape where the two transactions want each other's row), with this read moved below the inbox lock Postgres answers `40P01 deadlock detected` and kills the bind, while in the order shipped here both transactions commit. It is not a committed test: reproducing it needs the writer parked by a sleep, and a timed deadlock test is the kind that goes flaky and gets deleted.

After the account, because that keeps the module's documented order (account, then inbox) and the existing refusal precedence: a disconnected account still answers 409 rather than 404.

An unbind names no agent and creates no reference, so it takes nothing here.

Same shape as #501 on `Experiment.agentId`, and the same argument for why this is not solved by adding the foreign key: the delete side is already handled by hand, on purpose.

## Validation scope

Proven by test, in `tests/modules/chatwoot-bind-agent-race.test.ts`:

- **The effect**, driven through the real write and the real seam: the agent is deleted from INSIDE the Chatwoot call, which is where a concurrent delete lands. The bind is refused and the inbox stays unbound, with the deletion asserted to have actually happened inside the window (otherwise the refusal could be about an agent that was never there).
- **The control in the same shape**: with nobody deleting anything, the same call binds.
- **The mechanism**: the write is proved to WAIT on the agent's own lock, by holding `FOR UPDATE` on it and asking Postgres who is blocking whom (`pg_blocking_pids`); nothing is timed. That test provisions the bot FIRST and re-binds through a client that reports it alive, because otherwise `ensureAgentBot` inserts `chatwoot_agent_bots`, whose foreign key takes KEY SHARE on the agent and blocks against the holder all by itself. Written the obvious way, the assertion was green with no guard in the write at all.
- **The order**: parked on the agent, the write has not taken the inbox row, so a second transaction can still take it under a `statement_timeout`. That is the half a blocking assertion cannot see, and it is what keeps this off a deadlock with `deleteAgent`.
- **The unbind** does not wait on the agent it is removing.
- **The compatible half**, which is the round-2 finding turned into a test: holding `FOR NO KEY UPDATE` on the agent (what a save takes), the bind runs to completion anyway. It has no timer and no sleep — if the modes ever conflict again it does not fail with a message, it HANGS until the runner kills it, which is the loud version of the stall it is about.
- **The module fence for the other side**, because the test above proves the modes are compatible and not that the agents module still speaks the weak one: a third agent write added later with `FOR UPDATE` would stall the bind exactly like those two did, and that test would keep passing since it takes its own lock. `src/modules/agents/service.ts` is read as text and the single admissible `FOR UPDATE` must sit inside `deleteAgent`.
- The LOG the refusal leaves, which is the one thing this changes beyond the guard: the bot is attached upstream either way, and the line that already existed told the operator to retry. A retry repairs a failure (the audit insert, a lock); it cannot repair a refusal, which answers the same way for the same reason. The two are now logged as the different states they are, and the test pins both halves: the refusal warns "a retry refuses the same way", and the "retry the bind" line is NOT emitted for it.
- Mutation battery, 10 mutations across the two rounds, control first, every one dies: the mode swapped to `FOR NO KEY UPDATE` (1, the fence), the lock dropped from the read (2), the refusal disabled (1), the guard applied to unbinds too (5), the whole guard removed (3), the log branch collapsed back to one line (1), and — for the round-2 half — each of the two weakened writers put back to `FOR UPDATE` (1 each, the module fence) and the guard's own `FOR KEY SHARE` raised to `FOR NO KEY UPDATE` (2: the compatibility test hangs to its timeout, the module fence rejects the mode). Tree restored and diffed against the round's own patch afterwards.

Proven live, against the LOCAL Chatwoot fork (`localhost:3000`, account 1, a `bind546 live` inbox created for this and deleted afterwards), with the real client and a real bot provisioned and attached each time. The agent is deleted from inside the real `setInboxAgentBot`, which is the production window:

| tree | run | outcome | `inboxes.agent_id` | agent rows | dangling |
| --- | --- | --- | --- | --- | --- |
| base | control | bound | 244 | 1 | no |
| base | **race** | **bound** | **245** | **0** | **yes** |
| this | race | refused: agent not found | null | 0 | no |
| this | control | bound | 247 | 1 | no |

The bind took 162 ms and 94 ms of real Chatwoot work on the two base runs, which is the window measured rather than assumed.

Cleanup: the four `live546 *` agent bots and the inbox were deleted from the fork through its own API and re-listed as gone; the test tenant and everything under it (1 inbox, 2 agents, 2 bots, 1 account) were deleted from the dev database, counted before and after.

Not validated: nothing in the console. The screen calls the same endpoint, and the refusal it can now receive is the one it already renders for an agent that does not exist.

Fixes #546

