### PR TITLE
Say on the refusal note what the customer actually got, instead of claiming silence over the copy just sent

### DIFF
--- a/docs/contact-auth.md
+++ b/docs/contact-auth.md
@@ -279,8 +279,17 @@ message is folded into the memory thread like any other unanswered one.
 - **denied** → the `denyMessage` (when set) goes to the customer under the same `stillOurs` fence and
   persona token every gate message uses; the conversation is opened for humans (+ team) when
   `handoffEnabled`; a pt-BR private note tells the operator, with the `reason` code when one came.
+  That note carries what is **not** on the operator's screen, so what it says about the customer's
+  copy depends on what the customer actually got: when the copy was delivered the note says nothing
+  about it (the message is one line above; it keeps the reason code, which is the invisible part),
+  and it speaks up in the three cases where nothing reached the customer — no `denyMessage`
+  configured, the notice cooldown withholding a repeat, or nothing arriving at all (the send failed,
+  or the ownership fence stood it down; the runtime sees one boolean for both, so the note reports
+  the result and never names a cause it does not know).
 - **error** → nothing to the customer, no handoff (transient by contract: the next message retries),
-  a private note + a `warn` flow line.
+  a private note + a `warn` flow line. This note and the **no_identity** one are unchanged by the
+  above: both outcomes are silent to the customer by design, so there is no copy to describe and
+  "o agente não respondeu automaticamente" is simply true there.
 - **no_identity** (no phone, email or identifier) → nothing to the customer (the deny copy would
   mislead an unidentified web visitor), but the conversation IS opened for humans when
   `handoffEnabled`: a contact the gate can never authorize would otherwise stay pending and

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2285,6 +2285,18 @@ const CONTACT_AUTH_ERROR_LABELS: Record<string, string> = {
 // anything the customer wrote. This is also the ONE place the endpoint's own reason surfaces: the
 // note sits in the operator's Chatwoot, on the conversation it is about, unlike the execution log
 // that alert channels read.
+// What the CUSTOMER got on this refusal, which the note has to describe correctly. Only a `denied`
+// verdict can send a copy at all: `no_identity` and `error` are silent to the customer by design.
+export type ContactAuthCopyOutcome =
+  // The refusal notice reached the customer.
+  | "sent"
+  // No `denyMessage` configured: the customer got nothing, on purpose.
+  | "none"
+  // Configured, but the notice cooldown had already spoken inside the window.
+  | "suppressed"
+  // Configured and attempted, but the send did not land.
+  | "failed";
+
 export function contactAuthNoteText(
   verdict: {
     outcome: ContactAuthOutcome;
@@ -2293,6 +2305,8 @@ export function contactAuthNoteText(
     endpointReason?: string;
   },
   handedOff: boolean,
+  // Defaults to `none` so the sentence stays true for a caller that sends no copy.
+  copy: ContactAuthCopyOutcome = "none",
 ): string {
   const handoffLine = handedOff
     ? " A conversa foi aberta para atendimento humano."
@@ -2306,7 +2320,24 @@ export function contactAuthNoteText(
   if (verdict.outcome === "denied") {
     const motivo = verdict.endpointReason ?? verdict.reason;
     const reason = motivo ? ` Motivo: ${motivo}.` : "";
-    return `🔒 Contato não autorizado pela verificação externa.${reason} O agente não respondeu automaticamente.${handoffLine}`;
+    // The note used to say "O agente não respondeu automaticamente" on every refusal, including the
+    // ones where the deny message HAD just been posted to the customer — a sentence the operator
+    // reads directly below that very message, which makes the note look broken and hides that the
+    // customer already knows.
+    //
+    // The note earns its space by carrying what is NOT on screen. When the copy went out, the
+    // operator can see it: saying so adds nothing, so the note stays quiet about it and keeps only
+    // the reason code, which is the part no one can see. The three cases where NOTHING reached the
+    // customer are the invisible ones, and each is a different thing for the operator to do: nobody
+    // configured a copy, the cooldown withheld it, or the send failed and should be chased.
+    const copyLine = {
+      sent: "",
+      none: " Nenhum aviso foi enviado ao contato: não há mensagem de recusa configurada.",
+      suppressed:
+        " O aviso de recusa não foi repetido ao contato por causa da carência entre avisos.",
+      failed: " O envio do aviso de recusa ao contato NÃO foi concluído.",
+    }[copy];
+    return `🔒 Contato não autorizado pela verificação externa.${reason}${copyLine}${handoffLine}`;
   }
   const cause =
     verdict.status !== undefined
@@ -4072,11 +4103,20 @@ async function maybeConsumeCommandOrGate(params: {
           const denyMessage =
             verdict.outcome === "denied" ? authCfg.denyMessage : null;
           const copyClaim = denyMessage ? claim("copy") : false;
+          // Tracked so the operator note can say what the CUSTOMER actually got, instead of
+          // claiming silence on top of a refusal that was just delivered.
+          let copyOutcome: ContactAuthCopyOutcome = denyMessage
+            ? copyClaim
+              ? "failed"
+              : "suppressed"
+            : "none";
           if (denyMessage && copyClaim) {
             // The window is claimed before the send, because two settled deliveries racing must not
             // both speak — so a send that does not land has to give it back. Kept, it would silence
             // the next refusal for the whole window over a message the customer never received.
-            if (!(await postPublicMessage(denyMessage))) {
+            if (await postPublicMessage(denyMessage)) {
+              copyOutcome = "sent";
+            } else {
               releaseContactAuthNotice(copyClaim);
             }
           }
@@ -4090,7 +4130,9 @@ async function maybeConsumeCommandOrGate(params: {
           const noteClaim = claim("note");
           if (noteClaim) {
             if (
-              !(await postPrivateNote(contactAuthNoteText(verdict, handedOff)))
+              !(await postPrivateNote(
+                contactAuthNoteText(verdict, handedOff, copyOutcome),
+              ))
             ) {
               releaseContactAuthNotice(noteClaim);
             }

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2292,7 +2292,7 @@ export type ContactAuthCopyOutcome =
   | "sent"
   // No `denyMessage` configured: the customer got nothing, on purpose.
   | "none"
-  // Configured, but the notice cooldown had already spoken inside the window.
+  // Configured, but another refusal on this conversation holds the notice window.
   | "suppressed"
   // Configured and attempted, but nothing reached the customer: the send failed, or the
   // ownership fence stood it down.
@@ -2334,8 +2334,13 @@ export function contactAuthNoteText(
     const copyLine = {
       sent: "",
       none: " Nenhum aviso foi enviado ao contato: não há mensagem de recusa configurada.",
+      // Says the window was TAKEN, not that a copy landed. A concurrent refusal on the same
+      // conversation claims the copy window BEFORE it sends, so a claim that fails means "another
+      // refusal holds it" — which covers both the one that already spoke and the one still in
+      // flight, and that one may yet fail and give the window back. Whether a copy is on screen is
+      // the operator's to see; what they cannot see is that THIS message produced none, and why.
       suppressed:
-        " O aviso de recusa não foi repetido ao contato por causa da carência entre avisos.",
+        " O aviso de recusa não saiu nesta mensagem: a carência entre avisos já estava tomada por outra recusa.",
       // Says the RESULT, not a cause. This branch is reached both by a send that failed and by the
       // ownership fence standing the copy down (a human took the conversation, or the agent was
       // switched off, between the mode read and the refusal): `postPublicMessage` returns the same

--- a/src/modules/chatwoot/webhook.ts
+++ b/src/modules/chatwoot/webhook.ts
@@ -2294,7 +2294,8 @@ export type ContactAuthCopyOutcome =
   | "none"
   // Configured, but the notice cooldown had already spoken inside the window.
   | "suppressed"
-  // Configured and attempted, but the send did not land.
+  // Configured and attempted, but nothing reached the customer: the send failed, or the
+  // ownership fence stood it down.
   | "failed";
 
 export function contactAuthNoteText(
@@ -2335,7 +2336,12 @@ export function contactAuthNoteText(
       none: " Nenhum aviso foi enviado ao contato: não há mensagem de recusa configurada.",
       suppressed:
         " O aviso de recusa não foi repetido ao contato por causa da carência entre avisos.",
-      failed: " O envio do aviso de recusa ao contato NÃO foi concluído.",
+      // Says the RESULT, not a cause. This branch is reached both by a send that failed and by the
+      // ownership fence standing the copy down (a human took the conversation, or the agent was
+      // switched off, between the mode read and the refusal): `postPublicMessage` returns the same
+      // false for both, and naming "delivery failure" here would send the operator chasing a
+      // problem that does not exist on the second one.
+      failed: " O aviso de recusa NÃO chegou ao contato.",
     }[copy];
     return `🔒 Contato não autorizado pela verificação externa.${reason}${copyLine}${handoffLine}`;
   }

--- a/tests/modules/contact-auth-gate-e2e.test.ts
+++ b/tests/modules/contact-auth-gate-e2e.test.ts
@@ -979,9 +979,48 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
     // is a delivery problem to chase, not a decision someone made.
     const notes = cw.notesOn(convId);
     expect(notes).toHaveLength(1);
-    expect(notes[0]?.content).toContain("NÃO foi concluído");
+    expect(notes[0]?.content).toContain("NÃO chegou ao contato");
     expect(notes[0]?.content).not.toContain("carência");
     expect(notes[0]?.content).not.toContain("Nenhum aviso");
+  });
+
+  // The SAME false from postPublicMessage, for a completely different reason: the copy was stood
+  // down by the ownership fence because a human took the conversation inside the authorization
+  // round-trip. Nothing failed to deliver here, so a note that named a delivery failure would send
+  // the operator chasing one.
+  test("a copy the fence stood down reads as the copy not arriving, not as a broken send", async () => {
+    const convId = 9317;
+    await seedConversation(convId, inboxFullDbId);
+    const cw = stubChatwoot();
+    const auth = authDouble(async () => {
+      await suDb.conversation.updateMany({
+        where: {
+          tenantId,
+          chatwootInstanceId: instanceId,
+          chatwootConversationId: convId,
+        },
+        data: { assigneeType: "User", assigneeId: 44, status: "open" },
+      });
+      return denied();
+    });
+    await deliverCustomerMessage({
+      convId,
+      chatwootInboxId: INBOX_FULL,
+      senderId: 818,
+      phone: PHONE,
+      fetchImpl: auth.fetchImpl,
+      makeClient: cw.makeClient,
+    });
+    // The conversation is the human's: nothing is said to the customer and nothing is toggled.
+    expect(cw.publicOn(convId)).toEqual([]);
+    expect(cw.statusToggles).toEqual([]);
+    // The note still goes out (it has no fence: it is FOR the human who just took over), and it is
+    // true for them — it reports the result, and claims neither a delivery failure nor a handoff.
+    const notes = cw.notesOn(convId);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.content).toContain("NÃO chegou ao contato");
+    expect(notes[0]?.content).not.toContain("atendimento humano");
+    expect(notes[0]?.content).not.toContain("carência");
   });
 
   test("a repeat withheld by the cooldown is named as the cooldown, not as a failure", async () => {

--- a/tests/modules/contact-auth-gate-e2e.test.ts
+++ b/tests/modules/contact-auth-gate-e2e.test.ts
@@ -85,13 +85,21 @@ interface Sent {
 // Recording Chatwoot double, injected via deps.makeClient so neither the gate nor the turn ever
 // reaches a socket. The factory captures the bot token each client was built with: the deny copy
 // must leave as the PERSONA, not as a token-less client that a real Chatwoot would 401.
-function stubChatwoot() {
+// `fail` injects delivery failures, which is the only way to reach two of the four things the
+// operator note can say about the customer's copy: a send that did not land, and the cooldown
+// withholding a repeat (reachable when an earlier note failed and freed its own window while the
+// copy's stayed spent).
+function stubChatwoot(
+  fail: { publicSend?: boolean; firstNote?: boolean } = {},
+) {
   const sent: Sent[] = [];
   const statusToggles: Array<[number, string]> = [];
   const teamAssignments: Array<[number, number]> = [];
   let token = "";
+  let notes = 0;
   const client = {
     sendMessage: async (c: number, content: string) => {
+      if (fail.publicSend) throw new Error("chatwoot down: send refused");
       sent.push({
         conversationId: c,
         content,
@@ -101,6 +109,10 @@ function stubChatwoot() {
       return {};
     },
     sendPrivateNote: async (c: number, content: string) => {
+      notes += 1;
+      if (fail.firstNote && notes === 1) {
+        throw new Error("chatwoot down: note refused");
+      }
       sent.push({ conversationId: c, content, private: true, token });
       return {};
     },
@@ -567,6 +579,12 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
     expect(notes[0]?.content).toContain("não autorizado");
     expect(notes[0]?.content).toContain("not_customer");
     expect(notes[0]?.content).not.toContain(PHONE);
+    // The copy went out in this very conversation, one line above. The note used to claim "o agente
+    // não respondeu automaticamente" here, contradicting the screen; announcing that the contact WAS
+    // warned would be just as useless, because the operator can see the message. So the note carries
+    // only what is not on screen — the reason code above — and says nothing about the copy.
+    expect(notes[0]?.content).not.toContain("não respondeu automaticamente");
+    expect(notes[0]?.content).not.toContain("aviso");
     // The message is consumed: the watermark advanced so no later flush re-answers it.
     const conv = await suDb.conversation.findFirstOrThrow({
       where: { tenantId, chatwootConversationId: convId },
@@ -933,7 +951,67 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
     expect(cw.statusToggles).toEqual([[convId, "open"]]);
     // No team configured: open only, Chatwoot routes.
     expect(cw.teamAssignments).toEqual([]);
-    expect(cw.notesOn(convId)).toHaveLength(1);
+    // The note is the ONLY place this is visible: there is no message on screen to infer it from,
+    // so it names both the silence and its cause.
+    const notes = cw.notesOn(convId);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.content).toContain("Nenhum aviso foi enviado ao contato");
+    expect(notes[0]?.content).toContain(
+      "não há mensagem de recusa configurada",
+    );
+  });
+
+  test("a deny copy that does not land is named in the note as a delivery failure", async () => {
+    const convId = 9315;
+    await seedConversation(convId, inboxFullDbId);
+    const cw = stubChatwoot({ publicSend: true });
+    const auth = authDouble(() => denied());
+    await deliverCustomerMessage({
+      convId,
+      chatwootInboxId: INBOX_FULL,
+      senderId: 815,
+      phone: PHONE,
+      fetchImpl: auth.fetchImpl,
+      makeClient: cw.makeClient,
+    });
+    expect(cw.publicOn(convId)).toEqual([]);
+    // Nothing on screen says the send failed, and the difference matters to the operator: this one
+    // is a delivery problem to chase, not a decision someone made.
+    const notes = cw.notesOn(convId);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.content).toContain("NÃO foi concluído");
+    expect(notes[0]?.content).not.toContain("carência");
+    expect(notes[0]?.content).not.toContain("Nenhum aviso");
+  });
+
+  test("a repeat withheld by the cooldown is named as the cooldown, not as a failure", async () => {
+    const convId = 9316;
+    await seedConversation(convId, inboxFullDbId);
+    // The first note fails, so it gives ITS window back while the copy's stays spent. That is what
+    // separates the two windows, and it is the state in which the second refusal has a note to
+    // write about a copy it did not send.
+    const cw = stubChatwoot({ firstNote: true });
+    const auth = authDouble(
+      () => denied(),
+      () => denied(),
+    );
+    for (const senderId of [816, 817]) {
+      await deliverCustomerMessage({
+        convId,
+        chatwootInboxId: INBOX_FULL,
+        senderId,
+        phone: PHONE,
+        fetchImpl: auth.fetchImpl,
+        makeClient: cw.makeClient,
+      });
+    }
+    // One copy for the two refusals: the second was inside the window.
+    expect(cw.publicOn(convId)).toHaveLength(1);
+    const notes = cw.notesOn(convId);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.content).toContain("carência entre avisos");
+    expect(notes[0]?.content).toContain("não foi repetido");
+    expect(notes[0]?.content).not.toContain("NÃO foi concluído");
   });
 
   // A Chatwoot team id belongs to ONE account. The editor cannot warn about an agent MOVED to

--- a/tests/modules/contact-auth-gate-e2e.test.ts
+++ b/tests/modules/contact-auth-gate-e2e.test.ts
@@ -90,7 +90,13 @@ interface Sent {
 // withholding a repeat (reachable when an earlier note failed and freed its own window while the
 // copy's stayed spent).
 function stubChatwoot(
-  fail: { publicSend?: boolean; firstNote?: boolean } = {},
+  fail: {
+    publicSend?: boolean;
+    firstNote?: boolean;
+    // Holds the first public send open until the latch is released, so a second delivery can run to
+    // completion while the first is still awaiting Chatwoot.
+    holdFirstSend?: { entered: () => void; wait: Promise<"ok" | "throw"> };
+  } = {},
 ) {
   const sent: Sent[] = [];
   const statusToggles: Array<[number, string]> = [];
@@ -100,6 +106,14 @@ function stubChatwoot(
   const client = {
     sendMessage: async (c: number, content: string) => {
       if (fail.publicSend) throw new Error("chatwoot down: send refused");
+      const hold = fail.holdFirstSend;
+      if (hold) {
+        fail.holdFirstSend = undefined;
+        hold.entered();
+        if ((await hold.wait) === "throw") {
+          throw new Error("chatwoot down: send refused");
+        }
+      }
       sent.push({
         conversationId: c,
         content,
@@ -984,6 +998,58 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
     expect(notes[0]?.content).not.toContain("Nenhum aviso");
   });
 
+  // Two refusals racing on ONE conversation. Single-flight is keyed by contact AND request, so two
+  // different messages are two questions and two deliveries in flight at once. The loser of the copy
+  // claim writes its note while the winner is still awaiting Chatwoot — and the winner may yet fail
+  // and hand the window back. So the note that survives must not claim a copy landed: all it can
+  // say is that the window was taken.
+  test("a refusal that lost the copy window never claims the other one was delivered", async () => {
+    const convId = 9318;
+    await seedConversation(convId, inboxFullDbId);
+    let entrou = () => {};
+    const entered = new Promise<void>((r) => {
+      entrou = r;
+    });
+    let liberar: (v: "ok" | "throw") => void = () => {};
+    const wait = new Promise<"ok" | "throw">((r) => {
+      liberar = r;
+    });
+    const cw = stubChatwoot({ holdFirstSend: { entered: entrou, wait } });
+    const auth = authDouble(
+      () => denied(),
+      () => denied(),
+    );
+    const primeira = deliverCustomerMessage({
+      convId,
+      chatwootInboxId: INBOX_FULL,
+      senderId: 819,
+      phone: PHONE,
+      fetchImpl: auth.fetchImpl,
+      makeClient: cw.makeClient,
+    });
+    // The first delivery is now parked inside Chatwoot's send, holding the copy window.
+    await entered;
+    await deliverCustomerMessage({
+      convId,
+      chatwootInboxId: INBOX_FULL,
+      senderId: 819,
+      phone: PHONE,
+      fetchImpl: auth.fetchImpl,
+      makeClient: cw.makeClient,
+    });
+    // ...and only now does it fail, so NOTHING ever reached the customer on either message.
+    liberar("throw");
+    await primeira;
+    expect(cw.publicOn(convId)).toEqual([]);
+    // The second delivery took the note window, so its note is the only one the operator gets.
+    const notes = cw.notesOn(convId);
+    expect(notes).toHaveLength(1);
+    // It may say the window was taken. It may NOT say a notice was delivered or repeated: the copy
+    // it lost the race to never landed, and the conversation above it shows that.
+    expect(notes[0]?.content).toContain("não saiu nesta mensagem");
+    expect(notes[0]?.content).not.toContain("repetido");
+  });
+
   // The SAME false from postPublicMessage, for a completely different reason: the copy was stood
   // down by the ownership fence because a human took the conversation inside the authorization
   // round-trip. Nothing failed to deliver here, so a note that named a delivery failure would send
@@ -1049,8 +1115,8 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
     const notes = cw.notesOn(convId);
     expect(notes).toHaveLength(1);
     expect(notes[0]?.content).toContain("carência entre avisos");
-    expect(notes[0]?.content).toContain("não foi repetido");
-    expect(notes[0]?.content).not.toContain("NÃO foi concluído");
+    expect(notes[0]?.content).toContain("não saiu nesta mensagem");
+    expect(notes[0]?.content).not.toContain("NÃO chegou ao contato");
   });
 
   // A Chatwoot team id belongs to ONE account. The editor cannot warn about an agent MOVED to

--- a/tests/modules/contact-auth-gate-e2e.test.ts
+++ b/tests/modules/contact-auth-gate-e2e.test.ts
@@ -91,7 +91,9 @@ interface Sent {
 // copy's stayed spent).
 function stubChatwoot(
   fail: {
-    publicSend?: boolean;
+    // Only the FIRST send/note fails: the delivery after it has to be able to speak, which is what
+    // proves the claimed window was handed back.
+    firstSend?: boolean;
     firstNote?: boolean;
     // Holds the first public send open until the latch is released, so a second delivery can run to
     // completion while the first is still awaiting Chatwoot.
@@ -102,10 +104,14 @@ function stubChatwoot(
   const statusToggles: Array<[number, string]> = [];
   const teamAssignments: Array<[number, number]> = [];
   let token = "";
+  let sends = 0;
   let notes = 0;
   const client = {
     sendMessage: async (c: number, content: string) => {
-      if (fail.publicSend) throw new Error("chatwoot down: send refused");
+      sends += 1;
+      if (fail.firstSend && sends === 1) {
+        throw new Error("chatwoot down: send refused");
+      }
       const hold = fail.holdFirstSend;
       if (hold) {
         fail.holdFirstSend = undefined;
@@ -978,8 +984,11 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
   test("a deny copy that does not land is named in the note as a delivery failure", async () => {
     const convId = 9315;
     await seedConversation(convId, inboxFullDbId);
-    const cw = stubChatwoot({ publicSend: true });
-    const auth = authDouble(() => denied());
+    const cw = stubChatwoot({ firstSend: true });
+    const auth = authDouble(
+      () => denied("not_customer"),
+      () => denied("not_customer"),
+    );
     await deliverCustomerMessage({
       convId,
       chatwootInboxId: INBOX_FULL,
@@ -994,8 +1003,30 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
     const notes = cw.notesOn(convId);
     expect(notes).toHaveLength(1);
     expect(notes[0]?.content).toContain("NÃO chegou ao contato");
+    expect(notes[0]?.content).toContain("not_customer");
+    expect(notes[0]?.content).not.toContain(PHONE);
     expect(notes[0]?.content).not.toContain("carência");
     expect(notes[0]?.content).not.toContain("Nenhum aviso");
+    // And the window came back with it. A send that did not land must not silence the next refusal
+    // for the whole window over a message the customer never received, so the second delivery — well
+    // inside the 300s — speaks. This is what `releaseContactAuthNotice(copyClaim)` buys, and nothing
+    // else in the suite exercises it end to end.
+    await deliverCustomerMessage({
+      convId,
+      chatwootInboxId: INBOX_FULL,
+      senderId: 815,
+      phone: PHONE,
+      fetchImpl: auth.fetchImpl,
+      makeClient: cw.makeClient,
+    });
+    expect(cw.publicOn(convId)).toEqual([
+      {
+        conversationId: convId,
+        content: DENY_COPY,
+        private: false,
+        token: BOT_TOKEN,
+      },
+    ]);
   });
 
   // Two refusals racing on ONE conversation. Single-flight is keyed by contact AND request, so two
@@ -1097,8 +1128,8 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
     // write about a copy it did not send.
     const cw = stubChatwoot({ firstNote: true });
     const auth = authDouble(
-      () => denied(),
-      () => denied(),
+      () => denied("not_customer"),
+      () => denied("not_customer"),
     );
     for (const senderId of [816, 817]) {
       await deliverCustomerMessage({
@@ -1110,12 +1141,22 @@ describe.skipIf(!dbUp)("contact authorization gate (webhook e2e)", () => {
         makeClient: cw.makeClient,
       });
     }
-    // One copy for the two refusals: the second was inside the window.
-    expect(cw.publicOn(convId)).toHaveLength(1);
+    // One copy for the two refusals: the second was inside the window. Checked by content and token
+    // too — it has to be the deny copy, sent as the persona, not just "some message".
+    expect(cw.publicOn(convId)).toEqual([
+      {
+        conversationId: convId,
+        content: DENY_COPY,
+        private: false,
+        token: BOT_TOKEN,
+      },
+    ]);
     const notes = cw.notesOn(convId);
     expect(notes).toHaveLength(1);
     expect(notes[0]?.content).toContain("carência entre avisos");
     expect(notes[0]?.content).toContain("não saiu nesta mensagem");
+    expect(notes[0]?.content).toContain("not_customer");
+    expect(notes[0]?.content).not.toContain(PHONE);
     expect(notes[0]?.content).not.toContain("NÃO chegou ao contato");
   });
 

--- a/tests/modules/contact-auth-note-copy.test.ts
+++ b/tests/modules/contact-auth-note-copy.test.ts
@@ -34,10 +34,30 @@ describe("contactAuthNoteText: só diz o que não está na tela", () => {
     expect(nota).toContain("não foi repetido");
   });
 
-  test("send failed: named as a delivery problem, not as a decision", () => {
+  // `failed` covers two different causes — the send threw, and the ownership fence stood the copy
+  // down because a human took the conversation — and the call site sees the same `false` for both.
+  // So the note says what is TRUE of both, the result, and never names a delivery failure that the
+  // takeover case would not have.
+  test("nothing reached the contact: the note says the result, not a cause", () => {
     const nota = contactAuthNoteText(denied, true, "failed");
-    expect(nota).toContain("NÃO foi concluído");
+    expect(nota).toContain("NÃO chegou ao contato");
     expect(nota).not.toContain("carência");
+    expect(nota).not.toContain("envio");
+    expect(nota).not.toContain("falh");
+  });
+
+  // The strongest criterion here, and the one that does not depend on the words chosen: with the
+  // SAME reason code and the same handoff, the four states must read as four different notes.
+  // Before the fix they were byte-for-byte identical, which is what made the note unreadable.
+  test("the four outcomes are four distinct notes, and none of them leaks the contact", () => {
+    const notas = (["sent", "none", "suppressed", "failed"] as const).map((c) =>
+      contactAuthNoteText(denied, true, c),
+    );
+    expect(new Set(notas).size).toBe(4);
+    for (const nota of notas) {
+      expect(nota).toContain("not_customer");
+      expect(nota).not.toContain("+55");
+    }
   });
 
   test("default is `none`, so an omitted argument never overclaims", () => {

--- a/tests/modules/contact-auth-note-copy.test.ts
+++ b/tests/modules/contact-auth-note-copy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { contactAuthNoteText } from "@/modules/chatwoot/webhook";
+
+// The note earns its space by carrying what is NOT on screen. It used to say "o agente não respondeu
+// automaticamente" on every refusal, including the ones where the deny message had gone out one line
+// above — a note that contradicts the screen. Announcing the opposite ("o contato foi avisado") is
+// just as useless, for the same reason: the operator can see that message. So the note says nothing
+// about a copy that WAS delivered, and speaks up in the three cases where nothing reached the
+// customer, which are the ones nobody can see.
+describe("contactAuthNoteText: só diz o que não está na tela", () => {
+  const denied = { outcome: "denied" as const, endpointReason: "not_customer" };
+
+  test("copy delivered: the note says NOTHING about the copy, and never claims silence", () => {
+    const nota = contactAuthNoteText(denied, true, "sent");
+    // Not "não respondeu" (contradicts the screen) and not "foi avisado" (redundant with it).
+    expect(nota).not.toContain("não respondeu automaticamente");
+    expect(nota).not.toContain("aviso");
+    // What it keeps is the part the operator cannot see: the reason code, plus the handoff.
+    expect(nota).toContain("not_customer");
+    expect(nota).toContain("atendimento humano");
+  });
+
+  test("no deny message configured: the note says nothing reached the contact, and why", () => {
+    const nota = contactAuthNoteText(denied, false, "none");
+    expect(nota).toContain("Nenhum aviso foi enviado ao contato");
+    expect(nota).toContain("não há mensagem de recusa configurada");
+    expect(nota).not.toContain("atendimento humano");
+  });
+
+  test("cooldown: the operator learns the notice was withheld, not missing", () => {
+    // Without this the second refusal inside the window looks like a bug in the copy.
+    const nota = contactAuthNoteText(denied, true, "suppressed");
+    expect(nota).toContain("carência entre avisos");
+    expect(nota).toContain("não foi repetido");
+  });
+
+  test("send failed: named as a delivery problem, not as a decision", () => {
+    const nota = contactAuthNoteText(denied, true, "failed");
+    expect(nota).toContain("NÃO foi concluído");
+    expect(nota).not.toContain("carência");
+  });
+
+  test("default is `none`, so an omitted argument never overclaims", () => {
+    expect(contactAuthNoteText(denied, false)).toBe(
+      contactAuthNoteText(denied, false, "none"),
+    );
+  });
+
+  // The two verdicts that are silent to the customer BY DESIGN keep their wording: there is no copy
+  // to describe, and "não respondeu automaticamente" is the whole truth there.
+  // The `sent` note is the shortest of the four ON PURPOSE: everything it could add is already on
+  // screen. This pins that, so nobody "improves" it back into a redundant sentence.
+  test("`sent` is the shortest note of the four", () => {
+    const sent = contactAuthNoteText(denied, true, "sent");
+    for (const outro of ["none", "suppressed", "failed"] as const) {
+      expect(sent.length).toBeLessThan(
+        contactAuthNoteText(denied, true, outro).length,
+      );
+    }
+  });
+
+  test("no_identity and error are untouched", () => {
+    expect(
+      contactAuthNoteText({ outcome: "no_identity" }, false, "sent"),
+    ).toContain("não respondeu automaticamente");
+    expect(
+      contactAuthNoteText({ outcome: "error", status: 502 }, false, "sent"),
+    ).toContain("não respondeu automaticamente");
+  });
+});

--- a/tests/modules/contact-auth-note-copy.test.ts
+++ b/tests/modules/contact-auth-note-copy.test.ts
@@ -27,11 +27,15 @@ describe("contactAuthNoteText: só diz o que não está na tela", () => {
     expect(nota).not.toContain("atendimento humano");
   });
 
-  test("cooldown: the operator learns the notice was withheld, not missing", () => {
-    // Without this the second refusal inside the window looks like a bug in the copy.
+  test("cooldown: the note says the window was taken, never that a copy landed", () => {
+    // Without this the second refusal inside the window looks like a bug in the copy. But it must
+    // not claim delivery either: a concurrent refusal claims the copy window BEFORE it sends, so
+    // the one that lost the claim cannot know whether the other's send landed — and that one may
+    // still fail and hand the window back.
     const nota = contactAuthNoteText(denied, true, "suppressed");
     expect(nota).toContain("carência entre avisos");
-    expect(nota).toContain("não foi repetido");
+    expect(nota).toContain("não saiu nesta mensagem");
+    expect(nota).not.toContain("repetido");
   });
 
   // `failed` covers two different causes — the send threw, and the ownership fence stood the copy


### PR DESCRIPTION
Fixes #584

## What was wrong

The contact-auth gate posts a private note to the operator on every refusal. That note said **"O agente não respondeu automaticamente"** on *every* refusal, including the ones that had just posted the configured deny message to the customer one line above it.

The operator reads that note in the same conversation, directly below that message. So on the most common refusal the note contradicted what is on the screen, and — worse — it hid the thing whoever picks up the conversation needs: whether the customer already knows they were refused.

## What the note should carry

Not the opposite sentence. `"O contato foi avisado"` is just as useless, for the same reason: the message is visible. A private note earns its space by carrying what is **not** on screen.

So the note now says nothing about a copy that *was* delivered (it keeps the endpoint's reason code, which is the part nobody can see), and speaks up in the three cases where **nothing** reached the customer — each of which is a different action for the operator:

| what the customer got | note |
| --- | --- |
| the deny message | (nothing about the copy; reason code only) |
| nothing, no `denyMessage` configured | `Nenhum aviso foi enviado ao contato: não há mensagem de recusa configurada.` |
| nothing, another refusal holds the notice window | `O aviso de recusa não saiu nesta mensagem: a carência entre avisos já estava tomada por outra recusa.` |
| nothing arrived at all | `O aviso de recusa NÃO chegou ao contato.` |

Without the third line, a second refusal inside the window reads as a broken send; without the last one, a copy that never arrived reads as one that did.

The third line says the window was **taken**, not that a copy landed, and that is not pedantry: single-flight for the authorization call is keyed by contact *and* request, so two messages from the same person are two deliveries in flight on one conversation. The copy window is claimed before the send, so the delivery that loses the claim runs on, takes the note window, and writes its note while the winner is still awaiting Chatwoot. If the winner's send then fails, it hands the window back — and the only note the operator got would have claimed a delivery that never happened.

That last line reports the **result** and names no cause on purpose. `postPublicMessage` returns the same `false` for two different things: the send threw, and the ownership fence stood the copy down because a human took the conversation inside the authorization round-trip (or the agent was switched off in that window). The runtime cannot tell them apart, and the note has no fence of its own — it is written *for* the person who just took the conversation over. Saying "the send failed" there would send them chasing a problem that does not exist.

The call site already knew which of the four applied — it decides whether there is a `denyMessage`, whether the cooldown let it through, and whether the send landed. The knowledge simply never reached the note. `no_identity` and `error` are unchanged: they are silent to the customer by design, there is no copy to describe, and the old sentence was true there. The new parameter defaults to `none`, so any caller that sends no copy stays correct.

## Validation scope

**Proved by test**

- Red first: with `src/modules/chatwoot/webhook.ts` reverted to the base (`f1194d4d`) and the new tests in place, 6 of 20 fail — the five note-text cases plus the e2e `denied` assertion. With the fix, 22/22 pass (`bun test tests/modules/contact-auth-note-copy.test.ts tests/modules/contact-auth-gate-e2e.test.ts`).
- 7 unit tests on `contactAuthNoteText`, one of which pins the `sent` note as the **shortest** of the four, so nobody restores a redundant sentence.
- 7 end-to-end paths through the gate with the webhook, the DB and a Chatwoot double: copy delivered, no copy configured, send failed, repeat withheld by the cooldown, the copy stood down by the ownership fence, two refusals racing for the copy window where the winner's send fails last, and the delivery after a failed send, which pins that the claimed window was handed back rather than silencing the next refusal for the whole 300s over a message nobody received. The middle two are reachable only with injected delivery failures, which the stub now supports.
- A discrimination test that does not depend on the words chosen: with the same reason code and the same handoff, the four states must produce four different notes, each carrying the reason code and none carrying the contact's phone. Byte-identical notes were the actual defect, so this pins it independently of any wording.
- Mutation battery, 10 mutants over both the wording and the call-site mapping, **zero survivors**. Two survived the first pass — inverting `failed`/`suppressed`, and pinning the outcome to `none` — which is exactly why the two new e2e paths were added; both die now.
- `bun biome check` clean on the three touched files, `bunx tsc --noEmit` clean.

**Proved live**

Against a real Chatwoot (a local fork on `127.0.0.1:10997`, account 5, API inbox 11) with the gate driven through `processChatwootDelivery` and a real `ChatwootClient`, so the note is rendered by Chatwoot itself and read back over its API. Both halves, side by side:

- conversation 33, `webhook.ts` reverted to the base: the deny copy (msg 197) and, right below it, the note claiming the agent stayed silent (msg 198);
- conversation 37, this branch at its final head: same refusal, same copy delivered (msg 201), and the note (msg 202) no longer talks about the copy;
- conversation 38, an agent with no `denyMessage`: nothing to the customer, and the note (msg 203) says so and why;
- conversation 39, a human taking the conversation over during the authorization call: the fence stands the copy down, no handoff, and the note (msg 204) reports that nothing reached the contact without inventing a delivery failure.

**Not proved here**

- The full suite has one failure unrelated to this change, `tests/graph/tools-http-body-bound.test.ts` (a memory-pressure test), which fails identically on a clean checkout of the base on this machine.
- The live run above used a local Chatwoot, not the deployment where the defect was reported: seeing the fix there would mean deploying to it, which is a production change and out of scope for this PR.
- The `suppressed` state (an earlier note that failed frees its own window while the copy's stays spent) is exercised in the test suite, not in the live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
