### PR TITLE
Burn a fixture's job id from the sequence, and fence the two spellings that name a row

### DIFF
--- a/tests/modules/business-hours-exceptions.test.ts
+++ b/tests/modules/business-hours-exceptions.test.ts
@@ -12,6 +12,7 @@ import { getConversationDetail } from "@/modules/conversations/service";
 import { followUpHandler } from "@/modules/followups/handlers";
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 // Issue #129, wiring end. A BusinessHours profile only modelled the week, so a holiday had no
 // representation and every consumer read September 7 as an ordinary Monday. The RULE (which ranges
@@ -46,6 +47,9 @@ if (appUrl && suUrl) {
 }
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
+
+// Burned from `scheduler_jobs_id_seq`, never a literal: tests/utils/scheduler.ts says why.
+let phantomJobId = 0n;
 
 const TZ = "America/Sao_Paulo";
 // TEST-NET-3 on a closed port: passes the SSRF check without a DNS lookup, and nothing can reach it
@@ -168,6 +172,7 @@ async function seedConversation(
 
 describe.skipIf(!dbUp)("business-hours date exceptions (issue #129)", () => {
   beforeAll(async () => {
+    phantomJobId = await burnSchedulerJobId(suDb);
     installChatwootDouble();
     const t = await suDb.tenant.create({
       data: { name: "BHEXC", slug: `bhexc-${process.pid}` },
@@ -339,7 +344,7 @@ describe.skipIf(!dbUp)("business-hours date exceptions (issue #129)", () => {
     await seedConversation(convId);
     const s = stubClient();
     const job: ClaimedJob = {
-      id: 1n,
+      id: phantomJobId,
       tenantId,
       kind: "FOLLOWUP",
       payload: { threadId: threadOf(convId) },
@@ -472,7 +477,7 @@ describe.skipIf(!dbUp)("business-hours date exceptions (issue #129)", () => {
     const s = stubClient();
     const result = await followUpHandler(
       {
-        id: 2n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP",
         payload: { threadId: threadOf(convId) },

--- a/tests/modules/chatwoot-recover-delivery.test.ts
+++ b/tests/modules/chatwoot-recover-delivery.test.ts
@@ -32,6 +32,7 @@ import type { ClaimedJob } from "@/modules/scheduler/service";
 import { getJobHandler } from "@/modules/scheduler/worker";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import { flowLogRows } from "../utils/flowlog";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 // Answering the customer whose delivery a process death stranded (issue #295).
 //
@@ -68,6 +69,9 @@ if (appUrl && suUrl) {
 }
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
+
+// Burned from `scheduler_jobs_id_seq`, never a literal: tests/utils/scheduler.ts says why.
+let phantomJobId = 0n;
 
 const CHATWOOT_INBOX_ID = 71;
 // An inbox BOUND to an agent that has no `ChatwootAgentBot` row: the persona was never provisioned,
@@ -339,6 +343,7 @@ async function ledger(rowId: bigint) {
 
 describe.skipIf(!dbUp)("recovering a delivery the sweep gave up on", () => {
   beforeAll(async () => {
+    phantomJobId = await burnSchedulerJobId(suDb);
     // Registration is what src/index.ts does at boot, and it is idempotent. Read back through
     // `getJobHandler` rather than calling the handler function directly: a handler that is never
     // registered is a claimed job with nowhere to go, which is the failure the registry exists to
@@ -3561,9 +3566,9 @@ describe.skipIf(!dbUp)("recovering a delivery the sweep gave up on", () => {
   });
 
   describe("the job that runs it", () => {
-    function jobFor(payload: Record<string, unknown>, id = 1n): ClaimedJob {
+    function jobFor(payload: Record<string, unknown>): ClaimedJob {
       return {
-        id,
+        id: phantomJobId,
         tenantId,
         kind: "DELIVERY_RECOVERY",
         payload,

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -102,14 +102,20 @@ const MARKERS = /\bclaimSeq\b/g;
 // JSON inside a string (`const raw = '{"claimSeq":0}'`) would answer for a fixture that is not
 // there.
 const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
-// The annotation of a VALUE, which is what the initializer says: `job: ClaimedJob` on a parameter
-// names a job the function is handed, not one written here, and a sweep that counted it would call
-// the `{ id: 7n }` in that function's body a fixture. A FACTORY's return type is the same promise
-// about a literal, so `{` joins `=`: it reaches `function jobFor(): ClaimedJob {`, while `=` already
-// reached the arrow (`(): ClaimedJob => ({…})`, whose `=>` opens with one), and neither reaches
-// `function run(job: ClaimedJob) {`, where a `)` sits between the type and the brace.
+// An annotation over a literal WRITTEN AT THAT POINT, and the literal is the load-bearing half:
+// `= {`, `= [`, `=> ({`, or the `satisfies`/`as` that follow the literal they describe. Four rounds
+// of review were spent on the annotations that name a job WITHOUT one, and each answer bought the
+// next question, because they are all the same shape: `job: ClaimedJob` on a parameter, defaulted or
+// not, `function jobFor(): ClaimedJob {`, `Promise<ClaimedJob>` on an async factory. None of them
+// says where the literal is, so counting them is line proximity again, one indirection down, and
+// what it produces is the `{ id: 7n }` of some other object in the same fourteen lines.
+//
+// So a job produced by a function whose RETURN type is the only mention is out of the sweep's reach,
+// written down here and asserted below rather than left to be discovered. It is the narrow corner of
+// a case that is already narrow: a fixture is only invisible to `claimSeq` when the field arrives by
+// spread from another module, and then also has to spell a reachable id.
 const TYPE_MARKER =
-  /:\s*ClaimedJob(?:\[\])?\s*[={]|(?:satisfies|as)\s+ClaimedJob\b/g;
+  /:\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)[[{]|(?:satisfies|as)\s+ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -286,18 +292,31 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       "  const jobs: ClaimedJob[] = [{ id: 1n, ...b }];",
       true,
     ],
-    // A factory's return type promises the same thing about the literal it returns, in both
-    // spellings: the arrow's `=>` opens with the `=` the value form already reads, and the
-    // declaration's body opens with a brace.
+    // The arrow with an expression body is the one return type that DOES say where the literal is:
+    // it is the next thing after the annotation.
     [
-      "an arrow factory's return type",
+      "an arrow factory returning a literal",
       "  const jobFor = (): ClaimedJob => ({ id: 1n, ...baseJob });",
       true,
     ],
+    // The other side of that: a return type says what the function produces, not where the literal
+    // is, so these are the sweep's stated blind corner rather than a case it means to catch.
     [
       "a declared factory's return type",
       "  function jobFor(): ClaimedJob {\n    return { id: 1n, ...baseJob };",
-      true,
+      false,
+    ],
+    [
+      "an async factory's wrapped return type",
+      "  async function jobFor(): Promise<ClaimedJob> {\n    return { id: 1n, ...baseJob };",
+      false,
+    ],
+    // A defaulted parameter is still a parameter: the value is somebody else's, and the id below
+    // belongs to another object.
+    [
+      "a defaulted parameter",
+      "  function inspect(job: ClaimedJob = defaultJob) {\n    const tenant = { id: 7n };",
+      false,
     ],
     // A job the function is HANDED is not a job written here, and the id below belongs to a tenant.
     [

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -62,7 +62,7 @@ const ROOT = join(import.meta.dir, "..");
 // `reachableBySequence` normalises what is captured, so the grammar lives here and the arithmetic
 // lives there.
 // Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
-const NUMBER = String.raw`[+-]?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|[+-]?0[xX][\dA-Fa-f_]+|[+-]?0[oO][0-7_]+|[+-]?0[bB][01_]+`;
+const NUMBER = String.raw`[+-]?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?[\d_]+)?|[+-]?0[xX][\dA-Fa-f_]+|[+-]?0[oO][0-7_]+|[+-]?0[bB][01_]+`;
 const LITERAL_ID = new RegExp(
   String.raw`(?:\bid|["']id["'])(?:\s*:\s*[^=;,)\n]{1,80})?\s*[:=]\s*\(?\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?\s*(${NUMBER})n?\s*["'\`]?\s*\))`,
   "g",
@@ -124,7 +124,7 @@ const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // a case that is already narrow: a fixture is only invisible to `claimSeq` when the field arrives by
 // spread from another module, and then also has to spell a reachable id.
 const TYPE_MARKER =
-  /(?::\s*[^=;{}\n]*\bClaimedJob\b[^=;{}\n]*=\s*|:\s*ClaimedJob(?:\[\])?\s*=>\s*\(\s*|(?<![\w$])<\s*ClaimedJob\s*>\s*)[[{]|[}\]]\s*\)?\s*(?:(?:as|satisfies)\s+(?:unknown|const|readonly)\s+)*(?:as|satisfies)\s+ClaimedJob\b/g;
+  /(?::\s*[^=;{}\n]*\bClaimedJob\b[^=;{}\n]*=\s*\(?\s*|:\s*ClaimedJob(?:\[\])?\s*=>\s*\(\s*|(?<![\w$])<\s*ClaimedJob\s*>\s*)[[{]|[}\]]\s*\)?\s*(?:(?:as|satisfies)\s+(?:unknown|const|readonly)\s+)*(?:as|satisfies)\s+ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -263,6 +263,7 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     ["a BigInt() call over a bigint", fixture("BigInt(7n)"), true],
     // Neither is a bigint literal, and both are what BigInt turns into one.
     ["a BigInt() call over an exponent", fixture("BigInt(1e3)"), true],
+    ["a separator inside the exponent", fixture("BigInt(1e1_0)"), true],
     ["a BigInt() call over a whole float", fixture("BigInt(1.0)"), true],
     // Every base and the separator, because they all reach the same 7 and a decimal-only pattern
     // reads each of them as no id at all.
@@ -343,6 +344,12 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     [
       "a union annotation over a literal",
       "  const job: ClaimedJob | undefined = { id: 1n, ...b };",
+      true,
+    ],
+    // A parenthesised initializer is still an initializer, and `= (` cannot open a body.
+    [
+      "a parenthesised initializer",
+      "  const job: ClaimedJob = ({ ...baseJob, id: 1n });",
       true,
     ],
     // The literal side stays strict, and this is what that buys: a function TAKING a job and

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -103,7 +103,8 @@ const MARKERS = /\bclaimSeq\b/g;
 // there.
 const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // An annotation over a literal WRITTEN AT THAT POINT, and the literal is the load-bearing half:
-// `= {`, `= [`, `=> ({`, or a `satisfies`/`as` that follows a literal's own closing bracket, which
+// `= {`, `= [`, `=> ({`, `<ClaimedJob>{`, or a `satisfies`/`as` that follows a literal's own
+// closing bracket, which
 // is what tells `({…}) as unknown as ClaimedJob` (spend-ceiling-poll.test.ts, a fixture) from
 // `claimed.find(…) as ClaimedJob` (scheduler-claim-token.test.ts, a row that was found). Whatever
 // type-level words sit in between are a repeat of one pair, `as unknown as` and `as const satisfies`
@@ -119,7 +120,7 @@ const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // a case that is already narrow: a fixture is only invisible to `claimSeq` when the field arrives by
 // spread from another module, and then also has to spell a reachable id.
 const TYPE_MARKER =
-  /:\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)[[{]|[}\]]\s*\)?\s*(?:(?:as|satisfies)\s+(?:unknown|const|readonly)\s+)*(?:as|satisfies)\s+ClaimedJob\b/g;
+  /(?::\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)|(?<![\w$])<\s*ClaimedJob\s*>\s*)[[{]|[}\]]\s*\)?\s*(?:(?:as|satisfies)\s+(?:unknown|const|readonly)\s+)*(?:as|satisfies)\s+ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -284,6 +285,14 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     [
       "a spread fixture named by its type",
       "  const job: ClaimedJob = { id: 1n, ...baseJob };",
+      true,
+    ],
+    // The angle-bracket assertion is the same annotation written in front of the literal. Nothing in
+    // this tree spells one, and it costs one alternative to read, plus the lookbehind that keeps it
+    // from reading the `<ClaimedJob>` inside `Promise<ClaimedJob> {`, where the brace is a body.
+    [
+      "an angle-bracket assertion",
+      "  const job = <ClaimedJob>{ id: 1n, ...baseJob };",
       true,
     ],
     [

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -33,11 +33,25 @@ import { join } from "node:path";
 // is where a contributor's fixture arrives.
 const ROOT = join(import.meta.dir, "..");
 
-// `id` GIVEN a decimal literal, in either spelling a bigint takes and on either side of the two
-// operators that hand a fixture its id: a property (`id: 1n`) and a default parameter
-// (`function jobFor(p, id = 1n)`), which is how chatwoot-recover-delivery.test.ts spelled the same
-// landmine and how a property-only sweep missed it for a whole round.
-const LITERAL_ID = /\bid\s*[:=]\s*(?:(-?\d+)n|BigInt\(\s*(-?\d+)\s*\))/g;
+// `id` GIVEN a number, in every spelling that reaches the same value, because the sweep is only as
+// good as the grammar it admits and a fixture is written by whoever writes it next:
+//
+//   - both operators that hand a fixture its id: a property (`id: 1n`) and a default parameter
+//     (`function jobFor(p, id = 1n)`), which is how chatwoot-recover-delivery.test.ts spelled it and
+//     how a property-only sweep missed that file for a whole round;
+//   - a quoted key (`"id": 1n`), which a JSON-shaped literal carries;
+//   - every numeric base plus separators (`0x1n`, `0o7n`, `0b11n`, `1_000n`), all of which a
+//     decimal-only pattern reads as absent;
+//   - `BigInt(1)` and `BigInt("1")`, the constructor's two argument forms.
+//
+// `reachableBySequence` normalises what is captured, so the grammar lives here and the arithmetic
+// lives there.
+// Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
+const NUMBER = String.raw`-?\d[\d_]*|0[xX][\dA-Fa-f_]+|0[oO][0-7_]+|0[bB][01_]+`;
+const LITERAL_ID = new RegExp(
+  String.raw`(?:\bid|["']id["'])\s*[:=]\s*(?:(${NUMBER})n|BigInt\(\s*["']?(${NUMBER})["']?\s*\))`,
+  "g",
+);
 
 // What tells a `ClaimedJob` literal from every other object with an `id`: `claimSeq`, a required
 // field of the type that nothing else in the tree carries. Deliberately NOT `kind`, and not a
@@ -58,8 +72,10 @@ const MARKERS = /\bclaimSeq:/;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
+// `Number` reads every base the pattern above admits once the separators are gone, and answers NaN
+// for what it cannot read, which is not a positive number either.
 function reachableBySequence(value: string): boolean {
-  return Number(value) > 0;
+  return Number(value.replace(/_/g, "")) > 0;
 }
 
 export function fixtureIdHits(src: string): number[] {
@@ -148,6 +164,16 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
   test.each([
     ["a bigint literal", fixture("7n"), true],
     ["a BigInt() call", fixture("BigInt(7)"), true],
+    ["a BigInt() call over a string", fixture('BigInt("7")'), true],
+    // Every base and the separator, because they all reach the same 7 and a decimal-only pattern
+    // reads each of them as no id at all.
+    ["a hex literal", fixture("0x7n"), true],
+    ["an octal literal", fixture("0o7n"), true],
+    ["a binary literal", fixture("0b111n"), true],
+    ["digit separators", fixture("1_000n"), true],
+    ["a quoted key", fixture("7n").replace("id:", '"id":'), true],
+    // The sign test is about the VALUE, so it has to survive the spelling too.
+    ["a hex zero", fixture("0x0n"), false],
     [
       "a default parameter",
       "function jobFor(p: object, id = 1n) {\n  claimSeq: 0;",

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -46,12 +46,18 @@ const ROOT = join(import.meta.dir, "..");
 //   - every argument `BigInt` itself accepts and turns into a reachable id: `BigInt(1)`,
 //     `BigInt("1")`, `` BigInt(`1`) ``, `BigInt(1e3)`, `BigInt(1.0)`. The fraction and the exponent
 //     are not valid in a bigint LITERAL, so they only ever appear here, and admitting them costs
-//     nothing: an `id: 1.5n` that matched would be a syntax error long before this sweep read it.
+//     nothing: an `id: 1.5n` that matched would be a syntax error long before this sweep read it;
+//   - either sign, since `BigInt(+1)` is 1n and a pattern that reads only the minus calls it absent.
+//
+// The bound, stated rather than discovered next round: this reads LITERALS. An id computed at run
+// time (`BigInt(someVar)`, `ids[0]`, a call) is out of reach of any text sweep, and is exactly the
+// shape `burnSchedulerJobId` produces, so the sweep's blind spot and the fix's output are the same
+// thing. What it has to see is the spelling somebody types by hand, in any base, sign or quote.
 //
 // `reachableBySequence` normalises what is captured, so the grammar lives here and the arithmetic
 // lives there.
 // Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
-const NUMBER = String.raw`-?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|0[xX][\dA-Fa-f_]+|0[oO][0-7_]+|0[bB][01_]+`;
+const NUMBER = String.raw`[+-]?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|[+-]?0[xX][\dA-Fa-f_]+|[+-]?0[oO][0-7_]+|[+-]?0[bB][01_]+`;
 const LITERAL_ID = new RegExp(
   String.raw`(?:\bid|["']id["'])\s*[:=]\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})["'\`]?\s*\))`,
   "g",
@@ -181,6 +187,8 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     ["a BigInt() call", fixture("BigInt(7)"), true],
     ["a BigInt() call over a string", fixture('BigInt("7")'), true],
     ["a BigInt() call over a template", fixture("BigInt(`7`)"), true],
+    ["a BigInt() call over a signed number", fixture("BigInt(+7)"), true],
+    ["a BigInt() call over a signed string", fixture('BigInt("+7")'), true],
     // Neither is a bigint literal, and both are what BigInt turns into one.
     ["a BigInt() call over an exponent", fixture("BigInt(1e3)"), true],
     ["a BigInt() call over a whole float", fixture("BigInt(1.0)"), true],

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -64,7 +64,7 @@ const ROOT = join(import.meta.dir, "..");
 // Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
 const NUMBER = String.raw`[+-]?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|[+-]?0[xX][\dA-Fa-f_]+|[+-]?0[oO][0-7_]+|[+-]?0[bB][01_]+`;
 const LITERAL_ID = new RegExp(
-  String.raw`(?:\bid|["']id["'])(?:\s*:\s*[^=;,)\n]{1,80})?\s*[:=]\s*\(?\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})n?["'\`]?\s*\))`,
+  String.raw`(?:\bid|["']id["'])(?:\s*:\s*[^=;,)\n]{1,80})?\s*[:=]\s*\(?\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?\s*(${NUMBER})n?\s*["'\`]?\s*\))`,
   "g",
 );
 
@@ -104,7 +104,11 @@ const MARKERS = /\bclaimSeq\b/g;
 const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // An annotation over a literal WRITTEN AT THAT POINT, and the literal is the load-bearing half:
 // `= {`, `= [`, `=> ({`, `<ClaimedJob>{`, or a `satisfies`/`as` that follows a literal's own
-// closing bracket, which
+// closing bracket. The TYPE side of that is read the way the id's own annotation is, as whatever is
+// not the operator: `ClaimedJob`, `ClaimedJob[]`, `Array<ClaimedJob>`, `ClaimedJob | undefined` and
+// whatever else a type expression can be are one rule rather than the list they were becoming. The
+// LITERAL side stays strict, and that asymmetry is the whole design: a type expression is a language
+// and a literal is a brace, so the growth belongs on the side that can absorb it. Which
 // is what tells `({…}) as unknown as ClaimedJob` (spend-ceiling-poll.test.ts, a fixture) from
 // `claimed.find(…) as ClaimedJob` (scheduler-claim-token.test.ts, a row that was found). Whatever
 // type-level words sit in between are a repeat of one pair, `as unknown as` and `as const satisfies`
@@ -120,7 +124,7 @@ const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // a case that is already narrow: a fixture is only invisible to `claimSeq` when the field arrives by
 // spread from another module, and then also has to spell a reachable id.
 const TYPE_MARKER =
-  /(?::\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)|(?<![\w$])<\s*ClaimedJob\s*>\s*)[[{]|[}\]]\s*\)?\s*(?:(?:as|satisfies)\s+(?:unknown|const|readonly)\s+)*(?:as|satisfies)\s+ClaimedJob\b/g;
+  /(?::\s*[^=;{}\n]*\bClaimedJob\b[^=;{}\n]*=\s*|:\s*ClaimedJob(?:\[\])?\s*=>\s*\(\s*|(?<![\w$])<\s*ClaimedJob\s*>\s*)[[{]|[}\]]\s*\)?\s*(?:(?:as|satisfies)\s+(?:unknown|const|readonly)\s+)*(?:as|satisfies)\s+ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -248,6 +252,8 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     ["a BigInt() call", fixture("BigInt(7)"), true],
     ["a BigInt() call over a string", fixture('BigInt("7")'), true],
     ["a BigInt() call over a template", fixture("BigInt(`7`)"), true],
+    // `BigInt(" 1 ")` is `1n`: the quotes are trimmed before the number is read.
+    ["a BigInt() call over a padded string", fixture('BigInt(" 7 ")'), true],
     ["a BigInt() call over a signed number", fixture("BigInt(+7)"), true],
     ["a BigInt() call over a signed string", fixture('BigInt("+7")'), true],
     // `Number("+0x1")` is NaN while `BigInt(+0x1)` is `1n`, so the sign has to come off before the
@@ -328,6 +334,24 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       "  const jobs: ClaimedJob[] = [{ id: 1n, ...b }];",
       true,
     ],
+    // The type side is a language, so it is read as a rule rather than as a list of its spellings.
+    [
+      "a generic-array annotation",
+      "  const jobs: Array<ClaimedJob> = [{ id: 1n, ...b }];",
+      true,
+    ],
+    [
+      "a union annotation over a literal",
+      "  const job: ClaimedJob | undefined = { id: 1n, ...b };",
+      true,
+    ],
+    // The literal side stays strict, and this is what that buys: a function TAKING a job and
+    // returning some other object is not a fixture, however its parameter is typed.
+    [
+      "an arrow that takes a job and returns something else",
+      "  const f = (j: ClaimedJob) => ({ id: 7n });",
+      false,
+    ],
     // The arrow with an expression body is the one return type that DOES say where the literal is:
     // it is the next thing after the annotation.
     [
@@ -340,6 +364,11 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     [
       "a declared factory's return type",
       "  function jobFor(): ClaimedJob {\n    return { id: 1n, ...baseJob };",
+      false,
+    ],
+    [
+      "an arrow factory with a block body",
+      "  const jobFor = (): ClaimedJob => {\n    return { id: 1n, ...baseJob };",
       false,
     ],
     [

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// A `ClaimedJob` built by hand in a test is a FIXTURE, not a row: the handler only ever reads it
+// back. `jobRetired` (modules/scheduler/service.ts) looks the id up to find the tombstone a `/reset`
+// or a supersede leaves behind, and an id nobody holds answers "not retired", which is the benign
+// branch every one of these fixtures is written for.
+//
+// It stops being benign the moment the id names a row, because `scheduler_jobs_id_seq` hands out
+// exactly the numbers these fixtures spell: 1, 2, 9. The file's own `schedulerJob.create` takes id 1
+// whenever it is the first in the DATABASE to insert one, and a file that then retires that row (a
+// `retireJobsByDedupeKey` bumps `claim_seq`) has planted a tombstone under its own fixture. From
+// there the handler stands down without posting and every assertion about what should have been sent
+// fails with `Expected: 1, Received: 0`.
+//
+// Measured on this branch, in the real path: a cold sequence handed id 1 to an insert, a fixture
+// spelling `id: 1n` answered `jobRetired` false, `retireJobsByDedupeKey` retired that row, and the
+// same fixture then answered true. A fixture holding a burned id answered false on both sides.
+// Measured earlier, by #498, as five failures in `followup-resolved-guardrails.test.ts` under
+// `TRUNCATE scheduler_jobs RESTART IDENTITY`. No local run reproduced those, because a development
+// database has a warm sequence, and CI only showed them once two new files in #400 reshuffled the
+// shards and put the victim first.
+//
+// So the rule is not "these files are broken" (most are not, today). It is that a fixture must be
+// INCAPABLE of naming a row, in any order, on any shard, and the only ways to be sure are an id
+// burned from the sequence (`burnSchedulerJobId`, tests/utils/scheduler.ts) or a number the sequence
+// cannot reach.
+//
+// It sits here rather than beside the other static sweeps in tests/tooling/ because that directory
+// is dropped from BOTH derived repos (tooling/derivation/manifest.ts) while the fixtures it reads
+// ship to all three. A sweep that only runs in the master cannot fail the public repo's CI, which
+// is where a contributor's fixture arrives.
+const ROOT = join(import.meta.dir, "..");
+
+// `id` GIVEN a decimal literal, in either spelling a bigint takes and on either side of the two
+// operators that hand a fixture its id: a property (`id: 1n`) and a default parameter
+// (`function jobFor(p, id = 1n)`), which is how chatwoot-recover-delivery.test.ts spelled the same
+// landmine and how a property-only sweep missed it for a whole round.
+const LITERAL_ID = /\bid\s*[:=]\s*(?:(-?\d+)n|BigInt\(\s*(-?\d+)\s*\))/g;
+
+// What tells a `ClaimedJob` literal from every other object with an `id`: `claimSeq`, a required
+// field of the type that nothing else in the tree carries. Deliberately NOT `kind`, and not a
+// "does this file import ClaimedJob" gate:
+//
+//   - `kind` is somebody else's field name too. Measured: `resolveByModelName` answers
+//     `{ kind: "one", id }`, so namespace-resolve.test.ts's seven `{ id: 1n, name }` rows come back
+//     as job fixtures under a `kind` marker, and a sweep with seven false alarms is one that gets
+//     an exclusion list and then gets ignored.
+//   - the file's import is not the fixture. terminal-failure-announces.test.ts hands the RAG_INGEST
+//     handler a job-shaped literal without ever naming the type, and a gate on the name reads that
+//     file as having no fixtures at all. It is safe today only because its id is `0n`.
+//
+// A window rather than a parser, and its reach is pinned from both sides below, because a window
+// nobody measures is one that quietly grows to "the whole file" or shrinks to "the same line".
+const NEARBY = 14;
+const MARKERS = /\bclaimSeq:/;
+
+// A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
+// which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
+function reachableBySequence(value: string): boolean {
+  return Number(value) > 0;
+}
+
+export function fixtureIdHits(src: string): number[] {
+  const lines = src.split("\n");
+  const hits: number[] = [];
+  for (const m of src.matchAll(LITERAL_ID)) {
+    const value = m[1] ?? m[2];
+    if (!value || !reachableBySequence(value)) continue;
+    const line = src.slice(0, m.index).split("\n").length;
+    const window = lines
+      .slice(Math.max(0, line - 1 - NEARBY), line + NEARBY)
+      .join("\n");
+    if (!MARKERS.test(window)) continue;
+    hits.push(line);
+  }
+  return hits;
+}
+
+// Every TypeScript file under tests/, not only `*.test.ts`: a fixture builder moved into
+// tests/utils/ is the same fixture, and a sweep that only reads test files is one a refactor walks
+// out of without touching a line of the fixture.
+export function testFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...testFiles(p));
+    else if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))
+      out.push(p);
+  }
+  return out;
+}
+
+export function offendingFixtures(): string[] {
+  const hits: string[] = [];
+  for (const file of testFiles(ROOT)) {
+    // The sweep's own samples are fixtures on purpose, and a sweep that flags itself can only be
+    // silenced by weakening it.
+    if (file.endsWith("claimed-job-fixture-ids.test.ts")) continue;
+    const rel = file.slice(ROOT.length + 1);
+    for (const line of fixtureIdHits(readFileSync(file, "utf8")))
+      hits.push(`${rel}:${line}`);
+  }
+  return hits.sort();
+}
+
+const fixture = (id: string, gap = 1) =>
+  [
+    "  const job: ClaimedJob = {",
+    `    id: ${id},`,
+    ...Array.from({ length: gap - 1 }, () => "    // filler"),
+    "    kind: 'FOLLOWUP',",
+    "    claimSeq: 0,",
+    "  };",
+  ].join("\n");
+
+const untyped = [
+  "    const out = await handler({",
+  "      id: 7n,",
+  "      tenantId,",
+  "      kind: 'RAG_INGEST',",
+  "      claimSeq: 0,",
+  "    });",
+].join("\n");
+
+describe("a scheduler fixture may not name a row the sequence can hand out", () => {
+  test("no ClaimedJob literal carries an id a sequence reaches", () => {
+    expect(offendingFixtures()).toEqual([]);
+  });
+
+  // Pinned because nothing in the tree exercises it today: every fixture currently sits in a test
+  // file, so narrowing the sweep back to `*.test.ts` would break nothing and read as green. The
+  // file it has to reach is the shared helper's own neighbourhood, tests/utils/.
+  test("the sweep reads the helpers, not only the test files", () => {
+    const swept = testFiles(ROOT);
+    const helpers = swept.filter(
+      (f) => !f.endsWith(".test.ts") && !f.endsWith(".test.tsx"),
+    );
+    expect(helpers.length).toBeGreaterThan(0);
+    expect(helpers.some((f) => f.endsWith("/utils/scheduler.ts"))).toBe(true);
+  });
+
+  // The sweep's own eyesight, pinned on synthetic sources rather than on the tree. Without this, a
+  // sweep whose regex stopped matching or whose window collapsed would read as a clean tree, which
+  // is the failure mode every static sweep has and the one that matters most here: the whole point
+  // is to catch the NEXT file, and a green tree tells you nothing about whether it still can.
+  test.each([
+    ["a bigint literal", fixture("7n"), true],
+    ["a BigInt() call", fixture("BigInt(7)"), true],
+    [
+      "a default parameter",
+      "function jobFor(p: object, id = 1n) {\n  claimSeq: 0;",
+      true,
+    ],
+    ["a marker ten lines off", fixture("7n", 10), true],
+    // The shape is the fixture, whether or not the file ever names the type. This is
+    // terminal-failure-announces.test.ts, which hands a handler a job literal and imports nothing.
+    ["a fixture that never names the type", untyped, true],
+    // Zero and negatives are what a DB-free fixture is allowed to keep: no sequence produces them.
+    ["zero", fixture("0n"), false],
+    ["a negative", fixture("-1n"), false],
+    // An object with an `id` and no `claimSeq` is a message, a contact, a row read back from a
+    // create. None of those are the fixture this is about.
+    [
+      "an id with no claimSeq",
+      "  const job: ClaimedJob = {};\n  const msg = { id: 5n, kind: 'one' };",
+      false,
+    ],
+    // Forty lines from the marker is not one object literal, and treating it as one would flag every
+    // id in every file that happens to mention a job somewhere.
+    ["a marker forty lines off", fixture("7n", 40), false],
+  ])("sees %s: %p", (_name, src, expected) => {
+    expect(fixtureIdHits(src as string).length > 0).toBe(expected);
+  });
+
+  // `kind` is the marker this sweep deliberately does not use, pinned so that adding it back is a
+  // failing test rather than seven false alarms in namespace-resolve.test.ts.
+  test("kind alone is somebody else's field, and does not make a fixture", () => {
+    const src = [
+      "  const rows = [",
+      "    { id: 1n, name: 'Foo' },",
+      "  ];",
+      "  expect(resolveByModelName(rows, 'Foo')).toEqual({ kind: 'one', id: 1n });",
+    ].join("\n");
+    expect(fixtureIdHits(src)).toEqual([]);
+  });
+});

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -103,7 +103,9 @@ const MARKERS = /\bclaimSeq\b/g;
 // there.
 const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // An annotation over a literal WRITTEN AT THAT POINT, and the literal is the load-bearing half:
-// `= {`, `= [`, `=> ({`, or the `satisfies`/`as` that follow the literal they describe. Four rounds
+// `= {`, `= [`, `=> ({`, or a `satisfies`/`as` that follows a literal's own closing bracket, which
+// is what tells `({…}) as unknown as ClaimedJob` (spend-ceiling-poll.test.ts, a fixture) from
+// `claimed.find(…) as ClaimedJob` (scheduler-claim-token.test.ts, a row that was found). Four rounds
 // of review were spent on the annotations that name a job WITHOUT one, and each answer bought the
 // next question, because they are all the same shape: `job: ClaimedJob` on a parameter, defaulted or
 // not, `function jobFor(): ClaimedJob {`, `Promise<ClaimedJob>` on an async factory. None of them
@@ -115,7 +117,7 @@ const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // a case that is already narrow: a fixture is only invisible to `claimSeq` when the field arrives by
 // spread from another module, and then also has to spell a reachable id.
 const TYPE_MARKER =
-  /:\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)[[{]|(?:satisfies|as)\s+ClaimedJob\b/g;
+  /:\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)[[{]|[}\]]\s*\)?\s*(?:satisfies|as)\s+(?:unknown\s+as\s+)?ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -286,6 +288,17 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       "a spread fixture named by satisfies",
       "  const job = { id: 1n, ...baseJob } satisfies ClaimedJob;",
       true,
+    ],
+    // Both spellings the tree actually uses, and they differ by what sits before the `as`.
+    [
+      "a literal cast through unknown",
+      "  const job = ({ id: 1n, ...b }) as unknown as ClaimedJob;",
+      true,
+    ],
+    [
+      "a cast of a row that was found",
+      "  const mine = claimed.find((j) => j.id === id) as ClaimedJob;\n  const m = { id: 1n };",
+      false,
     ],
     [
       "an annotated array",

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { withoutComments } from "../utils/source-text";
 
 // A `ClaimedJob` built by hand in a test is a FIXTURE, not a row: the handler only ever reads it
 // back. `jobRetired` (modules/scheduler/service.ts) looks the id up to find the tombstone a `/reset`
@@ -42,14 +43,17 @@ const ROOT = join(import.meta.dir, "..");
 //   - a quoted key (`"id": 1n`), which a JSON-shaped literal carries;
 //   - every numeric base plus separators (`0x1n`, `0o7n`, `0b11n`, `1_000n`), all of which a
 //     decimal-only pattern reads as absent;
-//   - `BigInt(1)` and `BigInt("1")`, the constructor's two argument forms.
+//   - every argument `BigInt` itself accepts and turns into a reachable id: `BigInt(1)`,
+//     `BigInt("1")`, `` BigInt(`1`) ``, `BigInt(1e3)`, `BigInt(1.0)`. The fraction and the exponent
+//     are not valid in a bigint LITERAL, so they only ever appear here, and admitting them costs
+//     nothing: an `id: 1.5n` that matched would be a syntax error long before this sweep read it.
 //
 // `reachableBySequence` normalises what is captured, so the grammar lives here and the arithmetic
 // lives there.
 // Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
-const NUMBER = String.raw`-?\d[\d_]*|0[xX][\dA-Fa-f_]+|0[oO][0-7_]+|0[bB][01_]+`;
+const NUMBER = String.raw`-?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|0[xX][\dA-Fa-f_]+|0[oO][0-7_]+|0[bB][01_]+`;
 const LITERAL_ID = new RegExp(
-  String.raw`(?:\bid|["']id["'])\s*[:=]\s*(?:(${NUMBER})n|BigInt\(\s*["']?(${NUMBER})["']?\s*\))`,
+  String.raw`(?:\bid|["']id["'])\s*[:=]\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})["'\`]?\s*\))`,
   "g",
 );
 
@@ -81,7 +85,13 @@ function reachableBySequence(value: string): boolean {
   return Number(value.replace(/_/g, "")) > 0;
 }
 
-export function fixtureIdHits(src: string): number[] {
+export function fixtureIdHits(source: string): number[] {
+  // Prose that NAMES the shape is not the shape. A comment explaining what a fixture used to spell
+  // sits within the window of the fixture it explains, so a raw scan turns documentation into a red
+  // sweep, and the cheap way out of that is deleting the sentence that explained the trap. The strip
+  // preserves offsets, so the line numbers below still name the line the reader will open. Comments
+  // only, not string bodies: a quoted key (`"id": 1n`) is code, and this pattern reads it.
+  const src = withoutComments(source);
   const lines = src.split("\n");
   const hits: number[] = [];
   for (const m of src.matchAll(LITERAL_ID)) {
@@ -170,6 +180,10 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     ["a bigint literal", fixture("7n"), true],
     ["a BigInt() call", fixture("BigInt(7)"), true],
     ["a BigInt() call over a string", fixture('BigInt("7")'), true],
+    ["a BigInt() call over a template", fixture("BigInt(`7`)"), true],
+    // Neither is a bigint literal, and both are what BigInt turns into one.
+    ["a BigInt() call over an exponent", fixture("BigInt(1e3)"), true],
+    ["a BigInt() call over a whole float", fixture("BigInt(1.0)"), true],
     // Every base and the separator, because they all reach the same 7 and a decimal-only pattern
     // reads each of them as no id at all.
     ["a hex literal", fixture("0x7n"), true],
@@ -233,6 +247,20 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
   // The whole word, not a prefix of it: `claimDueJobs`, `claimed` and `claimOf` sit beside every real
   // row in the scheduler tests, and a marker matching "claim" would call each of those rows a
   // fixture.
+  // Prose about a fixture is not a fixture. The comment that explains what a line used to spell sits
+  // inside the window of the line it explains, so a sweep reading raw text turns the explanation into
+  // a red CI, and the cheapest way to green is deleting the explanation.
+  test("a comment naming the old spelling is not a fixture", () => {
+    const src = [
+      "  const job: ClaimedJob = {",
+      "    // was id: 1n, which the sequence hands out",
+      "    id: phantomJobId,",
+      "    claimSeq: 0,",
+      "  };",
+    ].join("\n");
+    expect(fixtureIdHits(src)).toEqual([]);
+  });
+
   test("a claim in the neighbourhood is not the field", () => {
     const src = [
       "  const [claimed] = await claimDueJobs(1, appDb, new Date(), tenantId);",

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -41,6 +41,8 @@ const ROOT = join(import.meta.dir, "..");
 //     (`function jobFor(p, id = 1n)`), which is how chatwoot-recover-delivery.test.ts spelled it and
 //     how a property-only sweep missed that file for a whole round;
 //   - a quoted key (`"id": 1n`), which a JSON-shaped literal carries;
+//   - a TYPED default parameter (`function job(id: bigint = 1n)`), where the annotation sits between
+//     the name and the operator, and a parenthesised value (`id: (1n)`);
 //   - every numeric base plus separators (`0x1n`, `0o7n`, `0b11n`, `1_000n`), all of which a
 //     decimal-only pattern reads as absent;
 //   - every argument `BigInt` itself accepts and turns into a reachable id: `BigInt(1)`,
@@ -59,7 +61,7 @@ const ROOT = join(import.meta.dir, "..");
 // Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
 const NUMBER = String.raw`[+-]?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|[+-]?0[xX][\dA-Fa-f_]+|[+-]?0[oO][0-7_]+|[+-]?0[bB][01_]+`;
 const LITERAL_ID = new RegExp(
-  String.raw`(?:\bid|["']id["'])\s*[:=]\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})n?["'\`]?\s*\))`,
+  String.raw`(?:\bid|["']id["'])(?:\s*:\s*[A-Za-z_$][\w$]*)?\s*[:=]\s*\(?\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})n?["'\`]?\s*\))`,
   "g",
 );
 
@@ -82,6 +84,11 @@ const NEARBY = 14;
 // variable produces, `"claimSeq": 0` in a JSON-shaped literal and `row.claimSeq` in the line
 // that fills it are all the same signal, and a marker spelled with a colon sees only the first.
 const MARKERS = /\bclaimSeq\b/;
+// Asked of the code, so `note: "claimSeq"` and the SQL alias `claim_seq AS "claimSeq"` (which
+// src/modules/scheduler/service.ts writes for real) are data rather than a job. That strip also
+// blanks a quoted KEY, which is a spelling of the field and not data, so the key is asked for
+// separately, against the unblanked window and by its shape: quoted, then a colon.
+const QUOTED_MARKER = /["']claimSeq["']\s*:/;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -109,16 +116,19 @@ export function fixtureIdHits(source: string): number[] {
   // inside a string body is text that spells a fixture (`payload: "id: 1n"`), not one.
   const code = codeOnly(source);
   const lines = src.split("\n");
+  const codeLines = code.split("\n");
   const hits: number[] = [];
   for (const m of src.matchAll(LITERAL_ID)) {
     const value = m[1] ?? m[2];
     if (!value || !reachableBySequence(value)) continue;
     if (m.index === undefined || code[m.index] !== src[m.index]) continue;
     const line = src.slice(0, m.index).split("\n").length;
-    const window = lines
-      .slice(Math.max(0, line - 1 - NEARBY), line + NEARBY)
-      .join("\n");
-    if (!MARKERS.test(window)) continue;
+    const from = Math.max(0, line - 1 - NEARBY);
+    const to = line + NEARBY;
+    const marked =
+      MARKERS.test(codeLines.slice(from, to).join("\n")) ||
+      QUOTED_MARKER.test(lines.slice(from, to).join("\n"));
+    if (!marked) continue;
     hits.push(line);
   }
   return hits;
@@ -222,6 +232,14 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       "function jobFor(p: object, id = 1n) {\n  claimSeq: 0;",
       true,
     ],
+    // The annotation sits between the name and the operator, which is where a pattern reading
+    // "name, then operator, then number" stops.
+    [
+      "a typed default parameter",
+      "function job(id: bigint = 1n) {\n  claimSeq: 0;",
+      true,
+    ],
+    ["a parenthesised value", fixture("(7n)"), true],
     ["a marker ten lines off", fixture("7n", 10), true],
     // The shape is the fixture, whether or not the file ever names the type. This is
     // terminal-failure-announces.test.ts, which hands a handler a job literal and imports nothing.
@@ -271,6 +289,17 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
   // The whole word, not a prefix of it: `claimDueJobs`, `claimed` and `claimOf` sit beside every real
   // row in the scheduler tests, and a marker matching "claim" would call each of those rows a
   // fixture.
+  // The marker has the same two sides as the id. `claimSeq` inside string DATA is not a field, and
+  // the case is not hypothetical: src/modules/scheduler/service.ts aliases a column as "claimSeq" in
+  // a raw query, and a test doing the same beside any id literal would fail the whole tree.
+  test("the marker inside string data is not the field", () => {
+    const src = [
+      '  const rows = await suDb.$queryRaw`SELECT claim_seq AS "claimSeq"`;',
+      "  const msg = { id: 7n, note: 'oi' };",
+    ].join("\n");
+    expect(fixtureIdHits(src)).toEqual([]);
+  });
+
   // Neither is a string that spells one. A payload or an expected message can carry the shape as
   // DATA, and a sweep that reads it as code fails the tree over somebody's fixture text, which is
   // the same red-for-nothing that a comment produces.

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -80,11 +80,13 @@ const LITERAL_ID = new RegExp(
 //     handler a job-shaped literal without ever naming the type, and a gate on the name reads that
 //     file as having no fixtures at all. It is safe today only because its id is `0n`.
 //
-// The ANNOTATION, though, is a marker of its own (`: ClaimedJob`, `satisfies ClaimedJob`,
-// `as ClaimedJob`), because a fixture can take its claim token from a spread whose source is
-// imported, and then nothing near the id spells `claimSeq` at all. It is the annotation and not the
-// bare word, so the `import type { ClaimedJob }` at the top of a file is not a marker over whatever
-// happens to sit in the fourteen lines below it. Measured: adding it flags nothing new in the tree.
+// The ANNOTATION OF A VALUE, though, is a marker of its own (`: ClaimedJob =`, `satisfies
+// ClaimedJob`, `as ClaimedJob`), because a fixture can take its claim token from a spread whose
+// source is imported, and then nothing near the id spells `claimSeq` at all. Not the bare word and
+// not every annotation: `import type { ClaimedJob }` sits at the top of every file that has one, and
+// `function run(job: ClaimedJob)` names a job the function is HANDED, so counting either would make
+// a marker out of whatever happens to sit in the fourteen lines below. The initializer is what
+// separates a job written here from a job mentioned here. Measured: it flags nothing new in the tree.
 //
 // A window rather than a parser, and its reach is pinned from both sides below, because a window
 // nobody measures is one that quietly grows to "the whole file" or shrinks to "the same line".
@@ -100,7 +102,11 @@ const MARKERS = /\bclaimSeq\b/g;
 // JSON inside a string (`const raw = '{"claimSeq":0}'`) would answer for a fixture that is not
 // there.
 const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
-const TYPE_MARKER = /(?::\s*|satisfies\s+|as\s+)ClaimedJob\b/g;
+// The annotation of a VALUE, which is the initializer: `job: ClaimedJob` on a parameter names a
+// job the function is handed, not one written here, and a sweep that counted it would call the
+// `{ id: 7n }` in that function's body a fixture.
+const TYPE_MARKER =
+  /:\s*ClaimedJob(?:\[\])?\s*=|(?:satisfies|as)\s+ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -271,6 +277,17 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       "a spread fixture named by satisfies",
       "  const job = { id: 1n, ...baseJob } satisfies ClaimedJob;",
       true,
+    ],
+    [
+      "an annotated array",
+      "  const jobs: ClaimedJob[] = [{ id: 1n, ...b }];",
+      true,
+    ],
+    // A job the function is HANDED is not a job written here, and the id below belongs to a tenant.
+    [
+      "a parameter annotation",
+      "  function inspect(job: ClaimedJob) {\n    const tenant = { id: 7n };",
+      false,
     ],
     // The import is not an annotation, and it sits at the top of every file that has one.
     [

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -80,6 +80,12 @@ const LITERAL_ID = new RegExp(
 //     handler a job-shaped literal without ever naming the type, and a gate on the name reads that
 //     file as having no fixtures at all. It is safe today only because its id is `0n`.
 //
+// The ANNOTATION, though, is a marker of its own (`: ClaimedJob`, `satisfies ClaimedJob`,
+// `as ClaimedJob`), because a fixture can take its claim token from a spread whose source is
+// imported, and then nothing near the id spells `claimSeq` at all. It is the annotation and not the
+// bare word, so the `import type { ClaimedJob }` at the top of a file is not a marker over whatever
+// happens to sit in the fourteen lines below it. Measured: adding it flags nothing new in the tree.
+//
 // A window rather than a parser, and its reach is pinned from both sides below, because a window
 // nobody measures is one that quietly grows to "the whole file" or shrinks to "the same line".
 const NEARBY = 14;
@@ -94,6 +100,7 @@ const MARKERS = /\bclaimSeq\b/g;
 // JSON inside a string (`const raw = '{"claimSeq":0}'`) would answer for a fixture that is not
 // there.
 const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
+const TYPE_MARKER = /(?::\s*|satisfies\s+|as\s+)ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -126,6 +133,7 @@ export function fixtureIdHits(source: string): number[] {
   // blanking would erase, and answers only where its own opening quote survived the blanking.
   const markerLines = new Set<number>();
   for (const m of code.matchAll(MARKERS)) markerLines.add(lineOf(m.index));
+  for (const m of code.matchAll(TYPE_MARKER)) markerLines.add(lineOf(m.index));
   for (const m of src.matchAll(QUOTED_MARKER))
     if (code[m.index] === src[m.index]) markerLines.add(lineOf(m.index));
 
@@ -171,9 +179,11 @@ export function offendingFixtures(): string[] {
   return hits.sort();
 }
 
+// Untyped on purpose: the annotation is a marker of its own now, so a sample carrying it would be
+// marked no matter what the `claimSeq` rows below are trying to measure.
 const fixture = (id: string, gap = 1) =>
   [
-    "  const job: ClaimedJob = {",
+    "  const job = {",
     `    id: ${id},`,
     ...Array.from({ length: gap - 1 }, () => "    // filler"),
     "    kind: 'FOLLOWUP',",
@@ -250,6 +260,24 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       true,
     ],
     ["a parenthesised value", fixture("(7n)"), true],
+    // The annotation is a marker in its own right, because a fixture can take its claim token from
+    // a spread whose source is imported, and then no `claimSeq` is written anywhere near the id.
+    [
+      "a spread fixture named by its type",
+      "  const job: ClaimedJob = { id: 1n, ...baseJob };",
+      true,
+    ],
+    [
+      "a spread fixture named by satisfies",
+      "  const job = { id: 1n, ...baseJob } satisfies ClaimedJob;",
+      true,
+    ],
+    // The import is not an annotation, and it sits at the top of every file that has one.
+    [
+      "an import of the type",
+      'import type { ClaimedJob } from "@/modules/scheduler/service";\n  const msg = { id: 5n };',
+      false,
+    ],
     // The annotation is whatever is not the operator: an indexed access and a union both read the
     // same way, and both are how a factory declares the id it defaults.
     [
@@ -271,11 +299,7 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     ["a negative", fixture("-1n"), false],
     // An object with an `id` and no `claimSeq` is a message, a contact, a row read back from a
     // create. None of those are the fixture this is about.
-    [
-      "an id with no claimSeq",
-      "  const job: ClaimedJob = {};\n  const msg = { id: 5n, kind: 'one' };",
-      false,
-    ],
+    ["an id with no claimSeq", "  const msg = { id: 5n, kind: 'one' };", false],
     // Forty lines from the marker is not one object literal, and treating it as one would flag every
     // id in every file that happens to mention a job somewhere.
     ["a marker forty lines off", fixture("7n", 40), false],

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -105,7 +105,9 @@ const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // An annotation over a literal WRITTEN AT THAT POINT, and the literal is the load-bearing half:
 // `= {`, `= [`, `=> ({`, or a `satisfies`/`as` that follows a literal's own closing bracket, which
 // is what tells `({…}) as unknown as ClaimedJob` (spend-ceiling-poll.test.ts, a fixture) from
-// `claimed.find(…) as ClaimedJob` (scheduler-claim-token.test.ts, a row that was found). Four rounds
+// `claimed.find(…) as ClaimedJob` (scheduler-claim-token.test.ts, a row that was found). Whatever
+// type-level words sit in between are a repeat of one pair, `as unknown as` and `as const satisfies`
+// alike, written as a repetition rather than as the list those two would start. Four rounds
 // of review were spent on the annotations that name a job WITHOUT one, and each answer bought the
 // next question, because they are all the same shape: `job: ClaimedJob` on a parameter, defaulted or
 // not, `function jobFor(): ClaimedJob {`, `Promise<ClaimedJob>` on an async factory. None of them
@@ -117,7 +119,7 @@ const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 // a case that is already narrow: a fixture is only invisible to `claimSeq` when the field arrives by
 // spread from another module, and then also has to spell a reachable id.
 const TYPE_MARKER =
-  /:\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)[[{]|[}\]]\s*\)?\s*(?:satisfies|as)\s+(?:unknown\s+as\s+)?ClaimedJob\b/g;
+  /:\s*ClaimedJob(?:\[\])?\s*(?:=>\s*\(\s*|=\s*)[[{]|[}\]]\s*\)?\s*(?:(?:as|satisfies)\s+(?:unknown|const|readonly)\s+)*(?:as|satisfies)\s+ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -293,6 +295,18 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     [
       "a literal cast through unknown",
       "  const job = ({ id: 1n, ...b }) as unknown as ClaimedJob;",
+      true,
+    ],
+    [
+      "a literal asserted const",
+      "  const job = { id: 1n, ...b } as const satisfies ClaimedJob;",
+      true,
+    ],
+    // Written as a repetition rather than as the list those two would start, so a third bridge is
+    // not a fourteenth round.
+    [
+      "a literal behind two bridges",
+      "  const job = { id: 1n, ...b } as const as unknown as ClaimedJob;",
       true,
     ],
     [

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -68,7 +68,10 @@ const LITERAL_ID = new RegExp(
 // A window rather than a parser, and its reach is pinned from both sides below, because a window
 // nobody measures is one that quietly grows to "the whole file" or shrinks to "the same line".
 const NEARBY = 14;
-const MARKERS = /\bclaimSeq:/;
+// The FIELD NAME, not one punctuation of it: `claimSeq: 0`, the shorthand `claimSeq,` a local
+// variable produces, `"claimSeq": 0` in a JSON-shaped literal and `row.claimSeq` in the line
+// that fills it are all the same signal, and a marker spelled with a colon sees only the first.
+const MARKERS = /\bclaimSeq\b/;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -208,6 +211,30 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       "    { id: 1n, name: 'Foo' },",
       "  ];",
       "  expect(resolveByModelName(rows, 'Foo')).toEqual({ kind: 'one', id: 1n });",
+    ].join("\n");
+    expect(fixtureIdHits(src)).toEqual([]);
+  });
+
+  // The marker's own spellings. A fixture whose `claimSeq` comes from a local variable is written as
+  // shorthand, and a JSON-shaped one quotes its keys: both are the same field, and a marker that
+  // demanded a colon read them as no job at all.
+  test.each([
+    ["a property", "    claimSeq: 0,"],
+    ["shorthand", "    claimSeq,"],
+    ["a quoted key", '    "claimSeq": 0,'],
+    ["a value read off a row", "    claimSeq: row.claimSeq,"],
+  ])("recognises claimSeq written as %s", (_name, line) => {
+    const src = ["  const job = {", "    id: 7n,", line, "  };"].join("\n");
+    expect(fixtureIdHits(src)).toEqual([2]);
+  });
+
+  // The whole word, not a prefix of it: `claimDueJobs`, `claimed` and `claimOf` sit beside every real
+  // row in the scheduler tests, and a marker matching "claim" would call each of those rows a
+  // fixture.
+  test("a claim in the neighbourhood is not the field", () => {
+    const src = [
+      "  const [claimed] = await claimDueJobs(1, appDb, new Date(), tenantId);",
+      "  const msg = { id: 7n, content: 'oi' };",
     ].join("\n");
     expect(fixtureIdHits(src)).toEqual([]);
   });

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -102,11 +102,14 @@ const MARKERS = /\bclaimSeq\b/g;
 // JSON inside a string (`const raw = '{"claimSeq":0}'`) would answer for a fixture that is not
 // there.
 const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
-// The annotation of a VALUE, which is the initializer: `job: ClaimedJob` on a parameter names a
-// job the function is handed, not one written here, and a sweep that counted it would call the
-// `{ id: 7n }` in that function's body a fixture.
+// The annotation of a VALUE, which is what the initializer says: `job: ClaimedJob` on a parameter
+// names a job the function is handed, not one written here, and a sweep that counted it would call
+// the `{ id: 7n }` in that function's body a fixture. A FACTORY's return type is the same promise
+// about a literal, so `{` joins `=`: it reaches `function jobFor(): ClaimedJob {`, while `=` already
+// reached the arrow (`(): ClaimedJob => ({…})`, whose `=>` opens with one), and neither reaches
+// `function run(job: ClaimedJob) {`, where a `)` sits between the type and the brace.
 const TYPE_MARKER =
-  /:\s*ClaimedJob(?:\[\])?\s*=|(?:satisfies|as)\s+ClaimedJob\b/g;
+  /:\s*ClaimedJob(?:\[\])?\s*[={]|(?:satisfies|as)\s+ClaimedJob\b/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -281,6 +284,19 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     [
       "an annotated array",
       "  const jobs: ClaimedJob[] = [{ id: 1n, ...b }];",
+      true,
+    ],
+    // A factory's return type promises the same thing about the literal it returns, in both
+    // spellings: the arrow's `=>` opens with the `=` the value form already reads, and the
+    // declaration's body opens with a brace.
+    [
+      "an arrow factory's return type",
+      "  const jobFor = (): ClaimedJob => ({ id: 1n, ...baseJob });",
+      true,
+    ],
+    [
+      "a declared factory's return type",
+      "  function jobFor(): ClaimedJob {\n    return { id: 1n, ...baseJob };",
       true,
     ],
     // A job the function is HANDED is not a job written here, and the id below belongs to a tenant.

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { withoutComments } from "../utils/source-text";
+import { codeOnly, withoutComments } from "../utils/source-text";
 
 // A `ClaimedJob` built by hand in a test is a FIXTURE, not a row: the handler only ever reads it
 // back. `jobRetired` (modules/scheduler/service.ts) looks the id up to find the tombstone a `/reset`
@@ -59,7 +59,7 @@ const ROOT = join(import.meta.dir, "..");
 // Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
 const NUMBER = String.raw`[+-]?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|[+-]?0[xX][\dA-Fa-f_]+|[+-]?0[oO][0-7_]+|[+-]?0[bB][01_]+`;
 const LITERAL_ID = new RegExp(
-  String.raw`(?:\bid|["']id["'])\s*[:=]\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})["'\`]?\s*\))`,
+  String.raw`(?:\bid|["']id["'])\s*[:=]\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})n?["'\`]?\s*\))`,
   "g",
 );
 
@@ -88,7 +88,11 @@ const MARKERS = /\bclaimSeq\b/;
 // `Number` reads every base the pattern above admits once the separators are gone, and answers NaN
 // for what it cannot read, which is not a positive number either.
 function reachableBySequence(value: string): boolean {
-  return Number(value.replace(/_/g, "")) > 0;
+  // The leading `+` goes because `Number("+0x1")` is NaN while `BigInt(+0x1)` is `1n`, and a sweep
+  // that reads a reachable id as unreadable calls it safe. The leading `-` STAYS, for the same
+  // arithmetic in the other direction: `Number("-0x1")` is NaN, and a negative id is unreachable
+  // anyway, so the NaN and the sign agree.
+  return Number(value.replace(/_/g, "").replace(/^\+/, "")) > 0;
 }
 
 export function fixtureIdHits(source: string): number[] {
@@ -98,11 +102,18 @@ export function fixtureIdHits(source: string): number[] {
   // preserves offsets, so the line numbers below still name the line the reader will open. Comments
   // only, not string bodies: a quoted key (`"id": 1n`) is code, and this pattern reads it.
   const src = withoutComments(source);
+  // The same source with string BODIES blanked too, offsets intact. It is not what the pattern runs
+  // over, because half of what the pattern reads is legitimately inside quotes: a quoted key
+  // (`"id": 1n`) and a stringified argument (`BigInt("7")`) are both real spellings of a fixture.
+  // What it answers is one question, about the FIRST character of the match: a match that STARTS
+  // inside a string body is text that spells a fixture (`payload: "id: 1n"`), not one.
+  const code = codeOnly(source);
   const lines = src.split("\n");
   const hits: number[] = [];
   for (const m of src.matchAll(LITERAL_ID)) {
     const value = m[1] ?? m[2];
     if (!value || !reachableBySequence(value)) continue;
+    if (m.index === undefined || code[m.index] !== src[m.index]) continue;
     const line = src.slice(0, m.index).split("\n").length;
     const window = lines
       .slice(Math.max(0, line - 1 - NEARBY), line + NEARBY)
@@ -189,6 +200,11 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
     ["a BigInt() call over a template", fixture("BigInt(`7`)"), true],
     ["a BigInt() call over a signed number", fixture("BigInt(+7)"), true],
     ["a BigInt() call over a signed string", fixture('BigInt("+7")'), true],
+    // `Number("+0x1")` is NaN while `BigInt(+0x1)` is `1n`, so the sign has to come off before the
+    // arithmetic or a reachable id reads as unreadable, and unreadable reads as safe.
+    ["a BigInt() call over a signed hex", fixture("BigInt(+0x7)"), true],
+    // BigInt over a bigint is the identity, and the `n` used to end the match before the `)`.
+    ["a BigInt() call over a bigint", fixture("BigInt(7n)"), true],
     // Neither is a bigint literal, and both are what BigInt turns into one.
     ["a BigInt() call over an exponent", fixture("BigInt(1e3)"), true],
     ["a BigInt() call over a whole float", fixture("BigInt(1.0)"), true],
@@ -255,6 +271,20 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
   // The whole word, not a prefix of it: `claimDueJobs`, `claimed` and `claimOf` sit beside every real
   // row in the scheduler tests, and a marker matching "claim" would call each of those rows a
   // fixture.
+  // Neither is a string that spells one. A payload or an expected message can carry the shape as
+  // DATA, and a sweep that reads it as code fails the tree over somebody's fixture text, which is
+  // the same red-for-nothing that a comment produces.
+  test("a string that spells a fixture is not a fixture", () => {
+    const src = [
+      "  const job: ClaimedJob = {",
+      "    id: phantomJobId,",
+      '    payload: { note: "id: 1n" },',
+      "    claimSeq: 0,",
+      "  };",
+    ].join("\n");
+    expect(fixtureIdHits(src)).toEqual([]);
+  });
+
   // Prose about a fixture is not a fixture. The comment that explains what a line used to spell sits
   // inside the window of the line it explains, so a sweep reading raw text turns the explanation into
   // a red CI, and the cheapest way to green is deleting the explanation.

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -157,7 +157,9 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       (f) => !f.endsWith(".test.ts") && !f.endsWith(".test.tsx"),
     );
     expect(helpers.length).toBeGreaterThan(0);
-    expect(helpers.some((f) => f.endsWith("/utils/scheduler.ts"))).toBe(true);
+    // Built with `join`, not spelled with a separator: the paths come from `join` too, and a "/"
+    // written here is a test that fails on the one platform whose separator is the other one.
+    expect(helpers).toContain(join(ROOT, "utils", "scheduler.ts"));
   });
 
   // The sweep's own eyesight, pinned on synthetic sources rather than on the tree. Without this, a

--- a/tests/modules/claimed-job-fixture-ids.test.ts
+++ b/tests/modules/claimed-job-fixture-ids.test.ts
@@ -42,7 +42,10 @@ const ROOT = join(import.meta.dir, "..");
 //     how a property-only sweep missed that file for a whole round;
 //   - a quoted key (`"id": 1n`), which a JSON-shaped literal carries;
 //   - a TYPED default parameter (`function job(id: bigint = 1n)`), where the annotation sits between
-//     the name and the operator, and a parenthesised value (`id: (1n)`);
+//     the name and the operator, and a parenthesised value (`id: (1n)`). The annotation is skipped as
+//     "whatever is not the operator", up to one line, so `ClaimedJob["id"]` and `bigint | undefined`
+//     pass with the bare `bigint`; a plain `id: 1n` still matches, because the engine backtracks out
+//     of an annotation that would leave no operator behind it;
 //   - every numeric base plus separators (`0x1n`, `0o7n`, `0b11n`, `1_000n`), all of which a
 //     decimal-only pattern reads as absent;
 //   - every argument `BigInt` itself accepts and turns into a reachable id: `BigInt(1)`,
@@ -61,7 +64,7 @@ const ROOT = join(import.meta.dir, "..");
 // Every base a bigint literal takes, plus the separator, normalised by `reachableBySequence` below.
 const NUMBER = String.raw`[+-]?\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?|[+-]?0[xX][\dA-Fa-f_]+|[+-]?0[oO][0-7_]+|[+-]?0[bB][01_]+`;
 const LITERAL_ID = new RegExp(
-  String.raw`(?:\bid|["']id["'])(?:\s*:\s*[A-Za-z_$][\w$]*)?\s*[:=]\s*\(?\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})n?["'\`]?\s*\))`,
+  String.raw`(?:\bid|["']id["'])(?:\s*:\s*[^=;,)\n]{1,80})?\s*[:=]\s*\(?\s*(?:(${NUMBER})n|BigInt\(\s*["'\`]?(${NUMBER})n?["'\`]?\s*\))`,
   "g",
 );
 
@@ -83,12 +86,14 @@ const NEARBY = 14;
 // The FIELD NAME, not one punctuation of it: `claimSeq: 0`, the shorthand `claimSeq,` a local
 // variable produces, `"claimSeq": 0` in a JSON-shaped literal and `row.claimSeq` in the line
 // that fills it are all the same signal, and a marker spelled with a colon sees only the first.
-const MARKERS = /\bclaimSeq\b/;
+const MARKERS = /\bclaimSeq\b/g;
 // Asked of the code, so `note: "claimSeq"` and the SQL alias `claim_seq AS "claimSeq"` (which
 // src/modules/scheduler/service.ts writes for real) are data rather than a job. That strip also
 // blanks a quoted KEY, which is a spelling of the field and not data, so the key is asked for
-// separately, against the unblanked window and by its shape: quoted, then a colon.
-const QUOTED_MARKER = /["']claimSeq["']\s*:/;
+// separately and by its shape: quoted, then a colon. Its opening quote must itself be code, or the
+// JSON inside a string (`const raw = '{"claimSeq":0}'`) would answer for a fixture that is not
+// there.
+const QUOTED_MARKER = /["']claimSeq["']\s*:/g;
 
 // A sequence starts at 1 and only ever climbs, so 0 and negatives are unreachable by construction,
 // which is what a fixture needs and the reason this is a sign test rather than a ban on literals.
@@ -115,19 +120,24 @@ export function fixtureIdHits(source: string): number[] {
   // What it answers is one question, about the FIRST character of the match: a match that STARTS
   // inside a string body is text that spells a fixture (`payload: "id: 1n"`), not one.
   const code = codeOnly(source);
-  const lines = src.split("\n");
-  const codeLines = code.split("\n");
+  const lineOf = (at: number) => src.slice(0, at).split("\n").length;
+  // Every line carrying the field, gathered once. `MARKERS` reads the blanked copy, so a word in
+  // string data never counts; `QUOTED_MARKER` reads the unblanked one for the key spelling that
+  // blanking would erase, and answers only where its own opening quote survived the blanking.
+  const markerLines = new Set<number>();
+  for (const m of code.matchAll(MARKERS)) markerLines.add(lineOf(m.index));
+  for (const m of src.matchAll(QUOTED_MARKER))
+    if (code[m.index] === src[m.index]) markerLines.add(lineOf(m.index));
+
   const hits: number[] = [];
   for (const m of src.matchAll(LITERAL_ID)) {
     const value = m[1] ?? m[2];
     if (!value || !reachableBySequence(value)) continue;
     if (m.index === undefined || code[m.index] !== src[m.index]) continue;
-    const line = src.slice(0, m.index).split("\n").length;
-    const from = Math.max(0, line - 1 - NEARBY);
-    const to = line + NEARBY;
-    const marked =
-      MARKERS.test(codeLines.slice(from, to).join("\n")) ||
-      QUOTED_MARKER.test(lines.slice(from, to).join("\n"));
+    const line = lineOf(m.index);
+    const marked = [...markerLines].some(
+      (l) => l >= line - NEARBY && l <= line + NEARBY,
+    );
     if (!marked) continue;
     hits.push(line);
   }
@@ -240,6 +250,18 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
       true,
     ],
     ["a parenthesised value", fixture("(7n)"), true],
+    // The annotation is whatever is not the operator: an indexed access and a union both read the
+    // same way, and both are how a factory declares the id it defaults.
+    [
+      "an indexed-access annotation",
+      'function job(id: ClaimedJob["id"] = 1n) {\n  claimSeq: 0;',
+      true,
+    ],
+    [
+      "a union annotation",
+      "function job(id: bigint | undefined = 1n) {\n  claimSeq: 0;",
+      true,
+    ],
     ["a marker ten lines off", fixture("7n", 10), true],
     // The shape is the fixture, whether or not the file ever names the type. This is
     // terminal-failure-announces.test.ts, which hands a handler a job literal and imports nothing.
@@ -295,6 +317,16 @@ describe("a scheduler fixture may not name a row the sequence can hand out", () 
   test("the marker inside string data is not the field", () => {
     const src = [
       '  const rows = await suDb.$queryRaw`SELECT claim_seq AS "claimSeq"`;',
+      "  const msg = { id: 7n, note: 'oi' };",
+    ].join("\n");
+    expect(fixtureIdHits(src)).toEqual([]);
+  });
+
+  // And JSON inside a string is not a key. The quoted spelling is admitted by SHAPE, so the only
+  // thing separating `"claimSeq": 0` from `'{"claimSeq":0}'` is whether the opening quote is code.
+  test("a quoted marker inside a string is not the field", () => {
+    const src = [
+      "  const raw = '{\"claimSeq\":0}';",
       "  const msg = { id: 7n, note: 'oi' };",
     ].join("\n");
     expect(fixtureIdHits(src)).toEqual([]);

--- a/tests/modules/compaction-worker.test.ts
+++ b/tests/modules/compaction-worker.test.ts
@@ -12,6 +12,9 @@ import type { ClaimedJob } from "@/modules/scheduler/service";
 const base = {} as PrismaClient;
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+// The reaped rows below carry `id: 0n`, a number no sequence hands out. Nothing here reaches a
+// database, so any id would run; the point is that a fixture copied out of this file into one
+// that DOES insert jobs cannot then name a real row. tests/utils/scheduler.ts covers that case.
 function job(id: number): ClaimedJob {
   return {
     id: BigInt(id),
@@ -60,7 +63,7 @@ describe("runCompactionTick", () => {
       run: async () => {},
       reap: async () => [
         {
-          id: 9n,
+          id: 0n,
           tenantId: 1n,
           kind: "MEMORY_COMPACT" as const,
           payload: {},
@@ -141,7 +144,7 @@ describe("runCompactionTick", () => {
           seen.push(kind);
           return [
             {
-              id: 9n,
+              id: 0n,
               tenantId: 1n,
               kind: "MEMORY_COMPACT",
               payload: {},

--- a/tests/modules/debounce-parallelism.test.ts
+++ b/tests/modules/debounce-parallelism.test.ts
@@ -11,6 +11,7 @@ import { flushDebounceJob } from "@/modules/debounce/handler";
 import { runDebounceTick } from "@/modules/debounce/worker";
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 // End-to-end parallelism harness (no Chatwoot, no LLM): drives N real turns through the actual tick
 // (runDebounceTick → flushDebounceJob → graph → runModelCall) with a stub Chatwoot client and a fake
@@ -39,6 +40,9 @@ if (appUrl && suUrl) {
 }
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
+
+// Burned from `scheduler_jobs_id_seq`, never a literal: tests/utils/scheduler.ts says why.
+let phantomJobId = 0n;
 
 let tenantId = 0n;
 let instanceId = 0n;
@@ -170,7 +174,7 @@ async function seedConversation(convId: number) {
 
 function jobFor(convId: number): ClaimedJob {
   return {
-    id: 1n,
+    id: phantomJobId,
     tenantId,
     kind: "DEBOUNCE",
     payload: { threadId: threadOf(convId), agentBotId: 9, burstStartedAt: 1 },
@@ -181,6 +185,7 @@ function jobFor(convId: number): ClaimedJob {
 
 describe.skipIf(!dbUp)("debounce parallelism", () => {
   beforeAll(async () => {
+    phantomJobId = await burnSchedulerJobId(suDb);
     const t = await suDb.tenant.create({
       data: { name: "DBP", slug: `dbp-${process.pid}` },
     });

--- a/tests/modules/debounce.test.ts
+++ b/tests/modules/debounce.test.ts
@@ -43,6 +43,7 @@ import {
 } from "@/tests/utils/flowlog";
 import { POLL_DEADLINE_MS } from "@/tests/utils/poll";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { burnSchedulerJobId } from "../utils/scheduler";
 import {
   EmptyThenReplyModel,
   guardrailModel,
@@ -74,6 +75,9 @@ if (appUrl && suUrl) {
 }
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
+
+// Burned from `scheduler_jobs_id_seq`, never a literal: tests/utils/scheduler.ts says why.
+let phantomJobId = 0n;
 
 let tenantId = 0n;
 let agentDbId = 0n;
@@ -240,7 +244,7 @@ function jobFor(
   extra: { lastMessageId?: number } = {},
 ): ClaimedJob {
   return {
-    id: 1n,
+    id: phantomJobId,
     tenantId,
     kind: "DEBOUNCE",
     payload: {
@@ -307,6 +311,7 @@ async function correctionLine(convId: number) {
 
 describe.skipIf(!dbUp)("debounce", () => {
   beforeAll(async () => {
+    phantomJobId = await burnSchedulerJobId(suDb);
     const t = await suDb.tenant.create({
       data: { name: "DBC", slug: `dbc-${process.pid}` },
     });

--- a/tests/modules/flowlog-retention.test.ts
+++ b/tests/modules/flowlog-retention.test.ts
@@ -6,6 +6,7 @@ import { registerFlowlogRetentionHandler } from "@/modules/flowlog/retention";
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import { getJobHandler, type JobResult } from "@/modules/scheduler/worker";
 import { clearFlowLog, flowLogRows } from "@/tests/utils/flowlog";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 // FLOWLOG_SWEEP retention handler: deletes execution_logs (+ terminal alert_deliveries) older than
 // the retention window, RLS-scoped to the job's tenant, and reschedules +24h (no attempt consumed).
@@ -33,10 +34,14 @@ if (appUrl && suUrl) {
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
 
+// Burned from `scheduler_jobs_id_seq`, never a literal: tests/utils/scheduler.ts says why.
+let phantomJobId = 0n;
+
 let tenantId = 0n;
 
 describe.skipIf(!dbUp)("flowlog retention", () => {
   beforeAll(async () => {
+    phantomJobId = await burnSchedulerJobId(suDb);
     tenantId = (
       await suDb.tenant.create({
         data: { name: "FlowR", slug: `flow-r-${process.pid}` },
@@ -71,7 +76,7 @@ describe.skipIf(!dbUp)("flowlog retention", () => {
     const handler = getJobHandler("FLOWLOG_SWEEP");
     expect(handler).toBeDefined();
     const job: ClaimedJob = {
-      id: 1n,
+      id: phantomJobId,
       tenantId,
       kind: "FLOWLOG_SWEEP",
       payload: {},

--- a/tests/modules/followup-handler.test.ts
+++ b/tests/modules/followup-handler.test.ts
@@ -20,6 +20,7 @@ import {
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import { getJobHandler } from "@/modules/scheduler/worker";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
 const suUrl = process.env.MIGRATION_DATABASE_URL;
@@ -43,6 +44,9 @@ if (appUrl && suUrl) {
 }
 const appDb = app as PrismaClient;
 const suDb = su as PrismaClient;
+
+// Burned from `scheduler_jobs_id_seq`, never a literal: tests/utils/scheduler.ts says why.
+let phantomJobId = 0n;
 
 let tenantId = 0n;
 let instanceId = 0n;
@@ -98,7 +102,7 @@ function threadOf(convId: number) {
 
 function jobFor(convId: number, stepIndex?: number): ClaimedJob {
   return {
-    id: 1n,
+    id: phantomJobId,
     tenantId,
     kind: "FOLLOWUP",
     payload:
@@ -229,6 +233,7 @@ async function lastFollowUpOf(convId: number): Promise<Date | null> {
 
 describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
   beforeAll(async () => {
+    phantomJobId = await burnSchedulerJobId(suDb);
     const t = await suDb.tenant.create({
       data: { name: "FUT", slug: `fut-${process.pid}` },
     });
@@ -814,7 +819,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     expect(sweep).toBeDefined();
     await sweep?.(
       {
-        id: 999n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -860,7 +865,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
       const sweep = getJobHandler("FOLLOWUP_SWEEP");
       await sweep?.(
         {
-          id: 998n,
+          id: phantomJobId,
           tenantId,
           kind: "FOLLOWUP_SWEEP",
           payload: {},
@@ -949,7 +954,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 998n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -984,7 +989,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 997n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1042,7 +1047,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 996n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1093,7 +1098,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 995n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1140,7 +1145,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 994n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1230,7 +1235,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 992n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1282,7 +1287,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 991n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1361,7 +1366,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
       registerFollowUpHandlers();
       await getJobHandler("FOLLOWUP_SWEEP")?.(
         {
-          id: 992n,
+          id: phantomJobId,
           tenantId,
           kind: "FOLLOWUP_SWEEP",
           payload: {},
@@ -1419,7 +1424,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     registerFollowUpHandlers();
     await getJobHandler("FOLLOWUP_SWEEP")?.(
       {
-        id: 993n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1519,7 +1524,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
       {
-        id: 998n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1558,7 +1563,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
       {
-        id: 997n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1593,7 +1598,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
       {
-        id: 996n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1636,7 +1641,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
       {
-        id: 995n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1678,7 +1683,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
       {
-        id: 993n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1719,7 +1724,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
       {
-        id: 994n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},
@@ -1812,7 +1817,7 @@ describe.skipIf(!dbUp)("followUpHandler — watermark guard", () => {
     const sweep = getJobHandler("FOLLOWUP_SWEEP");
     await sweep?.(
       {
-        id: 992n,
+        id: phantomJobId,
         tenantId,
         kind: "FOLLOWUP_SWEEP",
         payload: {},

--- a/tests/modules/followup-resolved-guardrails.test.ts
+++ b/tests/modules/followup-resolved-guardrails.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@/modules/scheduler/service";
 import { getJobHandler } from "@/modules/scheduler/worker";
 import { seedChatwootInstance } from "../utils/chatwoot";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 // NOTE: Guardrails da cadeia "follow-up em conversa resolvida" (post da comunidade "Followup indo como
 // conversa privada", 2026-08-06). O incidente: espelho local preso em `pending` (resolve perdido /
@@ -71,8 +72,9 @@ let inboxAId = 0n;
 let agentBId = 0n;
 let inboxBId = 0n;
 
-// O `id` de um ClaimedJob fabricado é QUEIMADO da sequência real, nunca escrito como literal — veja
-// `jobFor` para o que um literal custou.
+// O `id` de um ClaimedJob fabricado é QUEIMADO da sequência real, nunca escrito como literal. Veja
+// `jobFor` para o que um literal custou, e tests/utils/scheduler.ts para a queima em si, hoje
+// compartilhada com os outros sete arquivos que fabricavam job (#500).
 let phantomJobId = 0n;
 
 const INBOX_A = 71;
@@ -221,11 +223,7 @@ async function seedConversation(
 
 describe.skipIf(!dbUp)("follow-up em conversa resolvida — guardrails", () => {
   beforeAll(async () => {
-    const [burned] = await suDb.$queryRaw<{ nextval: bigint }[]>`
-      SELECT nextval('scheduler_jobs_id_seq')`;
-    if (!burned)
-      throw new Error("nextval('scheduler_jobs_id_seq') devolveu nada");
-    phantomJobId = BigInt(burned.nextval);
+    phantomJobId = await burnSchedulerJobId(suDb);
     const t = await suDb.tenant.create({
       data: { name: "FU-GUARD", slug: `fu-guard-${process.pid}` },
     });

--- a/tests/modules/scheduler.test.ts
+++ b/tests/modules/scheduler.test.ts
@@ -19,6 +19,7 @@ import {
   upsertJobRows,
 } from "@/modules/scheduler/service";
 import { registerJobHandler, runClaimed } from "@/modules/scheduler/worker";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 const appUrl = process.env.TEST_APP_DATABASE_URL;
 const suUrl = process.env.MIGRATION_DATABASE_URL;
@@ -910,6 +911,44 @@ describe.skipIf(!dbUp)("scheduler", () => {
     await suDb.schedulerJob.delete({ where: { id: gone.id } });
     expect(await jobRetired(gone, appDb)).toBe(false);
     expect(await sqlSaysRetired(gone)).toBe(false);
+  });
+
+  // The absent row above is the branch every hand-built `ClaimedJob` in this suite rides: an id
+  // nobody holds reads as NOT retired, which is what makes a fixture a fixture. What keeps it there
+  // is `burnSchedulerJobId`, and the guarantee it owes is not "an id that looks free" but one the
+  // sequence has already spent, since anything else is a number some later insert lands on.
+  // tests/modules/claimed-job-fixture-ids.test.ts carries the failure that costs.
+  test("a burned fixture id is one no insert can land on", async () => {
+    const burned = await burnSchedulerJobId(suDb);
+    expect(burned).toBeGreaterThan(0n);
+    const fixture: ClaimedJob = {
+      id: burned,
+      tenantId,
+      kind: "FOLLOWUP",
+      payload: {},
+      attempts: 0,
+      claimSeq: 0,
+    };
+    expect(await jobRetired(fixture, appDb)).toBe(false);
+
+    // The next row the sequence hands out, and the next burn after it: both strictly past the id the
+    // fixture holds, which is the whole claim. A helper that returned a constant would pass every
+    // other test in the tree, because an unreachable id and a stale one read the same until an
+    // insert takes it.
+    const id = await enqueueJob({
+      rearm: "same-work",
+      tenantId,
+      kind: "FOLLOWUP",
+      dedupeKey: "dk-burned-next",
+      // Not due, and deleted below: a claimable row left behind here is one the next test's
+      // `claimDueJobs(1, ...)` returns instead of its own.
+      runAt: new Date(Date.now() + 3_600_000),
+      base: appDb,
+    });
+    expect(id).toBeGreaterThan(burned);
+    expect(await burnSchedulerJobId(suDb)).toBeGreaterThan(id);
+    expect(await jobRetired(fixture, appDb)).toBe(false);
+    await suDb.schedulerJob.delete({ where: { id } });
   });
 
   // The reason jobRetired takes a connection at all, measured rather than argued. runScopedOn opens

--- a/tests/modules/spend-ceiling-poll.test.ts
+++ b/tests/modules/spend-ceiling-poll.test.ts
@@ -39,6 +39,7 @@ import {
 } from "@/modules/tenant-settings/service";
 import { formatVaultRef } from "@/modules/vault/service";
 import { clearFlowLog, flowLogRows } from "../utils/flowlog";
+import { burnSchedulerJobId } from "../utils/scheduler";
 
 // THE POLL THAT WRITES WHAT THE GATE READS (issue #426). One scheduler job per tenant with the
 // ceiling on, re-armed forever like the heartbeat, asking Langfuse for the month's cost per source
@@ -69,6 +70,9 @@ if (appUrl && suUrl) {
   }
 }
 const suDb = su as PrismaClient;
+
+// Burned from `scheduler_jobs_id_seq`, never a literal: tests/utils/scheduler.ts says why.
+let phantomJobId = 0n;
 const appDb = app as PrismaClient;
 
 const NOW = new Date("2026-08-15T12:00:00Z");
@@ -186,7 +190,7 @@ const snapshot = (tenantId: bigint, source: string, at = NOW) =>
 
 const job = (tenantId: bigint): ClaimedJob =>
   ({
-    id: 1n,
+    id: phantomJobId,
     tenantId,
     kind: "SPEND_CEILING_POLL",
     dedupeKey: SPEND_POLL_DEDUPE_KEY,
@@ -198,6 +202,7 @@ const job = (tenantId: bigint): ClaimedJob =>
 
 describe.skipIf(!dbUp)("the spend ceiling poll", () => {
   beforeAll(async () => {
+    phantomJobId = await burnSchedulerJobId(suDb);
     const a = await suDb.tenant.create({
       data: { name: "SP-A", slug: `sp-a-${process.pid}` },
     });

--- a/tests/utils/scheduler.ts
+++ b/tests/utils/scheduler.ts
@@ -1,0 +1,21 @@
+import type { PrismaClient } from "@/../generated/prisma/client";
+
+// An id for a `ClaimedJob` FIXTURE: a number `scheduler_jobs_id_seq` has already handed out and will
+// never hand out again, so no insert in any file, in any order, on any shard, can land a row under
+// it. `tests/modules/claimed-job-fixture-ids.test.ts` carries the failure this exists to prevent and
+// the measurement behind it; the contract asserted here is in tests/modules/scheduler.test.ts.
+//
+// It lives here rather than in each file because #498 fixed the one file that had already broken by
+// writing this query inline, and a recipe spelled out per file is one the next file gets written
+// without, which is how every other literal in the tree got there in the first place.
+//
+// Burned from the sequence rather than taken from a high constant: any constant is reachable by
+// enough inserts, and "enough" is a number nobody re-checks. `nextval` on the same database the test
+// writes to is the only answer that stays true as the suite grows. Call it once per fixture that
+// needs its own id; two calls never collide.
+export async function burnSchedulerJobId(db: PrismaClient): Promise<bigint> {
+  const [row] = await db.$queryRaw<{ nextval: bigint }[]>`
+    SELECT nextval('scheduler_jobs_id_seq')`;
+  if (!row) throw new Error("burnSchedulerJobId: nextval returned no row");
+  return BigInt(row.nextval);
+}


### PR DESCRIPTION
Burn a fixture's job id from the sequence, and fence the two spellings that name a row

A `ClaimedJob` built by hand in a test is a fixture, not a row: the handler only reads it back, and
`jobRetired` looks the id up to find the tombstone a `/reset` or a supersede leaves behind. An id
nobody holds answers "not retired", which is the branch every one of these fixtures is written for.

It stops being benign the moment the id names a row, because `scheduler_jobs_id_seq` hands out
exactly the numbers the fixtures spelled: 1, 2, 9. Whichever file is first in the DATABASE to insert
a job takes id 1, and a file that then retires that row has planted a tombstone under its own
fixture. From there the handler stands down without posting, and every assertion about what should
have been sent fails with `Expected: 1, Received: 0`.

Measured on this branch, against a cold sequence and the real path:

    row inserted with id 1
    burned fixture id 2
    before retire: literal false | burned false
    retired rows: 1
     after retire: literal true | burned false

`#498` fixed the one file that had already broken this way, in `followup-resolved-guardrails`, by
writing the `nextval` inline. A recipe spelled out per file is one the next file gets written
without, so the burn is now a shared helper (`burnSchedulerJobId`, tests/utils/scheduler.ts) and
every remaining fixture takes its id from it.

The sweep that keeps the next one out found more than the issue listed:

- 27 sites in 8 files, not the 7 files the issue names: `spend-ceiling-poll.test.ts` was missing
  from the table.
- a 28th site the first sweep missed, `chatwoot-recover-delivery.test.ts`, which spells the same
  landmine as a default parameter (`function jobFor(payload, id = 1n)`) rather than a property.
- `webhooks-outbound-heartbeat.test.ts` is NOT a site: its `id: 0n` is unreachable by construction,
  since a sequence starts at 1. That is why the rule is a sign test and not a ban on literals.
- `compaction-worker.test.ts` reaches no database at all, so its two literals become `0n` rather
  than a burn: a pure unit test should not acquire a Postgres dependency to hold a fixture.

The fence identifies a fixture by `claimSeq`, a required field of the type that nothing else in the
tree carries. Not by `kind`, which is somebody else's field name (`resolveByModelName` answers
`{ kind: "one", id }`, so namespace-resolve's rows come back as job fixtures under a `kind` marker),
and not by whether the file imports the type, because `terminal-failure-announces.test.ts` hands a
handler a job-shaped literal without ever naming it. Its own eyesight is pinned on synthetic sources
from both sides, including the window's reach, since once the tree is clean nothing else would
notice a sweep that stopped seeing.

The helper's contract is pinned in `scheduler.test.ts`, beside the tombstone table whose absent-row
branch is the one the fixtures ride: a helper that returned a constant would pass every other test
in the tree, because an unreachable id and a stale one read the same until an insert takes it.

Fixes #500