### PR TITLE
Commit the consent decision and the row that records it together

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -35332,6 +35332,28 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict — a duplicate or a state conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Conflict — a duplicate or a state conflict.",
+                  "type": "object",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "422": {
             "description": "Unprocessable — the input is syntactically valid but semantically rejected.",
             "content": {

--- a/src/api/v1/mcp-oauth.controller.ts
+++ b/src/api/v1/mcp-oauth.controller.ts
@@ -1,21 +1,19 @@
 import { randomBytes } from "node:crypto";
 import { Elysia, t } from "elysia";
 import type { UserRole } from "@/../generated/prisma/client";
-import logger from "@/api/lib/logger";
 import { doc, errors, OAuthErrorResponse } from "@/api/lib/openapi";
 import basePrisma from "@/api/lib/prisma";
 import { requireSession } from "@/api/lib/step-up";
 import { tenancyPlugin } from "@/api/middlewares/tenancy";
 import config from "@/config";
-import type { AuditAction } from "@/lib/audit/actions";
-import { NotFoundError, UnauthorizedError } from "@/lib/errors";
+import { ConflictError, NotFoundError, UnauthorizedError } from "@/lib/errors";
 import {
-  asSuperAdmin,
+  asPrincipalOn,
   roleAtLeast,
   runScoped,
   type TenantContext,
 } from "@/lib/tenancy";
-import { recordAudit } from "@/modules/audit/service";
+import { auditMutationOn } from "@/modules/audit/service";
 import {
   consumePendingAuthorization,
   createPendingAuthorization,
@@ -83,36 +81,6 @@ function authorizeRedirect(
   if (params.state) url.searchParams.set("state", params.state);
   url.searchParams.set("iss", issuerUrl());
   return url.toString();
-}
-
-// Best-effort audit of a consent decision; a failure here never blocks the user flow. SUPER_ADMIN
-// writes via the audited fleet path (any tenantId, incl. null); a tenant user writes scoped to their
-// tenant (the pending's tenantId always equals their own).
-async function auditConsentDecision(
-  user: { id: bigint; role: UserRole },
-  tenantId: bigint | null,
-  action: AuditAction,
-  clientId: string,
-  scopes: string[],
-): Promise<void> {
-  const entry = {
-    actorId: user.id,
-    actorType: "user" as const,
-    action,
-    target: `client:${clientId}`,
-    after: { scopes },
-  };
-  try {
-    if (user.role === "SUPER_ADMIN") {
-      await asSuperAdmin((db) => recordAudit(db, tenantId, entry));
-    } else if (tenantId !== null) {
-      await runScoped({ tenantId, userId: user.id, role: user.role }, (db) =>
-        recordAudit(db, tenantId, entry),
-      );
-    }
-  } catch (err) {
-    logger.warn({ err }, "MCP consent audit failed");
-  }
 }
 
 export const mcpOAuthController = new Elysia({
@@ -446,57 +414,86 @@ export const mcpOAuthController = new Elysia({
   // and remembers the approval. Returns the redirect URL for the SPA to navigate to.
   .post(
     "/consent/:req",
-    async ({ getAuthUser, params, body }) => {
-      const user = await getAuthUser();
-      if (!user) throw new UnauthorizedError();
-      requireSession(user);
-      const pending = await consumePendingAuthorization(
-        params.req,
-        user.id,
-        body.csrfToken,
-      );
-      if (!pending) throw new NotFoundError();
+    async ({ tenantContext, params, body }) => {
+      const ctx = tenantContext;
+      if (!ctx?.userId) throw new UnauthorizedError();
+      requireSession(ctx);
+      // Mirrors /authorize, which parks a tenant-less pending for a fleet-level SUPER_ADMIN: the
+      // console's `X-Tenant-Id` SELECTOR must not decide which trail a decision joins.
+      const scopeTenantId = ctx.role === "SUPER_ADMIN" ? null : ctx.tenantId;
+      const userId = ctx.userId;
 
-      if (body.decision === "deny") {
-        await auditConsentDecision(
-          user,
-          pending.tenantId,
-          "mcp_oauth_consent.deny",
+      // ONE TRANSACTION FOR THE DECISION AND ITS ROW. Consuming the pending, minting the code and
+      // remembering the approval used to commit first, and the row was appended afterwards through
+      // a `try/catch` that logged at warn — so a granted consent could leave nothing behind, and a
+      // reader cannot tell that from a consent that never happened. A DENIAL is a mutation too: the
+      // consumption is the write, and the row belongs to it.
+      const decided = await asPrincipalOn(basePrisma, ctx, async (db) => {
+        const pending = await consumePendingAuthorization(
+          params.req,
+          userId,
+          body.csrfToken,
+          db,
+        );
+        if (!pending) throw new NotFoundError();
+        // THE PRINCIPAL CHANGED UNDER THE REQUEST, and this used to be a fourth branch that wrote
+        // nothing and did not even warn. The pending's tenant is written from the role held at
+        // /authorize; if the role held now would file the row somewhere else, the decision cannot be
+        // attributed, and consenting on an unreadable trail is worse than refusing. Unreachable
+        // today and measured as such: only a SUPER_ADMIN parks a tenant-less pending,
+        // `users_role_tenant_check` forbids a SUPER_ADMIN with a tenant, and `updateUserRole` writes
+        // only the role — so the demotion this needs fails at the database (#534). It says so
+        // instead of falling through, because that is a constraint away from being reachable.
+        if (pending.tenantId !== scopeTenantId) {
+          throw new ConflictError(
+            "the signed-in principal no longer matches this authorization request",
+          );
+        }
+
+        if (body.decision === "deny") {
+          await auditMutationOn(db, ctx, pending.tenantId, {
+            action: "mcp_oauth_consent.deny",
+            target: `client:${pending.clientId}`,
+            after: { scopes: pending.scopes },
+          });
+          return {
+            redirect: authorizeRedirect(pending.redirectUri, {
+              error: "access_denied",
+              state: pending.state,
+            }),
+          };
+        }
+
+        const code = await createAuthorizationCode({
+          clientId: pending.clientId,
+          userId: pending.userId,
+          tenantId: pending.tenantId,
+          redirectUri: pending.redirectUri,
+          scopes: pending.scopes,
+          codeChallenge: pending.codeChallenge,
+          codeChallengeMethod: pending.codeChallengeMethod,
+          resource: pending.resource,
+          base: db,
+        });
+        await upsertApproval(
+          pending.userId,
           pending.clientId,
           pending.scopes,
+          db,
         );
+        await auditMutationOn(db, ctx, pending.tenantId, {
+          action: "mcp_oauth_consent.grant",
+          target: `client:${pending.clientId}`,
+          after: { scopes: pending.scopes },
+        });
         return {
           redirect: authorizeRedirect(pending.redirectUri, {
-            error: "access_denied",
+            code,
             state: pending.state,
           }),
         };
-      }
-
-      const code = await createAuthorizationCode({
-        clientId: pending.clientId,
-        userId: pending.userId,
-        tenantId: pending.tenantId,
-        redirectUri: pending.redirectUri,
-        scopes: pending.scopes,
-        codeChallenge: pending.codeChallenge,
-        codeChallengeMethod: pending.codeChallengeMethod,
-        resource: pending.resource,
       });
-      await upsertApproval(pending.userId, pending.clientId, pending.scopes);
-      await auditConsentDecision(
-        user,
-        pending.tenantId,
-        "mcp_oauth_consent.grant",
-        pending.clientId,
-        pending.scopes,
-      );
-      return {
-        redirect: authorizeRedirect(pending.redirectUri, {
-          code,
-          state: pending.state,
-        }),
-      };
+      return decided;
     },
     {
       detail: doc(

--- a/src/api/v1/mcp-oauth.controller.ts
+++ b/src/api/v1/mcp-oauth.controller.ts
@@ -501,7 +501,7 @@ export const mcpOAuthController = new Elysia({
         "Approves or denies a pending authorization. Verifies the CSRF token and single-use-consumes the request; on approve, mints the authorization code from the stored record and remembers the approval (revocable). Returns { redirect } for the SPA to navigate to.",
       ),
       requireAuth: true,
-      response: errors(400, 401, 403, 404, 422),
+      response: errors(400, 401, 403, 404, 409, 422),
       params: t.Object({
         req: t.String({
           minLength: 1,

--- a/src/modules/mcp/oauth/consent.ts
+++ b/src/modules/mcp/oauth/consent.ts
@@ -1,10 +1,15 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import type {
   McpOAuthPendingAuthorization,
-  PrismaClient,
+  Prisma,
 } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 
+// The base client OR a scoped transaction. These tables are global (no RLS), so what a write needs
+// from its client is not a role but a TRANSACTION: the consent decision and the row that records it
+// commit together or not at all (#497), and `Prisma.TransactionClient` is the surface both a plain
+// `PrismaClient` and the `ScopedDb` handed out by `runScopedOn` satisfy.
+type Db = Prisma.TransactionClient;
 // OAuth 2.1 consent state. A /authorize that is NOT auto-skipped (first-party client or a
 // sufficient prior approval) parks a pending record here and redirects the user to the SPA consent
 // screen; the screen reads the record and the user approves/denies. Security model mirrors the
@@ -36,7 +41,7 @@ export interface CreatePendingParams {
   codeChallengeMethod: string;
   resource?: string | null;
   state?: string | null;
-  base?: PrismaClient;
+  base?: Db;
 }
 
 // Parks a pending authorization; returns the opaque request id (in clear, once) that goes in the
@@ -69,7 +74,7 @@ export async function createPendingAuthorization(
 export async function getPendingAuthorization(
   requestId: string,
   userId: bigint,
-  base: PrismaClient = basePrisma,
+  base: Db = basePrisma,
 ): Promise<McpOAuthPendingAuthorization | null> {
   const row = await base.mcpOAuthPendingAuthorization.findUnique({
     where: { requestHash: sha256(requestId) },
@@ -87,7 +92,7 @@ export async function getPendingAuthorization(
 export async function issueConsentCsrf(
   requestId: string,
   userId: bigint,
-  base: PrismaClient = basePrisma,
+  base: Db = basePrisma,
 ): Promise<string | null> {
   const row = await getPendingAuthorization(requestId, userId, base);
   if (!row) return null;
@@ -107,7 +112,7 @@ export async function consumePendingAuthorization(
   requestId: string,
   userId: bigint,
   csrfToken: string,
-  base: PrismaClient = basePrisma,
+  base: Db = basePrisma,
 ): Promise<McpOAuthPendingAuthorization | null> {
   const row = await getPendingAuthorization(requestId, userId, base);
   if (!row) return null;
@@ -130,7 +135,7 @@ export async function consumePendingAuthorization(
 export async function findApproval(
   userId: bigint,
   clientId: string,
-  base: PrismaClient = basePrisma,
+  base: Db = basePrisma,
 ) {
   return base.mcpOAuthClientApproval.findUnique({
     where: { userId_clientId: { userId, clientId } },
@@ -148,19 +153,34 @@ export function isApprovalSufficient(
 
 // Records (or widens) the user's approval for a client. Stores the UNION so a later narrower
 // request stays covered; a wider one grows the set on the next approval.
+//
+// THE UNION IS COMPUTED BY THE DATABASE, INSIDE THE WRITE, and that is the whole point of the raw
+// statement (#497). Read-then-merge-then-upsert closes over a value read before the write: two
+// grants for the same (user, client) in flight together each merge against the set as it was BEFORE
+// either landed, so the second write replaces the first's scopes instead of adding to them. Both
+// calls return normally and the row is there, so the loss is silent — measured by blocking one
+// read until the other grant committed (`tests/modules/mcp-oauth-consent.test.ts`).
+//
+// `ON CONFLICT DO UPDATE` evaluates its SET against the row as it exists AT THE WRITE, under the
+// row lock the conflict takes, so there is nothing for a concurrent grant to slip between. No
+// `SELECT … FOR UPDATE` and no transaction: one statement cannot be interleaved.
+//
+// Prisma has no expression for this — `upsert` takes scalars it computed in JS — so it is raw. The
+// `ORDER BY 1` is not cosmetic: `DISTINCT unnest` has no defined order, and the stored order is
+// what every reader and every audit projection of this row sees.
 export async function upsertApproval(
   userId: bigint,
   clientId: string,
   scopes: string[],
-  base: PrismaClient = basePrisma,
+  base: Db = basePrisma,
 ): Promise<void> {
-  const existing = await findApproval(userId, clientId, base);
-  const merged = existing
-    ? Array.from(new Set([...existing.scopes, ...scopes]))
-    : scopes;
-  await base.mcpOAuthClientApproval.upsert({
-    where: { userId_clientId: { userId, clientId } },
-    create: { userId, clientId, scopes: merged },
-    update: { scopes: merged },
-  });
+  await base.$executeRaw`
+    INSERT INTO mcp_oauth_client_approvals (user_id, client_id, scopes, created_at, updated_at)
+         VALUES (${userId}, ${clientId}, ${scopes}, NOW(), NOW())
+    ON CONFLICT (user_id, client_id) DO UPDATE
+            SET scopes = ARRAY(
+                  SELECT DISTINCT unnest(mcp_oauth_client_approvals.scopes || EXCLUDED.scopes)
+                   ORDER BY 1
+                ),
+                updated_at = NOW()`;
 }

--- a/src/modules/mcp/oauth/grant.ts
+++ b/src/modules/mcp/oauth/grant.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
-import type { PrismaClient } from "@/../generated/prisma/client";
+import type { Prisma, PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
 import { AppError } from "@/lib/errors";
 import { mcpResourceId } from "./metadata";
@@ -30,6 +30,12 @@ function constantTimeEqual(a: string, b: string): boolean {
   return timingSafeEqual(ab, bb);
 }
 
+// The base client OR a scoped transaction, for the mint alone. What the code needs from its client
+// is not a role but a TRANSACTION: the consent decision, the code it mints and the row that records
+// the decision commit together or not at all (#497). Deliberately NOT applied to the rest of this
+// module — `/token` mints from its own request and shares no transaction with anything.
+type CodeDb = Prisma.TransactionClient;
+
 export interface CreateCodeParams {
   clientId: string;
   userId: bigint;
@@ -39,7 +45,7 @@ export interface CreateCodeParams {
   codeChallenge: string;
   codeChallengeMethod: string;
   resource?: string | null;
-  base?: PrismaClient;
+  base?: CodeDb;
 }
 
 // Mints an authorization code (returned once, in clear). Requires PKCE S256.

--- a/tests/api/v1/mcp-oauth-consent-seam.test.ts
+++ b/tests/api/v1/mcp-oauth-consent-seam.test.ts
@@ -1,0 +1,366 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { SignJWT } from "jose";
+import { PrismaClient, type UserRole } from "@/../generated/prisma/client";
+import config from "@/config";
+
+// The consent DECISION, driven through its own door (#497).
+//
+// `tests/modules/mcp-oauth-consent.test.ts` proves the pending record and the approvals. This file
+// answers what no module test can see: whether the row that records the decision shares the fate of
+// the decision. Until #497 it did not — the grant committed, then a second transaction appended the
+// row best-effort inside a `try/catch` that logged at warn — so a granted consent could leave
+// nothing behind, and a reader cannot tell that from a consent that never happened.
+
+const BunRequest = (globalThis as unknown as { BunRequest: typeof Request })
+  .BunRequest;
+
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (suUrl && appUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const suDb = su as PrismaClient;
+
+// THE APP'S OWN CLIENT, not the shared stub. `setupPrismaMock` replaces `@/api/lib/prisma` with a
+// mock carrying `user` and `tenant` only, so every request through this controller answered 500 on
+// `mcpOAuthPendingAuthorization` — and two of the assertions below went GREEN on it, because "the
+// grant did not stand" is also true when the request never reached the database. The principal is
+// therefore a real row, and the transaction under test is a real one.
+// The value the registry held before this file touched it, captured as the PROPERTY rather than as
+// the namespace: `mock.module` rewrites the namespace object in place, so handing that object back
+// at teardown puts nothing back (`tests/lib/module-mock-undo.test.ts` is the fence, and it
+// caught this file doing exactly that). A fresh literal holding the original client does restore it.
+const originalPrisma = (await import("@/api/lib/prisma")).default;
+mock.module("@/api/lib/prisma", () => ({ default: app }));
+// Top-level rather than inside the `describe`, since an `afterAll` in a describe that SKIPS never
+// runs while the mock above is already installed for the whole worker.
+afterAll(() => {
+  mock.module("@/api/lib/prisma", () => ({ default: originalPrisma }));
+});
+
+// The audit write is wrapped rather than stubbed: every other file's assertions about `recordAudit`
+// stay true, and this one only decides whether THIS call throws. `mock.module` is global to the
+// worker, so a stub that swallowed the real behaviour would turn them all green for the wrong
+// reason.
+const auditSvc = await import("@/modules/audit/service");
+const realAudit = { ...auditSvc };
+let auditFails = false;
+mock.module("@/modules/audit/service", () => ({
+  ...realAudit,
+  recordAudit: async (...args: Parameters<typeof realAudit.recordAudit>) => {
+    if (auditFails) throw new Error("audit write refused (test)");
+    return realAudit.recordAudit(...args);
+  },
+}));
+afterAll(() => {
+  mock.module("@/modules/audit/service", () => realAudit);
+});
+
+const server = (await import("@/app")).default;
+
+const USER_ID = 9_497_101n;
+const CLIENT = `seam-${process.pid}`;
+const REDIRECT = "https://client.example/cb";
+const PASSWORD = "the-step-up-password-9497";
+
+let tenantId = 0n;
+let cookie = "";
+let signedIn: { id: bigint; tenantId: bigint | null; role: UserRole } = {
+  id: USER_ID,
+  tenantId: 0n,
+  role: "TENANT_ADMIN",
+};
+
+async function signIn(as: typeof signedIn): Promise<string> {
+  signedIn = as;
+  const token = await new SignJWT({
+    userId: as.id.toString(),
+    email: `p${as.id}@seam497.test`,
+    role: as.role,
+    tenantId: as.tenantId === null ? null : as.tenantId.toString(),
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime("1h")
+    .sign(new TextEncoder().encode(config.jwtSecret));
+  return `fazerai_auth_token=${token}`;
+}
+
+function req(path: string, init: RequestInit = {}): Request {
+  return new BunRequest(`http://localhost/api${path}`, {
+    ...init,
+    headers: { "content-type": "application/json", cookie, ...init.headers },
+  });
+}
+
+// A pending authorization straight into the table, with the tenant the test needs. The state is
+// what the flow would have parked; going through /authorize as well would test that endpoint again.
+async function pending(
+  tenant: bigint | null,
+): Promise<{ requestId: string; csrf: string }> {
+  const { createPendingAuthorization, issueConsentCsrf } = await import(
+    "@/modules/mcp/oauth/consent"
+  );
+  const { requestId } = await createPendingAuthorization({
+    clientId: CLIENT,
+    userId: USER_ID,
+    tenantId: tenant,
+    redirectUri: REDIRECT,
+    scopes: ["mcp:read"],
+    codeChallenge: randomBytes(16).toString("base64url"),
+    codeChallengeMethod: "S256",
+    state: "xyz",
+    base: suDb,
+  });
+  const csrf = await issueConsentCsrf(requestId, USER_ID, suDb);
+  return { requestId, csrf: csrf as string };
+}
+
+const consentRows = async () =>
+  suDb.auditLog.findMany({
+    where: { actorId: USER_ID, action: { startsWith: "mcp_oauth_consent." } },
+    orderBy: { id: "asc" },
+  });
+
+const codes = async () =>
+  suDb.mcpOAuthAuthorizationCode.findMany({ where: { clientId: CLIENT } });
+
+const approvals = async () =>
+  suDb.mcpOAuthClientApproval.findMany({ where: { clientId: CLIENT } });
+
+const pendings = async () =>
+  suDb.mcpOAuthPendingAuthorization.findMany({ where: { clientId: CLIENT } });
+
+async function clear(): Promise<void> {
+  await suDb.$executeRawUnsafe(
+    `DELETE FROM audit_logs WHERE actor_id = ${USER_ID}`,
+  );
+  await suDb.$executeRawUnsafe(
+    `DELETE FROM mcp_oauth_authorization_codes WHERE client_id = '${CLIENT}'`,
+  );
+  await suDb.$executeRawUnsafe(
+    `DELETE FROM mcp_oauth_client_approvals WHERE client_id = '${CLIENT}'`,
+  );
+  await suDb.$executeRawUnsafe(
+    `DELETE FROM mcp_oauth_pending_authorizations WHERE client_id = '${CLIENT}'`,
+  );
+}
+
+describe.skipIf(!dbUp)(
+  "the consent decision and its row commit together",
+  () => {
+    beforeAll(async () => {
+      const t = await suDb.tenant.create({
+        data: { name: "Seam497", slug: `seam497-${process.pid}` },
+      });
+      tenantId = t.id;
+      const { hashPassword } = await import("@/api/features/auth/auth.service");
+      await suDb.user.create({
+        data: {
+          id: USER_ID,
+          tenantId,
+          email: `p${USER_ID}@seam497.test`,
+          passwordHash: await hashPassword(PASSWORD),
+          role: "TENANT_ADMIN",
+        },
+      });
+      await suDb.mcpOAuthClient.create({
+        data: {
+          clientId: CLIENT,
+          name: "Seam",
+          redirectUris: [REDIRECT],
+          grantTypes: ["authorization_code", "refresh_token"],
+          scopes: ["mcp:read"],
+        },
+      });
+      cookie = await signIn({ id: USER_ID, tenantId, role: "TENANT_ADMIN" });
+      await clear();
+    });
+
+    afterAll(async () => {
+      if (!dbUp) return;
+      await clear();
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM mcp_oauth_clients WHERE client_id = '${CLIENT}'`,
+      );
+      await suDb.$executeRawUnsafe(`DELETE FROM users WHERE id = ${USER_ID}`);
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+      await suDb.$disconnect();
+      await app?.$disconnect();
+    });
+
+    test("a grant records the decision on the tenant's trail", async () => {
+      await clear();
+      const { requestId, csrf } = await pending(tenantId);
+      const res = await server.handle(
+        req(`/v1/mcp/oauth/consent/${requestId}`, {
+          method: "POST",
+          body: JSON.stringify({ decision: "approve", csrfToken: csrf }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const rows = await consentRows();
+      expect(rows.map((r) => [r.action, r.tenantId])).toEqual([
+        ["mcp_oauth_consent.grant", tenantId],
+      ]);
+      // The three writes the row now shares a transaction with, asserted as effects rather than as
+      // calls: a code to exchange, the approval remembered so the next /authorize can skip consent,
+      // and the request spent.
+      expect({
+        codes: (await codes()).length,
+        approvals: (await approvals()).map((a) => a.scopes),
+        consumed: (await pendings()).filter((p) => p.consumedAt !== null)
+          .length,
+      }).toEqual({ codes: 1, approvals: [["mcp:read"]], consumed: 1 });
+    });
+
+    // The denial's own happy path, which is not implied by the failure case below: an assertion that
+    // only counts rows cannot tell a denial recorded as a denial from one recorded as a grant, and the
+    // two branches write the action from different literals.
+    test("a denial records a denial, and mints nothing", async () => {
+      await clear();
+      const { requestId, csrf } = await pending(tenantId);
+      const res = await server.handle(
+        req(`/v1/mcp/oauth/consent/${requestId}`, {
+          method: "POST",
+          body: JSON.stringify({ decision: "deny", csrfToken: csrf }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      const rows = await consentRows();
+      expect(rows.map((r) => [r.action, r.tenantId])).toEqual([
+        ["mcp_oauth_consent.deny", tenantId],
+      ]);
+      expect({
+        codes: (await codes()).length,
+        approvals: (await approvals()).length,
+      }).toEqual({ codes: 0, approvals: 0 });
+    });
+
+    // THE POINT OF THE SEAM. With the row's write refused, the grant must not stand: no code to
+    // exchange, no approval remembered, and the pending still unconsumed so the user can decide
+    // again. Before #497 the three writes had already committed and only the row was missing, which
+    // is the one outcome a trail must never produce — a grant nobody can read.
+    test("a refused audit write takes the whole grant with it", async () => {
+      await clear();
+      const { requestId, csrf } = await pending(tenantId);
+      auditFails = true;
+      const res = await server.handle(
+        req(`/v1/mcp/oauth/consent/${requestId}`, {
+          method: "POST",
+          body: JSON.stringify({ decision: "approve", csrfToken: csrf }),
+        }),
+      );
+      auditFails = false;
+      expect(res.status).toBeGreaterThanOrEqual(500);
+      expect({
+        rows: (await consentRows()).length,
+        codes: (await codes()).length,
+        approvals: (await approvals()).length,
+        consumed: (await pendings()).filter((p) => p.consumedAt !== null)
+          .length,
+      }).toEqual({ rows: 0, codes: 0, approvals: 0, consumed: 0 });
+    });
+
+    // A DENIAL IS A MUTATION TOO: consuming the pending is the write, and the row belongs to it.
+    test("a refused audit write leaves the denial undone as well", async () => {
+      await clear();
+      const { requestId, csrf } = await pending(tenantId);
+      auditFails = true;
+      const res = await server.handle(
+        req(`/v1/mcp/oauth/consent/${requestId}`, {
+          method: "POST",
+          body: JSON.stringify({ decision: "deny", csrfToken: csrf }),
+        }),
+      );
+      auditFails = false;
+      expect(res.status).toBeGreaterThanOrEqual(500);
+      expect({
+        rows: (await consentRows()).length,
+        consumed: (await pendings()).filter((p) => p.consumedAt !== null)
+          .length,
+      }).toEqual({ rows: 0, consumed: 0 });
+    });
+
+    // A FLEET-LEVEL SUPER_ADMIN, WITH A TENANT SELECTED IN THE CONSOLE. `/authorize` parks a
+    // tenant-less pending for that principal on purpose, so the decision has to file fleet-level too —
+    // and `X-Tenant-Id` is a SELECTOR, not the principal's tenant. Reading `ctx.tenantId` straight
+    // would make the refusal below fire on a legitimate grant, or file the row on whatever tab the
+    // admin had open, which is the same mistake `admin.service.ts` documents for its own family.
+    test("a fleet admin's decision is fleet-level, whatever tenant is selected", async () => {
+      await clear();
+      const previous = cookie;
+      cookie = await signIn({
+        id: USER_ID,
+        tenantId: null,
+        role: "SUPER_ADMIN",
+      });
+      await suDb.$executeRawUnsafe(
+        `UPDATE users SET role = 'SUPER_ADMIN', tenant_id = NULL WHERE id = ${USER_ID}`,
+      );
+      const { requestId, csrf } = await pending(null);
+      const res = await server.handle(
+        req(`/v1/mcp/oauth/consent/${requestId}`, {
+          method: "POST",
+          body: JSON.stringify({ decision: "approve", csrfToken: csrf }),
+          headers: { "x-tenant-id": String(tenantId) },
+        }),
+      );
+      await suDb.$executeRawUnsafe(
+        `UPDATE users SET role = 'TENANT_ADMIN', tenant_id = ${tenantId} WHERE id = ${USER_ID}`,
+      );
+      cookie = previous;
+      expect(res.status).toBe(200);
+      const rows = await consentRows();
+      expect(rows.map((r) => [r.action, r.tenantId])).toEqual([
+        ["mcp_oauth_consent.grant", null],
+      ]);
+    });
+
+    // THE FOURTH BRANCH, which wrote nothing and did not even warn. `auditConsentDecision` dispatched
+    // on the principal — SUPER_ADMIN, else a tenant, and no `else` — so a non-SUPER_ADMIN holding a
+    // pending with a null tenant fell through in silence.
+    //
+    // Reachable only if the role changed inside the pending's 10-minute TTL, and measured: the only
+    // producer of a null `tenantId` on a pending is a SUPER_ADMIN at /authorize, and `users_role_tenant_check`
+    // forbids a SUPER_ADMIN with a tenant, while `updateUserRole` writes only the role — so demoting
+    // one fails at the database today (that is #534). The state is therefore constructed here rather
+    // than driven, because the app cannot reach it yet and the code must still answer when #534 is
+    // fixed.
+    test("a principal that no longer matches the pending is refused, not ignored", async () => {
+      await clear();
+      const { requestId, csrf } = await pending(null);
+      const res = await server.handle(
+        req(`/v1/mcp/oauth/consent/${requestId}`, {
+          method: "POST",
+          body: JSON.stringify({ decision: "approve", csrfToken: csrf }),
+        }),
+      );
+      expect(res.status).toBe(409);
+      expect({
+        rows: (await consentRows()).length,
+        codes: (await codes()).length,
+        consumed: (await pendings()).filter((p) => p.consumedAt !== null)
+          .length,
+      }).toEqual({ rows: 0, codes: 0, consumed: 0 });
+    });
+  },
+);

--- a/tests/modules/mcp-oauth-consent.test.ts
+++ b/tests/modules/mcp-oauth-consent.test.ts
@@ -77,11 +77,14 @@ describe.skipIf(!dbUp)("mcp oauth consent (pending + approvals)", () => {
   });
 
   afterAll(async () => {
+    // BY PREFIX, not by the exact id: the tests below derive clients from `CLIENT` (`-race`,
+    // `-dup`), and an approval row has no foreign key to the user or the tenant deleted just after,
+    // so an exact match leaves them behind for good — one more orphan per local run.
     await suDb.$executeRawUnsafe(
-      `DELETE FROM mcp_oauth_pending_authorizations WHERE client_id = '${CLIENT}'`,
+      `DELETE FROM mcp_oauth_pending_authorizations WHERE client_id LIKE '${CLIENT}%'`,
     );
     await suDb.$executeRawUnsafe(
-      `DELETE FROM mcp_oauth_client_approvals WHERE client_id = '${CLIENT}'`,
+      `DELETE FROM mcp_oauth_client_approvals WHERE client_id LIKE '${CLIENT}%'`,
     );
     if (userId)
       await suDb.$executeRawUnsafe(`DELETE FROM users WHERE id = ${userId}`);

--- a/tests/modules/mcp-oauth-consent.test.ts
+++ b/tests/modules/mcp-oauth-consent.test.ts
@@ -29,6 +29,16 @@ if (suUrl) {
 const suDb = su as PrismaClient;
 
 const CLIENT = `consent-${process.pid}`;
+
+// Whether SOMETHING holds a row/tuple lock on the approvals table right now. The first grant's write
+// is uncommitted, so it cannot be read; what is observable is the lock it took.
+async function findApprovalUncommitted(_client: string): Promise<boolean> {
+  const rows = await suDb.$queryRaw<{ n: bigint }[]>`
+    SELECT count(*) AS n FROM pg_locks l
+      JOIN pg_class c ON c.oid = l.relation
+     WHERE c.relname = 'mcp_oauth_client_approvals' AND l.mode = 'RowExclusiveLock'`;
+  return (rows[0]?.n ?? 0n) > 0n;
+}
 const REDIRECT = "https://client.example/cb";
 let tenantId = 0n;
 let userId = 0n;
@@ -154,6 +164,83 @@ describe.skipIf(!dbUp)("mcp oauth consent (pending + approvals)", () => {
 
     await upsertApproval(userId, CLIENT, ["mcp:write"], suDb);
     approval = await findApproval(userId, CLIENT, suDb);
+    expect(new Set(approval?.scopes)).toEqual(
+      new Set(["mcp:read", "mcp:write"]),
+    );
+  });
+
+  // What the union has to be a union OF, pinned in the two directions the SQL can get wrong: a scope
+  // granted twice must not accumulate, and the stored ORDER is not incidental — it is what every
+  // reader of this row sees, including an audit projection of `{ scopes }`, where a re-grant that
+  // reshuffled the array would read as a change that did not happen.
+  test("re-granting a scope neither duplicates it nor reshuffles the row", async () => {
+    const client = `${CLIENT}-dup`;
+    await upsertApproval(userId, client, ["mcp:write", "mcp:read"], suDb);
+    await upsertApproval(userId, client, ["mcp:read"], suDb);
+    await upsertApproval(userId, client, ["mcp:read", "mcp:write"], suDb);
+    const approval = await findApproval(userId, client, suDb);
+    expect(approval?.scopes).toEqual(["mcp:read", "mcp:write"]);
+  });
+
+  // TWO GRANTS FOR THE SAME (user, client) AT ONCE, and the union has to hold across them (#497).
+  //
+  // The widening above is sequential, so it passes on a merge computed in application code from a
+  // value read earlier. This one is not: the first grant runs inside a transaction held open, so it
+  // keeps the row lock while the second one runs. A merge that closes over a read taken before that
+  // lock was released writes a set that never saw the other's scope, and the last write wins —
+  // silently, since both calls return normally and the approval row is there.
+  //
+  // THE RENDEZVOUS IS THE DATABASE'S OWN LOCK, not a hook on either implementation's queries. An
+  // earlier version of this blocked the approval's `findUnique`, which measured the SHAPE of the
+  // read-then-write and hung the moment the fix stopped reading. What both shapes must do is wait
+  // for that row, so the test waits for Postgres to say someone is waiting for it, and fails if
+  // nobody ever does rather than sleeping and hoping.
+  test("two grants at once keep both scopes, not the last writer's", async () => {
+    const client = `${CLIENT}-race`;
+    let release!: () => void;
+    const held = new Promise<void>((r) => {
+      release = r;
+    });
+
+    const blocked = async (): Promise<boolean> => {
+      const rows = await suDb.$queryRaw<{ n: bigint }[]>`
+        SELECT count(*) AS n FROM pg_stat_activity
+         WHERE wait_event_type = 'Lock'
+           AND query ILIKE '%mcp_oauth_client_approvals%'`;
+      return (rows[0]?.n ?? 0n) > 0n;
+    };
+
+    const first = suDb.$transaction(
+      async (tx) => {
+        await upsertApproval(
+          userId,
+          client,
+          ["mcp:read"],
+          tx as unknown as PrismaClient,
+        );
+        await held;
+      },
+      { timeout: 20_000 },
+    );
+    // The lock has to be taken before the second grant can queue behind it.
+    while (!(await findApprovalUncommitted(client))) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const second = upsertApproval(userId, client, ["mcp:write"], suDb);
+
+    let waited = false;
+    for (let i = 0; i < 200 && !waited; i++) {
+      waited = await blocked();
+      if (!waited) await new Promise((r) => setTimeout(r, 10));
+    }
+    // Without this the whole test is two sleeps with a better name: it would go green on a build
+    // where the second grant never contended at all.
+    expect(waited).toBe(true);
+
+    release();
+    await Promise.all([first, second]);
+
+    const approval = await findApproval(userId, client, suDb);
     expect(new Set(approval?.scopes)).toEqual(
       new Set(["mcp:read", "mcp:write"]),
     );


### PR DESCRIPTION
Commit the consent decision and the row that records it together

`auditConsentDecision` was the last audit write in the tree with the shape #392
exists to remove, and it had three defects in one function.

**It wrote in a second transaction.** `POST /consent/:req` consumed the pending
authorization, minted the code and remembered the approval, and only then opened
its own `runScoped`/`asSuperAdmin` to append the row. **And the failure was
swallowed**, in a `try/catch` that logged `"MCP consent audit failed"` at warn:
a consent that was granted could leave nothing behind, and a reader cannot tell
that from a consent that never happened.

All four writes now share one `asPrincipalOn` transaction. A DENIAL is a
mutation too — consuming the pending is the write — so it gets the same
treatment rather than its own answer.

**A fourth branch wrote nothing at all, and did not even warn.** The dispatch was
`SUPER_ADMIN` / else a tenant / no `else`, so a non-SUPER_ADMIN holding a pending
with a null tenant fell through in silence.

Whether that is reachable was measured rather than assumed, and the answer is
interesting: it is not, today, and only because of a different bug.

- a pending carries a null tenant only when the role at `/authorize` was
  SUPER_ADMIN;
- `users_role_tenant_check` requires every SUPER_ADMIN to have a null tenant and
  everyone else to have one;
- so the branch needs a demotion inside the pending's 10-minute TTL;
- and `updateUserRole` writes only `role`. Against a real Postgres, in a
  transaction rolled back:

      UPDATE users SET role='TENANT_ADMIN' WHERE ...
      ERROR: new row for relation "users" violates check constraint "users_role_tenant_check"

      UPDATE users SET role='TENANT_ADMIN', tenant_id=551 WHERE ...
      UPDATE 1

  which is #534. The silent branch is guarded by a defect, not by design, and
  the fix for #534 has to assign a tenant while demoting — the second statement
  — which makes it reachable.

So it says so instead of falling through: a 409 when the principal no longer
matches the pending, with nothing consumed and no code minted. The scope is
taken from the principal and NOT from `X-Tenant-Id`, which is a selector: a
fleet admin with a tenant open in one tab must still file the decision
fleet-level, the same trap `admin.service.ts` documents for its own family.

**`upsertApproval` merged scopes without holding the row it read.** Two grants
for the same (user, client) in flight together each merged against the set as it
was before either landed, so the second write replaced the first's scopes
instead of adding to them — silently, since both calls return and the row is
there. The union is now computed by the database inside `ON CONFLICT DO UPDATE`,
which evaluates against the row at the write, under the lock the conflict takes.

Its test blocks on the DATABASE'S lock rather than on either implementation's
queries: the first version hooked the approval's `findUnique`, which measured
the shape of read-then-write and hung the moment the fix stopped reading.

## Battery

| mutation | result |
| --- | --- |
| control | 16 pass / 0 fail |
| the principal refusal removed | 1 fail |
| scope read straight off the selector | 1 fail |
| a denial recorded as a grant | 1 fail |
| the approval not remembered | 1 fail |
| the code minted outside the transaction | 1 fail |
| `DISTINCT` dropped from the union | 1 fail |
| the union's order reversed | 1 fail |
| union replaced by the incoming set | 2 fail |
| `ON CONFLICT DO NOTHING` | 3 fail |

Two of those fences exist BECAUSE of the battery: nothing covered a fleet admin
with a tenant selected, or a denial on its happy path, and both mutants survived
the first round.

## Two things the round corrected in itself

The endpoint test first ran under `setupPrismaMock`, whose stub carries `user`
and `tenant` only — so every request answered 500 on
`mcpOAuthPendingAuthorization`, and two assertions went GREEN on it, because
"the grant did not stand" is also true when the request never reached the
database. It now drives the real app client against a real principal row.

Swapping that client is a `mock.module`, which is global to the worker, and the
teardown first handed the registry back the namespace `await import()` returned
— which `tests/lib/module-mock-undo.test.ts` exists to catch, and did. The
original client is captured as the property and restored through a fresh
literal.

`bun check`: 10419 pass, 4 skip, 0 fail, twice in a row.

Fixes #497
