### PR TITLE
The body-bound ceiling sat inside the noise, and the quantity that separates was read before its collection

### DIFF
--- a/tests/graph/tools-http-body-bound.test.ts
+++ b/tests/graph/tools-http-body-bound.test.ts
@@ -203,18 +203,32 @@ test("a body far larger than memory allows is never retained whole", async () =>
         }), { status: 200 }),
       },
     );
-    Bun.gc(true);
-    const before = process.memoryUsage().rss;
-    const heapBefore = heapStats().extraMemorySize;
+    // ONE SPELLING OF THE COLLECTION, and that is what makes the control below able to guard it.
+    // Both numbers report the LAST COLLECTION's accounting, and the body this test is about is
+    // external to it until one runs: read without forcing one, the defect grows them by exactly
+    // zero, which is how the heap quantity got written off the first time round. Written as a
+    // helper so the collection cannot be dropped for one reading and kept for another - remove it
+    // here and every reading goes stale at once, which is exactly what the control catches.
+    const medir = () => {
+      Bun.gc(true);
+      return { rss: process.memoryUsage().rss, extra: heapStats().extraMemorySize };
+    };
+    const a = medir();
     const out = String(await tool.invoke({}));
-    // THE COLLECTION BEFORE THE READING, not only before the baseline. Both numbers report the last
-    // collection's accounting, and the body this test is about is external to it until one runs:
-    // without this line the defect reads as zero growth, which is how the heap quantity got written
-    // off the first time round.
-    Bun.gc(true);
-    const grew = process.memoryUsage().rss - before;
-    const extra = heapStats().extraMemorySize - heapBefore;
-    console.log(JSON.stringify({ grew, extra, len: out.length }));
+    const b = medir();
+    // POSITIVE CONTROL, in the same process and through the same helper: a body we ARE holding.
+    // Every assertion in this test is an upper bound, and an instrument that stopped measuring
+    // satisfies all of them. This is the one lower bound, and it is what tells "the cap worked"
+    // from "the number stopped moving".
+    const retido = "y".repeat(40 * MB);
+    const c = medir();
+    console.log(JSON.stringify({
+      grew: b.rss - a.rss,
+      extra: b.extra - a.extra,
+      control: c.extra - b.extra,
+      len: out.length,
+      held: retido.length,
+    }));
   `;
   const proc = Bun.spawn(["bun", "-e", script], {
     cwd: process.cwd(),
@@ -229,13 +243,23 @@ test("a body far larger than memory allows is never retained whole", async () =>
   // whole assertion lives over there, so a probe that stops printing has to be a failure that says
   // so, naming the exit code and whatever the process managed to say.
   const line = out.trim().split("\n").at(-1) ?? "";
-  let got: { grew: number; extra: number; len: number } | null = null;
+  let got: {
+    grew: number;
+    extra: number;
+    control: number;
+    len: number;
+  } | null = null;
   try {
     got = JSON.parse(line) as typeof got;
   } catch {
     got = null;
   }
-  if (!got || typeof got.grew !== "number" || typeof got.extra !== "number") {
+  if (
+    !got ||
+    typeof got.grew !== "number" ||
+    typeof got.extra !== "number" ||
+    typeof got.control !== "number"
+  ) {
     throw new Error(
       `the memory probe printed no measurement (exit ${code}); stdout: ${out.slice(-400) || "(empty)"}; stderr: ${err.slice(-400) || "(empty)"}`,
     );
@@ -250,4 +274,8 @@ test("a body far larger than memory allows is never retained whole", async () =>
   // resident — so the ceiling clears the worst green ever measured here (57.2 MB, under parallel
   // load) by a factor of three, and still sits four times under the defect's 631 MB.
   expect(got.grew).toBeLessThan(180 * 1024 * 1024);
+  // THE INSTRUMENT IS LIVE. Every other assertion here is an upper bound, and a measurement that
+  // stopped moving satisfies all of them; 40 MB deliberately held is the one lower bound, and it is
+  // what tells "the cap worked" from "the number stopped working".
+  expect(got.control).toBeGreaterThan(30 * 1024 * 1024);
 }, 180_000);

--- a/tests/graph/tools-http-body-bound.test.ts
+++ b/tests/graph/tools-http-body-bound.test.ts
@@ -185,6 +185,17 @@ describe("what the operator is told when the body itself was cut", () => {
 // So RSS stays, with a ceiling that clears the noise by a factor of three, because it is the
 // quantity that matches the harm (the process dies); and `extraMemorySize` is added with a tight
 // one, because it is the quantity that separates. A defect has to beat both.
+//
+// NEITHER IS REDUNDANT, and this is the part to read before deleting one of them. The tight
+// quantity measures what is still HELD when the collection runs, not what was allocated on the way
+// there. A mutation that buffers the whole body and then materialises the prefix, so the big string
+// is collectable by the time anything is read, puts `extraMemorySize` back at 1.01 MB — green — and
+// 632 MB in RSS. The process still dies; only RSS sees it.
+//
+// And the reason the literal defect IS caught by the tight one is a runtime detail, not a law:
+// `clipText` ends in `value.slice(0, max)`, and a JSC substring retains its parent buffer. The day
+// that slice materialises, `extraMemorySize` goes green with the #464 defect fully present and RSS
+// is what is left. The precise assertion is the one that leans on someone else's implementation.
 test("a body far larger than memory allows is never retained whole", async () => {
   const script = `
     import { buildHttpTool } from "@/graph/tools/http";

--- a/tests/graph/tools-http-body-bound.test.ts
+++ b/tests/graph/tools-http-body-bound.test.ts
@@ -243,14 +243,15 @@ test("a body far larger than memory allows is never retained whole", async () =>
   // whole assertion lives over there, so a probe that stops printing has to be a failure that says
   // so, naming the exit code and whatever the process managed to say.
   const line = out.trim().split("\n").at(-1) ?? "";
-  let got: {
+  type Medida = {
     grew: number;
     extra: number;
     control: number;
     len: number;
-  } | null = null;
+  };
+  let got: Medida | null = null;
   try {
-    got = JSON.parse(line) as typeof got;
+    got = JSON.parse(line) as Medida;
   } catch {
     got = null;
   }

--- a/tests/graph/tools-http-body-bound.test.ts
+++ b/tests/graph/tools-http-body-bound.test.ts
@@ -162,12 +162,33 @@ describe("what the operator is told when the body itself was cut", () => {
 // Measured on `main` against a local server: 1,438 MiB of resident memory from a single call, three
 // seconds in and still climbing.
 //
-// IN A SUBPROCESS, and measuring RSS rather than `heapUsed`. The decoded body lives in native
-// memory: the same probe that showed 1.4 GiB of RSS showed the JS heap growing by 0.5 MiB, so a
-// heap-based threshold would be green with the defect fully present.
+// IN A SUBPROCESS, because the question is about a whole process's memory.
+//
+// TWO QUANTITIES, and the pair is the point. This test used to assert on RSS alone against a 50 MB
+// ceiling, and that ceiling sat INSIDE the noise: fourteen isolated runs on one machine spread from
+// 40.5 MB to 57.2 MB, seven of ten over the line, three of four over it under parallel load (#590).
+// A red pre-commit on unrelated work is worse than a slow test, because it teaches everyone to pass
+// `--no-verify` and the next real failure in this file gets the same shrug.
+//
+// The header here used to say a heap threshold "would be green with the defect fully present",
+// citing a probe that showed 1.4 GiB of RSS against 0.5 MiB of JS heap. That observation is
+// reproducible and its conclusion was wrong by one line: `heapUsed` and `heapStats()` report the
+// LAST COLLECTION's accounting, and the 300 MB string is external to it until one runs. Read
+// without forcing a collection, the defect grows the heap by exactly zero. Force it first and the
+// same defect grows `extraMemorySize` by 314.9 MB. Measured both ways, five runs each side:
+//
+//   quantity (after Bun.gc(true))   cap in place            cap removed       ratio   max/min green
+//   rss                             40.40 - 51.31 MB        631.1 - 631.6 MB   12.3x   1.27
+//   heapStats().heapSize             1.493 -  1.502 MB      315.014 MB        210x    1.0058
+//   heapStats().extraMemorySize      1.36205 - 1.36210 MB   314.876 MB        231x    1.00003
+//
+// So RSS stays, with a ceiling that clears the noise by a factor of three, because it is the
+// quantity that matches the harm (the process dies); and `extraMemorySize` is added with a tight
+// one, because it is the quantity that separates. A defect has to beat both.
 test("a body far larger than memory allows is never retained whole", async () => {
   const script = `
     import { buildHttpTool } from "@/graph/tools/http";
+    import { heapStats } from "bun:jsc";
     const MB = 1024 * 1024;
     // ONE buffer, enqueued many times: the producer allocates 1 MB and the consumer decodes each
     // chunk transiently, so the only thing that could hold 300 MB is the accumulator under test.
@@ -184,9 +205,16 @@ test("a body far larger than memory allows is never retained whole", async () =>
     );
     Bun.gc(true);
     const before = process.memoryUsage().rss;
+    const heapBefore = heapStats().extraMemorySize;
     const out = String(await tool.invoke({}));
+    // THE COLLECTION BEFORE THE READING, not only before the baseline. Both numbers report the last
+    // collection's accounting, and the body this test is about is external to it until one runs:
+    // without this line the defect reads as zero growth, which is how the heap quantity got written
+    // off the first time round.
+    Bun.gc(true);
     const grew = process.memoryUsage().rss - before;
-    console.log(JSON.stringify({ grew, len: out.length }));
+    const extra = heapStats().extraMemorySize - heapBefore;
+    console.log(JSON.stringify({ grew, extra, len: out.length }));
   `;
   const proc = Bun.spawn(["bun", "-e", script], {
     cwd: process.cwd(),
@@ -194,10 +222,32 @@ test("a body far larger than memory allows is never retained whole", async () =>
     stderr: "pipe",
   });
   const out = await new Response(proc.stdout).text();
-  const line = out.trim().split("\n").at(-1) as string;
-  const got = JSON.parse(line) as { grew: number; len: number };
+  const err = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  // A SUBPROCESS THAT DIED MEASURED NOTHING, and the difference matters: `JSON.parse("")` throws
+  // "Unexpected end of JSON input", which reads as a broken test rather than as an unrun one. The
+  // whole assertion lives over there, so a probe that stops printing has to be a failure that says
+  // so, naming the exit code and whatever the process managed to say.
+  const line = out.trim().split("\n").at(-1) ?? "";
+  let got: { grew: number; extra: number; len: number } | null = null;
+  try {
+    got = JSON.parse(line) as typeof got;
+  } catch {
+    got = null;
+  }
+  if (!got || typeof got.grew !== "number" || typeof got.extra !== "number") {
+    throw new Error(
+      `the memory probe printed no measurement (exit ${code}); stdout: ${out.slice(-400) || "(empty)"}; stderr: ${err.slice(-400) || "(empty)"}`,
+    );
+  }
   // The model still gets its clipped view — the cap is on what is read, not on what is answered.
   expect(got.len).toBeLessThan(5_000);
-  // Retaining 300 MB shows up as hundreds of MB of RSS; the cap keeps it in the low tens.
-  expect(got.grew).toBeLessThan(50 * 1024 * 1024);
+  // THE QUANTITY THAT SEPARATES. Retaining the body puts 314.9 MB here against 1.36 MB with the cap,
+  // and that 1.36 MB moved by 47 bytes across five runs. 20 MB is fourteen times the measured green
+  // and fifteen times under the measured defect.
+  expect(got.extra).toBeLessThan(20 * 1024 * 1024);
+  // THE QUANTITY THAT MATCHES THE HARM. Ambient by nature — it carries whatever the runtime had
+  // resident — so the ceiling clears the worst green ever measured here (57.2 MB, under parallel
+  // load) by a factor of three, and still sits four times under the defect's 631 MB.
+  expect(got.grew).toBeLessThan(180 * 1024 * 1024);
 }, 180_000);


### PR DESCRIPTION
## What was wrong

`tests/graph/tools-http-body-bound.test.ts` → "a body far larger than memory allows is never retained whole" asserted on RSS against a 50 MB ceiling, and that ceiling sat **inside the noise**. At the base of this branch the test failed 3 of 3 isolated runs; across fourteen isolated runs on one machine the measured value spread 40.5 MB to 57.2 MB, seven of ten over the line, three of four over it under parallel load.

The issue estimated the margin at about 1%. Measured, it is worse than that: the ceiling is below most of the distribution, not near its edge.

A red pre-commit on unrelated work is worse than a slow test. It teaches everyone to pass `--no-verify`, and the next real failure in that file gets the same shrug.

## What changed

**A second quantity, and the pair is the point.** `heapStats().extraMemorySize` is asserted with a tight ceiling alongside RSS with a generous one. Measured, five runs per side, after a forced collection:

| quantity | cap in place | cap removed | ratio | max/min green |
| --- | --- | --- | --- | --- |
| rss | 40.40 – 51.31 MB | 631.1 – 631.6 MB | 12.3x | 1.27 |
| `heapStats().heapSize` | 1.493 – 1.502 MB | 315.014 MB | 210x | 1.0058 |
| **`extraMemorySize`** | **1.36205 – 1.36210 MB** | **314.876 MB** | **231x** | **1.00003** |

**The collection goes before the reading, not only before the baseline.** The file's header said a heap threshold "would be green with the defect fully present", citing a probe that showed 1.4 GiB of RSS against 0.5 MiB of JS heap. That observation reproduces exactly, and its conclusion was wrong by one line: `heapUsed` and `heapStats()` report the **last collection's** accounting, and the buffered body is external to it until one runs. Read with no forced collection, the defect grows the heap by literally zero. Force it first and the same defect grows `extraMemorySize` by 314.9 MB. The header is corrected in place, since it is the reason nobody tried heap again.

**One spelling of the collection, plus a positive control.** Every assertion in this test is an upper bound, and a measurement stuck at zero satisfies all of them. The mutation battery caught that the first version of this fix had exactly that hole: removing the forced collection left everything green. The collection now lives in one `medir()` helper, so it cannot be dropped for one reading and kept for another, and the probe holds 40 MB on purpose and asserts the quantity moved by at least 30 MB. That is the only lower bound in the file, and the only assertion a dead instrument fails instead of passing.

**A subprocess that died measured nothing.** `JSON.parse("")` throws "Unexpected end of JSON input", which reads as a broken test rather than an unrun one. A missing measurement now names the exit code and whatever the process managed to print.

## Why both ceilings stay

Neither is redundant, and the reason is measured rather than argued.

The tight quantity measures what is still **held** when the collection runs, not the peak on the way there. A mutation that buffers the whole body like the real defect but materialises the prefix copy, so the big string is collectable by the time anything is read, puts `extraMemorySize` back at 1.01 MB (green) and RSS at 632 MB. The process still dies; only the ambient quantity sees it.

And the reason the literal #464 defect **is** caught by the tight one is a runtime detail, not a law: `clipText` ends in `value.slice(0, max)`, and a JSC substring retains its parent buffer. The day that slice materialises, `extraMemorySize` goes green with the defect fully present and RSS is what is left.

## Validation scope

**Red at base** (`49ecc1dc`): 3 of 3 isolated runs failed, `Received: 53018624` / `53100544` / `53018624` against the 50 MB ceiling.

**Mutation:** 6 valid mutants, **all killed**.

| mutant | killed by | received |
| --- | --- | --- |
| the accumulator retains the body (cap guard removed) | `extra` | 314.9 MB |
| `res.text()`, the literal #464 defect | `extra` | 314.9 MB |
| buffer-then-release (peak, not retention) | **`rss`** | 632.3 MB |
| the subprocess dies before measuring | missing measurement | — |
| the probe stops printing | missing measurement | — |
| the forced collection leaves `medir()` | **positive control** | 0 |

Three further mutants loosen the test's own assertion constants and survive. They are listed rather than dropped, because a test cannot detect the weakening of its own assertion and the distinction is worth being on the record instead of counted as coverage.

**Margins**, over 18 green runs (10 isolated, 8 under 4-way parallel load) and 6 mutated:

| | `extraMemorySize` | RSS |
| --- | --- | --- |
| worst green | 1,369,048 B | 57.4 MB |
| best mutated | 314.9 MB | 631.1 MB |
| ceiling | 20 MB | 180 MB |
| headroom below / above | 15.3x / 15.0x | 3.3x / 3.5x |
| max/min green | **1.00005** | 1.254 |

**Repeated runs:** 10 of 10 green isolated, 4 of 4 green under parallel load, at the HEAD of this branch.

**Suite:** `bun run test` 10955 pass / 4 skip / 0 fail across 667 files; `tsc` and `lint` clean.

**Not proven here:** this is calibrated on an 18-core Mac. The 4-vCPU ubuntu runner with Postgres beside it is a different machine, and CI on this PR is the first measurement of it.

Fixes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
