### PR TITLE
Refuse a re-engage that would run on top of a turn already reading the thread

### DIFF
--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -589,6 +589,7 @@
     "quotedCustomer": "Customer",
     "reengage": {
       "action": "Re-engage",
+      "busy": "The AI is already answering this conversation. Wait a moment and try again.",
       "empty": "Nothing new to answer.",
       "error": "Re-engage failed.",
       "failedTitle": "The AI couldn't finish its last turn",

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -605,6 +605,7 @@
     "quotedCustomer": "Cliente",
     "reengage": {
       "action": "Reengajar",
+      "busy": "A IA já está respondendo esta conversa. Espere um instante e tente de novo.",
       "empty": "Nada novo para responder.",
       "error": "Falha ao reengajar.",
       "failedTitle": "A IA não conseguiu concluir o último turno",

--- a/src/client/pages/ConversationDetailPage.tsx
+++ b/src/client/pages/ConversationDetailPage.tsx
@@ -1536,6 +1536,17 @@ export function ConversationDetailPage() {
           ),
           "warning",
         );
+      } else if (data.outcome === "busy") {
+        // Braço próprio, e não o `noReply` do fim: "a IA não produziu resposta" mandaria o operador
+        // esperar por nada, quando o que ele precisa saber é que já tem um turno rodando e que o
+        // clique dele não foi perdido, é só repetir daqui a pouco.
+        showToast(
+          t(
+            "conversation.reengage.busy",
+            "The AI is already answering this conversation. Wait a moment and try again.",
+          ),
+          "info",
+        );
       } else if (data.outcome === "empty") {
         showToast(
           t("conversation.reengage.empty", "Nothing new to answer."),

--- a/src/modules/conversations/reengage.ts
+++ b/src/modules/conversations/reengage.ts
@@ -239,15 +239,6 @@ export async function reengageConversation(
   );
   if (!gateOpen) return { outcome: "gate-closed" };
 
-  // A MESMA PERGUNTA, CEDO, pelo motivo que o portão de assignee logo acima já dá: recusar aqui
-  // evita gastar o que vem depois. Sem ela a recusa só acontece adiante, e o clique num contato que
-  // já está sendo respondido custa uma ida ao Chatwoot, o teto de gasto e, com o portão ligado, uma
-  // chamada ao endpoint de autorização de outra pessoa. Medido rodando o console de verdade: sem
-  // esta linha o caminho batia em `preview.getMessages` e devolvia 500 antes de chegar na recusa.
-  //
-  // Esta é a barata e otimista; a que DECIDE é a adjacente ao invoke, lá embaixo. Uma leitura só
-  // aqui teria a janela larga que a #588 fechou; uma leitura só lá gasta o caminho inteiro para
-  // recusar. As duas, exatamente como o portão de assignee é perguntado duas vezes.
   const graphThreadId = resolveGraphThreadId(
     tenantId,
     resolved.instanceId,
@@ -268,7 +259,6 @@ export async function reengageConversation(
       ))) ||
     isTurnInFlight(graphThreadId) ||
     isFlushHeld(graphThreadId);
-  if (await threadTomada()) return { outcome: "busy" };
 
   // WHAT THIS CLICK WOULD ANSWER, computed once and used twice: here, to decide whether there is a
   // turn at all, and inside `coalesceAndRunTurn`, to build it. One expression rather than two,
@@ -331,6 +321,25 @@ export async function reengageConversation(
     parseChatwootMessages(await preview.getMessages(resolved.conversationId)),
   );
   if (previewTail.length === 0) return { outcome: "empty" };
+
+  // A MESMA PERGUNTA, CEDO, pelo motivo que o portão de assignee logo acima já dá para si mesmo:
+  // recusar aqui evita gastar o que vem depois. Sem ela o clique num contato que já está sendo
+  // respondido ainda paga o teto de gasto e, com o portão ligado, uma chamada ao endpoint de
+  // autorização de outra pessoa, para no fim dizer "ocupado". Medido rodando o console de verdade.
+  //
+  // DEPOIS do portão de cauda vazia, não antes, pela regra que este arquivo já enuncia: nada a
+  // responder ⇒ nada a recusar. Um clique sem cauda nenhuma numa thread ocupada não é "ocupado", é
+  // "não há o que responder", e mandar o operador tentar de novo o faz clicar para nada. O preço é
+  // a leitura de mensagens que aquele portão faz de qualquer jeito, e que o próprio arquivo diz não
+  // ser um gasto.
+  //
+  // SÓ O PROCESSO, sem ir ao banco: a leitura durável custa uma consulta e o caminho limpo não pode
+  // pagar duas. Quem decide é a checagem adjacente ao invoke, lá embaixo, que pergunta as duas
+  // metades. Aqui é a barata e otimista, e na topologia no ar (réplica única) ela já pega tudo que
+  // importa; a metade entre réplicas é a #593.
+  if (isTurnInFlight(graphThreadId) || isFlushHeld(graphThreadId)) {
+    return { outcome: "busy" };
+  }
 
   // The spend ceiling, asked here for the reason every other turn seam asks it: this is a billed
   // call, and nothing above it is. An operator re-engaging a conversation by hand is spending the

--- a/src/modules/conversations/reengage.ts
+++ b/src/modules/conversations/reengage.ts
@@ -1,7 +1,15 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
 import basePrisma from "@/api/lib/prisma";
+import { resolveGraphThreadId } from "@/graph/checkpointer";
+import {
+  clearFlushHold,
+  isFlushHeld,
+  isTurnInFlight,
+  markFlushHold,
+} from "@/graph/inflight";
 import { loadAgentConfig } from "@/graph/prepare";
 import type { RunAgentTurnOutcome, RuntimeDeps } from "@/graph/runtime";
+import { turnOwnsThread } from "@/graph/thread-claim";
 import {
   AppError,
   NotFoundError,
@@ -83,7 +91,12 @@ export type ReengageOutcome =
   // The tenant is past its month's tokens. Its own outcome rather than a silent no-reply, because
   // this path is an operator pressing a button: they are owed the reason, and it is one they can
   // act on from the settings page.
-  | "over-ceiling";
+  | "over-ceiling"
+  // Outro turno já estava lendo esta thread de memória quando o botão foi apertado. Recusar, e não
+  // enfileirar, porque a rota é síncrona e o console segura o botão: uma espera sem teto vira
+  // spinner eterno e 502 do proxy, que diz ao operador menos do que este desfecho diz. Ele clica de
+  // novo, e quem responde o cliente nesse meio-tempo é o turno que já estava rodando.
+  | "busy";
 
 export interface ReengageResult {
   outcome: ReengageOutcome;
@@ -117,6 +130,10 @@ function resolveReengage(
         assigneeType: true,
         assigneeId: true,
         inboxId: true,
+        // A CHAVE DA EXCLUSÃO. A memória de um contato é uma thread só, e as conversas dele são
+        // várias: sem este campo a chave cai para a da conversa (`resolveGraphThreadId`), e um
+        // segundo turno na mesma memória passa despercebido, que é o mesmo defeito por outra porta.
+        contactInboxId: true,
       },
     });
     if (!conv) return "not-found" as const;
@@ -148,6 +165,7 @@ function resolveReengage(
       conversationId: conv.chatwootConversationId,
       inboxChatwootId: inbox.chatwootInboxId,
       threadId: conv.threadId,
+      contactInboxId: conv.contactInboxId,
       status: conv.status,
       assigneeType: conv.assigneeType,
       assigneeId: conv.assigneeId,
@@ -393,74 +411,121 @@ export async function reengageConversation(
     if (!stillOurs) return { outcome: "gate-closed" };
   }
 
-  const outcome = await coalesceAndRunTurn(
-    {
-      // An operator pressing "re-engage" in the console: the turn IS the action, there is no queued
-      // job behind it and nothing that could call it off while it runs.
-      stillWanted: null,
-      tenantId,
-      instanceId: resolved.instanceId,
-      conversationId: resolved.conversationId,
-      threadId: resolved.threadId,
-      agentBotId: resolved.loaded.agentBotId,
-      convDbId: resolved.convDbId,
-      loaded: resolved.loaded,
-      settings: resolved.settings,
-      authContext,
-      // The same expression the pre-check above used, re-evaluated against a FRESH fetch: the
-      // authorization call between them is a round trip long enough for the tail to change.
-      selectPending,
-      // THE ONE CALLER THAT ANSWERS WHAT THE WATERMARK ALREADY COVERS, and this is issue #452 in
-      // one line: the tail is chosen from the last OUTGOING message, and a deliberate skip (a
-      // human-owned stretch, an out-of-hours silence, a turn that ended without a reply) advances
-      // the watermark past it without ever writing one of ours. A claim that refused a covered
-      // burst would make the button a no-op on exactly the conversations it was written for.
-      //
-      // The ceiling is the mark this call READ ON THE WAY IN, not "no ceiling": what was already
-      // settled when the operator clicked is the tail they are asking about, but a skip that lands
-      // WHILE the model runs settled it for somebody else, and this click is not entitled to
-      // answer over that. Including when that reading was NULL — a conversation with no mark yet
-      // is the case with the least evidence the tail is unanswered, so a mark appearing under a
-      // running model refuses it there too.
-      claimHandledCeiling: () => floorAtEntry,
-      label: "reengage",
-    },
-    base,
-    deps,
-  );
-
-  // NOTE: The reply is with the customer from here, and clearing the error badge is our own bookkeeping:
-  // it can throw, and a row written only after it would be missing for a turn that did post. Same
-  // seam as the other four (`conversations/audit.ts`).
+  // ADJACENTE AO INVOKE, e não lá na entrada. Entre a entrada desta função e esta linha correm o
+  // preview do Chatwoot, o teto de gasto, a autorização do contato (que pode levar dez segundos) e
+  // a releitura do assignee. Uma checagem na entrada deixaria aberta uma janela mais larga do que a
+  // que a #588 fechou no flush, e o turno que ela ignorasse é o que está escrevendo o canal agora.
+  // O flush resolveu isso com adjacência (`markFlushHold`, ../debounce/handler.ts); aqui vale a
+  // mesma regra.
   //
-  // NOTE: A DECLARED GAP, and it is upstream of this line: `coalesceAndRunTurn` advances the handled
-  // watermark after the post and before it returns, so a failure there rejects without ever naming
-  // an outcome, and this call cannot know whether the customer was answered. No row is the honest
-  // answer to that, not a guess — and the same crash loses the turn's own bookkeeping either way.
-  // Closing it means recording at the posting seam itself, which is the turn's business rather than
-  // this button's.
-  try {
-    if (outcome === "posted") {
-      await clearConversationError({
+  // `turnOwnsThread` e não `isTurnInFlight`: a resposta certa é a do processo MAIS a da linha, e
+  // uma leitura que falha conta como ocupado. Recusar por engano custa um clique repetido; seguir
+  // por engano custa o canal.
+  //
+  // Sem `contact_inbox_id` não há claim durável a consultar (a linha é chaveada por ele), e a thread
+  // de grafo cai para a da conversa: sobra o registro do processo, que é o que existe hoje.
+  const graphThreadId = resolveGraphThreadId(
+    tenantId,
+    resolved.instanceId,
+    resolved.conversationId,
+    resolved.contactInboxId,
+  );
+  const contactInboxId = resolved.contactInboxId;
+  const donoDurável =
+    contactInboxId !== null &&
+    (await turnOwnsThread(
+      {
         tenantId,
         instanceId: resolved.instanceId,
-        chatwootConversationId: resolved.conversationId,
-        base,
-      });
-    }
-  } finally {
-    // NOTE: Recorded when the turn REACHED THE CUSTOMER, and only then, which is the one place this family
-    // does not record every apply. The other four call Chatwoot unconditionally; this one runs a model
-    // first and most of its outcomes are the button declining to act: an empty tail, a closed gate, a
-    // conversation somebody else holds. Those changed nothing outside this process and the flow log
-    // already narrates them for the operator asking why nothing happened (#317). `posted-partial` is
-    // on this side of the line because part of the reply IS with the customer.
-    if (outcome === "posted" || outcome === "posted-partial") {
-      await recordConversationAction(ctx, base, conversationDbId, {
-        action: "conversation.reengage",
-        after: { outcome },
-      });
-    }
+        contactInboxId,
+        graphThreadId,
+      },
+      base,
+    ));
+  if (
+    donoDurável ||
+    isTurnInFlight(graphThreadId) ||
+    isFlushHeld(graphThreadId)
+  ) {
+    return { outcome: "busy" };
   }
-  return { outcome };
+  // O MESMO REGISTRO QUE O FLUSH USA, pelo que ele já é: invisível para quem pergunta por TURNOS
+  // (ingestão, compactação, rollback) e visível para o flush, que é quem precisa adiar diante deste
+  // botão. Reusar o registro do turno aqui faria `drainPendingIngest` alcançar nada e todo rollback
+  // pular, com a suíte inteira verde: o defeito que o review da #588 já encontrou uma vez.
+  markFlushHold(graphThreadId);
+  try {
+    const outcome = await coalesceAndRunTurn(
+      {
+        // An operator pressing "re-engage" in the console: the turn IS the action, there is no queued
+        // job behind it and nothing that could call it off while it runs.
+        stillWanted: null,
+        tenantId,
+        instanceId: resolved.instanceId,
+        conversationId: resolved.conversationId,
+        threadId: resolved.threadId,
+        agentBotId: resolved.loaded.agentBotId,
+        convDbId: resolved.convDbId,
+        loaded: resolved.loaded,
+        settings: resolved.settings,
+        authContext,
+        // The same expression the pre-check above used, re-evaluated against a FRESH fetch: the
+        // authorization call between them is a round trip long enough for the tail to change.
+        selectPending,
+        // THE ONE CALLER THAT ANSWERS WHAT THE WATERMARK ALREADY COVERS, and this is issue #452 in
+        // one line: the tail is chosen from the last OUTGOING message, and a deliberate skip (a
+        // human-owned stretch, an out-of-hours silence, a turn that ended without a reply) advances
+        // the watermark past it without ever writing one of ours. A claim that refused a covered
+        // burst would make the button a no-op on exactly the conversations it was written for.
+        //
+        // The ceiling is the mark this call READ ON THE WAY IN, not "no ceiling": what was already
+        // settled when the operator clicked is the tail they are asking about, but a skip that lands
+        // WHILE the model runs settled it for somebody else, and this click is not entitled to
+        // answer over that. Including when that reading was NULL — a conversation with no mark yet
+        // is the case with the least evidence the tail is unanswered, so a mark appearing under a
+        // running model refuses it there too.
+        claimHandledCeiling: () => floorAtEntry,
+        label: "reengage",
+      },
+      base,
+      deps,
+    );
+
+    // NOTE: The reply is with the customer from here, and clearing the error badge is our own bookkeeping:
+    // it can throw, and a row written only after it would be missing for a turn that did post. Same
+    // seam as the other four (`conversations/audit.ts`).
+    //
+    // NOTE: A DECLARED GAP, and it is upstream of this line: `coalesceAndRunTurn` advances the handled
+    // watermark after the post and before it returns, so a failure there rejects without ever naming
+    // an outcome, and this call cannot know whether the customer was answered. No row is the honest
+    // answer to that, not a guess — and the same crash loses the turn's own bookkeeping either way.
+    // Closing it means recording at the posting seam itself, which is the turn's business rather than
+    // this button's.
+    try {
+      if (outcome === "posted") {
+        await clearConversationError({
+          tenantId,
+          instanceId: resolved.instanceId,
+          chatwootConversationId: resolved.conversationId,
+          base,
+        });
+      }
+    } finally {
+      // NOTE: Recorded when the turn REACHED THE CUSTOMER, and only then, which is the one place this family
+      // does not record every apply. The other four call Chatwoot unconditionally; this one runs a model
+      // first and most of its outcomes are the button declining to act: an empty tail, a closed gate, a
+      // conversation somebody else holds. Those changed nothing outside this process and the flow log
+      // already narrates them for the operator asking why nothing happened (#317). `posted-partial` is
+      // on this side of the line because part of the reply IS with the customer.
+      if (outcome === "posted" || outcome === "posted-partial") {
+        await recordConversationAction(ctx, base, conversationDbId, {
+          action: "conversation.reengage",
+          after: { outcome },
+        });
+      }
+    }
+    return { outcome };
+  } finally {
+    clearFlushHold(graphThreadId);
+  }
 }

--- a/src/modules/conversations/reengage.ts
+++ b/src/modules/conversations/reengage.ts
@@ -290,20 +290,6 @@ export async function reengageConversation(
     return { outcome: "busy" };
   };
 
-  const threadTomada = async () =>
-    (contactInboxId !== null &&
-      (await turnOwnsThread(
-        {
-          tenantId,
-          instanceId: resolved.instanceId,
-          contactInboxId,
-          graphThreadId,
-        },
-        base,
-      ))) ||
-    isTurnInFlight(graphThreadId) ||
-    isFlushHeld(graphThreadId);
-
   // WHAT THIS CLICK WOULD ANSWER, computed once and used twice: here, to decide whether there is a
   // turn at all, and inside `coalesceAndRunTurn`, to build it. One expression rather than two,
   // because the pre-check and the turn disagreeing is how a gate ends up refusing work that was
@@ -508,7 +494,32 @@ export async function reengageConversation(
   //
   // Sem `contact_inbox_id` não há claim durável a consultar (a linha é chaveada por ele), e a thread
   // de grafo cai para a da conversa: sobra o registro do processo, que é o que existe hoje.
-  if (await threadTomada()) return recusaOcupada("adjacente");
+  // A LEITURA DURÁVEL PRIMEIRO, E DEPOIS NADA DE `await` ATÉ A MARCA. Esta ordem é a correção
+  // inteira, e eu já a quebrei uma vez: extrair as duas metades para um predicado `async` põe um
+  // `await` ENTRE a checagem local e o `markFlushHold`, e duas chamadas concorrentes cedem o event
+  // loop no mesmo ponto, leem "livre" as duas e marcam as duas. O clique duplo passava mesmo assim,
+  // por sorte de escalonamento, e é isso que o teste da barreira abaixo tira da jogada.
+  //
+  // Por isso o predicado NÃO é compartilhado com a checagem antecipada: aquela é local e síncrona
+  // porque não pode custar consulta; esta é durável e tem que terminar em marca no mesmo tick.
+  const donoDuravel =
+    contactInboxId !== null &&
+    (await turnOwnsThread(
+      {
+        tenantId,
+        instanceId: resolved.instanceId,
+        contactInboxId,
+        graphThreadId,
+      },
+      base,
+    ));
+  if (
+    donoDuravel ||
+    isTurnInFlight(graphThreadId) ||
+    isFlushHeld(graphThreadId)
+  ) {
+    return recusaOcupada("adjacente");
+  }
   // O MESMO REGISTRO QUE O FLUSH USA, pelo que ele já é: invisível para quem pergunta por TURNOS
   // (ingestão, compactação, rollback) e visível para o flush, que é quem precisa adiar diante deste
   // botão. Reusar o registro do turno aqui faria `drainPendingIngest` alcançar nada e todo rollback

--- a/src/modules/conversations/reengage.ts
+++ b/src/modules/conversations/reengage.ts
@@ -239,6 +239,37 @@ export async function reengageConversation(
   );
   if (!gateOpen) return { outcome: "gate-closed" };
 
+  // A MESMA PERGUNTA, CEDO, pelo motivo que o portão de assignee logo acima já dá: recusar aqui
+  // evita gastar o que vem depois. Sem ela a recusa só acontece adiante, e o clique num contato que
+  // já está sendo respondido custa uma ida ao Chatwoot, o teto de gasto e, com o portão ligado, uma
+  // chamada ao endpoint de autorização de outra pessoa. Medido rodando o console de verdade: sem
+  // esta linha o caminho batia em `preview.getMessages` e devolvia 500 antes de chegar na recusa.
+  //
+  // Esta é a barata e otimista; a que DECIDE é a adjacente ao invoke, lá embaixo. Uma leitura só
+  // aqui teria a janela larga que a #588 fechou; uma leitura só lá gasta o caminho inteiro para
+  // recusar. As duas, exatamente como o portão de assignee é perguntado duas vezes.
+  const graphThreadId = resolveGraphThreadId(
+    tenantId,
+    resolved.instanceId,
+    resolved.conversationId,
+    resolved.contactInboxId,
+  );
+  const contactInboxId = resolved.contactInboxId;
+  const threadTomada = async () =>
+    (contactInboxId !== null &&
+      (await turnOwnsThread(
+        {
+          tenantId,
+          instanceId: resolved.instanceId,
+          contactInboxId,
+          graphThreadId,
+        },
+        base,
+      ))) ||
+    isTurnInFlight(graphThreadId) ||
+    isFlushHeld(graphThreadId);
+  if (await threadTomada()) return { outcome: "busy" };
+
   // WHAT THIS CLICK WOULD ANSWER, computed once and used twice: here, to decide whether there is a
   // turn at all, and inside `coalesceAndRunTurn`, to build it. One expression rather than two,
   // because the pre-check and the turn disagreeing is how a gate ends up refusing work that was
@@ -424,31 +455,7 @@ export async function reengageConversation(
   //
   // Sem `contact_inbox_id` não há claim durável a consultar (a linha é chaveada por ele), e a thread
   // de grafo cai para a da conversa: sobra o registro do processo, que é o que existe hoje.
-  const graphThreadId = resolveGraphThreadId(
-    tenantId,
-    resolved.instanceId,
-    resolved.conversationId,
-    resolved.contactInboxId,
-  );
-  const contactInboxId = resolved.contactInboxId;
-  const donoDurável =
-    contactInboxId !== null &&
-    (await turnOwnsThread(
-      {
-        tenantId,
-        instanceId: resolved.instanceId,
-        contactInboxId,
-        graphThreadId,
-      },
-      base,
-    ));
-  if (
-    donoDurável ||
-    isTurnInFlight(graphThreadId) ||
-    isFlushHeld(graphThreadId)
-  ) {
-    return { outcome: "busy" };
-  }
+  if (await threadTomada()) return { outcome: "busy" };
   // O MESMO REGISTRO QUE O FLUSH USA, pelo que ele já é: invisível para quem pergunta por TURNOS
   // (ingestão, compactação, rollback) e visível para o flush, que é quem precisa adiar diante deste
   // botão. Reusar o registro do turno aqui faria `drainPendingIngest` alcançar nada e todo rollback

--- a/src/modules/conversations/reengage.ts
+++ b/src/modules/conversations/reengage.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient } from "@/../generated/prisma/client";
+import logger from "@/api/lib/logger";
 import basePrisma from "@/api/lib/prisma";
 import { resolveGraphThreadId } from "@/graph/checkpointer";
 import {
@@ -246,6 +247,49 @@ export async function reengageConversation(
     resolved.contactInboxId,
   );
   const contactInboxId = resolved.contactInboxId;
+  // UMA RECUSA QUE NÃO DEIXA RASTRO LÊ COMO UM CLIQUE QUE NUNCA ACONTECEU, e este arquivo já diz
+  // isso em voz alta na recusa de autorização, poucas linhas abaixo: "It is logged, though — a
+  // refused re-engage that left no trace would read in the flowlog as if the click never happened."
+  // Vale igual aqui, e com um motivo a mais: o operador que apertou o botão e não viu nada mudar vai
+  // procurar no log, e "recusei porque a thread estava tomada" e "o clique não chegou" mandam
+  // investigar coisas completamente diferentes.
+  //
+  // `skipped`, e não `error`: nada falhou. Um turno estava rodando e este clique cedeu a vez, que é
+  // o desfecho correto e não um incidente.
+  const recusaOcupada = (onde: "cedo" | "adjacente"): ReengageResult => {
+    logger.info(
+      "reengage refused: a turn already owns thread=%s (conv=%s, check=%s)",
+      graphThreadId,
+      String(resolved.conversationId),
+      onde,
+    );
+    emitFlowEvent(
+      {
+        tenantId,
+        turnId: crypto.randomUUID(),
+        source: "inbox",
+        conversationId: resolved.convDbId,
+        agentId: resolved.loaded.agentId,
+        inboxId: resolved.loaded.inboxDbId,
+        threadId: resolved.threadId,
+        base,
+      },
+      {
+        stage: "debounce",
+        level: "info",
+        status: "skipped",
+        detail: {
+          outcome: "busy",
+          label: "reengage",
+          // Qual das duas checagens recusou, porque a resposta muda o que se investiga: a barata
+          // diz "turno neste processo"; a adjacente pode ser de outra réplica.
+          check: onde,
+        },
+      },
+    );
+    return { outcome: "busy" };
+  };
+
   const threadTomada = async () =>
     (contactInboxId !== null &&
       (await turnOwnsThread(
@@ -338,7 +382,7 @@ export async function reengageConversation(
   // metades. Aqui é a barata e otimista, e na topologia no ar (réplica única) ela já pega tudo que
   // importa; a metade entre réplicas é a #593.
   if (isTurnInFlight(graphThreadId) || isFlushHeld(graphThreadId)) {
-    return { outcome: "busy" };
+    return recusaOcupada("cedo");
   }
 
   // The spend ceiling, asked here for the reason every other turn seam asks it: this is a billed
@@ -464,7 +508,7 @@ export async function reengageConversation(
   //
   // Sem `contact_inbox_id` não há claim durável a consultar (a linha é chaveada por ele), e a thread
   // de grafo cai para a da conversa: sobra o registro do processo, que é o que existe hoje.
-  if (await threadTomada()) return { outcome: "busy" };
+  if (await threadTomada()) return recusaOcupada("adjacente");
   // O MESMO REGISTRO QUE O FLUSH USA, pelo que ele já é: invisível para quem pergunta por TURNOS
   // (ingestão, compactação, rollback) e visível para o flush, que é quem precisa adiar diante deste
   // botão. Reusar o registro do turno aqui faria `drainPendingIngest` alcançar nada e todo rollback

--- a/tests/client/reengage-outcome-messages.test.ts
+++ b/tests/client/reengage-outcome-messages.test.ts
@@ -19,10 +19,17 @@ const PT = "src/client/locales/pt-BR.json";
 // nomear. Os herdados de `RunAgentTurnOutcome` valem pelos ramos que já existem (`posted`,
 // `posted-partial`) e pelo `else` final, que é o lugar legítimo de "o turno rodou e não respondeu".
 function desfechosProprios(fonte: string): string[] {
-  const bloco = fonte.slice(
-    fonte.indexOf("export type ReengageOutcome"),
-    fonte.indexOf("export interface ReengageResult"),
-  );
+  // Âncoras conferidas antes do recorte. `indexOf` devolve -1 para o que sumiu, `slice(-1, -1)`
+  // devolve "" e um recorte vazio não declara desfecho nenhum: a cerca passaria justamente no
+  // commit que renomeou o tipo. Padrão que para de casar tem que reprovar, não silenciar.
+  const abre = fonte.indexOf("export type ReengageOutcome");
+  const fecha = fonte.indexOf("export interface ReengageResult");
+  if (abre < 0 || fecha <= abre) {
+    throw new Error(
+      `âncoras de ReengageOutcome não encontradas em ${REENGAGE} (abre=${abre}, fecha=${fecha})`,
+    );
+  }
+  const bloco = fonte.slice(abre, fecha);
   return [...bloco.matchAll(/\|\s*"([a-z-]+)"/g)].map((m) => m[1] as string);
 }
 

--- a/tests/client/reengage-outcome-messages.test.ts
+++ b/tests/client/reengage-outcome-messages.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+// CERCA, não checklist. Issue #594 acrescentou um desfecho (`busy`) e, com ele, a pergunta que vai
+// se repetir a cada desfecho novo: o operador vai ler alguma coisa sobre isso, e nos dois idiomas?
+//
+// A resposta cai no `else` final ("The AI produced no reply.") quando ninguém lembra, e esse texto
+// manda o operador esperar por nada. O defeito não aparece em nenhum teste de comportamento: a
+// chamada devolve o desfecho certo e a tela mostra a frase errada.
+//
+// Por isso a varredura é do FONTE. Um desfecho que o módulo declara e a tela não trata reprova aqui,
+// no commit que o declarou, e não meses depois num relato de operador.
+
+const REENGAGE = "src/modules/conversations/reengage.ts";
+const CONSOLE = "src/client/pages/ConversationDetailPage.tsx";
+const EN = "src/client/locales/en.json";
+const PT = "src/client/locales/pt-BR.json";
+
+// Os desfechos que ESTE módulo acrescenta, que são os que a tela do re-engage tem obrigação de
+// nomear. Os herdados de `RunAgentTurnOutcome` valem pelos ramos que já existem (`posted`,
+// `posted-partial`) e pelo `else` final, que é o lugar legítimo de "o turno rodou e não respondeu".
+function desfechosProprios(fonte: string): string[] {
+  const bloco = fonte.slice(
+    fonte.indexOf("export type ReengageOutcome"),
+    fonte.indexOf("export interface ReengageResult"),
+  );
+  return [...bloco.matchAll(/\|\s*"([a-z-]+)"/g)].map((m) => m[1] as string);
+}
+
+function ramosDaTela(fonte: string): Set<string> {
+  return new Set(
+    [...fonte.matchAll(/data\.outcome === "([a-z-]+)"/g)].map(
+      (m) => m[1] as string,
+    ),
+  );
+}
+
+function chaves(json: string): Set<string> {
+  const d = JSON.parse(json) as {
+    conversation?: { reengage?: Record<string, string> };
+  };
+  return new Set(Object.keys(d.conversation?.reengage ?? {}));
+}
+
+describe("todo desfecho do re-engage tem o que dizer ao operador", () => {
+  test("cada desfecho próprio tem ramo na tela e chave nos dois locales", async () => {
+    const proprios = desfechosProprios(await Bun.file(REENGAGE).text());
+    const ramos = ramosDaTela(await Bun.file(CONSOLE).text());
+    const en = chaves(await Bun.file(EN).text());
+    const pt = chaves(await Bun.file(PT).text());
+
+    // A cerca só vale se a varredura achou alguma coisa: um regex que para de casar passaria vazio.
+    expect(proprios.length).toBeGreaterThanOrEqual(5);
+    expect(proprios).toContain("busy");
+
+    const semRamo = proprios.filter((o) => !ramos.has(o));
+    expect(semRamo).toEqual([]);
+
+    // A chave segue o mesmo nome em camelCase que a tela já usa: "gate-closed" -> "gateClosed".
+    const camel = (o: string) =>
+      o.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    const semEn = proprios.filter((o) => !en.has(camel(o)));
+    const semPt = proprios.filter((o) => !pt.has(camel(o)));
+    expect(semEn).toEqual([]);
+    expect(semPt).toEqual([]);
+  });
+
+  test("os dois locales têm exatamente as mesmas chaves de re-engage", async () => {
+    const en = [...chaves(await Bun.file(EN).text())].sort();
+    const pt = [...chaves(await Bun.file(PT).text())].sort();
+    expect(pt).toEqual(en);
+  });
+});

--- a/tests/modules/flowlog-reader-scope.test.ts
+++ b/tests/modules/flowlog-reader-scope.test.ts
@@ -227,7 +227,7 @@ const FLOWLOG_READERS: Record<string, number> = {
   "tests/modules/memory-dead-letter.test.ts": 1,
   "tests/modules/observe-job.test.ts": 1,
   "tests/modules/playground-guardrails.test.ts": 1,
-  "tests/modules/reengage.test.ts": 2,
+  "tests/modules/reengage.test.ts": 3,
   "tests/modules/model-fallback-turn.test.ts": 1,
   "tests/modules/spend-ceiling-gate-e2e.test.ts": 1,
   "tests/modules/spend-ceiling-paths-e2e.test.ts": 3,

--- a/tests/modules/reengage-gate-atomic.test.ts
+++ b/tests/modules/reengage-gate-atomic.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+// CERCA DE FORMA, porque a de comportamento não existe.
+//
+// A correção da #594 é uma ORDEM, não um valor: a leitura durável primeiro e, depois dela, nada de
+// `await` até `markFlushHold`. Extrair as duas metades para um predicado `async` põe um `await` no
+// meio, as duas chamadas concorrentes cedem o event loop no mesmo ponto, leem "livre" as duas e
+// marcam as duas. Foi exatamente o que aconteceu na rodada 4 do review desta PR.
+//
+// O motivo desta cerca existir é medido, não suposto. O teste de clique duplo de
+// tests/modules/reengage.test.ts foi rodado pelo verificador contra o fonte QUEBRADO e passou 5 de
+// 5, com a barreira nos dois únicos pontos injetáveis de fora do módulo (a leitura do Chatwoot e o
+// endpoint de autorização). A razão é estrutural: a barreira sincroniza a ENTRADA, e depois da
+// largada cada chamada ainda faz duas idas ao banco cuja diferença de latência re-serializa as duas
+// antes do portão. Só uma costura DENTRO do módulo, depois do último `await`, faria as duas
+// chegarem juntas — e uma costura assim é superfície de produção existindo só para o teste.
+//
+// Então o que sobra é o que esta cerca faz: afirmar a forma, no idioma que o repo já usa em
+// tests/client/reengage-outcome-messages.test.ts. Ela pega a regressão que de fato aconteceu, é
+// determinística, e não custa nada em produção. O que ela NÃO é: prova de que o portão exclui. Isso
+// está escrito aqui para ninguém ler o verde dela como a medição que ela não fez.
+//
+// A cerca falha DURO quando as âncoras somem. Um padrão que para de casar e devolve verde é o modo
+// de falha que já custou três falsos sobreviventes na bateria de mutação desta mesma PR.
+
+const ARQUIVO = "src/modules/conversations/reengage.ts";
+const ABRE = "const donoDuravel =";
+const FECHA = "markFlushHold(graphThreadId);";
+
+function semComentarios(fonte: string): string {
+  return fonte.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+}
+
+describe("o portão do re-engage é um bloco síncrono", () => {
+  test("entre a leitura durável e a marca não existe outro await", async () => {
+    const fonte = await Bun.file(ARQUIVO).text();
+
+    // As âncoras primeiro, e cada uma exatamente uma vez: sem isso o recorte abaixo pode ficar
+    // vazio, e um recorte vazio passa em toda asserção que vem depois.
+    expect(fonte.split(ABRE).length - 1).toBe(1);
+    expect(fonte.split(FECHA).length - 1).toBe(1);
+
+    const inicio = fonte.indexOf(ABRE);
+    const fim = fonte.indexOf(FECHA) + FECHA.length;
+    expect(fim).toBeGreaterThan(inicio);
+
+    const trecho = semComentarios(fonte.slice(inicio, fim));
+
+    // A checagem local mora DENTRO do recorte, isto é, depois da leitura durável e antes da marca.
+    // Se ela subir para antes do `await`, o recorte deixa de descrever o que ele afirma proteger.
+    expect(trecho).toContain("isTurnInFlight(graphThreadId)");
+    expect(trecho).toContain("isFlushHeld(graphThreadId)");
+
+    const esperas = [...trecho.matchAll(/\bawait\b/g)];
+    expect(esperas).toHaveLength(1);
+
+    // E o único `await` permitido é o da própria leitura durável. Um predicado extraído mantém a
+    // contagem em 1 e troca o nome; é essa a regressão da rodada 4.
+    const unica = trecho.slice(esperas[0]?.index ?? 0);
+    expect(unica.startsWith("await turnOwnsThread(")).toBe(true);
+  });
+});

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -4,6 +4,7 @@ import { MemorySaver } from "@langchain/langgraph";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
+import { clearTurnInFlight, markTurnInFlight } from "@/graph/inflight";
 import type { TenantContext } from "@/lib/tenancy";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { reengageConversation } from "@/modules/conversations/reengage";
@@ -102,6 +103,7 @@ async function seedConversation(
     lastError?: string | null;
     contactId?: bigint;
     lastHandledMessageId?: number;
+    contactInboxId?: number;
   } = {},
 ): Promise<bigint> {
   const c = await suDb.conversation.create({
@@ -119,6 +121,9 @@ async function seedConversation(
       lastError: over.lastError ?? null,
       lastErrorAt: over.lastError ? new Date() : null,
       lastHandledMessageId: over.lastHandledMessageId ?? null,
+      ...(over.contactInboxId !== undefined
+        ? { contactInboxId: over.contactInboxId }
+        : {}),
     },
   });
   return c.id;
@@ -803,7 +808,17 @@ describe.skipIf(!dbUp)("reengage", () => {
         reengageConversation(ctx(), id, deps(), appDb),
       ]);
       expect(sent.length).toBe(1);
-      expect([a.outcome, b.outcome].sort()).toEqual(["posted", "superseded"]);
+      // MUDOU COM A #594, e a metade que importa não mudou: uma resposta só. O perdedor agora é
+      // recusado ANTES de gastar um turno, e não depois de o claim de resposta tirá-lo do caminho,
+      // então ele lê `busy` em vez de `superseded`. É a resposta mais verdadeira no instante em que
+      // é dada, e economiza uma chamada ao modelo por clique duplo.
+      //
+      // `superseded` continua existindo para o caso em que a cauda é consumida ENQUANTO o modelo
+      // roda (o teste do skip logo abaixo): lá o turno chegou a acontecer.
+      //
+      // Determinístico, não corrida: a checagem e o `markFlushHold` são um bloco síncrono só, então
+      // as duas chamadas não podem passar as duas pela checagem.
+      expect([a.outcome, b.outcome].sort()).toEqual(["busy", "posted"]);
     });
 
     // THE CEILING IS THE MARK THIS CLICK READ ON THE WAY IN, not "no ceiling" (issue #452). What was
@@ -1263,5 +1278,55 @@ describe.skipIf(!dbUp)("reengage", () => {
       }),
     ).toBe(1);
     expect(capture.systemPrompts.join("\n")).toContain("VARIANT PROMPT");
+  });
+  // Issue #594. Um turno já rodando na MESMA thread de grafo, e o operador aperta re-engage. Hoje o
+  // re-engage abre um segundo turno concorrente, posta, e devolve `posted` atrás de um 200: o canal do
+  // checkpoint fica exposto ao read-modify-write que a #588 fechou, só que pela porta do operador.
+  //
+  // A ocupação é marcada no registro do PROCESSO de propósito: é assim que o defeito acontece hoje em
+  // réplica única, que é a topologia no ar. A metade entre réplicas é a #593.
+  //
+  // A conversa nasce com `contact_inbox_id`, e isso não é detalhe: a thread de grafo de um contato com
+  // duas conversas é a do contato-inbox, e `resolveReengage` hoje nem seleciona esse campo. Uma
+  // correção que se apoie no `threadId` da conversa passa num teste sem ele e erra calada o caso real.
+  describe("re-engage com turno em voo na mesma thread", () => {
+    test("não roda por cima do turno, e diz isso ao operador", async () => {
+      const CONV = 9594;
+      const CONTACT_INBOX = 594;
+      const id = await seedConversation(CONV, {
+        contactInboxId: CONTACT_INBOX,
+      });
+      const graphThreadId = `${tenantId}:${instanceId}:ci:${CONTACT_INBOX}`;
+      const sent: Array<[number, string]> = [];
+
+      markTurnInFlight(graphThreadId);
+      try {
+        const res = await reengageConversation(
+          ctx(),
+          id,
+          {
+            makeModel: fakeModel,
+            makeClient: makeStub({
+              page: page([
+                { id: 1, content: "oi", type: 0 },
+                { id: 2, content: "resposta antiga", type: 1 },
+                { id: 3, content: "e aí, esqueceu de mim?", type: 0 },
+              ]),
+              sent,
+            }),
+            checkpointer: new MemorySaver(),
+          },
+          appDb,
+        );
+        console.log(
+          `[594] desfecho=${res.outcome} envios=${sent.length} thread=${graphThreadId}`,
+        );
+        // As duas metades que o cenário proíbe juntas: rodar por cima E dizer que deu certo.
+        expect(sent).toEqual([]);
+        expect(res.outcome).not.toBe("posted");
+      } finally {
+        clearTurnInFlight(graphThreadId);
+      }
+    });
   });
 });

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -66,11 +66,15 @@ function makeStub(opts: {
   // Roda a cada leitura de mensagens, que é o único momento em que o hold do botão e a marca do
   // turno podem ser distinguidos de fora: o coalesce lê ANTES de o turno se marcar.
   onGetMessages?: () => void;
+  // A versão que pode ESPERAR, para uma barreira de largada sincronizar duas chamadas no mesmo
+  // ponto. `onGetMessages` é síncrono de propósito (é sonda); esta serve para segurar.
+  onGetMessagesAsync?: () => Promise<void>;
 }) {
   let i = 0;
   const client = {
     getMessages: async () => {
       opts.onGetMessages?.();
+      if (opts.onGetMessagesAsync) await opts.onGetMessagesAsync();
       if (!opts.pages) return opts.page;
       const p = opts.pages[Math.min(i, opts.pages.length - 1)];
       i += 1;
@@ -1593,5 +1597,56 @@ describe.skipIf(!dbUp)("reengage", () => {
     } finally {
       clearTurnInFlight(graphThreadId);
     }
+  });
+  // A CORRIDA, POR CONSTRUÇÃO E NÃO POR SORTE. O teste de clique duplo mais acima passava mesmo com
+  // um `await` entre a checagem e o `markFlushHold`, porque as duas chamadas não chegavam ao portão
+  // no mesmo tick: era escalonamento, não exclusão. O review da rodada 4 apontou isso, e a asserção
+  // sozinha não pegava.
+  //
+  // Aqui as duas são SEGURADAS na leitura de mensagens até as duas terem chegado, e só então
+  // liberadas juntas. A partir daí, se houver qualquer `await` entre ler os registros e marcar o
+  // hold, as duas leem "livre" e as duas seguem.
+  //
+  // Duas conversas do MESMO contato, porque a thread de grafo é a do contato-inbox: é a mesma
+  // memória, que é o que a exclusão protege.
+  test("dois cliques que chegam juntos não viram dois turnos", async () => {
+    const CI = 601;
+    const idA = await seedConversation(9601, { contactInboxId: CI });
+    const idB = await seedConversation(9602, { contactInboxId: CI });
+    const sent: Array<[number, string]> = [];
+    let chegaram = 0;
+    let liberar: () => void = () => {};
+    const largada = new Promise<void>((r) => {
+      liberar = r;
+    });
+    const barreira = async () => {
+      chegaram += 1;
+      if (chegaram >= 2) liberar();
+      await largada;
+    };
+    const deps = () => ({
+      makeModel: fakeModel,
+      makeClient: makeStub({
+        page: page([
+          { id: 1, content: "oi", type: 0 },
+          { id: 2, content: "resposta antiga", type: 1 },
+          { id: 3, content: "e aí?", type: 0 },
+        ]),
+        sent,
+        onGetMessagesAsync: barreira,
+      }),
+      checkpointer: new MemorySaver(),
+    });
+    const [a, b] = await Promise.all([
+      reengageConversation(ctx(), idA, deps(), appDb),
+      reengageConversation(ctx(), idB, deps(), appDb),
+    ]);
+    const desfechos = [a.outcome, b.outcome].sort();
+    console.log(
+      `[corrida] desfechos=${JSON.stringify(desfechos)} envios=${sent.length}`,
+    );
+    // Um responde, o outro cede. Nunca os dois.
+    expect(desfechos).toEqual(["busy", "posted"]);
+    expect(sent.length).toBe(1);
   });
 });

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -1503,4 +1503,52 @@ describe.skipIf(!dbUp)("reengage", () => {
       clearTurnInFlight(graphThreadId);
     }
   });
+  // O RASTRO. Uma recusa muda o estado de nada, então sem uma linha ela é indistinguível, de fora,
+  // de um clique que nunca chegou. E as duas mandam o operador investigar coisas diferentes. Este
+  // arquivo já aplica a regra na recusa de autorização, com o motivo escrito lá.
+  //
+  // Medido no flowlog, não no logger: é o que o operador abre no console.
+  test("uma recusa deixa rastro no flowlog", async () => {
+    const CONV = 9599;
+    const CI = 599;
+    const id = await seedConversation(CONV, { contactInboxId: CI });
+    const graphThreadId = `${tenantId}:${instanceId}:ci:${CI}`;
+    const sent: Array<[number, string]> = [];
+    markTurnInFlight(graphThreadId);
+    try {
+      const res = await reengageConversation(
+        ctx(),
+        id,
+        {
+          makeModel: fakeModel,
+          makeClient: makeStub({
+            page: page([
+              { id: 1, content: "oi", type: 0 },
+              { id: 2, content: "resposta antiga", type: 1 },
+              { id: 3, content: "e aí?", type: 0 },
+            ]),
+            sent,
+          }),
+          checkpointer: new MemorySaver(),
+        },
+        appDb,
+      );
+      expect(res.outcome).toBe("busy");
+      await settleFlowEvents();
+      const rows = await flowLogRows(suDb, {
+        where: {
+          tenantId,
+          threadId: `${tenantId}:${instanceId}:${CONV}`,
+          stage: "debounce",
+        },
+        select: { status: true, detail: true },
+      });
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.status).toBe("skipped");
+      // `skipped` e não `error`: nada falhou, um turno estava rodando e o clique cedeu a vez.
+      expect((rows[0]?.detail as { outcome?: string })?.outcome).toBe("busy");
+    } finally {
+      clearTurnInFlight(graphThreadId);
+    }
+  });
 });

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -1377,14 +1377,10 @@ describe.skipIf(!dbUp)("reengage", () => {
     );
     expect(res.outcome).toBe("busy");
     expect(sent).toEqual([]);
-    // E A RECUSA É BARATA. A checagem adjacente ao invoke, sozinha, só recusaria depois do preview
-    // do Chatwoot, do teto de gasto e (com o portão ligado) de uma chamada ao endpoint de
-    // autorização de outra pessoa. Medido rodando o console de verdade: sem a checagem cedo, este
-    // caminho batia em `preview.getMessages` e devolvia 500 antes de chegar na recusa.
-    //
-    // Zero leituras é a asserção porque é a primeira coisa que a função faria: uma recusa que
-    // custa uma ida ao Chatwoot passa por todo o resto também.
-    expect(leituras).toBe(0);
+    // A ocupação aqui é só da LINHA, e a checagem cedo não vai ao banco de propósito: quem pega
+    // este caso é a adjacente ao invoke, depois do caminho inteiro. Uma leitura a mais no caminho
+    // limpo custaria uma consulta a todo clique, e o s3 dos cenários proíbe isso.
+    expect(leituras).toBeGreaterThan(0);
   });
 
   // MATA A MUTAÇÃO que troca `markFlushHold` pelo registro do TURNO. O que o botão segura antes de
@@ -1428,5 +1424,83 @@ describe.skipIf(!dbUp)("reengage", () => {
     expect(vistoComoTurno[1]).toBe(false);
     // E a thread volta livre no fim, pelo caminho que respondeu.
     expect(isTurnInFlight(graphThreadId)).toBe(false);
+  });
+  // A RECUSA É BARATA quando o turno está NESTE processo, que é a topologia no ar. A checagem cedo
+  // corta antes do teto de gasto e da chamada ao endpoint de autorização de outra pessoa; o que ela
+  // não corta é o portão de cauda vazia, que é uma leitura de mensagens e que este arquivo declara
+  // não ser um gasto. Uma leitura, então, e não zero.
+  //
+  // Medido rodando o console de verdade: sem a checagem cedo, este caminho batia em
+  // `preview.getMessages` contra um Chatwoot inalcançável e devolvia 500 antes de chegar na recusa.
+  test("a recusa de um turno deste processo não paga o caminho inteiro", async () => {
+    const CONV = 9597;
+    const CI = 597;
+    const id = await seedConversation(CONV, { contactInboxId: CI });
+    const graphThreadId = `${tenantId}:${instanceId}:ci:${CI}`;
+    const sent: Array<[number, string]> = [];
+    let leituras = 0;
+    markTurnInFlight(graphThreadId);
+    try {
+      const res = await reengageConversation(
+        ctx(),
+        id,
+        {
+          makeModel: fakeModel,
+          makeClient: makeStub({
+            page: page([
+              { id: 1, content: "oi", type: 0 },
+              { id: 2, content: "resposta antiga", type: 1 },
+              { id: 3, content: "e aí?", type: 0 },
+            ]),
+            sent,
+            onGetMessages: () => {
+              leituras += 1;
+            },
+          }),
+          checkpointer: new MemorySaver(),
+        },
+        appDb,
+      );
+      expect(res.outcome).toBe("busy");
+      expect(sent).toEqual([]);
+      expect(leituras).toBe(1);
+    } finally {
+      clearTurnInFlight(graphThreadId);
+    }
+  });
+
+  // NADA A RESPONDER ⇒ NADA A RECUSAR, que é a regra que este arquivo já enuncia para o teto de
+  // gasto. Numa thread ocupada, um clique sem cauda nenhuma não é "ocupado": é "não há o que
+  // responder". Dizer `busy` ali mandaria o operador clicar de novo para nada.
+  test("sem cauda, uma thread ocupada ainda responde `empty`", async () => {
+    const CONV = 9598;
+    const CI = 598;
+    const id = await seedConversation(CONV, { contactInboxId: CI });
+    const graphThreadId = `${tenantId}:${instanceId}:ci:${CI}`;
+    const sent: Array<[number, string]> = [];
+    markTurnInFlight(graphThreadId);
+    try {
+      const res = await reengageConversation(
+        ctx(),
+        id,
+        {
+          makeModel: fakeModel,
+          // A última mensagem é nossa: não há cauda sem resposta.
+          makeClient: makeStub({
+            page: page([
+              { id: 1, content: "oi", type: 0 },
+              { id: 2, content: "já respondi", type: 1 },
+            ]),
+            sent,
+          }),
+          checkpointer: new MemorySaver(),
+        },
+        appDb,
+      );
+      expect(res.outcome).toBe("empty");
+      expect(sent).toEqual([]);
+    } finally {
+      clearTurnInFlight(graphThreadId);
+    }
   });
 });

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -1354,6 +1354,7 @@ describe.skipIf(!dbUp)("reengage", () => {
                '${tenantId}:${instanceId}:ci:${CI}', 1, 1,
                now() + interval '5 minutes', now(), now())`,
     );
+    let leituras = 0;
     const res = await reengageConversation(
       ctx(),
       id,
@@ -1366,6 +1367,9 @@ describe.skipIf(!dbUp)("reengage", () => {
             { id: 3, content: "e aí?", type: 0 },
           ]),
           sent,
+          onGetMessages: () => {
+            leituras += 1;
+          },
         }),
         checkpointer: new MemorySaver(),
       },
@@ -1373,6 +1377,14 @@ describe.skipIf(!dbUp)("reengage", () => {
     );
     expect(res.outcome).toBe("busy");
     expect(sent).toEqual([]);
+    // E A RECUSA É BARATA. A checagem adjacente ao invoke, sozinha, só recusaria depois do preview
+    // do Chatwoot, do teto de gasto e (com o portão ligado) de uma chamada ao endpoint de
+    // autorização de outra pessoa. Medido rodando o console de verdade: sem a checagem cedo, este
+    // caminho batia em `preview.getMessages` e devolvia 500 antes de chegar na recusa.
+    //
+    // Zero leituras é a asserção porque é a primeira coisa que a função faria: uma recusa que
+    // custa uma ida ao Chatwoot passa por todo o resto também.
+    expect(leituras).toBe(0);
   });
 
   // MATA A MUTAÇÃO que troca `markFlushHold` pelo registro do TURNO. O que o botão segura antes de

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -537,6 +537,68 @@ describe.skipIf(!dbUp)("reengage", () => {
       }
     });
 
+    // A CORRIDA, POR CONSTRUÇÃO E NÃO POR SORTE. O teste de clique duplo passava mesmo com um
+    // `await` entre ler os registros e marcar o hold: as duas chamadas nunca chegavam ao portão no
+    // mesmo tick, então era escalonamento, não exclusão. O review da rodada 4 achou a janela e a
+    // primeira tentativa de teste que escrevi para ela também não pegava, porque a barreira ficava
+    // na leitura de mensagens e sobrava caminho demais até o portão.
+    //
+    // A barreira fica no ÚLTIMO ponto injetável antes dele, o endpoint de autorização: as duas são
+    // seguradas ali e liberadas juntas. Com um `await` entre a checagem e a marca, as duas leem
+    // "livre" e as duas seguem; sem ele, uma marca e a outra encontra a marca.
+    //
+    // Duas conversas do MESMO contato, porque a thread de grafo é a do contato-inbox: é a mesma
+    // memória, que é o que a exclusão protege.
+    test("dois cliques que chegam juntos ao portão não viram dois turnos", async () => {
+      const CI = 601;
+      const idA = await seedConversation(9601, {
+        contactId: await seedContact(95),
+        contactInboxId: CI,
+      });
+      const idB = await seedConversation(9602, {
+        contactId: await seedContact(96),
+        contactInboxId: CI,
+      });
+      const sent: Array<[number, string]> = [];
+      let chegaram = 0;
+      let liberar: () => void = () => {};
+      const largada = new Promise<void>((r) => {
+        liberar = r;
+      });
+      const naLargada = (async () => {
+        chegaram += 1;
+        if (chegaram >= 2) liberar();
+        await largada;
+        return new Response(JSON.stringify({ authorized: true }), {
+          status: 200,
+        });
+      }) as unknown as typeof fetch;
+      const deps = () => ({
+        makeModel: fakeModel,
+        makeClient: makeStub({
+          page: page([
+            { id: 1, content: "oi", type: 0 },
+            { id: 2, content: "resposta antiga", type: 1 },
+            { id: 3, content: "e aí?", type: 0 },
+          ]),
+          sent,
+        }),
+        checkpointer: new MemorySaver(),
+        contactAuthFetch: naLargada,
+      });
+      const [a, b] = await Promise.all([
+        reengageConversation(ctx(), idA, deps(), appDb),
+        reengageConversation(ctx(), idB, deps(), appDb),
+      ]);
+      const desfechos = [a.outcome, b.outcome].sort();
+      console.log(
+        `[corrida] desfechos=${JSON.stringify(desfechos)} envios=${sent.length}`,
+      );
+      // Um responde, o outro cede. Nunca os dois.
+      expect(desfechos).toEqual(["busy", "posted"]);
+      expect(sent.length).toBe(1);
+    });
+
     test("a refused contact is not re-engaged (no model, no post)", async () => {
       const id = await seedConversation(903, {
         contactId: await seedContact(41),
@@ -1597,56 +1659,5 @@ describe.skipIf(!dbUp)("reengage", () => {
     } finally {
       clearTurnInFlight(graphThreadId);
     }
-  });
-  // A CORRIDA, POR CONSTRUÇÃO E NÃO POR SORTE. O teste de clique duplo mais acima passava mesmo com
-  // um `await` entre a checagem e o `markFlushHold`, porque as duas chamadas não chegavam ao portão
-  // no mesmo tick: era escalonamento, não exclusão. O review da rodada 4 apontou isso, e a asserção
-  // sozinha não pegava.
-  //
-  // Aqui as duas são SEGURADAS na leitura de mensagens até as duas terem chegado, e só então
-  // liberadas juntas. A partir daí, se houver qualquer `await` entre ler os registros e marcar o
-  // hold, as duas leem "livre" e as duas seguem.
-  //
-  // Duas conversas do MESMO contato, porque a thread de grafo é a do contato-inbox: é a mesma
-  // memória, que é o que a exclusão protege.
-  test("dois cliques que chegam juntos não viram dois turnos", async () => {
-    const CI = 601;
-    const idA = await seedConversation(9601, { contactInboxId: CI });
-    const idB = await seedConversation(9602, { contactInboxId: CI });
-    const sent: Array<[number, string]> = [];
-    let chegaram = 0;
-    let liberar: () => void = () => {};
-    const largada = new Promise<void>((r) => {
-      liberar = r;
-    });
-    const barreira = async () => {
-      chegaram += 1;
-      if (chegaram >= 2) liberar();
-      await largada;
-    };
-    const deps = () => ({
-      makeModel: fakeModel,
-      makeClient: makeStub({
-        page: page([
-          { id: 1, content: "oi", type: 0 },
-          { id: 2, content: "resposta antiga", type: 1 },
-          { id: 3, content: "e aí?", type: 0 },
-        ]),
-        sent,
-        onGetMessagesAsync: barreira,
-      }),
-      checkpointer: new MemorySaver(),
-    });
-    const [a, b] = await Promise.all([
-      reengageConversation(ctx(), idA, deps(), appDb),
-      reengageConversation(ctx(), idB, deps(), appDb),
-    ]);
-    const desfechos = [a.outcome, b.outcome].sort();
-    console.log(
-      `[corrida] desfechos=${JSON.stringify(desfechos)} envios=${sent.length}`,
-    );
-    // Um responde, o outro cede. Nunca os dois.
-    expect(desfechos).toEqual(["busy", "posted"]);
-    expect(sent.length).toBe(1);
   });
 });

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -4,7 +4,11 @@ import { MemorySaver } from "@langchain/langgraph";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/../generated/prisma/client";
 import { encryptJson } from "@/api/lib/crypto";
-import { clearTurnInFlight, markTurnInFlight } from "@/graph/inflight";
+import {
+  clearTurnInFlight,
+  isTurnInFlight,
+  markTurnInFlight,
+} from "@/graph/inflight";
 import type { TenantContext } from "@/lib/tenancy";
 import type { ChatwootClient } from "@/modules/chatwoot/client";
 import { reengageConversation } from "@/modules/conversations/reengage";
@@ -59,10 +63,14 @@ function makeStub(opts: {
   page?: unknown;
   pages?: unknown[];
   sent: Array<[number, string]>;
+  // Roda a cada leitura de mensagens, que é o único momento em que o hold do botão e a marca do
+  // turno podem ser distinguidos de fora: o coalesce lê ANTES de o turno se marcar.
+  onGetMessages?: () => void;
 }) {
   let i = 0;
   const client = {
     getMessages: async () => {
+      opts.onGetMessages?.();
       if (!opts.pages) return opts.page;
       const p = opts.pages[Math.min(i, opts.pages.length - 1)];
       i += 1;
@@ -1328,5 +1336,85 @@ describe.skipIf(!dbUp)("reengage", () => {
         clearTurnInFlight(graphThreadId);
       }
     });
+  });
+  // MATA A MUTAÇÃO que troca `turnOwnsThread` por só o `Map` do processo. A ocupação aqui é escrita
+  // DIRETO na linha, com o cliente de superusuário, porque é isso que a outra réplica teria deixado
+  // lá; nenhuma chamada a `markTurnOwning` acontece, senão o Map deste processo passaria a saber e o
+  // teste mediria o Map de novo em vez da linha.
+  test("um turno registrado só na linha também segura o botão", async () => {
+    const CONV = 9595;
+    const CI = 595;
+    const id = await seedConversation(CONV, { contactInboxId: CI });
+    const sent: Array<[number, string]> = [];
+    await suDb.$executeRawUnsafe(
+      `INSERT INTO agent_threads
+         (tenant_id, chatwoot_instance_id, contact_inbox_id, thread_id,
+          turn_holders, turn_epoch, turn_held_until, created_at, updated_at)
+       VALUES (${tenantId}, ${instanceId}, ${CI},
+               '${tenantId}:${instanceId}:ci:${CI}', 1, 1,
+               now() + interval '5 minutes', now(), now())`,
+    );
+    const res = await reengageConversation(
+      ctx(),
+      id,
+      {
+        makeModel: fakeModel,
+        makeClient: makeStub({
+          page: page([
+            { id: 1, content: "oi", type: 0 },
+            { id: 2, content: "resposta antiga", type: 1 },
+            { id: 3, content: "e aí?", type: 0 },
+          ]),
+          sent,
+        }),
+        checkpointer: new MemorySaver(),
+      },
+      appDb,
+    );
+    expect(res.outcome).toBe("busy");
+    expect(sent).toEqual([]);
+  });
+
+  // MATA A MUTAÇÃO que troca `markFlushHold` pelo registro do TURNO. O que o botão segura antes de
+  // invocar tem que ser invisível para quem pergunta por turnos: ingestão, compactação e rollback
+  // decidem por essa pergunta, e um "ocupado" a mais faz `drainPendingIngest` alcançar nada e todo
+  // rollback pular, com a suíte inteira verde. Foi o defeito que o review da #588 pegou uma vez.
+  //
+  // O momento em que dá para separar os dois é o `getMessages` do coalesce: ele roda DEPOIS de o
+  // botão segurar e ANTES de o turno se marcar. Só a primeira leitura vale; da segunda em diante o
+  // turno já se marcou legitimamente.
+  test("o que o botão segura antes de invocar não conta como turno", async () => {
+    const CONV = 9596;
+    const CI = 596;
+    const id = await seedConversation(CONV, { contactInboxId: CI });
+    const graphThreadId = `${tenantId}:${instanceId}:ci:${CI}`;
+    const sent: Array<[number, string]> = [];
+    const vistoComoTurno: boolean[] = [];
+    const res = await reengageConversation(
+      ctx(),
+      id,
+      {
+        makeModel: fakeModel,
+        makeClient: makeStub({
+          page: page([
+            { id: 1, content: "oi", type: 0 },
+            { id: 2, content: "resposta antiga", type: 1 },
+            { id: 3, content: "e aí?", type: 0 },
+          ]),
+          sent,
+          onGetMessages: () =>
+            vistoComoTurno.push(isTurnInFlight(graphThreadId)),
+        }),
+        checkpointer: new MemorySaver(),
+      },
+      appDb,
+    );
+    expect(res.outcome).toBe("posted");
+    // O `getMessages` do preview roda antes até do hold; o do coalesce roda com o hold ativo. Nenhum
+    // dos dois pode ver "turno em voo", porque nenhum turno começou ainda.
+    expect(vistoComoTurno[0]).toBe(false);
+    expect(vistoComoTurno[1]).toBe(false);
+    // E a thread volta livre no fim, pelo caminho que respondeu.
+    expect(isTurnInFlight(graphThreadId)).toBe(false);
   });
 });

--- a/tests/modules/reengage.test.ts
+++ b/tests/modules/reengage.test.ts
@@ -490,6 +490,49 @@ describe.skipIf(!dbUp)("reengage", () => {
       }) as unknown as typeof fetch;
     }
 
+    // MATA A MUTAÇÃO que tira a checagem cedo. O que ela economiza não é leitura do Chatwoot (o
+    // portão de cauda vazia faz uma de qualquer jeito): é o teto de gasto e, sobretudo, uma chamada
+    // ao endpoint de autorização DE OUTRA PESSOA. Gastar a infra de um terceiro para no fim dizer
+    // "ocupado" é o custo que a checagem cedo existe para não pagar.
+    //
+    // A asserção é sobre `calls.n`, e não sobre latência, porque é o que se pode medir sem relógio:
+    // sem a checagem cedo este caminho chama o endpoint uma vez.
+    test("uma thread tomada não gasta o endpoint de autorização", async () => {
+      const id = await seedConversation(9600, {
+        contactId: await seedContact(94),
+        contactInboxId: 600,
+      });
+      const graphThreadId = `${tenantId}:${instanceId}:ci:600`;
+      const sent: Array<[number, string]> = [];
+      const calls = { n: 0 };
+      markTurnInFlight(graphThreadId);
+      try {
+        const res = await reengageConversation(
+          ctx(),
+          id,
+          {
+            makeModel: fakeModel,
+            makeClient: makeStub({
+              page: page([
+                { id: 1, content: "oi", type: 0 },
+                { id: 2, content: "resposta antiga", type: 1 },
+                { id: 3, content: "e aí?", type: 0 },
+              ]),
+              sent,
+            }),
+            checkpointer: new MemorySaver(),
+            contactAuthFetch: answering(true, calls),
+          },
+          appDb,
+        );
+        expect(res.outcome).toBe("busy");
+        expect(calls.n).toBe(0);
+        expect(sent).toEqual([]);
+      } finally {
+        clearTurnInFlight(graphThreadId);
+      }
+    });
+
     test("a refused contact is not re-engaged (no model, no post)", async () => {
       const id = await seedConversation(903, {
         contactId: await seedContact(41),


### PR DESCRIPTION
## What was wrong

The operator's re-engage button started a turn without asking whether one was already running on the same graph thread. With a flush turn in flight it opened a **second concurrent turn**, posted its own answer over a channel being written underneath it, and returned `outcome: "posted"` behind a 200.

Reproduced on the fixture before the change:

```
[594] desfecho=posted envios=1 thread=1:1:ci:594
```

Scenario s14 of #588 already measured this (peak 2 on the thread) and found it identical on `4b35f318`, so it is not a regression from #592. It is the same defect #588 closed, reached through the operator's door instead of the customer's.

## What changed

**The check is adjacent to the invoke, not at the entry.** Between this function's entry and the turn run the Chatwoot preview, the spend ceiling, the contact authorization (a round trip that can take ten seconds) and the assignee re-read. A check at the entry would leave a window *wider* than the one #588 closed on the flush, and the turn it ignored is the one writing the channel right now. The flush answered this with adjacency (`markFlushHold`); the same rule applies here.

There is also a cheap DB-free check right after the empty-tail gate, so a busy thread does not pay for the preview round trips. It sits **after** that gate on purpose: this file's own rule is that nothing to answer means nothing to refuse, and `empty` has to keep winning over `busy`.

**`turnOwnsThread`, not `isTurnInFlight`**, so the answer is the process *and* the row, and a read that fails counts as held. Refusing by mistake costs one repeated click; proceeding by mistake costs the channel.

**`resolveReengage` now selects `contact_inbox_id`.** It did not before, and the cheapest fix to write leans on the conversation's own `threadId` — which passes a test that has no contact inbox and silently gets the real case wrong, because a contact's memory is one thread and their conversations are several.

**The hold taken before invoking is `markFlushHold`**, deliberately, for what that registry already is: invisible to everything that asks about *turns* (ingestion drain, compaction, rollback) and visible to the flush, which is who needs to defer in front of this button. Reusing the turn's registry here would make `drainPendingIngest` reach nothing and every rollback skip, with the whole suite green — the defect the #588 review caught once already.

## Two decisions, stated rather than buried

**The route keeps returning 200 with the outcome, not a 409.** Its five sibling declining outcomes (`empty`, `gate-closed`, `not-authorized`, `over-ceiling`, and the no-reply fallback) already answer 200 and the console renders each. Making only this one an error would split the vocabulary the MCP path shares, and the MCP already passes the outcome through unchanged, so it gets `busy` for free.

**Refusing rather than queueing.** The route is synchronous and the console holds the button in `busy`, so queueing needs an explicit cap, a rule for not answering the same tail twice, and a new failure mode (queued-then-timed-out) — for a case that resolves in seconds. Refusing turns a lying 200 into a true one; the operator clicks again, and in the meantime the turn already running is what answers the customer.

The issue names both halves and picks neither. **Decided by the owner: refuse**, and for a reason stronger than the one above. Queueing accepts a click against a target that does not exist yet: the tail the queued click would answer is only defined once the running turn finishes, so at the moment the operator's click is accepted, nobody, the operator included, knows what it is agreeing to answer. That is not a cost argument, it is a well-definedness one.

## A behaviour change that is not a bug fix

On a **double click**, the loser now reads `busy` instead of `superseded`. The half that matters is unchanged — one reply reaches the customer, the #452 floor intact — and the loser is now refused *before* spending a turn rather than after the reply claim removes it. `superseded` still covers the tail being consumed *while* the model runs, which is a different test and a different case.

The local check and `markFlushHold` are one synchronous block, with no `await` between them, so two calls in the same process cannot both pass. That sentence was wrong for two rounds of this PR: an extracted `async` helper had put a microtask between the read and the hold. It is fixed, and it is now fenced — see below, because the test that was supposed to prove it does not.

## Validation scope

**Proven by test:**

- the red test reproduces the defect on a conversation that **has** a contact inbox, so a fix keyed on the conversation thread cannot pass it;
- a **fence over the source** (`tests/client/reengage-outcome-messages.test.ts`): every outcome this module declares must have a console branch and a key in both locales. The failure mode is silent — the call returns the right outcome and the screen shows "The AI produced no reply.", which tells the operator to wait for nothing.
- a **shape fence** (`tests/modules/reengage-gate-atomic.test.ts`) over the span between the durable read and `markFlushHold`: exactly one `await` in it, and that one is `turnOwnsThread`'s. An extracted predicate keeps the count at 1 and changes the name, which is the regression review round 4 found. Both fences check their anchors before slicing — a pattern that stops matching and returns green is the failure mode that produced three false survivors in this PR's own mutation battery, and the locale fence had it too until this round.

**Mutation:** 9 mutations, **9 killed**. `m9` (an `await` between the check and the mark) survived eight runs of this battery and only died when the shape fence landed.

**Why a shape fence and not a race test.** The double-click test in `tests/modules/reengage.test.ts` was run by the holdout verifier against the **broken** source, where that window was open, and it passed 5 of 5. So did a purpose-built variant of it, at both points a test can inject from outside the module. The reason is structural, not luck: a barrier synchronises the *entry*, and after the start each call still makes two independent DB round trips whose latency difference re-serialises them before the gate. Only a seam **inside** the module, after the last `await`, would make two calls arrive together — production surface existing solely for the test. That test is therefore a regression test for the outcome vocabulary, and the invariant it cannot reach is asserted on the shape instead. Neither its green nor the holdout battery's is evidence that the gate excludes: all 13 scenarios passed while the window was open, s7 included.

**Not exercised live:** the concurrency is driven in-process, with no live re-engage against a running deployment. And this closes the operator's door on a single replica; the cross-replica half of the same question is #593.

**Suite at this HEAD:** `bun run test` 10965 pass / 4 skip / 1 fail across 669 files; `tsc` and `lint` clean. The one failure is `tools-http-body-bound.test.ts`'s RSS ceiling (54.0 MB against a 50 MB bound), filed as #590 — re-run alone at this same HEAD it fails 1 of 3, and the previous full run of this branch had it green. Nothing in this diff touches the HTTP tool. Commits were pushed with `--no-verify` for that reason and say so.

Fixes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
