### PR TITLE
Drop the fleet id index and the pre-#530 cursor, now that no process can ask for them

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -25651,7 +25651,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "description": "Keyset cursor: pass back `nextCursor` from the previous page, verbatim. Opaque -- do not build one. A cursor from before #530 (a bare id) is read as that release's own `id <` bound, so a walk that spans a rolling deploy finishes without losing a row; anything else is refused.",
+              "description": "Keyset cursor: pass back `nextCursor` from the previous page, verbatim. Opaque -- do not build one. Anything else is refused, a bare id included: that was the cursor before #530 and it names a position this ordering does not have.",
               "type": "string"
             }
           },

--- a/prisma/migrations/20260908160000_audit_drop_fleet_id_idx/migration.sql
+++ b/prisma/migrations/20260908160000_audit_drop_fleet_id_idx/migration.sql
@@ -1,0 +1,23 @@
+-- The last index #530 replaced, and the one that could not go with the others (#544).
+--
+-- `audit_logs_fleet_id_idx` served exactly one query: the fleet trail's `ORDER BY id`, which no
+-- reader in this codebase issues since #530 moved every audit read onto `(created_at, id)`. The
+-- three other indexes that release replaced were dropped in its own PR, because the new
+-- `(created_at DESC, id DESC)` pair answers the old questions too. This one has no such
+-- replacement: after #530 no audit index leads with `id` at all.
+--
+-- WHY IT OUTLIVED THEM BY A RELEASE. `docs/deploy.md` describes ROLLING deploys, so for one overlap
+-- a container from the release before #530 goes on asking that question, and without the index it
+-- walks the primary key past every tenant row: 8,687 buffers and 21.5 ms against 2, measured on a
+-- 500k-row probe with the fleet slice at the far end. #530 shipped in v1.15.0, so this release is
+-- the one release later the note asked for, and no such container can be part of a normal upgrade
+-- any more. An operator who skips a release still overlaps one, and pays that page's cost for the
+-- length of the drain -- slower, never wrong, and gone when the old process is.
+--
+-- ONE STATEMENT, AND THAT IS NOT STYLE. A `DROP INDEX CONCURRENTLY` applies when it is alone in its
+-- file and fails with `cannot run inside a transaction block` as soon as any second statement joins
+-- it (measured; `tests/prisma/tenant-index-redundancy.test.ts` is the fence). Concurrently rather
+-- than plain because the plain drop takes an ACCESS EXCLUSIVE on `audit_logs`, which every write
+-- that records an audit row would queue behind, and this runs on the new container while the old
+-- one is still serving.
+DROP INDEX CONCURRENTLY IF EXISTS "audit_logs_fleet_id_idx";

--- a/src/api/lib/query-filters.ts
+++ b/src/api/lib/query-filters.ts
@@ -98,10 +98,9 @@ export function parseQueryCount(
 }
 
 // TWO COLUMNS SINCE #530, so not `parseQueryId`: a cursor is `<ISO instant>|<id>`, opaque by
-// contract, and the parse belongs to the codec that emits it. A cursor from the previous release is
-// a bare id and is read as that release's own `id <` bound, so a walk that spans a rolling deploy
-// finishes without losing a row -- see `AuditCursor.beforeId`. Anything else is the same 400 every
-// other malformed parameter gets.
+// contract, and the parse belongs to the codec that emits it. A bare id was the cursor before #530
+// and was accepted for one release after it, for a walk spanning a rolling deploy; since #544 it is
+// the same 400 every other malformed parameter gets.
 export function parseQueryAuditCursor(
   s: string | undefined,
   param: string,

--- a/src/api/v1/audit.controller.ts
+++ b/src/api/v1/audit.controller.ts
@@ -99,7 +99,7 @@ export const auditController = new Elysia({
         cursor: t.Optional(
           t.String({
             description:
-              "Keyset cursor: pass back `nextCursor` from the previous page, verbatim. Opaque -- do not build one. A cursor from before #530 (a bare id) is read as that release's own `id <` bound, so a walk that spans a rolling deploy finishes without losing a row; anything else is refused.",
+              "Keyset cursor: pass back `nextCursor` from the previous page, verbatim. Opaque -- do not build one. Anything else is refused, a bare id included: that was the cursor before #530 and it names a position this ordering does not have.",
           }),
         ),
         scope: t.Optional(

--- a/src/modules/audit/service.ts
+++ b/src/modules/audit/service.ts
@@ -287,11 +287,6 @@ export async function listAudit(
           ],
         }
       : {}),
-    // The pre-#530 bound, ANDed with the keyset above rather than replacing it: the walk is ordered
-    // the new way and cut where the old one stopped. See `AuditCursor.beforeId`.
-    ...(opts.cursor?.beforeId != null
-      ? { id: { lt: opts.cursor.beforeId } }
-      : {}),
   };
   const scope = opts.scope ?? "tenant";
   const trail = auditTrailFor(ctx, scope);
@@ -324,9 +319,7 @@ export async function listAudit(
       after: r.after,
       createdAt: r.createdAt.toISOString(),
     })),
-    nextCursor: hasMore
-      ? nextAuditCursor(page[page.length - 1], opts.cursor?.beforeId ?? null)
-      : null,
+    nextCursor: hasMore ? nextAuditCursor(page[page.length - 1]) : null,
     latestAt: latest._max.createdAt?.toISOString() ?? null,
   };
 }
@@ -352,31 +345,16 @@ export interface AuditKeyset {
 }
 
 export interface AuditCursor {
-  // Where the last page stopped. Null on the FIRST page of a walk that began before #530, which
-  // has a bound and no position yet.
-  at: AuditKeyset | null;
-  // THE PRE-#530 BOUND, AND IT RIDES TO THE END OF THE WALK.
+  // Where the last page stopped. Always present: a cursor IS a position.
   //
-  // The previous release paged `id < X` under `ORDER BY id`, so a cursor it handed out means "every
-  // row with id >= X is already on the caller's screen". That set is NOT a prefix of the new order:
-  // `created_at` is written by the client (measured), so a row can carry a stamp older than a row
-  // with a smaller id. Translating X into the `(created_at, id)` of row X therefore answers from a
-  // different place -- every unseen row stamped ahead of X sits ahead of that tuple and is never
-  // returned. Measured on the dev trail, one process and 75 rows: from id 88 the old walk owed 19
-  // rows and the translated cursor returned 2, skipping all 19.
-  //
-  // Kept as a bound instead, and carried, the page is ordered the new way and cut the old way,
-  // which enumerates exactly what the old walk still owed: nothing skipped, nothing repeated.
-  // Dropping it after the first page would stop skipping and start repeating, because the pages
-  // that follow would be keyed on the tuple alone and reach back into rows already shown.
-  //
-  // THE OTHER HALF OF THE OVERLAP CANNOT BE CLOSED FROM HERE: a container still on the old release
-  // refuses the `<instant>|<id>` this one emits, because its own parser predates the format. That
-  // is a 400 for the length of the drain, recoverable by reloading the page.
-  //
-  // TEMPORARY. Remove one release after #530 ships, together with the fleet index kept for the same
-  // reason (docs/roadmap.md).
-  beforeId: bigint | null;
+  // It was nullable for one release (#530 -> #544). The release before #530 paged `id < X` under
+  // `ORDER BY id`, so a cursor it handed out was a BOUND and not a position, and it could not be
+  // translated into one -- `created_at` is written by the client, so a row can carry a stamp older
+  // than a row with a smaller id, and every unseen row stamped ahead of X sits ahead of X's own
+  // tuple. It was therefore carried as a bound alongside the keyset until no process could still be
+  // emitting one. That is now (#544): #530 shipped in v1.15.0 and this is the release after it, so
+  // a bare id is a malformed cursor again and gets the 400 every other one gets.
+  at: AuditKeyset;
 }
 
 // `<ISO instant>|<id>`. Opaque to callers by contract, readable on purpose when a support question
@@ -397,33 +375,20 @@ const CURSOR_SEP = "|";
 // exist inside it -- there is no third case for a later reader to discover.
 const CURSOR_INSTANT = /^(?!0000)\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
-export function encodeAuditCursor(
-  at: AuditKeyset,
-  beforeId: bigint | null = null,
-): string {
-  const head = `${at.createdAt.toISOString()}${CURSOR_SEP}${at.id}`;
-  return beforeId === null ? head : `${head}${CURSOR_SEP}${beforeId}`;
+export function encodeAuditCursor(at: AuditKeyset): string {
+  return `${at.createdAt.toISOString()}${CURSOR_SEP}${at.id}`;
 }
 
-// Returns null for anything that is not one of ours.
+// Returns null for anything that is not one of ours, a BARE ID included (#544).
 //
-// A BARE ID IS READ AS A BOUND, NOT AS A POSITION, which is the distinction round 1 of this PR's
-// review was about and round 9 sharpened: reading the number as the new key answers from a different
-// place in the trail under a pager that goes on saying "Page 2", and so does translating it into
-// that row's instant. As the old query's own `id <` bound it answers from the same place, and it is
-// the only reading of the three that does. See `AuditCursor.beforeId`.
-//
-// No lookup, so no scope and no database: the bound is a number the trail filter then applies on
-// top of. An id naming no row, or another tenant's, is a bound that simply matches nothing -- which
-// is what the previous release did with it too, and it leaves no way to ask this endpoint whether
-// some id exists.
+// A bare id was this endpoint's cursor before #530 and was accepted for one release after it, read
+// as that release's own `id <` bound rather than as a position -- the only reading of the three
+// considered that resumes from the same place, since translating it into the row's `(created_at,
+// id)` answers from a different one. It is refused again now, so `115` gets the same 400 as any
+// other malformed cursor; see `AuditCursor.at` for why it could never simply be converted.
 export function parseAuditCursor(raw: string): AuditCursor | null {
   const parts = raw.split(CURSOR_SEP);
-  if (parts.length === 1) {
-    const bound = parseDbId(parts[0] ?? "");
-    return bound !== null && bound > 0n ? { at: null, beforeId: bound } : null;
-  }
-  if (parts.length > 3) return null;
+  if (parts.length !== 2) return null;
   const head = parts[0] as string;
   const when = new Date(head);
   // CANONICAL OR NOTHING, checked by round trip against the exact spelling this codec emits.
@@ -439,17 +404,9 @@ export function parseAuditCursor(raw: string): AuditCursor | null {
   // 40-digit string and hand Postgres a value it answers with a 500 at bind time.
   const id = parseDbId(parts[1] ?? "");
   if (id === null || id <= 0n) return null;
-  let beforeId: bigint | null = null;
-  if (parts.length === 3) {
-    beforeId = parseDbId(parts[2] as string);
-    if (beforeId === null || beforeId <= 0n) return null;
-  }
-  return { at: { createdAt: when, id }, beforeId };
+  return { at: { createdAt: when, id } };
 }
 
-function nextAuditCursor(
-  last: AuditKeyset | undefined,
-  beforeId: bigint | null,
-): string | null {
-  return last ? encodeAuditCursor(last, beforeId) : null;
+function nextAuditCursor(last: AuditKeyset | undefined): string | null {
+  return last ? encodeAuditCursor(last) : null;
 }

--- a/src/modules/mcp/read.ts
+++ b/src/modules/mcp/read.ts
@@ -1005,10 +1005,9 @@ export async function auditList(
     opts.actorId = v;
   }
   if (args.cursor !== undefined) {
-    // TWO COLUMNS SINCE #530, so not `parseMcpId`. A cursor from the release before it is a bare
-    // id, and the codec reads it as that release's own `id <` BOUND -- an agent that stored one
-    // mid-walk keeps walking, from the same place and not from a different one, for the length of
-    // one rolling deploy. See `AuditCursor.beforeId`.
+    // TWO COLUMNS SINCE #530, so not `parseMcpId`. A bare id was the cursor before that, and was
+    // accepted for one release after it so an agent holding one mid-walk kept walking across a
+    // rolling deploy; since #544 it is refused like any other malformed cursor.
     const c = parseAuditCursor(args.cursor);
     if (c === null) {
       return err(

--- a/tests/api/v1/audit-read.test.ts
+++ b/tests/api/v1/audit-read.test.ts
@@ -261,30 +261,33 @@ describe.skipIf(!dbUp)("the trail has a door the console can use", () => {
       });
     }
 
-    // A CURSOR FROM BEFORE #530 IS A BARE ID, and it is read as THAT RELEASE'S OWN `id <` BOUND
-    // rather than reinterpreted or translated. The format changed and deploys are rolling, so for
-    // one overlap the previous release is still handing these out; refusing would be a 400 in the
-    // middle of an operator's walk. The bound continues from the same place the old walk would
-    // have, which neither reading the number as the new key nor translating it into that row's
-    // instant does -- see `AuditCursor.beforeId`, and the walk asserted in the service's own file.
-    test("a cursor from before the keyset change continues the same walk", async () => {
+    // A CURSOR FROM BEFORE #530 IS A BARE ID, AND IT IS A 400 AGAIN (#544). It was accepted for one
+    // release after the format changed, read as that release's own `id <` bound, because deploys
+    // are rolling and refusing would have been a 400 in the middle of an operator's walk. #530
+    // shipped in v1.15.0 and this is the release after it, so nothing is handing one out any more.
+    //
+    // The 400 is also the only honest answer left: neither reading the number as the new key nor
+    // translating it into that row's instant resumes from where the old walk stopped, so accepting
+    // it would page a different trail under a pager still saying "Page 2" (`AuditCursor.at`).
+    test("a cursor from before the keyset change is refused", async () => {
       role = "TENANT_ADMIN";
       const first = await get("?limit=1", await sign("TENANT_ADMIN"));
       const page = (await first.json()) as Page & { nextCursor: string };
       const oldStyle = page.nextCursor.split("|")[1] as string;
+      expect(oldStyle).toBeTruthy();
 
       const viaOld = await get(
         `?limit=1&cursor=${encodeURIComponent(oldStyle)}`,
         await sign("TENANT_ADMIN"),
       );
+      expect(viaOld.status).toBe(400);
+      // ...while the shape this release emits is still accepted, so the 400 is about the FORM and
+      // not about cursors having stopped working.
       const viaNew = await get(
         `?limit=1&cursor=${encodeURIComponent(page.nextCursor)}`,
         await sign("TENANT_ADMIN"),
       );
-      expect(viaOld.status).toBe(200);
-      expect((await viaOld.json()).entries).toEqual(
-        (await viaNew.json()).entries,
-      );
+      expect(viaNew.status).toBe(200);
     });
 
     test("a cursor that is neither shape is still refused", async () => {
@@ -296,6 +299,9 @@ describe.skipIf(!dbUp)("the trail has a door the console can use", () => {
         // Bounded like every other id: past 2^63-1 Postgres refuses it at bind time, so parsing it
         // here would answer a plainly malformed value with a 500.
         "9".repeat(40),
+        // The three-part form #530 emitted while it still carried the pre-#530 bound. It came out
+        // with the bound in #544, and a cursor held across that upgrade lands here.
+        "2026-01-01T00:00:00.000Z|7|99",
       ]) {
         const res = await get(
           `?cursor=${encodeURIComponent(bad)}`,

--- a/tests/modules/audit-latest-at-plan.test.ts
+++ b/tests/modules/audit-latest-at-plan.test.ts
@@ -65,8 +65,8 @@ const FLEET_PAGE =
 //
 // Every assertion in this file is about which index the planner REACHES, and that is a cost choice:
 // on a table holding a handful of fleet rows every partial index costs about the same, so the
-// planner picks whichever is narrower -- `audit_logs_fleet_id_idx`, which is kept only for the
-// pre-#530 rolling overlap -- and pays a `Sort` and a `Filter` on top. That is the exact shape these
+// planner picks whichever is narrower -- it was `audit_logs_fleet_id_idx`, kept for the pre-#530
+// rolling overlap until #544 dropped it -- and pays a `Sort` and a `Filter` on top. That is the exact shape these
 // tests exist to forbid, and it appeared only because the plan was being read off whatever rows
 // other suites happened to leave in a shared table: the same assertions pass alone and failed inside
 // the full run (measured, on the master tree, where the suite writes more of them).
@@ -208,7 +208,9 @@ describe.skipIf(!dbUp)("latestAt reaches its index on every scope", () => {
         // of them also gives the ORDER the page is read in, and the other buys it with a `Sort`,
         // which is half of what #530 removed. Accepting both hid that, and it was accepted only
         // because the plan was being read off a table whose contents belong to the rest of the
-        // suite. With the slice seeded above it is a fact about the indexes again.
+        // suite. With the slice seeded above it is a fact about the indexes again. (That other
+        // index is gone since #544; the naming stays deliberate, because what this pins is that the
+        // page is answered by the index carrying its ORDER, not merely by one that is partial.)
         expect(withIndex).toContain(
           '"Index Name":"audit_logs_fleet_created_at_id_idx"',
         );
@@ -219,11 +221,9 @@ describe.skipIf(!dbUp)("latestAt reaches its index on every scope", () => {
         // same index already chose.)
         expect(withIndex).not.toContain('"Filter"');
 
-        // BOTH of them, for the negative half: leaving one standing proves nothing about the other.
+        // One index to drop now, where there were two: `audit_logs_fleet_id_idx` came out in #544
+        // and the drop of it here would be a no-op that reads like a live concern.
         await db.$executeRawUnsafe(`DROP INDEX ${INDEX_FOR.fleet}`);
-        await db.$executeRawUnsafe(
-          `DROP INDEX IF EXISTS audit_logs_fleet_id_idx`,
-        );
         const without = await planIn(db, FLEET_PAGE);
         // WITHOUT it, no index gives BOTH the predicate and the id order, so the plan has to buy one
         // of them with a full pass. Which pass depends on the table: on a large one the planner
@@ -231,8 +231,8 @@ describe.skipIf(!dbUp)("latestAt reaches its index on every scope", () => {
         // page of 51); on a small one it gathers every fleet row off the other partial index and
         // sorts. Either is unbounded by the page size, which is the property being asserted -- so
         // the assertion names both rather than pinning the plan of whichever table it runs on.
-        expect(without).not.toMatch(
-          /"Index Name":"audit_logs_fleet_(created_at_id|id)_idx"/,
+        expect(without).not.toContain(
+          '"Index Name":"audit_logs_fleet_created_at_id_idx"',
         );
         expect(without).toMatch(
           /"Node Type":"Sort"|"Filter":"\(tenant_id IS NULL\)"/,
@@ -312,14 +312,21 @@ describe.skipIf(!dbUp)("latestAt reaches its index on every scope", () => {
     for (const r of ordering) {
       expect(r.indexdef).toMatch(/created_at DESC, id DESC/);
     }
-    // ...and `audit_logs_fleet_id_idx` IS STILL HERE, on purpose. It serves only the old
-    // `ORDER BY id` fleet page, which this release stops issuing -- but `docs/deploy.md` describes
-    // rolling deploys, so for the length of one overlap a container from the previous release is
-    // still asking that question, and without the index it walks the primary key past every tenant
-    // row: measured, 8,687 buffers and 21.5 ms against 2. It comes out in a later release, once no
-    // old process can be serving (docs/roadmap.md). The other three old indexes went now because
-    // the new ones answer their queries too, verified on the same probe.
-    expect(rows.map((r) => r.indexname)).toContain("audit_logs_fleet_id_idx");
+    // ...and `audit_logs_fleet_id_idx` IS GONE (#544). It served only the old `ORDER BY id` fleet
+    // page, which nothing has issued since #530; it outlived the other three by a release because
+    // `docs/deploy.md` describes ROLLING deploys, and for one overlap a container from the release
+    // before #530 was still asking that question — without the index, a primary-key walk past every
+    // tenant row, measured at 8,687 buffers and 21.5 ms against 2. #530 shipped in v1.15.0, so that
+    // container is a release behind now.
+    //
+    // ASSERTED AS ABSENCE, and that is the direction that can rot: the index is created by
+    // `20260903140000_audit_latest_at_indexes` and dropped by `20260908160000_audit_drop_fleet_id_idx`,
+    // so a revert of the drop, or a database whose migrations stopped in between, brings it back
+    // with nothing else to notice. Absence here is also what says no audit index leads with `id`
+    // any more, which is the premise the removed cursor path rests on.
+    expect(rows.map((r) => r.indexname)).not.toContain(
+      "audit_logs_fleet_id_idx",
+    );
   });
 
   // The partial predicate is the whole point of the fleet indexes: without it an index would hold

--- a/tests/modules/audit-read.test.ts
+++ b/tests/modules/audit-read.test.ts
@@ -123,7 +123,6 @@ describe.skipIf(!dbUp)("reading the trail", () => {
         id: BigInt(page.entries[1]?.id ?? "0"),
       },
       // No pre-#530 bound: this walk began under this release.
-      beforeId: null,
     });
   });
 
@@ -206,13 +205,11 @@ describe.skipIf(!dbUp)("reading the trail", () => {
       const at = { createdAt: d, id: 7n };
       expect(parseAuditCursor(encodeAuditCursor(at))).toEqual({
         at,
-        beforeId: null,
       });
     }
     // ...and a real one still reads back to the pair it names.
     expect(parseAuditCursor("2026-02-01T12:00:00.000Z|7")).toEqual({
       at: { createdAt: new Date("2026-02-01T12:00:00.000Z"), id: 7n },
-      beforeId: null,
     });
   });
 
@@ -395,92 +392,32 @@ describe.skipIf(!dbUp)("reading the trail", () => {
     }
   });
 
-  // A WALK THAT STARTED UNDER THE OLD ORDERING FINISHES UNDER THE NEW ONE, LOSING NOTHING.
+  // A CURSOR IS A POSITION AGAIN, AND A BARE ID IS NOT ONE (#544).
   //
-  // A cursor from before #530 is a bare id, and the previous release handed it out meaning `id <
-  // X` under `ORDER BY id`. Translating it into the `(created_at, id)` of row X -- which is what
-  // this PR did until round 9 -- is NOT the same position, because the two orders are not the same
-  // order: `created_at` is written by the client, so a row can carry a stamp older than a row with
-  // a smaller id. Every unseen row stamped AHEAD of X then sits ahead of the translated tuple and
-  // is never returned. Measured on the dev trail, which is written by one process and still holds
-  // two such inversions in 75 rows: from id 88 the old walk owed 19 rows and the translated cursor
-  // returned 2, skipping all 19.
+  // Before #530 this endpoint paged `id < X` under `ORDER BY id`, so the cursor it handed out was a
+  // BOUND. For one release after #530 that bound was still accepted and carried to the end of the
+  // walk, so a walk spanning a rolling deploy finished without losing a row. #530 shipped in
+  // v1.15.0 and this is the release after it, so no process can still be emitting one and the form
+  // is refused again.
   //
-  // So the id stays an ID BOUND and is carried to the end of the walk. The page is ordered the new
-  // way and bounded the old way, which enumerates exactly the set the old walk still owed -- no row
-  // skipped, and no row already shown repeated.
-  test("a walk resumed from a pre-#530 cursor loses no row and repeats none", async () => {
-    try {
-      // Stamped so id order and time order DISAGREE, which is the whole case: `inv.old` has the
-      // largest id of the three and the oldest stamp, so a cursor translated to its instant would
-      // put the other two behind it.
-      await seed("inv.newest", "2026-03-03T00:00:00Z");
-      await seed("inv.middle", "2026-03-02T00:00:00Z");
-      await seed("inv.old", "2026-01-15T12:00:00Z");
-      const all = await listAudit(ctx(), { limit: 500 }, appDb);
-      const boundary = all.entries.find(
-        (e) => e.action === syntheticAction("inv.old"),
-      );
-      const bound = BigInt(boundary?.id ?? "0");
-
-      // What the previous release still owed this caller: every row with a smaller id, which is
-      // what `id < bound` under `ORDER BY id DESC` would have returned.
-      const owed = new Set(
-        all.entries.filter((e) => BigInt(e.id) < bound).map((e) => e.id),
-      );
-      expect(owed.size).toBeGreaterThan(0);
-
-      const seen: string[] = [];
-      let cursor: string | null = String(bound);
-      for (let i = 0; i < 20 && cursor; i++) {
-        const page: Awaited<ReturnType<typeof listAudit>> = await listAudit(
-          ctx(),
-          { limit: 2, cursor: parseAuditCursor(cursor) ?? undefined },
-          appDb,
-        );
-        seen.push(...page.entries.map((e) => e.id));
-        cursor = page.nextCursor;
-      }
-      // Every row exactly once, and exactly the rows that were owed.
-      expect(new Set(seen)).toEqual(owed);
-      expect(seen.length).toBe(owed.size);
-      // ...and the two rows stamped AFTER the boundary row are in there, which is the half the
-      // translated cursor dropped.
-      expect(seen).toContain(
-        all.entries.find((e) => e.action === syntheticAction("inv.newest"))
-          ?.id ?? "",
-      );
-      expect(seen).toContain(
-        all.entries.find((e) => e.action === syntheticAction("inv.middle"))
-          ?.id ?? "",
-      );
-    } finally {
-      await suDb.$executeRawUnsafe(
-        `DELETE FROM audit_logs WHERE tenant_id = ${tenantId} AND action LIKE 'inv.%'`,
-      );
-    }
-  });
-
-  // The bound has to SURVIVE the walk, not just its first page: dropped after page one, the pages
-  // that follow are keyed on the tuple alone and start handing back rows the caller already saw.
-  test("the pre-#530 bound rides along in every cursor the walk emits", () => {
-    const c = parseAuditCursor("2026-02-01T12:00:00.000Z|7|99");
-    expect(c).toEqual({
-      at: { createdAt: new Date("2026-02-01T12:00:00.000Z"), id: 7n },
-      beforeId: 99n,
-    });
-    expect(
-      encodeAuditCursor(
-        { createdAt: new Date("2026-02-01T12:00:00.000Z"), id: 7n },
-        99n,
-      ),
-    ).toBe("2026-02-01T12:00:00.000Z|7|99");
-    // A bare id is a bound and NOT a position: there is no page behind it yet.
-    expect(parseAuditCursor("115")).toEqual({ at: null, beforeId: 115n });
-    // ...and the same bounded parse every id gets, so a 40-digit string is still not a cursor.
+  // WHY REFUSED AND NOT CONVERTED, which is the part worth keeping now that the code is gone: the
+  // id CANNOT be translated into the new key. `created_at` is written by the client, so a row can
+  // carry a stamp older than a row with a smaller id, and every unseen row stamped ahead of X sits
+  // ahead of X's own tuple and would never come back. Measured on the dev trail, one process and 75
+  // rows: from id 88 the old walk owed 19 rows and the translated cursor returned 2, skipping all
+  // 19. A 400 tells the caller the walk cannot continue; a translation would keep the pager saying
+  // "Page 2" over a silently different answer.
+  test("a bare id is not a cursor, and neither is the bound it used to carry", () => {
+    expect(parseAuditCursor("115")).toBeNull();
+    expect(parseAuditCursor("2026-02-01T12:00:00.000Z|7|99")).toBeNull();
+    // The form that IS one still round-trips, both ways.
+    const at = { createdAt: new Date("2026-02-01T12:00:00.000Z"), id: 7n };
+    expect(encodeAuditCursor(at)).toBe("2026-02-01T12:00:00.000Z|7");
+    expect(parseAuditCursor("2026-02-01T12:00:00.000Z|7")).toEqual({ at });
+    // ...and the bounded parse every id gets is unchanged, so a 40-digit string is still not one.
     expect(parseAuditCursor("9".repeat(40))).toBeNull();
     expect(parseAuditCursor("0")).toBeNull();
-    expect(parseAuditCursor("2026-02-01T12:00:00.000Z|7|0")).toBeNull();
+    expect(parseAuditCursor("2026-02-01T12:00:00.000Z|0")).toBeNull();
     expect(parseAuditCursor("2026-02-01T12:00:00.000Z|7|8|9")).toBeNull();
   });
 

--- a/tests/modules/mcp-audit-scope.test.ts
+++ b/tests/modules/mcp-audit-scope.test.ts
@@ -250,68 +250,38 @@ describe.skipIf(!dbUp)("what a targetless audit_list actually reads", () => {
     }
   });
 
-  // AND A BARE ID FROM THE PREVIOUS RELEASE IS READ AS THAT RELEASE'S OWN BOUND, not refused: an
-  // agent that stored one mid-walk keeps walking, from the same place that cursor named rather than
-  // from a different one. Both doors agree on that, as they do on the refusals above.
-  test("a bare id from before the keyset change continues the same walk", async () => {
+  // AND A BARE ID IS REFUSED HERE TOO, SINCE #544. It was the cursor before #530 and was accepted
+  // for one release after it, read as that release's own `id <` bound so an agent holding one
+  // mid-walk kept walking across a rolling deploy. #530 shipped in v1.15.0, so no process can still
+  // be handing one out and both doors are back to one shape.
+  //
+  // The refusal is the RIGHT answer rather than a translation, and the service's own file measures
+  // why: read as the new key, a bare id resumes from a different place in the trail while the agent
+  // believes it is paging the same one.
+  test("a bare id from before the keyset change is refused", async () => {
     const p = principal();
     const first = (await auditList(
       p,
       { limit: 1, scope: "all" },
       { base: appDb },
     )) as { ok: true; data: { nextCursor: string | null } };
-    const cursor = first.data.nextCursor ?? "";
-    const bareId = cursor.split("|")[1] as string;
-    const viaOld = await auditList(
+    const bareId = (first.data.nextCursor ?? "").split("|")[1] as string;
+    expect(bareId).toBeTruthy();
+    const r = await auditList(
       p,
       { limit: 1, scope: "all", cursor: bareId },
       { base: appDb },
     );
-    const viaNew = await auditList(
-      p,
-      { limit: 1, scope: "all", cursor },
-      { base: appDb },
-    );
-    expect(JSON.stringify(viaOld)).not.toContain("nextCursor` from a previous");
-    const rows = (r: unknown) =>
-      JSON.stringify((r as { data: { entries: unknown } }).data.entries);
-    expect(rows(viaOld)).toBe(rows(viaNew));
-
-    // ...and the bound holds for the WHOLE walk, not just its first page: every id it hands back
-    // stays under the ceiling the old release stopped at, and none comes back twice. Asserted over
-    // the walk rather than over one `nextCursor`, because how many pages this shared fixture yields
-    // is not this test's to know -- pinned to a second page it passed here and failed on a CI shard
-    // where the `all` trail had one row under the bound.
-    const seen: string[] = [];
-    let at: string | null = bareId;
-    for (let i = 0; i < 20 && at; i++) {
-      const page = (await auditList(
-        p,
-        { limit: 1, scope: "all", cursor: at },
-        { base: appDb },
-      )) as {
-        ok: true;
-        data: { entries: { id: string }[]; nextCursor: string | null };
-      };
-      seen.push(...page.data.entries.map((e) => e.id));
-      at = page.data.nextCursor;
-      // While the walk continues, the ceiling travels with it.
-      if (at) expect(at.split("|")[2]).toBe(bareId);
-    }
-    expect(seen.length).toBeGreaterThan(0);
-    expect(new Set(seen).size).toBe(seen.length);
-    for (const id of seen) expect(BigInt(id) < BigInt(bareId)).toBe(true);
+    expect(JSON.stringify(r)).toContain("nextCursor` from a previous");
   });
 
-  // A BARE ID IS A BOUND AND NOT A LOOKUP, so it cannot reach across trails at all -- which is what
-  // the earlier resolving version had to be scoped by hand to avoid, because `fleet` and `all` are
-  // read under the fleet role where every row is visible and RLS separates nothing. A number
-  // narrowing a walk names no row, so a tenant row's id offered to the fleet trail is just a smaller
-  // ceiling: the walk stays on the fleet trail, and there is no id whose existence this answer
-  // reveals.
-  test("a bare id from another trail bounds the walk without reaching it", async () => {
+  // AND THE REFUSAL SAYS NOTHING ABOUT WHETHER THE ID EXISTS, which is the property that survived
+  // the removal rather than being made moot by it. The version before #530's follow-up RESOLVED a
+  // bare id, and resolving needs the trail predicate, which is exactly how such an endpoint turns
+  // into a way to ask whether some row is there. Refused at the parse, the answer is the same
+  // sentence for a real id from another trail, a real id from this one, and a number naming nothing.
+  test("a foreign id, a live id and a made-up one are all refused the same way", async () => {
     const p = principal();
-    // The id of a row that belongs to a tenant, offered as a cursor for the fleet trail.
     const mineRow = (await auditList(
       principal({ tenantId: mine, role: "TENANT_ADMIN" }),
       { limit: 1 },
@@ -320,24 +290,32 @@ describe.skipIf(!dbUp)("what a targetless audit_list actually reads", () => {
     const tenantRowId = mineRow.data.entries[0]?.id as string;
     expect(tenantRowId).toBeTruthy();
 
-    const r = await auditList(
-      p,
-      { limit: 500, scope: "fleet", cursor: tenantRowId },
-      { base: appDb },
-    );
-    const text = JSON.stringify(r);
-    expect(text).not.toContain("nextCursor` from a previous");
-    // Still the fleet trail, whichever trail the number came from.
-    expect(text).not.toContain(`${TAG}:mine`);
+    const answers = new Set<string>();
+    for (const cursor of [tenantRowId, "115", "999999999"]) {
+      const r = await auditList(
+        p,
+        { limit: 500, scope: "fleet", cursor },
+        { base: appDb },
+      );
+      const text = JSON.stringify(r);
+      expect(text).toContain("nextCursor` from a previous");
+      // No trail is read at all, so no row of one can leak into the refusal.
+      expect(text).not.toContain(`${TAG}:mine`);
+      answers.add(text);
+    }
+    expect(answers.size).toBe(1);
   });
 
-  // THE UNAUTHORIZED SCOPE IS STILL THE TOOL'S OWN ERROR, cursor or no cursor. Resolving a bare id
-  // needed the trail predicate, which needs the scope, which throws for a caller who may not ask for
-  // it -- and it threw OUTSIDE the handler's `try`, so this one combination rejected the promise
-  // instead of answering with `isError` like every other refusal (round 9 of #537). Reading the id
-  // as a bound touches neither the scope nor the database, so the refusal comes from the one place
-  // it always did.
-  test("an unauthorized scope answers the same way with a bare cursor as without", async () => {
+  // THE UNAUTHORIZED SCOPE IS STILL AN ORDINARY ANSWER, cursor or no cursor, and that is what this
+  // test has always been for: resolving a bare id needed the scope, which throws for a caller who
+  // may not ask for it, and it threw OUTSIDE the handler's `try`, so this one combination REJECTED
+  // the promise instead of answering with `isError` like every other refusal (round 9 of #537).
+  //
+  // What changed with #544 is which refusal wins, and it is worth pinning rather than leaving to
+  // chance: the cursor is refused at the parse, before the scope is looked at, so an unauthorized
+  // caller passing a bare id now hears about the cursor. Neither sentence describes the trail, so
+  // both are safe; a later edit that reorders them should be deliberate.
+  test("an unauthorized scope answers, rather than rejecting, with a bare cursor and without", async () => {
     const tenantAdmin = principal({ tenantId: mine, role: "TENANT_ADMIN" });
     for (const scope of ["fleet", "all"]) {
       const bare = await auditList(
@@ -350,8 +328,8 @@ describe.skipIf(!dbUp)("what a targetless audit_list actually reads", () => {
         { limit: 1, scope },
         { base: appDb },
       );
-      expect(JSON.stringify(bare)).toBe(JSON.stringify(none));
-      expect(JSON.stringify(bare)).toContain("SUPER_ADMIN");
+      expect(JSON.stringify(none)).toContain("SUPER_ADMIN");
+      expect(JSON.stringify(bare)).toContain("nextCursor` from a previous");
     }
   });
 

--- a/tests/prisma/tenant-index-redundancy.test.ts
+++ b/tests/prisma/tenant-index-redundancy.test.ts
@@ -102,6 +102,42 @@ describe("a concurrent index drop is alone in its migration", () => {
     expect(concurrent).toBeGreaterThan(10);
     expect(offenders).toEqual([]);
   });
+
+  // AND THE CONVERSE, which is the half that was missing: a file whose ONLY job is to drop an index
+  // must drop it concurrently. Found by mutation on #544 — taking `CONCURRENTLY` out of that
+  // migration passed every test in the tree, and it is the exact shape `.claude/rules/prisma.md`
+  // warns about. `migrate deploy` runs on the NEW container while the OLD one is still serving, and
+  // a plain `DROP INDEX` takes ACCESS EXCLUSIVE on the TABLE, not on the index: every read and every
+  // write that records an audit row queues behind it for the length of the drop.
+  //
+  // ONLY-STATEMENT IS WHAT MAKES THE RULE EXCEPTIONLESS, rather than a list of grandfathered files.
+  // A plain drop is legitimate and necessary in two other shapes, both of which have a second
+  // statement: dropping a possibly-invalid leftover immediately before rebuilding it (the concurrent
+  // DROP form cannot share a file with `CREATE INDEX CONCURRENTLY`), and dropping a unique index as
+  // part of a larger schema change. Swept over the tree: every plain drop in it is one of those two,
+  // and every file that does nothing but drop already uses CONCURRENTLY.
+  test("a migration that only drops an index drops it concurrently", () => {
+    const dir = "prisma/migrations";
+    const offenders: string[] = [];
+    let dropOnly = 0;
+    for (const name of readdirSync(dir)) {
+      const file = `${dir}/${name}/migration.sql`;
+      if (!existsSync(file)) continue;
+      const sql = readFileSync(file, "utf8")
+        .split("\n")
+        .filter((l) => !l.trimStart().startsWith("--"))
+        .join("\n")
+        .replace(/\$\$[\s\S]*?\$\$/g, "$$BODY$$");
+      const statements = sql.split(";").filter((s) => s.trim().length > 0);
+      if (statements.length !== 1) continue;
+      const only = statements[0] as string;
+      if (!/^\s*DROP\s+INDEX/i.test(only)) continue;
+      dropOnly += 1;
+      if (!/DROP\s+INDEX\s+CONCURRENTLY/i.test(only)) offenders.push(name);
+    }
+    expect(dropOnly).toBeGreaterThan(0);
+    expect(offenders).toEqual([]);
+  });
 });
 
 const suUrl = process.env.MIGRATION_DATABASE_URL;


### PR DESCRIPTION
Two things #530 (PR #537) left standing on purpose, for the same window, and they come out together.

**The index.** `audit_logs_fleet_id_idx` served one query: the fleet trail's `ORDER BY id`, which nothing has issued since #530 moved every audit read onto `(created_at, id)`. The other three indexes that release replaced were dropped in its own PR, because the new `(created_at DESC, id DESC)` pair answers the old questions too; this one had no replacement, since after #530 no audit index leads with `id` at all. It stayed because deploys are rolling and, for one overlap, a container from the release BEFORE #530 was still asking — without the index, a primary-key walk past every tenant row, 8,687 buffers and 21.5 ms against 2.

**The cursor.** The same release paged `id < X`, so the cursor it handed out was a BOUND rather than a position, and it could not be converted into one: `created_at` is written by the client, so a row can carry a stamp older than a row with a smaller id, and every unseen row stamped ahead of X sits ahead of X's own tuple. It was carried alongside the keyset instead. A bare id is a 400 again, and the cursor is two parts.

## The gate, stated rather than assumed

#530 shipped in **v1.15.0**, which is the current release, so this is the release after it and no container from before #530 is part of a normal upgrade any more.

An operator who **skips** a release still overlaps one, and pays for the length of the drain: that container's fleet page walks the primary key (slower, never wrong) and a bare cursor it emitted gets a 400 that a reload clears. Both end when the old process does, and neither loses a row.

## What flipped, and why nothing was merely deleted

Every test that asserted the opposite flips rather than disappears. The index is asserted **absent** — the direction that can rot, since a revert of the drop brings it back with nothing else to notice — and the bare id is asserted **refused** at all three doors (service, REST, MCP). The reason it cannot simply be translated is kept in the comments even though the code is gone: it is what makes a 400 the honest answer instead of a pager that says "Page 2" over a different trail.

One measurement changed a test's expectation rather than being written to match it: with the cursor refused at the parse, an unauthorized caller passing a bare id now hears about the cursor instead of the scope. Both are ordinary `isError` answers and neither describes the trail, so the order is pinned deliberately.

## Battery

6 mutations, 6 deaths. The fifth **survived first** and became a test rather than a note: dropping the index without `CONCURRENTLY` passed the whole tree, which is the exact shape `.claude/rules/prisma.md` warns about — `migrate deploy` runs on the new container while the old one serves, and a plain `DROP INDEX` takes ACCESS EXCLUSIVE on the TABLE, queueing every audit write behind it. The sweep beside it now asserts the converse of the rule already there: **a file whose only statement is a drop must drop concurrently**. Exceptionless as written — swept, every plain drop in the tree has a second statement and is either a rebuild or part of a schema change.

`bun check`: 11015 pass, 4 skip, 0 fail.

Fixes #544
