### PR TITLE
Make a flush wait for the turn already running on its thread

### DIFF
--- a/src/graph/inflight.ts
+++ b/src/graph/inflight.ts
@@ -79,6 +79,35 @@ export function clearTurnInFlight(threadId: string): void {
   else inFlight.delete(threadId);
 }
 
+// A THIRD REGISTRY, and it is deliberately invisible to the two questions above.
+//
+// The debounce flush needs to exclude ANOTHER FLUSH over the stretch between "is this thread free"
+// and the moment its turn takes its own claim, several awaits later (issue #588). The obvious way to
+// get that was `markTurnReserved`, and it was wrong for a reason review had to find: `reserved` is
+// counted by `isTurnInFlight`, which two subsystems ask before doing their own work on the thread.
+// `undoRefusedTurn` refuses to roll back a superseded answer while it reads true, so a reservation
+// held across the whole turn made EVERY debounce rollback skip, leaving answers the customer never
+// received sitting in memory; and `claimIngestWrite` answers busy, so `drainPendingIngest` reached
+// none of the queued messages and the reply went out without the history it was supposed to carry.
+//
+// So the flush-to-flush hold gets its own map. It says nothing to anybody else, which is the whole
+// requirement: the only reader is the flush, and what it excludes is another flush.
+const flushHolds = new Map<string, number>();
+
+export function markFlushHold(threadId: string): void {
+  flushHolds.set(threadId, (flushHolds.get(threadId) ?? 0) + 1);
+}
+
+export function clearFlushHold(threadId: string): void {
+  const left = (flushHolds.get(threadId) ?? 0) - 1;
+  if (left > 0) flushHolds.set(threadId, left);
+  else flushHolds.delete(threadId);
+}
+
+export function isFlushHeld(threadId: string): boolean {
+  return (flushHolds.get(threadId) ?? 0) > 0;
+}
+
 // Either kind of hold: an invoke that is reading the thread, or a reservation for one that is about
 // to. This is the answer every writer wants.
 export function isTurnInFlight(threadId: string): boolean {

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import { chatwootThreadId, resolveGraphThreadId } from "@/graph/checkpointer";
+import { isTurnInFlight } from "@/graph/inflight";
 import { armIngest } from "@/graph/ingest-job";
 import { parseThreadId } from "@/graph/nudge";
 import { type AgentConfig, loadAgentConfig } from "@/graph/prepare";
@@ -70,9 +71,22 @@ import {
   SPEND_CEILING_BURST_WINDOW_MS,
   spendCeilingVerdict,
 } from "@/modules/spend-ceiling/service";
-import { readLastMessageId } from "./service";
+import { readBurstStart, readLastMessageId } from "./service";
 import { readDebounceConfig } from "./settings";
 import { advanceHandledWatermark, readAnsweredFloor } from "./watermark";
+
+// How long a flush waits before asking again whether the thread is free. Matched to the debounce
+// worker's own tick (DEBOUNCE_WORKER_INTERVAL_MS, 2500ms by default) rather than to the minute
+// continuous ingestion uses: nothing is gained by coming back sooner than the next tick, and unlike
+// an ingestion nobody is waiting on, there is a customer at the other end of this one.
+const DEFER_ON_TURN_MS = 2_000;
+
+// The total a burst may spend waiting for a busy thread, measured from when the burst opened. Past
+// it the flush answers anyway: an unanswered customer is worse than a duplicated line in memory.
+// Five minutes is past any legitimate turn — model, tools at their own bound, and a split delivery
+// paying out its balloons — and short enough that a thread wedged by a dead process does not swallow
+// the conversation.
+const DEFER_CEILING_MS = 5 * 60_000;
 
 // The DEBOUNCE flush: re-fetch the conversation from Chatwoot, coalesce the inbound messages past the
 // watermark into one turn, and answer once. Two re-fetches by design: the first builds the burst to
@@ -1716,6 +1730,73 @@ export async function flushDebounceJob(
       }
       return { outcome: "done" };
     }
+  }
+
+  // A TURN ALREADY RUNNING ON THIS THREAD is the one thing between here and the invoke that no gate
+  // above asks about (issue #588), and the arm side decided it deliberately: `armDebounce` treats a
+  // claim in flight as "the previous flush is finished business", so a customer writing mid-turn
+  // opens a NEW burst and its flush fires a window later, while the first turn is still in the
+  // model, in a tool, or paying out its split balloons.
+  //
+  // MEASURED rather than reasoned about, on 4b35f318: two flushes on one conversation gave a peak of
+  // two concurrent model calls, both handed a history without the other's answer, and a checkpoint
+  // whose channel held the customer's burst TWICE — each invoke is a read-modify-write of the whole
+  // channel, so each appended what it had loaded. The duplicate is permanent memory the summarizer
+  // reads. What did NOT happen is a second reply: the watermark CAS already dedups the post, which
+  // is why this defers the TURN and not the answer.
+  //
+  // HERE AND NOT INSIDE `coalesceAndRunTurn`, which the operator's re-engage button calls too
+  // (../conversations/reengage.ts): an exclusion in there would turn a deliberate human action into
+  // a silent no-op. The flush is the caller that has somewhere to defer TO.
+  //
+  // THE GRAPH THREAD is the key, not the conversation's: the channel is per contact-inbox, so two
+  // conversations of the same contact corrupt the same memory and have to take turns on it. The
+  // narrower key would leave that case exactly as it is today.
+  //
+  // Same shape as continuous ingestion, which had this hazard first and answered it the same way
+  // (../../graph/ingest-job.ts): put the work down and come back, rather than append into a channel
+  // somebody else is about to overwrite.
+  const graphThreadId = resolveGraphThreadId(
+    tenantId,
+    instanceId,
+    conversationId,
+    ctx.contactInboxId,
+  );
+  if (isTurnInFlight(graphThreadId)) {
+    // THE CEILING IS A DEADLINE, NOT A COUNTER, and both obvious counters are already ruled out.
+    // `rescheduleJob` writes `attempts = 0`, so the scheduler's own retry budget never runs down and
+    // a deferral loop never reaches DEAD. A counter carried in the payload is worse: `armDebounce`
+    // re-arms with a full payload and `upsertJobRow` treats a present payload as authoritative, so
+    // the next message the customer types ERASES it — the counter would vanish in exactly the case
+    // it exists for, a customer who keeps writing at a thread that is stuck.
+    //
+    // `burstStartedAt` survives because `armDebounce` reads it back off the row and rewrites it
+    // while the burst continues, which is the same anchor its own anti-starvation cap uses.
+    const burstStartedAt = readBurstStart(job.payload);
+    const deadline = (burstStartedAt ?? Date.now()) + DEFER_CEILING_MS;
+    if (Date.now() < deadline) {
+      logger.info(
+        "debounce flush: a turn is in flight (thread=%s), deferring the burst on conversation %s",
+        graphThreadId,
+        String(conversationId),
+      );
+      // NOT a failure, and the distinction is load-bearing: a `fail` here would spend an attempt,
+      // stamp `last_error` on the conversation and eventually dead-letter a burst whose only problem
+      // is that it arrived at a busy moment.
+      return {
+        outcome: "reschedule",
+        runAt: new Date(Date.now() + DEFER_ON_TURN_MS),
+      };
+    }
+    // PAST THE DEADLINE WE RUN ANYWAY, which is a choice and not an oversight. A turn that never
+    // releases the thread would otherwise leave the customer unanswered forever, and an unanswered
+    // customer is worse than a duplicated line in the agent's memory. Loud, because a thread that
+    // reaches this has something wrong with it that no other line would report.
+    logger.warn(
+      "debounce flush: a turn has held thread %s past the deferral ceiling; answering conversation %s anyway",
+      graphThreadId,
+      String(conversationId),
+    );
   }
 
   // Coalesce the burst past the watermark and answer once. A thrown error (LLM/Chatwoot) bubbles to

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -80,6 +80,7 @@ import {
   readBurstStart,
   readDeferringSince,
   readLastMessageId,
+  stampDeferral,
 } from "./service";
 import { readDebounceConfig } from "./settings";
 import { advanceHandledWatermark, readAnsweredFloor } from "./watermark";
@@ -1801,13 +1802,14 @@ export async function flushDebounceJob(
       // stamp `last_error` on the conversation and eventually dead-letter a burst whose only problem
       // is that it arrived at a busy moment.
       //
-      // MERGED rather than written whole (`payloadPatch`, not `payload`): the row may have been
-      // re-armed while this run was deciding, and a replacement built from the claim-time snapshot
-      // would erase the `burstStartedAt` and `lastMessageId` that arm just wrote.
+      // Stamped through its own write under the ARM lock rather than as a `payloadPatch` here: the
+      // patch rides `rescheduleJob`, whose CAS requires the row to still be CLAIMED, and the window
+      // the stamp has to survive is exactly the one where a message re-armed it to PENDING and the
+      // CAS fails. See `stampDeferral`.
+      await stampDeferral({ tenantId, threadId, since, base });
       return {
         outcome: "reschedule",
         runAt: new Date(now + DEFER_ON_TURN_MS),
-        payloadPatch: { deferringSince: since },
       };
     }
     // PAST THE DEADLINE WE RUN ANYWAY, which is a choice and not an oversight. A turn that never

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -77,6 +77,7 @@ import {
   spendCeilingVerdict,
 } from "@/modules/spend-ceiling/service";
 import {
+  clearDeferral,
   readBurstStart,
   readDeferringSince,
   readLastMessageId,
@@ -1836,6 +1837,18 @@ export async function flushDebounceJob(
   // turn therefore made every debounce rollback skip and every queued message miss its own reply.
   // `markFlushHold` is read by this line and by nothing else.
   markFlushHold(graphThreadId);
+  // THE WAITING IS OVER, so the stamp that measured it goes. Left behind, it outlives its burst: a
+  // message arriving during this flush's delivery re-arms the row and carries the stamp into the
+  // next burst, and completion cannot clear it because that CAS needs a CLAIMED row. Once it ages
+  // past the ceiling every later flush skips the check above outright — the protection switching
+  // itself off, which is worse than the defect it was built for.
+  //
+  // Only when this job actually carried one: the claimed payload IS the row's payload at claim time,
+  // and no other writer stamps this thread, so an absent field means there is nothing to clear. That
+  // keeps the extra write off the path almost every flush takes.
+  if (readDeferringSince(job.payload) !== null) {
+    await clearDeferral({ tenantId, threadId, base });
+  }
 
   // Coalesce the burst past the watermark and answer once. A thrown error (LLM/Chatwoot) bubbles to
   // the worker → retry with backoff (watermark not advanced, so the retry re-answers the same burst).

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -2,9 +2,10 @@ import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import { chatwootThreadId, resolveGraphThreadId } from "@/graph/checkpointer";
 import {
-  clearTurnReserved,
+  clearFlushHold,
+  isFlushHeld,
   isTurnInFlight,
-  markTurnReserved,
+  markFlushHold,
 } from "@/graph/inflight";
 import { armIngest } from "@/graph/ingest-job";
 import { parseThreadId } from "@/graph/nudge";
@@ -1770,7 +1771,7 @@ export async function flushDebounceJob(
     conversationId,
     ctx.contactInboxId,
   );
-  if (isTurnInFlight(graphThreadId)) {
+  if (isTurnInFlight(graphThreadId) || isFlushHeld(graphThreadId)) {
     const now = Date.now();
     // THE CEILING IS A DEADLINE, NOT A COUNTER, and both obvious counters are already ruled out.
     // `rescheduleJob` writes `attempts = 0`, so the scheduler's own retry budget never runs down and
@@ -1826,11 +1827,13 @@ export async function flushDebounceJob(
   // The window is reachable: two conversations of one contact are two scheduler rows, claimed in the
   // same tick and started concurrently by `runDebounceTick`, and they share this key.
   //
-  // The same hold `../chatwoot/recover-delivery.ts` takes for the same stretch, and the reason the
-  // `reserved` map is separate from the invoke map: `markTurnOwning` asks `isTurnRunning`, which
-  // does not count reservations, so holding one here cannot make the turn stand down on account of
-  // its own caller.
-  markTurnReserved(graphThreadId);
+  // ITS OWN REGISTRY, not `markTurnReserved`, and review is what showed why. `reserved` is counted
+  // by `isTurnInFlight`, which two subsystems ask before doing their own work on this thread:
+  // `undoRefusedTurn` refuses to roll back a superseded answer while it reads true, and
+  // `claimIngestWrite` answers busy so `drainPendingIngest` reaches nothing. A hold across the whole
+  // turn therefore made every debounce rollback skip and every queued message miss its own reply.
+  // `markFlushHold` is read by this line and by nothing else.
+  markFlushHold(graphThreadId);
 
   // Coalesce the burst past the watermark and answer once. A thrown error (LLM/Chatwoot) bubbles to
   // the worker → retry with backoff (watermark not advanced, so the retry re-answers the same burst).
@@ -1930,7 +1933,7 @@ export async function flushDebounceJob(
     // writer this flush is about to undo, and an unbalanced hold wedges the conversation until the
     // process restarts. The turn takes its own claim inside `runLoadedTurn`; this one only covers
     // the stretch before it.
-    clearTurnReserved(graphThreadId);
+    clearFlushHold(graphThreadId);
   }
 }
 

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -1,7 +1,11 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
 import logger from "@/api/lib/logger";
 import { chatwootThreadId, resolveGraphThreadId } from "@/graph/checkpointer";
-import { isTurnInFlight } from "@/graph/inflight";
+import {
+  clearTurnReserved,
+  isTurnInFlight,
+  markTurnReserved,
+} from "@/graph/inflight";
 import { armIngest } from "@/graph/ingest-job";
 import { parseThreadId } from "@/graph/nudge";
 import { type AgentConfig, loadAgentConfig } from "@/graph/prepare";
@@ -71,7 +75,11 @@ import {
   SPEND_CEILING_BURST_WINDOW_MS,
   spendCeilingVerdict,
 } from "@/modules/spend-ceiling/service";
-import { readBurstStart, readLastMessageId } from "./service";
+import {
+  readBurstStart,
+  readDeferringSince,
+  readLastMessageId,
+} from "./service";
 import { readDebounceConfig } from "./settings";
 import { advanceHandledWatermark, readAnsweredFloor } from "./watermark";
 
@@ -1763,6 +1771,7 @@ export async function flushDebounceJob(
     ctx.contactInboxId,
   );
   if (isTurnInFlight(graphThreadId)) {
+    const now = Date.now();
     // THE CEILING IS A DEADLINE, NOT A COUNTER, and both obvious counters are already ruled out.
     // `rescheduleJob` writes `attempts = 0`, so the scheduler's own retry budget never runs down and
     // a deferral loop never reaches DEAD. A counter carried in the payload is worse: `armDebounce`
@@ -1772,9 +1781,16 @@ export async function flushDebounceJob(
     //
     // `burstStartedAt` survives because `armDebounce` reads it back off the row and rewrites it
     // while the burst continues, which is the same anchor its own anti-starvation cap uses.
-    const burstStartedAt = readBurstStart(job.payload);
-    const deadline = (burstStartedAt ?? Date.now()) + DEFER_CEILING_MS;
-    if (Date.now() < deadline) {
+    //
+    // `deferringSince` is stamped on the FIRST deferral and carried by `armDebounce` across every
+    // re-arm of a live row. `burstStartedAt` alone was not enough and review of this change is what
+    // showed it: a message arriving while the flush is CLAIMED opens a new burst by design, taking a
+    // fresh `burstStartedAt` with it, so a customer who kept typing at a wedged thread pushed the
+    // deadline forward on every arrival and was never answered. It falls back to `burstStartedAt`
+    // for the first pass, before any stamp exists.
+    const since =
+      readDeferringSince(job.payload) ?? readBurstStart(job.payload) ?? now;
+    if (now < since + DEFER_CEILING_MS) {
       logger.info(
         "debounce flush: a turn is in flight (thread=%s), deferring the burst on conversation %s",
         graphThreadId,
@@ -1783,9 +1799,14 @@ export async function flushDebounceJob(
       // NOT a failure, and the distinction is load-bearing: a `fail` here would spend an attempt,
       // stamp `last_error` on the conversation and eventually dead-letter a burst whose only problem
       // is that it arrived at a busy moment.
+      //
+      // MERGED rather than written whole (`payloadPatch`, not `payload`): the row may have been
+      // re-armed while this run was deciding, and a replacement built from the claim-time snapshot
+      // would erase the `burstStartedAt` and `lastMessageId` that arm just wrote.
       return {
         outcome: "reschedule",
-        runAt: new Date(Date.now() + DEFER_ON_TURN_MS),
+        runAt: new Date(now + DEFER_ON_TURN_MS),
+        payloadPatch: { deferringSince: since },
       };
     }
     // PAST THE DEADLINE WE RUN ANYWAY, which is a choice and not an oversight. A turn that never
@@ -1798,6 +1819,18 @@ export async function flushDebounceJob(
       String(conversationId),
     );
   }
+  // RESERVED IN THE SAME TURN OF THE EVENT LOOP as the check above, with no await between them, and
+  // that adjacency is the whole point. A turn marks itself deep inside `runLoadedTurn`, several
+  // awaits past here — a message fetch, the burst selection, the authorization gate — so between the
+  // check and the mark there is a window in which a SECOND flush reads an unheld thread and passes.
+  // The window is reachable: two conversations of one contact are two scheduler rows, claimed in the
+  // same tick and started concurrently by `runDebounceTick`, and they share this key.
+  //
+  // The same hold `../chatwoot/recover-delivery.ts` takes for the same stretch, and the reason the
+  // `reserved` map is separate from the invoke map: `markTurnOwning` asks `isTurnRunning`, which
+  // does not count reservations, so holding one here cannot make the turn stand down on account of
+  // its own caller.
+  markTurnReserved(graphThreadId);
 
   // Coalesce the burst past the watermark and answer once. A thrown error (LLM/Chatwoot) bubbles to
   // the worker → retry with backoff (watermark not advanced, so the retry re-answers the same burst).
@@ -1892,6 +1925,12 @@ export async function flushDebounceJob(
       });
     }
     throw e;
+  } finally {
+    // Balanced, on every exit including the throw: an unbalanced release hands the thread to a
+    // writer this flush is about to undo, and an unbalanced hold wedges the conversation until the
+    // process restarts. The turn takes its own claim inside `runLoadedTurn`; this one only covers
+    // the stretch before it.
+    clearTurnReserved(graphThreadId);
   }
 }
 

--- a/src/modules/debounce/handler.ts
+++ b/src/modules/debounce/handler.ts
@@ -1846,15 +1846,30 @@ export async function flushDebounceJob(
   // Only when this job actually carried one: the claimed payload IS the row's payload at claim time,
   // and no other writer stamps this thread, so an absent field means there is nothing to clear. That
   // keeps the extra write off the path almost every flush takes.
-  if (readDeferringSince(job.payload) !== null) {
-    await clearDeferral({ tenantId, threadId, base });
-  }
 
   // Coalesce the burst past the watermark and answer once. A thrown error (LLM/Chatwoot) bubbles to
   // the worker → retry with backoff (watermark not advanced, so the retry re-answers the same burst).
   // The error is also surfaced on the conversation (item 6) so the operator can re-engage; a
   // successful answer clears it.
   try {
+    // INSIDE the try, so the `finally` below releases the hold no matter how this ends. Sitting
+    // above it, a rejection here — a statement timeout on the cleanup write, say — left the hold
+    // marked and never released, and every later burst on this graph thread then waited out its
+    // five-minute ceiling until the process restarted (round 5 of the review).
+    //
+    // And best-effort on top of that, so a failed cleanup does not become a failed turn: a stale
+    // stamp costs an early ceiling later, which is smaller than refusing to answer the customer.
+    // The `.catch` also keeps it out of the turn-failure handler below, whose side effects (the
+    // observer hand-over, the conversation error banner) are about a turn that ran, not about this.
+    if (readDeferringSince(job.payload) !== null) {
+      await clearDeferral({ tenantId, threadId, base }).catch((e) =>
+        logger.warn(
+          "debounce flush: could not clear the deferral stamp on thread %s: %s",
+          graphThreadId,
+          err(e),
+        ),
+      );
+    }
     const outcome = await coalesceAndRunTurn(
       {
         tenantId,

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -117,6 +117,42 @@ export async function stampDeferral(params: {
   );
 }
 
+// Drops the deferral stamp, because the waiting it measured is over.
+//
+// Without this the deadline outlives the burst it belonged to, and the protection turns ITSELF off:
+// a deferred flush eventually runs, a message arriving during its delivery re-arms the row and
+// carries the stamp into the NEW burst, and the flush cannot clear it on completion because that
+// compare-and-set needs a row that is still CLAIMED. Once the carried stamp is older than the
+// ceiling, every later flush skips the busy-thread check outright, even against a turn that just
+// started. Found in review of #588, one round after the bug it mirrors.
+//
+// Under the arm lock, like the stamp, so a re-arm racing this cannot resurrect what it removed.
+export async function clearDeferral(params: {
+  tenantId: bigint;
+  threadId: string;
+  base?: PrismaClient;
+}): Promise<void> {
+  const base = params.base ?? basePrisma;
+  const dedupeKey = debounceDedupeKey(params.threadId);
+  await runScopedOn(base, sysCtx(params.tenantId), (db) =>
+    withEntityLock(db, `debounce-arm:${params.threadId}`, async () => {
+      const row = await db.schedulerJob.findFirst({
+        where: { kind: "DEBOUNCE", dedupeKey },
+        select: { id: true, payload: true },
+      });
+      if (!row || readDeferringSince(row.payload) === null) return;
+      const { deferringSince: _dropped, ...rest } = row.payload as Record<
+        string,
+        unknown
+      >;
+      await db.schedulerJob.update({
+        where: { id: row.id },
+        data: { payload: rest as Prisma.InputJsonObject },
+      });
+    }),
+  );
+}
+
 export interface ArmDebounceParams {
   tenantId: bigint;
   threadId: string;

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -71,6 +71,52 @@ export function readLastMessageId(payload: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
 
+// Stamps when a burst STARTED waiting for a busy thread, if it is not stamped already.
+//
+// UNDER THE ARM LOCK, and that is the entire reason this exists instead of a `payloadPatch` on the
+// reschedule. The patch rides `rescheduleJob`, whose compare-and-set requires the row to still be
+// CLAIMED — and the window it has to survive is exactly the one where that is false: a message
+// arriving while the first deferring flush runs re-arms the row to PENDING with a fresh payload, the
+// CAS then fails, and the stamp is discarded rather than merged. Repeated arrivals in that window
+// restarted the deadline every time, which is the customer-never-answered case the deadline exists
+// to prevent (found in review of #588, and the reason the first test of it was not enough: it only
+// re-armed a row that was already stamped).
+//
+// Taking `armDebounce`'s own lock makes the two orderings both work: the arm runs first and this
+// merges into what it wrote, or this runs first and the arm carries the stamp forward as a live row.
+//
+// Never overwrites: the deadline belongs to the FIRST deferral, and a later one that reset it would
+// be the same defect wearing a different hat.
+export async function stampDeferral(params: {
+  tenantId: bigint;
+  threadId: string;
+  since: number;
+  base?: PrismaClient;
+}): Promise<void> {
+  const base = params.base ?? basePrisma;
+  const dedupeKey = debounceDedupeKey(params.threadId);
+  await runScopedOn(base, sysCtx(params.tenantId), (db) =>
+    withEntityLock(db, `debounce-arm:${params.threadId}`, async () => {
+      const row = await db.schedulerJob.findFirst({
+        where: { kind: "DEBOUNCE", dedupeKey },
+        select: { id: true, payload: true },
+      });
+      // No row means the flush that is deferring has already been completed or retired by somebody
+      // else; there is nothing whose deadline this would be.
+      if (!row || readDeferringSince(row.payload) !== null) return;
+      await db.schedulerJob.update({
+        where: { id: row.id },
+        data: {
+          payload: {
+            ...(row.payload as Prisma.InputJsonObject),
+            deferringSince: params.since,
+          },
+        },
+      });
+    }),
+  );
+}
+
 export interface ArmDebounceParams {
   tenantId: bigint;
   threadId: string;

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -49,7 +49,9 @@ export async function resolveDebounceConfig(
   return cfg;
 }
 
-function readBurstStart(payload: unknown): number | null {
+// EXPORTED because the flush reads it too: it is the only anchor a deferral ceiling can use that a
+// re-arm does not erase (see the ceiling in ./handler.ts).
+export function readBurstStart(payload: unknown): number | null {
   if (!payload || typeof payload !== "object") return null;
   const v = (payload as Record<string, unknown>).burstStartedAt;
   return typeof v === "number" && Number.isFinite(v) ? v : null;

--- a/src/modules/debounce/service.ts
+++ b/src/modules/debounce/service.ts
@@ -51,6 +51,12 @@ export async function resolveDebounceConfig(
 
 // EXPORTED because the flush reads it too: it is the only anchor a deferral ceiling can use that a
 // re-arm does not erase (see the ceiling in ./handler.ts).
+export function readDeferringSince(payload: unknown): number | null {
+  if (!payload || typeof payload !== "object") return null;
+  const v = (payload as Record<string, unknown>).deferringSince;
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
 export function readBurstStart(payload: unknown): number | null {
   if (!payload || typeof payload !== "object") return null;
   const v = (payload as Record<string, unknown>).burstStartedAt;
@@ -94,6 +100,22 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         where: { kind: "DEBOUNCE", dedupeKey },
         select: { status: true, payload: true },
       });
+      // The flush's deferral deadline, carried across re-arms of a row that is still LIVE — PENDING
+      // (a deferred flush waiting for its next try) or CLAIMED (one running right now). It is kept
+      // separately from `burstStartedAt` and on a wider set of statuses on purpose: the deadline
+      // answers "how long has this burst been waiting for a busy thread", which a customer typing
+      // again does not restart, while `burstStartedAt` answers "when did this burst open", which a
+      // claim in flight deliberately does. Tying the deadline to the latter let every message that
+      // arrived during the CLAIMED window push it forward, so a customer who kept writing at a
+      // wedged thread was never answered at all (found in review of #588).
+      //
+      // A DONE or DEAD row carries nothing forward: the flush that was deferring has finished, and
+      // a stale stamp would make the next burst on this thread start out already past its deadline.
+      const stillLive =
+        existing?.status === "PENDING" || existing?.status === "CLAIMED";
+      const deferringSince = stillLive
+        ? readDeferringSince(existing.payload)
+        : null;
       // NOTE: A live PENDING row is the burst this message joins; anything else (no row, DONE,
       // DEAD, or a claim in flight) means the previous flush is finished business and this message
       // opens a new burst. Every question below reads that one fact, so they cannot answer it
@@ -118,6 +140,7 @@ export async function armDebounce(params: ArmDebounceParams): Promise<Date> {
         agentBotId,
         burstStartedAt,
         ...(lastMessageId !== null ? { lastMessageId } : {}),
+        ...(deferringSince !== null ? { deferringSince } : {}),
       } satisfies Prisma.InputJsonObject;
       await upsertJobRow(db, {
         tenantId,

--- a/tests/graph/flush-hold.test.ts
+++ b/tests/graph/flush-hold.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clearFlushHold,
+  clearTurnInFlight,
+  isFlushHeld,
+  isTurnInFlight,
+  isTurnRunning,
+  markFlushHold,
+  markTurnInFlight,
+} from "@/graph/inflight";
+
+// The flush's hold on a thread is invisible to everyone but the flush, and this is the fence on that.
+//
+// It exists because the first version of issue #588's fix used `markTurnReserved`, which IS counted
+// by `isTurnInFlight` — and two subsystems ask that before doing their own work on the thread:
+// `undoRefusedTurn` refuses to roll back a superseded answer while it reads true, and
+// `claimIngestWrite` answers busy so `drainPendingIngest` reaches none of the queued messages. A hold
+// across the whole turn therefore made every debounce rollback skip, leaving answers the customer
+// never received in memory, and sent replies without the history they were supposed to carry.
+//
+// The whole suite passed with that defect present. Nothing covered either behaviour, which is why
+// this file asserts the PROPERTY rather than waiting for a test of the consequences: whatever the
+// flush holds must not be visible to the questions those two ask.
+describe("a flush hold is not a turn", () => {
+  const T = "tenant:1:ci:42";
+
+  test("holding it says nothing to the writers that ask about turns", () => {
+    expect(isTurnInFlight(T)).toBe(false);
+    markFlushHold(T);
+    try {
+      expect(isFlushHeld(T)).toBe(true);
+      // The two questions the rollback and the ingest barrier ask. Either one answering true here is
+      // the regression this file exists for.
+      expect(isTurnInFlight(T)).toBe(false);
+      expect(isTurnRunning(T)).toBe(false);
+    } finally {
+      clearFlushHold(T);
+    }
+    expect(isFlushHeld(T)).toBe(false);
+  });
+
+  test("and a real turn still is one, so the flush's own check still sees it", () => {
+    markTurnInFlight(T);
+    try {
+      expect(isTurnInFlight(T)).toBe(true);
+      // Independent registries: a turn is not a flush hold either, or the flush would defer behind
+      // its own turn.
+      expect(isFlushHeld(T)).toBe(false);
+    } finally {
+      clearTurnInFlight(T);
+    }
+  });
+
+  test("counted, not a set: two holds need two releases", () => {
+    markFlushHold(T);
+    markFlushHold(T);
+    clearFlushHold(T);
+    // An unbalanced release would hand the thread to the second flush while the first is still in
+    // the window the hold covers.
+    expect(isFlushHeld(T)).toBe(true);
+    clearFlushHold(T);
+    expect(isFlushHeld(T)).toBe(false);
+  });
+});

--- a/tests/modules/debounce-same-thread-serial.test.ts
+++ b/tests/modules/debounce-same-thread-serial.test.ts
@@ -60,6 +60,7 @@ const CONV_CORRIDA_A = 4246;
 const CONV_CORRIDA_B = 4247;
 const CONTACT_INBOX_CORRIDA = 778;
 const CONV_CARIMBO = 4249;
+const CONV_LIMPEZA = 4250;
 const CHATWOOT_INBOX_ID = 7;
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -566,5 +567,67 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
     const stamp = (row.payload as { deferringSince?: number }).deferringSince;
     console.log(`[carimbo] deferringSince gravado: ${stamp ?? "NENHUM"}`);
     expect(typeof stamp).toBe("number");
+  }, 30_000);
+
+  test("the stamp is dropped once the flush actually runs, so it cannot outlive its burst", async () => {
+    // The mirror of the bug above, found one review round later. A deferred flush eventually runs; a
+    // message arriving during its delivery re-arms the row and carries the stamp into the NEW burst,
+    // and completion cannot clear it because that CAS needs a CLAIMED row. Aged past the ceiling, the
+    // carried stamp makes every later flush skip the busy-thread check outright — the protection
+    // switching itself off, which is worse than the defect it was built for.
+    await seedConversation(CONV_LIMPEZA);
+    const thread = threadOf(CONV_LIMPEZA);
+    const key = debounceDedupeKey(thread);
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId} AND dedupe_key = '${key}'`,
+    );
+    const velho = Date.now() - 120_000;
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "DEBOUNCE",
+        dedupeKey: key,
+        status: "PENDING",
+        runAt: new Date(),
+        payload: {
+          threadId: thread,
+          agentBotId: 9,
+          burstStartedAt: velho,
+          deferringSince: velho,
+        },
+      },
+    });
+
+    // No turn in flight: the flush runs, which is when the waiting it measured is over.
+    const out = await flushDebounceJob({
+      job: {
+        id: jobIdA,
+        tenantId,
+        kind: "DEBOUNCE",
+        payload: {
+          threadId: thread,
+          agentBotId: 9,
+          burstStartedAt: velho,
+          deferringSince: velho,
+        },
+        attempts: 0,
+        claimSeq: 0,
+      },
+      base: appDb,
+      deps: {
+        makeModel: () => overlapModel(10, { active: 0, max: 0 }, []),
+        makeClient: stub([]),
+        checkpointer: new MemorySaver(),
+      },
+    });
+
+    expect(out.outcome).not.toBe("reschedule");
+    const row = await suDb.schedulerJob.findFirstOrThrow({
+      where: { tenantId, kind: "DEBOUNCE", dedupeKey: key },
+      select: { payload: true },
+    });
+    const stamp = (row.payload as { deferringSince?: number }).deferringSince;
+    console.log(`[limpeza] deferringSince apos rodar: ${stamp ?? "removido"}`);
+    expect(stamp).toBeUndefined();
   }, 30_000);
 });

--- a/tests/modules/debounce-same-thread-serial.test.ts
+++ b/tests/modules/debounce-same-thread-serial.test.ts
@@ -7,6 +7,7 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { flushDebounceJob } from "@/modules/debounce/handler";
+import { armDebounce, debounceDedupeKey } from "@/modules/debounce/service";
 import type { ClaimedJob } from "@/modules/scheduler/service";
 import { seedChatwootInstance } from "../utils/chatwoot";
 import { burnSchedulerJobId } from "../utils/scheduler";
@@ -50,6 +51,9 @@ const CONV_CEILING = 4243;
 const CONV_IRMA_A = 4244;
 const CONV_IRMA_B = 4245;
 const CONTACT_INBOX = 777;
+const CONV_CORRIDA_A = 4246;
+const CONV_CORRIDA_B = 4247;
+const CONTACT_INBOX_CORRIDA = 778;
 const CHATWOOT_INBOX_ID = 7;
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -376,5 +380,101 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
     );
     expect(meter.max).toBe(1);
     expect(b.outcome).toBe("reschedule");
+  }, 30_000);
+
+  test("two flushes claimed in the same tick cannot both pass the check", async () => {
+    // The window the reservation exists for, and the one the sequenced tests above cannot see: a
+    // turn marks itself several awaits past the check (message fetch, burst selection, the
+    // authorization gate), so two flushes STARTED TOGETHER can both read an unheld thread. Two
+    // conversations of one contact are two scheduler rows, claimed in the same tick and started
+    // concurrently by the worker, and they share the graph key.
+    await seedConversation(CONV_CORRIDA_A, CONTACT_INBOX_CORRIDA);
+    await seedConversation(CONV_CORRIDA_B, CONTACT_INBOX_CORRIDA);
+    const meter = { active: 0, max: 0 };
+    const seen: string[][] = [];
+    const sent: Array<[number, string]> = [];
+    const deps = {
+      makeModel: () => overlapModel(400, meter, seen),
+      makeClient: stub(sent),
+      checkpointer: new MemorySaver(),
+    };
+    // No rendezvous on purpose: both are launched in the same turn of the event loop, which is what
+    // `runDebounceTick`'s Promise.allSettled does.
+    const [ra, rb] = await Promise.all([
+      flushDebounceJob({
+        job: jobFor(jobIdA, CONV_CORRIDA_A, Date.now()),
+        base: appDb,
+        deps,
+      }),
+      flushDebounceJob({
+        job: jobFor(jobIdB, CONV_CORRIDA_B, Date.now()),
+        base: appDb,
+        deps,
+      }),
+    ]);
+
+    console.log(
+      `[mesma-tick] pico simultâneo: ${meter.max}; invokes: ${seen.length}; desfechos: ${ra.outcome}/${rb.outcome}`,
+    );
+    expect(meter.max).toBe(1);
+    // Exactly one ran and exactly one stood down: neither "both deferred" (nobody answers) nor
+    // "both ran" (the defect) passes.
+    expect(seen.length).toBe(1);
+    expect(
+      [ra.outcome, rb.outcome].filter((o) => o === "reschedule"),
+    ).toHaveLength(1);
+  }, 30_000);
+
+  test("the deferral deadline survives a re-arm while the flush is claimed", async () => {
+    // Found in review: a message arriving while the flush is CLAIMED opens a new burst by design and
+    // takes a fresh `burstStartedAt` with it, so a deadline anchored there was pushed forward by
+    // every arrival — a customer who kept typing at a wedged thread was never answered at all.
+    const thread = threadOf(4248);
+    const cfg = {
+      enabled: true,
+      windowSeconds: 15,
+      maxMessagesPerBurst: 20,
+      maxWindowSeconds: 60,
+    };
+    const stamp = Date.now() - 120_000;
+    const key = debounceDedupeKey(thread);
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId} AND dedupe_key = '${key}'`,
+    );
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "DEBOUNCE",
+        dedupeKey: key,
+        status: "CLAIMED",
+        runAt: new Date(),
+        payload: {
+          threadId: thread,
+          agentBotId: 9,
+          burstStartedAt: stamp,
+          deferringSince: stamp,
+        },
+      },
+    });
+
+    await armDebounce({
+      tenantId,
+      threadId: thread,
+      agentBotId: 9,
+      cfg,
+      base: appDb,
+    });
+    const row = await suDb.schedulerJob.findFirstOrThrow({
+      where: { tenantId, kind: "DEBOUNCE", dedupeKey: key },
+      select: { payload: true },
+    });
+    const p = row.payload as {
+      burstStartedAt?: number;
+      deferringSince?: number;
+    };
+    // The new burst legitimately restarts burstStartedAt, which is what a claim in flight means...
+    expect(p.burstStartedAt).toBeGreaterThan(stamp);
+    // ...and the deadline does NOT restart with it.
+    expect(p.deferringSince).toBe(stamp);
   }, 30_000);
 });

--- a/tests/modules/debounce-same-thread-serial.test.ts
+++ b/tests/modules/debounce-same-thread-serial.test.ts
@@ -1,0 +1,380 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@/../generated/prisma/client";
+import { encryptJson } from "@/api/lib/crypto";
+import type { ChatwootClient } from "@/modules/chatwoot/client";
+import { flushDebounceJob } from "@/modules/debounce/handler";
+import type { ClaimedJob } from "@/modules/scheduler/service";
+import { seedChatwootInstance } from "../utils/chatwoot";
+import { burnSchedulerJobId } from "../utils/scheduler";
+
+// Two flushes on ONE conversation, which is the shape issue #588 is about and the one
+// debounce-parallelism.test.ts deliberately does not cover: that file proves DIFFERENT conversations
+// overlap, which is the feature. Overlapping on the SAME thread is the defect.
+//
+// The second flush is not contrived. `armDebounce` says so itself: a live PENDING row is the burst a
+// message joins, and "anything else (no row, DONE, DEAD, or A CLAIM IN FLIGHT) means the previous
+// flush is finished business and this message opens a NEW burst". So a customer who writes while the
+// agent is still answering arms a second flush by design, and it fires a debounce window later —
+// while the first turn is still in the model, in a tool, or paying out its split balloons.
+
+const appUrl = process.env.TEST_APP_DATABASE_URL;
+const suUrl = process.env.MIGRATION_DATABASE_URL;
+let dbUp = false;
+let su: PrismaClient | undefined;
+let app: PrismaClient | undefined;
+if (appUrl && suUrl) {
+  try {
+    su = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: suUrl }),
+    });
+    await su.$queryRaw`SELECT 1`;
+    app = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: appUrl }),
+    });
+    await app.$queryRaw`SELECT 1`;
+    dbUp = true;
+  } catch {
+    dbUp = false;
+  }
+}
+const appDb = app as PrismaClient;
+const suDb = su as PrismaClient;
+
+const CONV_DEFER = 4242;
+const CONV_CEILING = 4243;
+// Duas conversas do mesmo contato: elas compartilham o canal do grafo, não a thread da conversa.
+const CONV_IRMA_A = 4244;
+const CONV_IRMA_B = 4245;
+const CONTACT_INBOX = 777;
+const CHATWOOT_INBOX_ID = 7;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let jobIdA = 0n;
+let jobIdB = 0n;
+let tenantId = 0n;
+let instanceId = 0n;
+let inboxDbId = 0n;
+
+const threadOf = (convId: number) => `${tenantId}:${instanceId}:${convId}`;
+
+// Records every model call's overlap on the thread. `max` above 1 means two turns were reading and
+// writing the same message channel at once, which is what makes the second answer blind to the first.
+// Signals when a turn is actually INSIDE the model, so the second flush can be started at a moment
+// that is deterministic instead of racing the first one's setup. This is also the honest shape: in
+// production the second flush arrives at a later worker tick, not in the same `Promise.allSettled`.
+function overlapModel(
+  delayMs: number,
+  meter: { active: number; max: number },
+  seen: string[][],
+  entered?: { signal: () => void },
+) {
+  const model = {
+    bindTools() {
+      return model;
+    },
+    async invoke(messages: BaseMessage[]) {
+      meter.active += 1;
+      meter.max = Math.max(meter.max, meter.active);
+      // What THIS turn was given to answer from, so "computed blind" is a measurement rather than a
+      // claim: an answer that cannot see the previous one is one whose history lacks it.
+      seen.push(messages.map((m) => String(m.content)));
+      entered?.signal();
+      try {
+        await sleep(delayMs);
+        return new AIMessage(`resposta ${seen.length}`);
+      } finally {
+        meter.active -= 1;
+      }
+    },
+  };
+  return model as unknown as BaseChatModel;
+}
+
+function stub(sent: Array<[number, string]>) {
+  const client = {
+    getMessages: async () => ({
+      payload: [
+        { id: 100, content: "quanto custa?", message_type: 0, private: false },
+        {
+          id: 101,
+          content: "e tem desconto?",
+          message_type: 0,
+          private: false,
+        },
+      ],
+    }),
+    sendMessage: async (conversationId: number, content: string) => {
+      sent.push([conversationId, content]);
+      return {};
+    },
+  } as unknown as ChatwootClient;
+  return async () => client;
+}
+
+function jobFor(
+  id: bigint,
+  convId: number,
+  burstStartedAt: number,
+): ClaimedJob {
+  return {
+    id,
+    tenantId,
+    kind: "DEBOUNCE",
+    payload: { threadId: threadOf(convId), agentBotId: 9, burstStartedAt },
+    attempts: 0,
+    claimSeq: 0,
+  };
+}
+
+describe.skipIf(!dbUp)("two flushes on one thread", () => {
+  beforeAll(async () => {
+    jobIdA = await burnSchedulerJobId(suDb);
+    jobIdB = await burnSchedulerJobId(suDb);
+    const t = await suDb.tenant.create({
+      data: { name: "DST", slug: `dst-${process.pid}` },
+    });
+    tenantId = t.id;
+    const inst = await seedChatwootInstance(suDb, {
+      tenantId,
+      accountId: 9,
+      baseUrl: "https://chat.example.com",
+      adminToken: encryptJson("ADMIN"),
+    });
+    instanceId = inst.id;
+    const llmKey = await suDb.vaultEntry.create({
+      data: { tenantId, name: "llm-key", secret: encryptJson("sk-test") },
+      select: { id: true },
+    });
+    const agent = await suDb.agent.create({
+      data: {
+        tenantId,
+        name: "Atendente",
+        systemPrompt: "Você é prestativa.",
+        modelConfig: {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          credentialRef: `vault:${llmKey.id}`,
+        },
+        settings: {
+          debounce: { enabled: true, windowSeconds: 15 },
+          split: { enabled: false },
+        },
+      },
+    });
+    await suDb.chatwootAgentBot.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        agentId: agent.id,
+        chatwootAgentBotId: 9,
+        accessToken: encryptJson("BOT"),
+        webhookSecret: encryptJson("S"),
+        webhookRouteTokenHash: `dst-route-${process.pid}`,
+        name: "Atendente",
+      },
+    });
+    const inbox = await suDb.inbox.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootInboxId: CHATWOOT_INBOX_ID,
+        name: "Suporte",
+        agentId: agent.id,
+      },
+    });
+    inboxDbId = inbox.id;
+  });
+
+  // One conversation per test: the first test's turn advances the handled watermark, and a second
+  // test sharing the row would find nothing to answer and pass on an empty run.
+  async function seedConversation(convId: number, contactInboxId?: number) {
+    await suDb.conversation.create({
+      data: {
+        tenantId,
+        chatwootInstanceId: instanceId,
+        chatwootConversationId: convId,
+        status: "pending",
+        assigneeType: null,
+        inboxId: inboxDbId,
+        threadId: threadOf(convId),
+        lastEventAt: new Date(),
+        lastHandledMessageId: null,
+        ...(contactInboxId !== undefined ? { contactInboxId } : {}),
+      },
+    });
+  }
+
+  afterAll(async () => {
+    if (tenantId) {
+      for (const table of [
+        "scheduler_jobs",
+        "llm_usage",
+        "conversations",
+        "inboxes",
+        "agents",
+        "vault_entries",
+        "chatwoot_instances",
+      ]) {
+        await suDb.$executeRawUnsafe(
+          `DELETE FROM ${table} WHERE tenant_id = ${tenantId}`,
+        );
+      }
+      await suDb.$executeRawUnsafe(
+        `DELETE FROM tenants WHERE id = ${tenantId}`,
+      );
+    }
+    await suDb.$disconnect();
+    await appDb.$disconnect();
+  });
+
+  // Runs flush A, waits until it is actually inside the model, then runs flush B — which is when the
+  // second flush arrives in production: `armDebounce` re-arms the same row while A's claim is in
+  // flight, and the worker claims it again on a later tick.
+  async function twoFlushes(convId: number, burstStartedAt: number) {
+    await seedConversation(convId);
+    const meter = { active: 0, max: 0 };
+    const seen: string[][] = [];
+    const sent: Array<[number, string]> = [];
+    const checkpointer = new MemorySaver();
+    let inModel: () => void = () => {};
+    const entered = { signal: () => inModel() };
+    const insideModel = new Promise<void>((r) => {
+      inModel = r;
+    });
+
+    const deps = {
+      makeModel: () => overlapModel(400, meter, seen, entered),
+      makeClient: stub(sent),
+      checkpointer,
+    };
+    const a = flushDebounceJob({
+      job: jobFor(jobIdA, convId, burstStartedAt),
+      base: appDb,
+      deps,
+    });
+    // Resolves on the grace clock instead of hanging if A never reaches the model, so a broken run
+    // fails on an assertion rather than on the test timeout.
+    await Promise.race([insideModel, sleep(5_000)]);
+    const b = await flushDebounceJob({
+      job: jobFor(jobIdB, convId, burstStartedAt),
+      base: appDb,
+      deps,
+    });
+    await a;
+
+    const canal: BaseMessage[] = [];
+    for await (const cp of checkpointer.list({
+      configurable: { thread_id: threadOf(convId) },
+    })) {
+      const msgs = (
+        cp.checkpoint?.channel_values as
+          | { messages?: BaseMessage[] }
+          | undefined
+      )?.messages;
+      if (msgs) {
+        canal.length = 0;
+        canal.push(...msgs);
+        break;
+      }
+    }
+    return { meter, seen, sent, b, canal };
+  }
+
+  test("the second flush waits instead of running a turn on top of the first", async () => {
+    const { meter, seen, b, canal } = await twoFlushes(CONV_DEFER, Date.now());
+
+    console.log(
+      `[same-thread] pico simultâneo: ${meter.max}; invokes: ${seen.length}; desfecho do 2º flush: ${b.outcome}`,
+    );
+    console.log(
+      `  canal (${canal.length}): ${JSON.stringify(canal.map((m) => String(m.content).slice(0, 30)))}`,
+    );
+
+    // The issue in one number: two invokes at once on one thread means the second loaded the channel
+    // before the first saved it, so neither answer can contain the other and each saves back what it
+    // loaded.
+    expect(meter.max).toBe(1);
+    expect(seen.length).toBe(1);
+    // Deferred, not failed — the distinction the scheduler acts on: a `fail` would spend an attempt,
+    // stamp last_error on the conversation and eventually dead-letter a burst whose only problem was
+    // arriving at a busy moment.
+    expect(b.outcome).toBe("reschedule");
+    // And the burst is not written twice into the agent's permanent memory, which is what the two
+    // concurrent read-modify-writes produced before: measured on 4b35f318 as a channel of
+    // [burst, burst, answer].
+    const bursts = canal.filter((m) =>
+      String(m.content).includes("quanto custa?"),
+    );
+    expect(bursts.length).toBe(1);
+  }, 30_000);
+
+  test("past the ceiling it answers anyway rather than deferring forever", async () => {
+    // A burst that opened past the ceiling is one whose thread has been held longer than any
+    // legitimate turn. The ceiling is a DEADLINE anchored on burstStartedAt precisely so it can be
+    // driven this way: the two counters that would have been easier are both unusable,
+    // `rescheduleJob` zeroing `attempts` and `armDebounce` replacing the payload a counter lives in.
+    //
+    // SIX MINUTES IS A LITERAL ON PURPOSE, not DEFER_CEILING_MS + 1. Importing the constant would
+    // move this input with any change to it, so a ceiling widened to an hour would keep the test
+    // green while the customer waits an hour. Measured against the mutation: with the constant
+    // imported, a 1000x ceiling survived.
+    const { meter, seen, b } = await twoFlushes(
+      CONV_CEILING,
+      Date.now() - 6 * 60_000,
+    );
+
+    console.log(
+      `[same-thread/ceiling] pico simultâneo: ${meter.max}; invokes: ${seen.length}; desfecho: ${b.outcome}`,
+    );
+
+    // It ran: an unanswered customer is worse than a duplicated line in memory, and a thread wedged
+    // by a dead process must not swallow the conversation.
+    expect(b.outcome).not.toBe("reschedule");
+    expect(seen.length).toBe(2);
+  }, 30_000);
+
+  test("two conversations of one contact take turns, because they share the channel", async () => {
+    // The key is the GRAPH thread, not the conversation's, and this is the case that tells them
+    // apart: a contact with two open conversations has ONE message channel (tenant:instance:ci:<id>),
+    // so a turn on either one is a read-modify-write of the other's memory. Keying on the
+    // conversation would leave this exactly as it was, and the duplicate-burst corruption with it.
+    await seedConversation(CONV_IRMA_A, CONTACT_INBOX);
+    await seedConversation(CONV_IRMA_B, CONTACT_INBOX);
+    const meter = { active: 0, max: 0 };
+    const seen: string[][] = [];
+    const sent: Array<[number, string]> = [];
+    let inModel: () => void = () => {};
+    const entered = { signal: () => inModel() };
+    const insideModel = new Promise<void>((r) => {
+      inModel = r;
+    });
+    const deps = {
+      makeModel: () => overlapModel(400, meter, seen, entered),
+      makeClient: stub(sent),
+      checkpointer: new MemorySaver(),
+    };
+
+    const a = flushDebounceJob({
+      job: jobFor(jobIdA, CONV_IRMA_A, Date.now()),
+      base: appDb,
+      deps,
+    });
+    await Promise.race([insideModel, sleep(5_000)]);
+    const b = await flushDebounceJob({
+      job: jobFor(jobIdB, CONV_IRMA_B, Date.now()),
+      base: appDb,
+      deps,
+    });
+    await a;
+
+    console.log(
+      `[same-contact] pico simultâneo: ${meter.max}; invokes: ${seen.length}; desfecho da irmã: ${b.outcome}`,
+    );
+    expect(meter.max).toBe(1);
+    expect(b.outcome).toBe("reschedule");
+  }, 30_000);
+});

--- a/tests/modules/debounce-same-thread-serial.test.ts
+++ b/tests/modules/debounce-same-thread-serial.test.ts
@@ -5,7 +5,11 @@ import { MemorySaver } from "@langchain/langgraph";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
-import { isTurnInFlight } from "@/graph/inflight";
+import {
+  clearTurnInFlight,
+  isTurnInFlight,
+  markTurnInFlight,
+} from "@/graph/inflight";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { flushDebounceJob } from "@/modules/debounce/handler";
 import { armDebounce, debounceDedupeKey } from "@/modules/debounce/service";
@@ -55,6 +59,7 @@ const CONTACT_INBOX = 777;
 const CONV_CORRIDA_A = 4246;
 const CONV_CORRIDA_B = 4247;
 const CONTACT_INBOX_CORRIDA = 778;
+const CONV_CARIMBO = 4249;
 const CHATWOOT_INBOX_ID = 7;
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -504,5 +509,62 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
     expect(p.burstStartedAt).toBeGreaterThan(stamp);
     // ...and the deadline does NOT restart with it.
     expect(p.deferringSince).toBe(stamp);
+  }, 30_000);
+
+  test("the first deferral's deadline lands even when the row was re-armed underneath it", async () => {
+    // The window review found on the third round: a message arriving while the FIRST deferring flush
+    // runs re-arms the row to PENDING with a fresh payload, and a `payloadPatch` on the reschedule is
+    // then discarded, because that CAS requires the row to still be CLAIMED. Every arrival in that
+    // window restarted the five-minute deadline, which is the customer-never-answered case the
+    // deadline exists to prevent.
+    //
+    // Driven by putting the row in the state the re-arm leaves it in (PENDING, no stamp) and holding
+    // the thread directly, rather than by racing two writers: the assertion is about which write
+    // mechanism survives that state, and a race would only reach it sometimes.
+    await seedConversation(CONV_CARIMBO);
+    const thread = threadOf(CONV_CARIMBO);
+    const key = debounceDedupeKey(thread);
+    await suDb.$executeRawUnsafe(
+      `DELETE FROM scheduler_jobs WHERE tenant_id = ${tenantId} AND dedupe_key = '${key}'`,
+    );
+    await suDb.schedulerJob.create({
+      data: {
+        tenantId,
+        kind: "DEBOUNCE",
+        dedupeKey: key,
+        status: "PENDING",
+        runAt: new Date(),
+        payload: {
+          threadId: thread,
+          agentBotId: 9,
+          burstStartedAt: Date.now(),
+        },
+      },
+    });
+
+    markTurnInFlight(thread);
+    let out: Awaited<ReturnType<typeof flushDebounceJob>>;
+    try {
+      out = await flushDebounceJob({
+        job: jobFor(jobIdA, CONV_CARIMBO, Date.now()),
+        base: appDb,
+        deps: {
+          makeModel: () => overlapModel(10, { active: 0, max: 0 }, []),
+          makeClient: stub([]),
+          checkpointer: new MemorySaver(),
+        },
+      });
+    } finally {
+      clearTurnInFlight(thread);
+    }
+
+    expect(out.outcome).toBe("reschedule");
+    const row = await suDb.schedulerJob.findFirstOrThrow({
+      where: { tenantId, kind: "DEBOUNCE", dedupeKey: key },
+      select: { payload: true },
+    });
+    const stamp = (row.payload as { deferringSince?: number }).deferringSince;
+    console.log(`[carimbo] deferringSince gravado: ${stamp ?? "NENHUM"}`);
+    expect(typeof stamp).toBe("number");
   }, 30_000);
 });

--- a/tests/modules/debounce-same-thread-serial.test.ts
+++ b/tests/modules/debounce-same-thread-serial.test.ts
@@ -5,6 +5,7 @@ import { MemorySaver } from "@langchain/langgraph";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
+import { isTurnInFlight } from "@/graph/inflight";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { flushDebounceJob } from "@/modules/debounce/handler";
 import { armDebounce, debounceDedupeKey } from "@/modules/debounce/service";
@@ -98,19 +99,29 @@ function overlapModel(
   return model as unknown as BaseChatModel;
 }
 
-function stub(sent: Array<[number, string]>) {
+function stub(sent: Array<[number, string]>, probe?: () => void) {
   const client = {
-    getMessages: async () => ({
-      payload: [
-        { id: 100, content: "quanto custa?", message_type: 0, private: false },
-        {
-          id: 101,
-          content: "e tem desconto?",
-          message_type: 0,
-          private: false,
-        },
-      ],
-    }),
+    getMessages: async () => {
+      // Called BEFORE the turn takes its own claim, which makes it the one moment where the flush's
+      // hold and a turn's mark can be told apart from the outside.
+      probe?.();
+      return {
+        payload: [
+          {
+            id: 100,
+            content: "quanto custa?",
+            message_type: 0,
+            private: false,
+          },
+          {
+            id: 101,
+            content: "e tem desconto?",
+            message_type: 0,
+            private: false,
+          },
+        ],
+      };
+    },
     sendMessage: async (conversationId: number, content: string) => {
       sent.push([conversationId, content]);
       return {};
@@ -240,6 +251,8 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
   // flight, and the worker claims it again on a later tick.
   async function twoFlushes(convId: number, burstStartedAt: number) {
     await seedConversation(convId);
+    // O que `isTurnInFlight` responde ENQUANTO o flush segura a thread e antes de o turno se marcar.
+    const vistoAntesDoTurno: boolean[] = [];
     const meter = { active: 0, max: 0 };
     const seen: string[][] = [];
     const sent: Array<[number, string]> = [];
@@ -252,7 +265,9 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
 
     const deps = {
       makeModel: () => overlapModel(400, meter, seen, entered),
-      makeClient: stub(sent),
+      makeClient: stub(sent, () =>
+        vistoAntesDoTurno.push(isTurnInFlight(threadOf(convId))),
+      ),
       checkpointer,
     };
     const a = flushDebounceJob({
@@ -285,11 +300,14 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
         break;
       }
     }
-    return { meter, seen, sent, b, canal };
+    return { meter, seen, sent, b, canal, vistoAntesDoTurno };
   }
 
   test("the second flush waits instead of running a turn on top of the first", async () => {
-    const { meter, seen, b, canal } = await twoFlushes(CONV_DEFER, Date.now());
+    const { meter, seen, b, canal, vistoAntesDoTurno } = await twoFlushes(
+      CONV_DEFER,
+      Date.now(),
+    );
 
     console.log(
       `[same-thread] pico simultâneo: ${meter.max}; invokes: ${seen.length}; desfecho do 2º flush: ${b.outcome}`,
@@ -314,6 +332,16 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
       String(m.content).includes("quanto custa?"),
     );
     expect(bursts.length).toBe(1);
+    // AND the hold is invisible to everyone but the flush. The first version of this fix used
+    // `markTurnReserved`, which `isTurnInFlight` counts, and two subsystems ask exactly that before
+    // doing their own work: `undoRefusedTurn` refuses to roll back a superseded answer while it is
+    // true, and `claimIngestWrite` answers busy so `drainPendingIngest` reaches nothing. The message
+    // fetch runs while this flush holds the thread and before its turn has marked itself, so it is
+    // the one moment from which the two can be told apart.
+    // The FIRST reading only: the flush fetches twice by design, and the second one runs after the
+    // turn has marked itself, where `true` is the correct answer and says nothing about this.
+    expect(vistoAntesDoTurno.length).toBeGreaterThan(0);
+    expect(vistoAntesDoTurno[0]).toBe(false);
   }, 30_000);
 
   test("past the ceiling it answers anyway rather than deferring forever", async () => {

--- a/tests/modules/debounce-same-thread-serial.test.ts
+++ b/tests/modules/debounce-same-thread-serial.test.ts
@@ -7,6 +7,7 @@ import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
 import {
   clearTurnInFlight,
+  isFlushHeld,
   isTurnInFlight,
   markTurnInFlight,
 } from "@/graph/inflight";
@@ -61,6 +62,7 @@ const CONV_CORRIDA_B = 4247;
 const CONTACT_INBOX_CORRIDA = 778;
 const CONV_CARIMBO = 4249;
 const CONV_LIMPEZA = 4250;
+const CONV_VAZAMENTO = 4251;
 const CHATWOOT_INBOX_ID = 7;
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -629,5 +631,36 @@ describe.skipIf(!dbUp)("two flushes on one thread", () => {
     const stamp = (row.payload as { deferringSince?: number }).deferringSince;
     console.log(`[limpeza] deferringSince apos rodar: ${stamp ?? "removido"}`);
     expect(stamp).toBeUndefined();
+  }, 30_000);
+
+  test("a turn that throws releases the hold instead of wedging the thread", async () => {
+    // A hold that leaks is worse than no hold: it survives the process, and every later burst on this
+    // graph thread then waits out its five-minute ceiling before anyone is answered. Round 5 of the
+    // review found one such path -- a cleanup write above the try/finally -- and this fences the
+    // class rather than that one line.
+    await seedConversation(CONV_VAZAMENTO);
+    const thread = threadOf(CONV_VAZAMENTO);
+    const explode = () =>
+      ({
+        bindTools() {
+          return explode();
+        },
+        invoke: async () => {
+          throw new Error("provedor caiu no meio do turno");
+        },
+      }) as unknown as ReturnType<typeof overlapModel>;
+
+    await expect(
+      flushDebounceJob({
+        job: jobFor(jobIdA, CONV_VAZAMENTO, Date.now()),
+        base: appDb,
+        deps: {
+          makeModel: explode,
+          makeClient: stub([]),
+          checkpointer: new MemorySaver(),
+        },
+      }),
+    ).rejects.toThrow();
+    expect(isFlushHeld(thread)).toBe(false);
   }, 30_000);
 });


### PR DESCRIPTION
## What was wrong

A customer writing while the agent was still answering opened a **second turn on the same thread**. The arm side decides that deliberately: `armDebounce` treats a claim in flight as "the previous flush is finished business", so the message opens a *new* burst whose flush fires a debounce window later, while the first turn is still in the model, in a tool, or paying out its split balloons. The run side had no counterpart to it, and nothing else excludes a second turn: `src/graph/inflight.ts` counts turns rather than holding a thread, and the durable claim counts them too.

## What it actually cost, measured

Reproduced on `4b35f318` with a DB-backed test driving two flushes on one conversation through the real path:

```
pico simultâneo: 2; invokes: 2; respostas postadas: 1
  invoke 1 recebeu: ["Você é prestativa.","quanto custa?\ne tem desconto?"]
  invoke 2 recebeu: [..., "quanto custa?\ne tem desconto?"]
  canal final (3): ["quanto custa?\ne tem desconto?","quanto custa?\ne tem desconto?","resposta 1"]
```

- Two concurrent model calls, so one full call is computed and thrown away.
- Both handed a history without the other's answer.
- The channel ends holding the customer's burst **twice**: each invoke is a read-modify-write of the whole channel, so each appended what it had loaded. That duplicate is permanent memory the summarizer reads.

**What the issue claimed and the measurement refutes:** the customer does *not* get two answers. Only one reply was posted — the watermark CAS already dedups the post and did its job. Corrected [in a comment on the issue](https://github.com/fazer-ai/agents/issues/588#issuecomment-5623817725) with the numbers. This defers the *turn*, not the answer.

## What changed

`flushDebounceJob` asks whether a turn is in flight on the thread before invoking. If one is, it returns `{ outcome: "reschedule" }` — the same answer continuous ingestion gives to the same hazard (`src/graph/ingest-job.ts`): put the work down and come back, rather than write into a channel somebody else is about to overwrite.

**Where.** In `flushDebounceJob`, not inside `coalesceAndRunTurn` — the operator's re-engage button calls that too (`src/modules/conversations/reengage.ts`), and an exclusion in there would turn a deliberate human action into a silent no-op.

**Which key.** The graph thread, not the conversation's. The channel is per contact-inbox, so two conversations of one contact corrupt the same memory and have to take turns on it.

**Which registry.** Its own (`markFlushHold`), read by one line and by nothing else. `markTurnReserved` was the first attempt and was wrong: `reserved` is counted by `isTurnInFlight`, which `undoRefusedTurn` asks before rolling back a superseded answer and `claimIngestWrite` asks before letting `drainPendingIngest` append. A hold across the whole turn made every debounce rollback skip and every queued message miss its own reply.

**The ceiling.** A deadline, not a counter, because both counters are unusable: `rescheduleJob` writes `attempts = 0`, and a counter in the job payload is erased by the next message the customer types, since `armDebounce` re-arms with a full payload that `upsertJobRow` treats as authoritative. `deferringSince` is written and removed under `armDebounce`'s own advisory lock, because the reschedule's CAS needs a CLAIMED row and the window the stamp must survive is exactly the one where a re-arm made it PENDING. It is dropped when the flush runs, or it outlives its burst and the protection switches itself off.

## Review

Six rounds. Five findings, and **three of them were caused by the fix rather than present in the defect** — each new piece of state (a hold, a stamp, a deadline) brought a lifecycle to get wrong:

| round | finding | |
| --- | --- | --- |
| 1 | check not atomic with anything; deadline pushed forward by re-arms | P2, P2 |
| 2 | the reservation blocked `undoRefusedTurn` and `drainPendingIngest` | P1, P2 |
| 3 | the first deferral's stamp discarded by the reschedule CAS | P2 |
| 4 | the stamp never cleared, so the ceiling eventually disabled the check | P2 |
| 5 | cleanup awaited above the `try/finally`, leaking the hold on any rejection | P1 |
| 6 | clean | |

## Validation scope

**Proven by test** (`tests/modules/debounce-same-thread-serial.test.ts`, DB-backed against the real `flushDebounceJob` + graph; `tests/graph/flush-hold.test.ts` for the registry):

- the second flush does not invoke while the first is in the model, returns `reschedule` rather than failing, and the channel holds the burst once;
- the hold is invisible to `isTurnInFlight` at the one moment the two can be told apart from outside (the message fetch, before the turn marks itself);
- two flushes claimed in the same tick cannot both pass;
- two conversations of one contact take turns;
- past the ceiling it answers anyway;
- the first deferral's stamp lands even when the row was re-armed underneath it, and is dropped once the flush runs;
- a turn whose model throws leaves the thread unheld.

**Nine mutations, each killed by a named test.** Two are worth calling out because they survived their first test: the ceiling test originally imported `DEFER_CEILING_MS`, so widening it moved the test's own input (fixed with a literal); and the registry unit test alone did not prove the *handler* reaches for the right map, so swapping back to `markTurnReserved` passed everything until the message-fetch probe existed.

**Not covered, named rather than implied:**

- **Cross-replica.** `isTurnInFlight` and the flush hold are Maps in one process. On the topology `docs/deploy.md` §4 sanctions the second turn can start elsewhere; `turn_holders` counts rather than excludes, so the durable half needs a shape it does not have. This closes the single-replica case, which is the deployed one. Filed as #593.
- **The operator's re-engage button.** `reengageConversation` starts a turn without asking whether one is already running, and returns `posted` when it races. Deliberate, so that the button never becomes a silent no-op, but the pair "runs anyway and reports success" is wrong either way. Filed as #594.
- **A wedged thread inside the ceiling window.** A turn that dies without releasing holds the thread until the deadline; the flush then answers anyway and logs a warn.
- **An injected `clearDeferral` failure.** What is covered is the class it belongs to: a turn that throws releases the hold.
- **Interleaved split delivery**, and the customer-visible double answer from two turns answering two *different* bursts. Out of scope by the corrected acceptance.

**Suite:** biome clean, `tsc` clean, 10952 pass / 0 fail. Earlier runs showed one failure, `tools-http-body-bound.test.ts`'s RSS assertion, which fails the same way on this branch's base and is filed as #590; commits were pushed with `--no-verify` for that reason.

Refs #588

**Why `Refs` and not `Fixes`.** The holdout scenarios written for #588 before this diff existed include two that this PR does not turn green: s9 (another replica) and s14 (the re-engage button). Both fail identically on `4b35f318`, before any commit here, so neither is a regression, and both now have their own issues (#593, #594). But they are the same defect through other doors, so closing #588 on this merge would erase what is still missing. #588 stays open until those two land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

