### PR TITLE
Enforce the last-administrator invariant on every write that can break it

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1729,7 +1729,7 @@
           "Admin"
         ],
         "summary": "Update user role",
-        "description": "Change a user's role within the caller's tenant scope.",
+        "description": "Change a user's role within the caller's tenant scope. Refuses (409) to demote the last administrator of a scope.",
         "parameters": [
           {
             "name": "id",
@@ -1881,6 +1881,28 @@
               "application/json": {
                 "schema": {
                   "description": "Not found.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — a duplicate or a state conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Conflict — a duplicate or a state conflict.",
                   "type": "object",
                   "required": [
                     "error"

--- a/src/api/features/admin/admin.controller.ts
+++ b/src/api/features/admin/admin.controller.ts
@@ -202,6 +202,17 @@ export const adminController = new Elysia({
           },
         };
       } catch (error) {
+        // The same invariant the delete answers with a 409, on the write that reduces the scope's
+        // administrator count without removing anybody (#496).
+        if (error instanceof LastAdminError) {
+          set.status = 409;
+          return {
+            error: translate(
+              "errors.lastAdminRole",
+              "Cannot demote the last admin of this scope",
+            ),
+          };
+        }
         if (error instanceof UserNotInScopeError) {
           set.status = 404;
           return {
@@ -222,9 +233,9 @@ export const adminController = new Elysia({
       }),
       detail: doc(
         "Update user role",
-        "Change a user's role within the caller's tenant scope.",
+        "Change a user's role within the caller's tenant scope. Refuses (409) to demote the last administrator of a scope.",
       ),
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404, 409, 422),
     },
   )
   // Permanently delete a user (within the caller's tenant scope). Step-up (`confirmStepUp`): the

--- a/src/api/features/admin/admin.service.ts
+++ b/src/api/features/admin/admin.service.ts
@@ -51,6 +51,66 @@ async function lockUserInScope(
      FOR UPDATE`;
 }
 
+// THE INVARIANT, in one place: a scope keeps somebody who can administer it. Every write that can
+// reduce a scope's administrator count asks this, and it is one function because the question is one
+// (#496): the delete asked it and the demote did not, so the same tenant could be emptied by the
+// cheaper of the two paths.
+//
+// The count is plain because `lockAdminScope` below is what serialises it. Counting under a row lock
+// on the TARGET, which is what the delete used to do, is the other half of that issue: two removals
+// aimed at DIFFERENT administrators lock different rows, so nothing serialises them, each counts the
+// other as remaining, and the scope ends with none.
+async function assertScopeKeepsAnAdmin(
+  db: ScopedDb,
+  role: "TENANT_ADMIN" | "SUPER_ADMIN",
+  tenantId: bigint | null,
+  leavingUserId: bigint,
+): Promise<void> {
+  const remaining = await db.user.count({
+    where: { role, tenantId, id: { not: leavingUserId } },
+  });
+  if (remaining === 0) {
+    throw new LastAdminError();
+  }
+}
+
+// One lock per SCOPE, taken before any row, by every write that can change that scope's
+// administrator count. An advisory lock rather than the administrator rows themselves, and that is
+// the whole design: a set of rows has to be locked in some order, and two writers that disagree
+// about the order (a target read as an AGENT while somebody promotes it, a scan that comes back the
+// other way round) each end up holding a row the other needs. A single lock taken FIRST cannot be
+// held by anyone who is waiting for another, so this family has no lock cycle to reason about.
+//
+// The scope is the target's tenant, and the fleet (`tenantId` null) is a scope like any other. A
+// user never changes tenant — nothing in the tree writes `users.tenant_id` after creation, and only
+// `updateUserRole` writes `users.role` — so the tenant read to build this key cannot be stale in the
+// way the role can, which is what lets the key be chosen before the row is locked.
+//
+// `hashtext` maps to int4, so two scopes can share a slot: that over-serialises two tenants' admin
+// writes and never lets two holders of the same scope run at once, which is the direction that
+// matters (the same trade-off `withEntityLock` documents).
+async function lockAdminScope(
+  db: ScopedDb,
+  tenantId: bigint | null,
+): Promise<void> {
+  const key = `admin-scope:${tenantId === null ? "fleet" : tenantId}`;
+  await db.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${key})::bigint)`;
+}
+
+// The scope this write belongs to, read with the caller's own fence so naming an id from another
+// tenant cannot make the lock above serialise that tenant. Null when the target is not visible here
+// at all: the read under the lock is what answers 404, and this one only picks the key.
+async function scopeOfTarget(
+  db: ScopedDb,
+  callerTenantId: bigint | null,
+  userId: bigint,
+): Promise<{ tenantId: bigint | null } | null> {
+  return db.user.findFirst({
+    where: { id: userId, ...tenantScope(callerTenantId) },
+    select: { tenantId: true },
+  });
+}
+
 // What a user's row carries when their membership changes.
 //
 // The email is IN it, and that is a decision rather than an oversight. The trail exists to answer
@@ -206,6 +266,14 @@ export async function updateUserRole(
     // Two admins re-roling the same person otherwise both read the same value and both record the
     // same transition, so the trail shows one of the two changes twice and the other not at all —
     // on the family where the recorded transition is the entire point.
+    // NOTE: the scope lock comes BEFORE the row lock, and nothing here takes a second one. Which
+    // scope is a question the unlocked read below can answer, because a user never changes tenant;
+    // which ROLE they hold is not, which is why the guard is evaluated on the locked read further
+    // down rather than on this one.
+    const scope = await scopeOfTarget(db, ctx.tenantId, userId);
+    if (scope !== null) {
+      await lockAdminScope(db, scope.tenantId);
+    }
     await lockUserInScope(db, ctx.tenantId, userId);
     const before = await db.user.findFirst({
       where: { id: userId, ...tenantScope(ctx.tenantId) },
@@ -215,6 +283,14 @@ export async function updateUserRole(
     // edit — the same fence the `updateMany` this replaced carried in its `where`.
     if (!before) {
       throw new UserNotInScopeError();
+    }
+    // The guard, on the role the LOCKED read reports and not on any earlier one: a demote only
+    // threatens the invariant when it takes an administrator role away.
+    if (
+      (before.role === "TENANT_ADMIN" || before.role === "SUPER_ADMIN") &&
+      before.role !== role
+    ) {
+      await assertScopeKeepsAnAdmin(db, before.role, before.tenantId, userId);
     }
     const user = await db.user.update({
       where: { id: userId },
@@ -254,12 +330,13 @@ export async function deleteUser(
     // Locked before it is read, which serialises two acts on the SAME user: without it both read the
     // row, both record a `before` naming a live account, and the trail carries the deletion twice.
     //
-    // NOTE: it does NOT close the last-admin race, and the guard below is still open under
-    // concurrency — two deletes aimed at DIFFERENT admins lock different rows, so nothing serialises
-    // them, each counts the other as remaining, and the scope ends with none. Closing it means
-    // locking the scope's whole admin set rather than the target, and the same invariant is broken
-    // more cheaply one function up (`updateUserRole` demotes the last admin with no guard at all),
-    // so it is one question about the invariant and not two about this transaction. Issue #496.
+    // NOTE: the scope lock first and the row second, for the reason `updateUserRole` gives at the
+    // same call. Taking it here rather than counting under the target's own row lock is what stops
+    // two deletes aimed at different administrators from each reading the other as remaining.
+    const scope = await scopeOfTarget(db, callerTenantId, userId);
+    if (scope !== null) {
+      await lockAdminScope(db, scope.tenantId);
+    }
     await lockUserInScope(db, callerTenantId, userId);
     const target = await db.user.findFirst({
       where: { id: userId, ...tenantScope(callerTenantId) },
@@ -268,18 +345,9 @@ export async function deleteUser(
     if (!target) {
       throw new UserNotInScopeError();
     }
+    // For a tenant admin "the scope" is the tenant; for a super-admin (tenantId null), the fleet.
     if (target.role === "TENANT_ADMIN" || target.role === "SUPER_ADMIN") {
-      // For a tenant admin, "the scope" is the tenant; for a super-admin (tenantId null), the fleet.
-      const remaining = await db.user.count({
-        where: {
-          role: target.role,
-          id: { not: userId },
-          tenantId: target.tenantId === null ? null : target.tenantId,
-        },
-      });
-      if (remaining === 0) {
-        throw new LastAdminError();
-      }
+      await assertScopeKeepsAnAdmin(db, target.role, target.tenantId, userId);
     }
     const removed = await db.user.deleteMany({
       where: { id: userId, ...tenantScope(callerTenantId) },

--- a/src/api/locales/en.json
+++ b/src/api/locales/en.json
@@ -134,6 +134,7 @@
     "inviteNotFound": "Invitation not found",
     "knowledgeBaseNotFound": "Knowledge base not found.",
     "lastAdmin": "Cannot delete the last admin of this scope",
+    "lastAdminRole": "Cannot demote the last admin of this scope",
     "logoNotFound": "Logo not found",
     "mcpApprovalNotFound": "MCP approval not found",
     "mcpClientNotFound": "MCP client not found",

--- a/src/api/locales/pt-BR.json
+++ b/src/api/locales/pt-BR.json
@@ -134,6 +134,7 @@
     "inviteNotFound": "Convite não encontrado",
     "knowledgeBaseNotFound": "Base de conhecimento não encontrada.",
     "lastAdmin": "Não é possível excluir o último admin deste escopo",
+    "lastAdminRole": "Não é possível rebaixar o último admin deste escopo",
     "logoNotFound": "Logo não encontrado",
     "mcpApprovalNotFound": "Aprovação MCP não encontrada",
     "mcpClientNotFound": "Cliente MCP não encontrado",

--- a/tests/api/v1/actor-audit-actor.test.ts
+++ b/tests/api/v1/actor-audit-actor.test.ts
@@ -259,6 +259,46 @@ describe.skipIf(!dbUp)("the admin pages name who wrote", () => {
     expect(row?.after).toMatchObject({ role: "TENANT_ADMIN" });
   });
 
+  // The door's other half of #496: the service now refuses to demote a scope's last administrator,
+  // and that refusal has to arrive as the 409 the console renders rather than as the 500 an unmapped
+  // error produces. Its own tenant, seeded and removed here, because the guard counts the scope.
+  test("demoting a tenant's last administrator answers 409, not 500", async () => {
+    cookie = await signIn({
+      id: FLEET_ADMIN_ID,
+      tenantId: null,
+      role: "SUPER_ADMIN",
+    });
+    const lonely = await (su as PrismaClient).tenant.create({
+      data: { name: "LA409", slug: `la409-${process.pid}` },
+      select: { id: true },
+    });
+    try {
+      const onlyAdmin = await seedUser(lonely.id, "TENANT_ADMIN");
+      const res = await server.handle(
+        req(`/admin/users/${onlyAdmin.id}/role`, {
+          method: "PATCH",
+          body: JSON.stringify({ role: "AGENT" }),
+        }),
+      );
+      expect(res.status).toBe(409);
+      // A sentence, not the sentence: which one depends on the reader's locale, and what this test
+      // is about is that the refusal was MAPPED at all — unmapped, it leaves as a 500 with none.
+      expect(typeof (await res.json()).error).toBe("string");
+      const after = await (su as PrismaClient).user.findUnique({
+        where: { id: onlyAdmin.id },
+        select: { role: true },
+      });
+      expect(after?.role).toBe("TENANT_ADMIN");
+    } finally {
+      await (su as PrismaClient).$executeRawUnsafe(
+        `DELETE FROM users WHERE tenant_id = ${lonely.id}`,
+      );
+      await (su as PrismaClient).$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${lonely.id}`,
+      );
+    }
+  });
+
   test("deleting a user from the console records what the account was", async () => {
     cookie = await signIn({
       id: TENANT_ADMIN_ID,

--- a/tests/modules/last-admin-invariant.test.ts
+++ b/tests/modules/last-admin-invariant.test.ts
@@ -1,0 +1,318 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import {
+  deleteUser,
+  LastAdminError,
+  updateUserRole,
+} from "@/api/features/admin/admin.service";
+import type { TenantContext } from "@/lib/tenancy";
+
+// The invariant is "a scope keeps somebody who can administer it", and #496 is about WHERE it is
+// enforced: `deleteUser` refuses to remove the last admin, `updateUserRole` demotes them with no
+// guard at all, and the count the delete does read is not serialised against another delete aimed
+// at a DIFFERENT admin of the same scope.
+//
+// Every test here scopes itself to a tenant created for it. The fleet half of the same invariant
+// (the last SUPER_ADMIN, tenantId null) is deliberately NOT asserted by counting: `users` is global,
+// the suite runs against a database other files write to, and a count keyed on a scope everyone
+// shares measures the neighbour rather than the rule.
+const actor = (tenantId: bigint | null, userId: bigint): TenantContext => ({
+  tenantId,
+  userId,
+  role: tenantId === null ? "SUPER_ADMIN" : "TENANT_ADMIN",
+});
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const suDb = su as PrismaClient;
+const appDb = app as PrismaClient;
+
+describe.skipIf(!dbUp)("a scope keeps an administrator", () => {
+  const tenants: bigint[] = [];
+  let seq = 0;
+
+  // A tenant of its own per test, because the count the guard reads is over the scope: two tests
+  // sharing a tenant would each be measuring the other's admins.
+  async function scope(admins: number, agents = 0) {
+    seq += 1;
+    const t = await suDb.tenant.create({
+      data: { name: `LA${seq}`, slug: `la-${process.pid}-${seq}` },
+    });
+    tenants.push(t.id);
+    const mk = async (role: "TENANT_ADMIN" | "AGENT", n: number) =>
+      (
+        await suDb.user.create({
+          data: {
+            tenantId: t.id,
+            email: `la-${process.pid}-${seq}-${role}-${n}@x.test`,
+            role,
+            passwordHash: "x",
+          },
+          select: { id: true },
+        })
+      ).id;
+    const adminIds: bigint[] = [];
+    for (let i = 0; i < admins; i += 1)
+      adminIds.push(await mk("TENANT_ADMIN", i));
+    const agentIds: bigint[] = [];
+    for (let i = 0; i < agents; i += 1) agentIds.push(await mk("AGENT", i));
+    return { tenantId: t.id, adminIds, agentIds };
+  }
+
+  // Fleet administrators belong to no tenant, so they are tracked by id and cleaned up by id.
+  const fleetIds: bigint[] = [];
+  async function fleetAdmin(n: number): Promise<bigint> {
+    const row = await suDb.user.create({
+      data: {
+        tenantId: null,
+        email: `la-fleet-${process.pid}-${n}@x.test`,
+        role: "SUPER_ADMIN",
+        passwordHash: "x",
+      },
+      select: { id: true },
+    });
+    fleetIds.push(row.id);
+    return row.id;
+  }
+
+  const adminsOf = (tenantId: bigint) =>
+    suDb.user.count({ where: { tenantId, role: "TENANT_ADMIN" } });
+
+  interface Holder {
+    pid: number;
+    release: () => void;
+    done: Promise<void>;
+  }
+
+  // Holds `FOR UPDATE` on the rows the two writers are going to want, and resolves once it HAS them.
+  // Its own connection, so parking it cannot starve the pool the writers run on.
+  async function holdRows(ids: bigint[]): Promise<Holder> {
+    const conn = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl as string }),
+    });
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let ready!: (pid: number) => void;
+    const got = new Promise<number>((r) => {
+      ready = r;
+    });
+    const done = conn
+      .$transaction(
+        async (tx) => {
+          await tx.$queryRawUnsafe(
+            `SELECT id FROM users WHERE id IN (${ids.join(",")}) ORDER BY id FOR UPDATE`,
+          );
+          const [row] = await tx.$queryRaw<Array<{ pid: number }>>`
+            SELECT pg_backend_pid()::int AS pid`;
+          ready(row?.pid ?? 0);
+          await gate;
+        },
+        { timeout: 30_000, maxWait: 30_000 },
+      )
+      .then(() => conn.$disconnect());
+    return { pid: await got, release, done };
+  }
+
+  // How many backends are parked behind this one, DIRECTLY or through another waiter. The chain is
+  // the point and counting only direct blockers is what made the first version of this helper lie:
+  // with the fix in, the two writers queue on the same row, so Postgres reports the second as blocked
+  // by the FIRST WRITER and not by the holder, and a direct count sees one waiter forever.
+  async function blockedBy(pid: number): Promise<number> {
+    const [row] = await suDb.$queryRaw<Array<{ n: bigint }>>`
+      WITH RECURSIVE waiting AS (
+        SELECT a.pid, unnest(pg_blocking_pids(a.pid)) AS blocker
+          FROM pg_stat_activity a
+         WHERE cardinality(pg_blocking_pids(a.pid)) > 0
+      ),
+      chain AS (
+        SELECT pid FROM waiting WHERE blocker = ${pid}
+        UNION
+        SELECT w.pid FROM waiting w JOIN chain c ON w.blocker = c.pid
+      )
+      SELECT count(*)::bigint AS n FROM chain`;
+    return Number(row?.n ?? 0n);
+  }
+
+  async function waitUntilBlocked(pid: number, n: number): Promise<number> {
+    for (let i = 0; i < 300; i += 1) {
+      if ((await blockedBy(pid)) >= n) return i;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    return -1;
+  }
+
+  afterAll(async () => {
+    if (fleetIds.length > 0) {
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM users WHERE id IN (${fleetIds.join(",")})`,
+      );
+    }
+    if (tenants.length > 0) {
+      const list = tenants.join(",");
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM audit_logs WHERE tenant_id IN (${list})`,
+      );
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM users WHERE tenant_id IN (${list})`,
+      );
+      await suDb.$executeRawUnsafe(`DELETE FROM tenants WHERE id IN (${list})`);
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  // The half the issue is titled after: the same invariant the delete enforces, on the write that
+  // reduces the count without removing anybody.
+  test("demoting the last administrator of a tenant is refused", async () => {
+    const { tenantId, adminIds } = await scope(1);
+    await expect(
+      updateUserRole(
+        actor(null, 999_999n),
+        adminIds[0] as bigint,
+        "AGENT",
+        appDb,
+      ),
+    ).rejects.toBeInstanceOf(LastAdminError);
+    expect(await adminsOf(tenantId)).toBe(1);
+  });
+
+  // The control in the same shape: with somebody else holding the scope, the demote goes through.
+  test("demoting one of two administrators is allowed", async () => {
+    const { tenantId, adminIds } = await scope(2);
+    const after = await updateUserRole(
+      actor(null, 999_999n),
+      adminIds[0] as bigint,
+      "AGENT",
+      appDb,
+    );
+    expect(after.role).toBe("AGENT");
+    expect(await adminsOf(tenantId)).toBe(1);
+  });
+
+  // A demote of somebody who is not an administrator has nothing to do with the invariant, and must
+  // not start refusing (or waiting) because of it.
+  test("re-roling a regular user is untouched by the guard", async () => {
+    const { tenantId, agentIds } = await scope(1, 1);
+    const after = await updateUserRole(
+      actor(null, 999_999n),
+      agentIds[0] as bigint,
+      "TENANT_ADMIN",
+      appDb,
+    );
+    expect(after.role).toBe("TENANT_ADMIN");
+    expect(await adminsOf(tenantId)).toBe(2);
+  });
+
+  // The fleet is the other scope the invariant answers for, and it is asserted only in the direction
+  // a shared database can answer: with two fleet administrators seeded here, removing one is allowed.
+  // The opposite claim (the LAST one is refused) would have to count a scope every other suite writes
+  // to, so it is left to the tenant tests above, which own their scope.
+  //
+  // What this pins is the scope predicate: the fleet's rows have `tenant_id IS NULL`, and a guard
+  // written with `=` instead of `IS NOT DISTINCT FROM` matches nothing there, so it reads an empty
+  // set and refuses every fleet removal.
+  test("removing one of two fleet administrators is allowed", async () => {
+    const keep = await fleetAdmin(1);
+    const goes = await fleetAdmin(2);
+    await deleteUser(actor(null, keep), goes, appDb);
+    expect(await suDb.user.count({ where: { id: goes } })).toBe(0);
+    expect(await suDb.user.count({ where: { id: keep } })).toBe(1);
+  });
+
+  // The one property with no behavioural test, pinned on the source instead of left unsaid: the
+  // scope is locked BEFORE any row, in both writers. That order is what makes the family free of
+  // lock cycles, and losing it does not fail a test — it produces a deadlock under an interleaving
+  // no test can force (a target read as an AGENT while somebody promotes it).
+  test("both writers lock the scope before they lock a row", async () => {
+    const src = await Bun.file(
+      new URL("../../src/api/features/admin/admin.service.ts", import.meta.url),
+    ).text();
+    const code = src.replace(/^\s*\/\/.*$/gm, "");
+    for (const fn of ["updateUserRole", "deleteUser"]) {
+      const start = code.indexOf(`export async function ${fn}(`);
+      const body = code.slice(start, code.indexOf("\nexport ", start + 1));
+      const scopeLock = body.indexOf("lockAdminScope(");
+      const rowLock = body.indexOf("lockUserInScope(");
+      expect(scopeLock).toBeGreaterThan(-1);
+      expect(rowLock).toBeGreaterThan(scopeLock);
+    }
+    // And nothing takes the scope lock a second time, which is the shape that would put a scope
+    // lock after a row lock and bring the cycle back.
+    expect(code.match(/await lockAdminScope\(/g) ?? []).toHaveLength(2);
+  });
+
+  // Run two writers so they read the scope at the same instant, and PROVE they did: both are parked
+  // on rows a third transaction holds, both are asserted to be blocked by it, and only then is it
+  // released. Started plain, the two just run one after the other on a quiet machine — measured,
+  // that is exactly what happened, and the race test passed against the tree that has the defect.
+  async function bothAtOnce(
+    rows: bigint[],
+    writers: Array<() => Promise<unknown>>,
+  ): Promise<Array<PromiseSettledResult<unknown>>> {
+    const holder = await holdRows(rows);
+    const running = writers.map((w) => w());
+    const settled = Promise.allSettled(running);
+    const iterations = await waitUntilBlocked(holder.pid, writers.length);
+    expect(iterations).toBeGreaterThanOrEqual(0);
+    holder.release();
+    await holder.done;
+    return settled;
+  }
+
+  // The half the delete's own NOTE admits: two writes aimed at DIFFERENT administrators of the same
+  // tenant lock different rows, so each reads the other as remaining and the tenant ends with none.
+  // Run together, not interleaved by hand: what has to hold is that they cannot BOTH win, however
+  // the engine orders them.
+  test("two deletes aimed at different administrators cannot both win", async () => {
+    const { tenantId, adminIds } = await scope(2);
+    const [a, b] = adminIds as [bigint, bigint];
+    const outcomes = await bothAtOnce(adminIds as bigint[], [
+      () => deleteUser(actor(tenantId, 999_999n), a, appDb),
+      () => deleteUser(actor(tenantId, 999_999n), b, appDb),
+    ]);
+    const refused = outcomes.filter((o) => o.status === "rejected");
+    expect(refused).toHaveLength(1);
+    expect((refused[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      LastAdminError,
+    );
+    expect(await adminsOf(tenantId)).toBe(1);
+  });
+
+  // Same race across the two functions, which is the shape the fix has to answer as one invariant
+  // rather than as two guards: whoever loses is refused, and the tenant keeps an administrator.
+  test("a delete and a demote aimed at different administrators cannot both win", async () => {
+    const { tenantId, adminIds } = await scope(2);
+    const [a, b] = adminIds as [bigint, bigint];
+    const outcomes = await bothAtOnce(adminIds as bigint[], [
+      () => deleteUser(actor(tenantId, 999_999n), a, appDb),
+      () => updateUserRole(actor(tenantId, 999_999n), b, "AGENT", appDb),
+    ]);
+    const refused = outcomes.filter((o) => o.status === "rejected");
+    expect(refused).toHaveLength(1);
+    expect((refused[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      LastAdminError,
+    );
+    expect(await adminsOf(tenantId)).toBe(1);
+  });
+});


### PR DESCRIPTION
`deleteUser` refuses to remove the last administrator of a scope. `updateUserRole`, one function above it in the same file, changed the same person's role with no such guard, so the invariant that keeps a tenant administrable was enforced on one path and absent on the other.

## The two halves, both measured

A SUPER_ADMIN calling `PATCH /api/admin/users/:id/role` with `{"role":"AGENT"}` against a tenant's only `TENANT_ADMIN` left that tenant with none. Nobody inside it could then invite, re-role or remove anyone; recovery needed a fleet admin, and the console gave no sign. The controller's only guard was self-demotion, which stops an admin locking *themselves* out and says nothing about the scope.

The guard that did exist was open under concurrency, and its own `NOTE` said so (it named this issue). It counted the administrators other than the target while holding a lock on the TARGET row: two removals aimed at DIFFERENT administrators of the same scope lock different rows, so nothing serialises them, each counts the other as remaining, and the scope ends with zero.

The second half does not reproduce by running two calls at once. Measured: started plain, the two writers just ran one after the other on a quiet machine and the race test passed **against the tree that has the defect**. It only shows up when both are made to read the scope at the same instant, which is what the rendezvous below does.

## The fix

One lock per SCOPE, taken by both writers before any row, and the count that lock makes safe:

```ts
await lockAdminScope(db, scope.tenantId);   // pg_advisory_xact_lock(hashtext(`admin-scope:${…}`))
await lockUserInScope(db, callerTenantId, userId);
```

An advisory lock rather than the administrator rows themselves, and that is the whole design. The first version of this PR locked the administrator SET with `ORDER BY id ... FOR UPDATE`, which is correct for two writers that agree on the order and wrong for the pair that does not: a target read as an `AGENT` while somebody promotes it skips the set lock, waits on the row, and then wants the set while a concurrent removal holds an older administrator's row and wants the newly promoted one. Round 1 of review found exactly that, and the answer is not a better order — it is having no order to get wrong. A single lock taken FIRST cannot be held by anyone who is waiting for another.

The key is the target's tenant, the fleet (`tenantId` null) being a scope like any other. It is read with the caller's own fence, so naming an id from another tenant cannot make this serialise that tenant, and it can be read before the row is locked because a user never changes tenant: nothing in the tree writes `users.tenant_id` after creation, and only `updateUserRole` writes `users.role`. The role, which CAN move, is read under the row lock, and that locked read is what the guard is evaluated on.

`hashtext` maps to int4, so two scopes can share a slot. That over-serialises two tenants' administrator writes and never lets two holders of one scope run at once, which is the direction that matters, and it is the trade-off `withEntityLock` already documents for this family of locks.

At the door, the demote's refusal is mapped to the same 409 the delete already answered with, under its own message (`errors.lastAdminRole`, en + pt-BR). Unmapped, a refusal the console can now receive would leave as a 500.

## Validation scope

Proven by test, in `tests/modules/last-admin-invariant.test.ts`:

- **The effect**: demoting a tenant's only administrator is refused and the row keeps its role.
- **The control in the same shape**: with a second administrator, the same demote goes through.
- **The write the invariant says nothing about**: re-roling a regular user is untouched.
- **Both races**, each proved rather than hoped: two deletes aimed at different administrators, and a delete racing a demote. Both writers are parked on rows a third transaction holds, both are ASSERTED to be blocked (walking `pg_blocking_pids` transitively, because with the fix in they queue behind each other and only the first is blocked by the holder), and only then is the holder released. Nothing is timed.
- **The fleet scope**, asserted only in the direction a shared database can answer: with two fleet administrators seeded, removing one is allowed. The opposite claim (the LAST one is refused) would have to count a scope every other suite writes to, so it is left to the tenant tests, which own their scope.
- **The lock order**, pinned on the source, because losing it does not fail a test: it produces a deadlock under an interleaving no test can force. Both writers must take the scope lock before any row lock, and the scope lock must appear exactly twice, since a third one is how a scope lock ends up after a row lock and brings the cycle back.
- The door, in `tests/api/v1/actor-audit-actor.test.ts`: the demote of a lonely tenant's administrator answers **409**, not 500, and the role is unchanged after it.

Mutation battery, 8 mutations, control first, and one deliberate survivor. Dead: the guard dropped from the demote (2 fail), dropped from the delete (3), the scope lock dropped from the demote (2), dropped from the delete (3), the count no longer excluding the target (4), the row lock moved ahead of the scope lock (1, the source fence), and the 409 branch removed from the controller (1). **Survivor, on purpose**: collapsing the lock key to a single global one. It only over-serialises, which is correctness-safe, and pinning a throughput choice with a test would be pinning the wrong thing — the same reason `locks.ts` documents its hash collisions rather than testing them away.

`bun check` green on the whole suite after the redesign (10451 pass, 0 fail).

**Not validated**: nothing in the console. The screen already surfaces the server's message in a toast on this path, and the refusal it can now receive is the shape it already renders for the delete.

**Deliberately out of scope**: #534, the 500 `users_role_tenant_check` produces when a SUPER_ADMIN with no tenant is demoted. Same function, different defect, and it stays a separate issue rather than riding along here.

Fixes #496

